### PR TITLE
Mailserver role

### DIFF
--- a/nixos/lib/network.nix
+++ b/nixos/lib/network.nix
@@ -26,24 +26,24 @@ rec {
   ip' = a: "ip " + (if isIp4 a then "-4" else if isIp6 a then "-6" else "");
 
   # list IP addresses for service configuration (e.g. nginx)
-  listenAddresses = interface:
-    if interface == "lo"
+  listenAddresses = iface:
+    if iface == "lo"
     # lo isn't part of the enc. Hard code it here.
     then [ "127.0.0.1" "::1" ]
     else
-      if hasAttr interface config.networking.interfaces
+      if hasAttr iface config.networking.interfaces
       then
         let
-          interface_config = getAttr interface config.networking.interfaces;
+          interface_config = getAttr iface config.networking.interfaces;
         in
           (map (addr: addr.address) interface_config.ipv4.addresses) ++
           (map (addr: addr.address) interface_config.ipv6.addresses)
       else [];
 
-  listenAddressesQuotedV6 = interface:
-    map
-      (addr: if isIp6 addr then "[${addr}]" else addr)
-      (listenAddresses interface);
+  quoteIPv6Address = addr: if isIp6 addr then "[${addr}]" else addr;
+
+  listenAddressesQuotedV6 =
+    iface: map quoteIPv6Address (listenAddresses iface);
 
   listServiceAddresses = service:
   (map

--- a/nixos/platform/enc.nix
+++ b/nixos/platform/enc.nix
@@ -2,21 +2,9 @@
 
 let
   cfg = config.flyingcircus;
-
   fclib = config.fclib;
 
-  enc = fclib.jsonFromFile cfg.encPath {};
-
-  encAddresses = fclib.jsonFromFile cfg.encAddressesPath "[]";
-
-  encServices = fclib.jsonFromFile cfg.encServicesPath "[]";
-
-  encServiceClients = fclib.jsonFromFile cfg.encServiceClientsPath "[]";
-
-  systemState = fclib.jsonFromFile cfg.systemStatePath "{}";
-
 in
-
 with lib;
 {
   options.flyingcircus = with types; {

--- a/nixos/platform/packages.nix
+++ b/nixos/platform/packages.nix
@@ -37,11 +37,12 @@
         links
         lsof
         lynx
+        mailx
         mercurial
         mmv
         nano
-        netcat
         ncdu
+        netcat
         netcat
         ngrep
         nmap

--- a/nixos/roles/default.nix
+++ b/nixos/roles/default.nix
@@ -9,6 +9,7 @@ let
 
 in {
   imports = [
+    ./mailserver.nix
     ./memcached.nix
     ./redis.nix
     ./statshost

--- a/nixos/roles/mailserver.nix
+++ b/nixos/roles/mailserver.nix
@@ -1,0 +1,79 @@
+{ config, lib, pkgs, ... }:
+
+with builtins;
+
+let
+  params = lib.attrByPath [ "parameters" ] {} config.flyingcircus.enc;
+  fclib = config.fclib;
+  roles = config.flyingcircus.roles;
+
+  listenFe = fclib.listenAddresses "ethfe";
+
+  # default domain should be changed to to fcio.net once #14970 is finished
+  defaultHostname =
+    if (params ? location &&
+        lib.hasAttrByPath [ "interfaces" "fe" ] params &&
+        (length listenFe > 0))
+    then "${config.networking.hostName}.fe.${params.location}.gocept.net"
+    else "${config.networking.hostName}.gocept.net";
+
+in
+{
+  options = {
+
+    flyingcircus.roles.mailserver = with lib; {
+      # The mailserver role was/is thought to implement an entire mailserver,
+      # and would be billed as component.
+
+      enable = mkEnableOption ''
+        Enable the Flying Circus mailserver out role and configure
+        mailout on all nodes in this RG/location.
+      '';
+
+      hostname = mkOption {
+        type = types.str;
+        default = fclib.configFromFile
+          /etc/local/postfix/myhostname defaultHostname;
+        description = ''
+          Set the FQDN the mail server announces in its SMTP dialogues. Must
+          match forward and reverse DNS.
+        '';
+        example = "mail.project.example.com";
+      };
+
+      smtpBindAddresses = mkOption {
+        type = with types; listOf str;
+        default = listenFe;
+        description = ''
+          List of IP addresses for outgoing SMTP connections. If there is more
+          than one address for any address family, only the first one will be
+          used.
+        '';
+      };
+    };
+
+    flyingcircus.roles.mailout = {
+      # Mailout is considered to be included in the webgateway, but only
+      # sometimes required. So it's a separate role, which is not a billable
+      # component.
+      enable = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = ''
+          Enable the Flying Circus mailserver out role and configure
+          mailout on all nodes in this RG/location.
+        '';
+      };
+    };
+  };
+
+  # `mailserver` will grow into a full-featured mail solution some day while
+  # `mailout` configures SMTP sending serivces for its RG.
+  config = {
+    flyingcircus.services.postfix.enable =
+      (roles.mailserver.enable || roles.mailout.enable);
+
+    flyingcircus.services.ssmtp.enable =
+      !(roles.mailserver.enable || roles.mailout.enable);
+  };
+}

--- a/nixos/services/default.nix
+++ b/nixos/services/default.nix
@@ -10,9 +10,11 @@
     ./haproxy.nix
     ./logrotate
     ./nginx
+    ./postfix.nix
     ./prometheus.nix
     ./redis.nix
     ./sensu.nix
+    ./ssmtp.nix
     ./syslog.nix
     ./telegraf.nix
   ];

--- a/nixos/services/postfix.nix
+++ b/nixos/services/postfix.nix
@@ -1,0 +1,122 @@
+{ config, pkgs, lib, ... }:
+
+with builtins;
+
+let
+  cfg = config.flyingcircus.roles.mailserver;
+  fclib = config.fclib;
+
+  interfaces =
+    lib.attrByPath [ "parameters" "interfaces" ] {} config.flyingcircus.enc;
+
+  listen4 = filter fclib.isIp4 cfg.smtpBindAddresses;
+  listen6 = filter fclib.isIp6 cfg.smtpBindAddresses;
+
+  mainCf = [
+    (lib.optionalString
+      (length listen4 > 0)
+      "smtp_bind_address=${head listen4}")
+    (lib.optionalString
+      (length listen6 > 0)
+      "smtp_bind_address6=${head listen6}")
+    (fclib.configFromFile "/etc/local/postfix/main.cf" "")
+    (lib.optionalString
+      (lib.pathExists "/etc/local/postfix/canonical.pcre")
+      "canonical_maps = pcre:${/etc/local/postfix/canonical.pcre}\n")
+  ];
+
+  masterCf = [
+    (lib.optionalString
+      (lib.pathExists "/etc/local/postfix/master.cf")
+      (lib.readFile /etc/local/postfix/master.cf))
+  ];
+
+in
+{
+  options = {
+    flyingcircus.services.postfix.enable = lib.mkEnableOption ''
+      Postfix mailserver|mailout role with FCIO custom config
+    '';
+  };
+
+  config = (lib.mkIf config.flyingcircus.services.postfix.enable {
+    services.postfix = {
+      enable = true;
+      enableSubmission = true;
+      hostname = cfg.hostname;
+      extraConfig = lib.concatStringsSep "\n" mainCf;
+      extraMasterConf = lib.concatStringsSep "\n" masterCf;
+      # Trust all networks on the SRV interface.
+      networks =
+        map fclib.quoteIPv6Address
+        (attrNames (lib.attrByPath [ "srv" "networks" ] {} interfaces));
+      destination = [
+        "localhost"
+        cfg.hostname
+        config.networking.hostName
+        "${config.networking.hostName}.gocept.net"
+        "${config.networking.hostName}.fcio.net"
+      ];
+    };
+
+    environment.etc."local/postfix/README.txt".text = ''
+      Put your local postfix configuration here.
+
+      Use `main.cf` for pure configuration settings like
+      setting message_size_limit. Please do use normal main.cf syntax,
+      as this will extend the basic configuration file.
+
+      Make usage of `myhostname` to provide a hostname Postfix shall
+      use to configure its own myhostname variable. If not set, the
+      default hostname will be used instead.
+
+      If you need to reference to some map, these are currently available:
+      * canonical_maps - /etc/local/postfix/canonical.pcre
+
+      The file `master.cf` may contain everything you want to add to
+      postfix' master.cf-file e.g. to enable the submission port.
+
+      In case you need to extend this list, get in contact with our
+      support.
+    '';
+
+    environment.systemPackages = with pkgs; [ mailutils ];
+
+    flyingcircus.services.sensu-client.checks = {
+      # FIXME check_mailq does not call `mailq` correctly
+      # - needs patch
+      # postfix_mailq = {
+      #   command =
+      #     "sudo ${pkgs.monitoring-plugins}/bin/check_mailq " +
+      #     "-M postfix -w 200 -c 400";
+      #   notification = "Too many undelivered mails in Postfix mail queue.";
+      # };
+
+      postfix_smtp_port = {
+        command = ''
+          check_smtp -H localhost -p 25 -e Postfix -w 5 -c 10 -t 60
+        '';
+        notification = "Postfix SMTP (25) not reachable at localhost.";
+      };
+
+      postfix_submission_port = {
+        command = ''
+          check_smtp -H localhost -p 587 -e Postfix -w 5 -c 10 -t 60
+        '';
+        notification = "Postfix Submission (587) not reachable at localhost.";
+      };
+    };
+
+    security.sudo.extraRules = [
+      {
+        commands = [ "${pkgs.monitoring-plugins}/bin/check_mailq" ];
+        groups = [ "sensuclient" ];
+      }
+    ];
+
+    systemd.tmpfiles.rules = [
+      "d /etc/local/postfix 2775 root service"
+    ];
+
+  });
+}

--- a/nixos/services/sensu.nix
+++ b/nixos/services/sensu.nix
@@ -250,6 +250,7 @@ in {
       after = [ "network.target" ];
       stopIfChanged = false;
       path = with pkgs; [
+        "/run/wrappers"
         bash
         coreutils
         fc.sensuplugins-rb
@@ -257,7 +258,6 @@ in {
         lm_sensors
         monitoring-plugins
         sensu
-        sudo
         sysstat
       ];
       script = ''

--- a/nixos/services/ssmtp.nix
+++ b/nixos/services/ssmtp.nix
@@ -1,0 +1,33 @@
+{ config, lib, ... }:
+
+with builtins;
+
+let
+  fclib = config.fclib;
+  net = config.networking;
+
+  mailoutService =
+    let services =
+      # Prefer mailout. This would allow splitting in and out automagically.
+      (fclib.listServiceAddresses "mailout-mailout" ++
+       fclib.listServiceAddresses "mailserver-mailout");
+    in
+      if services == [] then null else head services;
+
+in
+{
+  options.flyingcircus.services.ssmtp.enable = lib.mkEnableOption ''
+    Dumb mail relay to the next 'mailout' server
+  '';
+
+  config = lib.mkIf (config.flyingcircus.services.ssmtp.enable &&
+                     mailoutService != null) {
+    networking.defaultMailServer = {
+      directDelivery = true;
+      domain =
+        lib.optionalString (net.domain != null) "${net.hostName}.${net.domain}";
+      hostName = mailoutService;
+      root = "admin@flyingcircus.io";
+    };
+  };
+}

--- a/pkgs/mailx.nix
+++ b/pkgs/mailx.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
     makeFlagsArray=(
     MANDIR=$out/share/man1
     PREFIX=$out
-    SENDMAIL=/run/current-system/sw/bin/sendmail
+    SENDMAIL=/run/wrappers/bin/sendmail
     SYSCONFDIR=$out/etc
     UCBINSTALL=${pkgs.coreutils}/bin/install
     BINDIR=$out/bin

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -23,6 +23,7 @@ in {
   garbagecollect = callTest ./garbagecollect.nix {};
   login = callTest ./login.nix {};
   logrotate = callTest ./logrotate.nix {};
+  mail = callSubTests ./mail.nix {};
   memcached = callTest ./memcached.nix {};
   network = callSubTests ./network {};
   prometheus = callTest ./prometheus.nix {};

--- a/tests/mail.nix
+++ b/tests/mail.nix
@@ -1,0 +1,68 @@
+{ system ? builtins.currentSystem
+, nixpkgs ? (import ../versions.nix { inherit pkgs; }).nixpkgs
+, pkgs ? import ../. {}
+}:
+
+with import "${nixpkgs}/nixos/lib/testing.nix" { inherit system; };
+with pkgs.lib;
+
+let
+  testCases = {
+    mailout = {
+      name = "mailout";
+      nodes.client =
+        { lib, ... }:
+        {
+          imports = [ ../nixos ];
+          config = {
+            flyingcircus.services.ssmtp.enable = true;
+            flyingcircus.encServices = [
+              {
+                service = "mailout-mailout";
+                address = "mailer";
+              }
+            ];
+          };
+        };
+      nodes.mailer =
+        { ... }:
+        {
+          imports = [ ../nixos ../nixos/roles ];
+          flyingcircus.roles.mailout.enable = true;
+          flyingcircus.roles.mailserver.hostname = "mailer";
+          users.users.foo.isNormalUser = true;
+          networking.firewall.allowedTCPPorts = [ 25 ];
+        };
+      testScript = ''
+        startAll;
+        $mailer->waitForUnit("postfix.service");
+
+        # test mail delivery
+        $client->succeed('echo test mail | mailx -s test foo@mailer');
+        $mailer->waitUntilSucceeds('ls /var/spool/mail/foo/new/*.mailer');
+        my $m = $mailer->succeed('cat /var/spool/mail/foo/new/*.mailer');
+        print($m);
+        $m =~ /^From: .*<root\@client>/m or die "no valid 'From:'";
+        $m =~ /^To: foo\@mailer/m or die "no valid 'To:'";
+        $m =~ /^Subject: test/m or die "no valid 'Subject:'";
+
+        # test SMTP dialogue
+        $mailer->succeed(<<_EOT_);
+        ${pkgs.monitoring-plugins}/bin/check_smtp -v -H localhost \\
+           -C 'MAIL FROM:<root>' -R 250 \\
+           -C 'RCPT TO:<foo\@mailer>' -R 250 \\
+           -C 'DATA' -R 354 \\
+           -C 'Subject: test2\r\n\r\ntest2\r\n.' -R 250
+        _EOT_
+      '';
+    };
+
+    # mailserver = {
+    # TBD
+    # };
+  };
+
+in
+mapAttrs
+(const (attrs: makeTest (attrs // { name = "mail-${attrs.name}"; })))
+testCases


### PR DESCRIPTION
* "mailout" defines an outgoing SMTP gateway for all VM in the same
  location and resource group.
* "mailserver" is meant to configure a full-featured mail server with
  IMAP etc. in the future. Until now it is sort of a stub.

The mail server's hostname defaults to the FE FQDN/address if there is
one. Otherwise, the SRV FQDN/address is selected. It is possible to
override the hostname via /etc/local/postfix/myhostname.