### PR TITLE
enable cron service by default

### DIFF
--- a/nixos/platform/default.nix
+++ b/nixos/platform/default.nix
@@ -56,6 +56,7 @@ with lib;
       # reduce build time
       nixosManual.enable = mkDefault false;
 
+      cron.enable = mkDefault true;
       nscd.enable = true;
       openssh.enable = mkDefault true;
     };


### PR DESCRIPTION
fixes case 110441

@flyingcircusio/release-managers

Impact:

Changelog:

* Enable cron service by default on 18.09 (#110441)