### PR TITLE
port redis role

### DIFF
--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -7,6 +7,7 @@ with builtins;
     ./infrastructure
     ./lib
     ./platform
+    ./rename.nix
     ./services
     ./version.nix
   ];

--- a/nixos/platform/static.nix
+++ b/nixos/platform/static.nix
@@ -124,6 +124,9 @@ with lib;
       uchiwa = 31003;
       sensuclient = 31004;
       powerdns = 31005;
+      
+      # removed by upstream, we want to keep it
+      redis = 181; 
     };
 
     ids.gids = {

--- a/nixos/rename.nix
+++ b/nixos/rename.nix
@@ -1,0 +1,8 @@
+{ lib, pkgs, ... }:
+{
+  imports = with lib; [
+    # old -> new
+    # redis and redis4 roles do the same
+    (mkRenamedOptionModule [ "flyingcircus" "roles" "redis4" ] [ "flyingcircus" "roles" "redis" ])
+  ];
+}

--- a/nixos/roles/default.nix
+++ b/nixos/roles/default.nix
@@ -9,6 +9,7 @@ let
 
 in {
   imports = [
+    ./redis.nix
     ./statshost
     ./webgateway.nix
     ./webproxy.nix

--- a/nixos/roles/redis.nix
+++ b/nixos/roles/redis.nix
@@ -1,0 +1,15 @@
+{ config, pkgs, lib, ... }:
+let
+  roles = config.flyingcircus.roles;
+in {
+  options = {
+    # redis4 is an alias for redis, see rename.nix
+    flyingcircus.roles.redis.enable = 
+      lib.mkEnableOption "Flying Circus Redis";
+  };
+
+  config = {
+      flyingcircus.services.redis.enable = roles.redis.enable;
+      flyingcircus.roles.statshost.globalAllowedMetrics = [ "redis" ];
+    };
+}

--- a/nixos/services/default.nix
+++ b/nixos/services/default.nix
@@ -10,6 +10,7 @@
     ./logrotate
     ./nginx
     ./prometheus.nix
+    ./redis.nix
     ./sensu.nix
     ./syslog.nix
     ./telegraf.nix

--- a/nixos/services/redis.nix
+++ b/nixos/services/redis.nix
@@ -1,0 +1,113 @@
+{ config, lib, pkgs, ... }:
+
+with builtins;
+
+let
+  cfg = config.flyingcircus.services.redis;
+  fclib = config.fclib;
+
+  listen_addresses =
+    fclib.listenAddresses "lo" ++
+    fclib.listenAddresses "ethsrv";
+
+  generatedPassword =
+    lib.removeSuffix "\n" (readFile
+      (pkgs.runCommand "redis.password" {}
+      "${pkgs.apg}/bin/apg -a 1 -M lnc -n 1 -m 32 > $out"));
+
+  password = lib.removeSuffix "\n" (
+    if cfg.password == null
+    then (fclib.configFromFile /etc/local/redis/password generatedPassword)
+    else cfg.password
+  );
+
+  extraConfig = fclib.configFromFile /etc/local/redis/custom.conf "";
+
+in {
+  options = with lib; {
+
+    flyingcircus.services.redis = {
+      enable = mkEnableOption "Preconfigured Redis";
+
+      password = mkOption {
+        type = types.nullOr types.string;
+        default = null;
+        description = ''
+          The password for redis. If null, a random password will be generated.
+        '';
+      };
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.redis;
+        description = "The precise Redis package to use";
+        example = "pkgs.redis";
+      };
+    };
+
+  };
+
+  config =
+    lib.mkIf cfg.enable {
+
+      services.redis.enable = true;
+      services.redis.package = cfg.package;
+      services.redis.requirePass = password;
+      services.redis.bind = concatStringsSep " " listen_addresses;
+      services.redis.extraConfig = extraConfig;
+
+      system.activationScripts.fcio-redis = ''
+        install -d -o ${toString config.ids.uids.redis} -g service -m 02775 \
+          /etc/local/redis/
+        if [[ ! -e /etc/local/redis/password ]]; then
+          ( umask 007;
+            echo ${lib.escapeShellArg password} > /etc/local/redis/password
+            chown redis:service /etc/local/redis/password
+          )
+        fi
+        chmod 0660 /etc/local/redis/password
+      '';
+
+      systemd.services.redis = rec {
+        serviceConfig = {
+          LimitNOFILE = 64000;
+          PermissionsStartOnly = true;
+        };
+
+        after = [ "network.target" ];
+        wants = after;
+        preStart = "echo never > /sys/kernel/mm/transparent_hugepage/enabled";
+        postStop = "echo madvise > /sys/kernel/mm/transparent_hugepage/enabled";
+      };
+
+      flyingcircus.services = {
+        sensu-client.checks.redis = {
+          notification = "Redis alive";
+          command = "check-redis-ping.rb -h localhost -P ${lib.escapeShellArg password}";
+        };
+
+        telegraf.inputs.redis = [
+          {
+            servers = [
+              "tcp://:${password}@localhost:${toString config.services.redis.port}"
+            ];
+          }
+        ];
+      };
+
+      boot.kernel.sysctl = {
+        "vm.overcommit_memory" = 1;
+        "net.core.somaxconn" = 512;
+      };
+
+      environment.etc."local/redis/README.txt".text = ''
+        Redis is running on this machine.
+
+        You can find the password for the redis in the `password`. You can also change
+        the redis password by changing the `password` file.
+
+        To change the redis configuration, add a file `custom.conf`, which will be
+        appended to the redis configuration.
+      '';
+    };
+}

--- a/tests/redis.nix
+++ b/tests/redis.nix
@@ -1,0 +1,20 @@
+import ./make-test.nix ({ ... }:
+{
+  name = "redis";
+  nodes = {
+    redis =
+      { ... }:
+      {
+        imports = [ ../nixos ../nixos/roles ];
+        flyingcircus.roles.redis.enable = true;
+      };
+  };
+
+  testScript = ''
+    $redis->waitForUnit("redis.service");
+    my $cli = "redis-cli -a `< /etc/local/redis/password `";
+    $redis->waitUntilSucceeds("$cli ping | grep PONG");
+    $redis->succeed("$cli set msg 'hello world'");
+    $redis->succeed("$cli get msg | grep 'hello world'");
+  '';
+})


### PR DESCRIPTION
There's only one redis role now; redis4 remains as an alias to redis.