### PR TITLE
Port PostgreSQL role

### DIFF
--- a/nixos/roles/default.nix
+++ b/nixos/roles/default.nix
@@ -11,6 +11,7 @@ in {
   imports = [
     ./mailserver.nix
     ./memcached.nix
+    ./postgresql.nix
     ./redis.nix
     ./statshost
     ./webgateway.nix

--- a/nixos/roles/postgresql.nix
+++ b/nixos/roles/postgresql.nix
@@ -1,0 +1,46 @@
+{ config, lib, pkgs, ... }:
+
+with builtins;
+{
+  options = 
+  let
+    mkRole = v: lib.mkEnableOption
+      "Enable the Flying Circus PostgreSQL ${v} server role.";
+  in {
+    flyingcircus.roles = {
+      postgresql95.enable = mkRole "9.5";
+      postgresql96.enable = mkRole "9.6";
+      postgresql10.enable = mkRole "10";
+    };
+  };
+
+  config = 
+  let
+    pgroles = with config.flyingcircus.roles; {
+      "9.5" = postgresql95.enable;
+      "9.6" = postgresql96.enable;
+      "10" = postgresql10.enable;
+    };
+    enabledRoles = lib.filterAttrs (n: v: v) pgroles;
+    enabledRolesCount = length (lib.attrNames enabledRoles);
+  
+  in lib.mkMerge [
+    (lib.mkIf (enabledRolesCount > 0) {
+      assertions = 
+        [ 
+          { 
+            assertion = enabledRolesCount == 1;
+            message = "PostgreSQL roles are mutually exclusive. Only one may be enabled.";
+          }
+        ]; 
+
+      flyingcircus.services.postgresql.enable = true;
+      flyingcircus.services.postgresql.majorVersion = 
+        head (lib.attrNames enabledRoles);
+    })
+
+    {
+      flyingcircus.roles.statshost.globalAllowedMetrics = [ "postgresql" ];
+    }
+  ];
+}

--- a/nixos/services/default.nix
+++ b/nixos/services/default.nix
@@ -11,6 +11,7 @@
     ./logrotate
     ./nginx
     ./postfix.nix
+    ./postgresql.nix
     ./prometheus.nix
     ./redis.nix
     ./sensu.nix

--- a/nixos/services/postgresql-init.sql
+++ b/nixos/services/postgresql-init.sql
@@ -1,0 +1,2 @@
+CREATE USER root SUPERUSER;
+CREATE DATABASE root owner=root;

--- a/nixos/services/postgresql.nix
+++ b/nixos/services/postgresql.nix
@@ -1,0 +1,221 @@
+{ config, lib, pkgs, ... }:
+
+with builtins;
+
+let
+  cfg = config.flyingcircus.services.postgresql;
+  fclib = config.fclib;
+  packages = {
+    "9.5" = pkgs.postgresql95;
+    "9.6" = pkgs.postgresql96;
+    "10" = pkgs.postgresql100;
+  };
+
+  listenAddresses =
+    fclib.listenAddresses "lo" ++
+    fclib.listenAddresses "ethsrv";
+
+  currentMemory = fclib.currentMemory 256;
+  sharedMemoryMax = currentMemory / 2 * 1048576;
+
+  sharedBuffers =
+    fclib.min [
+      (fclib.max [16 (currentMemory / 4)])
+      (sharedMemoryMax * 4 / 5)];
+
+  walBuffers =
+    fclib.max [
+      (fclib.min [64 (sharedBuffers / 32)])
+      1];
+
+  workMem = fclib.max [1 (sharedBuffers / 200)];
+  maintenanceWorkMem = fclib.max [16 workMem (currentMemory / 20)];
+
+  randomPageCost =
+    let rbdPool =
+      lib.attrByPath [ "parameters" "rbd_pool" ] null config.flyingcircus.enc;
+    in
+    if rbdPool == "rbd.ssd" then 1 else 4;
+
+  # using this ugly expression is the only way to get a dynamic path into the
+  # Nix store
+  localConfigPath = /etc/local/postgresql + "/${cfg.majorVersion}";
+
+  localConfig =
+    if pathExists localConfigPath
+    then "include_dir '${localConfigPath}'"
+    else "";
+
+in {
+  options = with lib; {
+
+    flyingcircus.services.postgresql = {
+      enable = mkEnableOption "Enable preconfigured PostgreSQL";
+      majorVersion = mkOption {
+          type = types.string;
+          description = ''
+            The major version of PostgreSQL to use (9.5, 9.6, 10).
+          '';
+        };
+    };
+
+  };
+
+  config = 
+  (lib.mkIf cfg.enable (
+  let
+    postgresqlPkg = getAttr cfg.majorVersion packages;
+
+  in {
+    services.postgresql.enable = true;
+    services.postgresql.package = postgresqlPkg;
+    services.postgresql.extraPlugins = [
+      (pkgs.temporal_tables.override { postgresql = postgresqlPkg; })
+      (pkgs.postgis.override { postgresql = postgresqlPkg; })
+    ] ++ lib.optionals
+      (lib.versionAtLeast cfg.majorVersion "9.6")
+      [ (pkgs.rum.override { postgresql = postgresqlPkg; }) ];
+
+    services.postgresql.initialScript = ./postgresql-init.sql;
+    services.postgresql.dataDir = "/srv/postgresql/${cfg.majorVersion}";
+    systemd.services.postgresql.bindsTo = [ "network-addresses-ethsrv.service" ];
+
+    systemd.services.postgresql.postStart =
+    let
+      psql = "${postgresqlPkg}/bin/psql";
+    in ''
+      if ! ${psql} -c '\du' template1 | grep -q '^ *nagios *|'; then
+        ${psql} -c 'CREATE ROLE nagios NOSUPERUSER NOCREATEDB NOCREATEROLE NOINHERIT LOGIN' template1
+      fi
+      if ! ${psql} -l | grep -q '^ *nagios *|'; then
+        ${postgresqlPkg}/bin/createdb nagios
+      fi
+      ${psql} -q -d nagios -c 'REVOKE ALL ON SCHEMA public FROM PUBLIC CASCADE;'
+    '';
+
+    users.users.postgres = {
+      shell = "/run/current-system/sw/bin/bash";
+      home = lib.mkForce "/srv/postgresql";
+    };
+
+    system.activationScripts.flyingcircus_postgresql = ''
+      install -d -o ${toString config.ids.uids.postgres} /srv/postgresql
+      install -d -o ${toString config.ids.uids.postgres} -g service -m 02775 \
+        /etc/local/postgresql/${cfg.majorVersion}
+    '';
+
+    security.sudo.extraConfig = ''
+      # Service users may switch to the postgres system user
+      %sudo-srv ALL=(postgres) ALL
+      %service ALL=(postgres) ALL
+      %sensuclient ALL=(postgres) ALL
+    '';
+
+    # System tweaks
+    boot.kernel.sysctl = {
+      "kernel.shmmax" = toString sharedMemoryMax;
+      "kernel.shmall" = toString (sharedMemoryMax / 4096);
+    };
+
+    services.udev.extraRules = ''
+      # increase readahead for postgresql
+      SUBSYSTEM=="block", ATTR{queue/rotational}=="1", ACTION=="add|change", KERNEL=="vd[a-z]", ATTR{bdi/read_ahead_kb}="1024", ATTR{queue/read_ahead_kb}="1024"
+    '';
+
+    # Custom postgresql configuration
+    services.postgresql.extraConfig = ''
+      #------------------------------------------------------------------------------
+      # CONNECTIONS AND AUTHENTICATION
+      #------------------------------------------------------------------------------
+      listen_addresses = '${concatStringsSep "," listenAddresses}'
+      max_connections = 400
+      #------------------------------------------------------------------------------
+      # RESOURCE USAGE (except WAL)
+      #------------------------------------------------------------------------------
+      # available memory: ${toString currentMemory}MB
+      shared_buffers = ${toString sharedBuffers}MB   # starting point is 25% RAM
+      temp_buffers = 16MB
+      work_mem = ${toString workMem}MB
+      maintenance_work_mem = ${toString maintenanceWorkMem}MB
+      #------------------------------------------------------------------------------
+      # QUERY TUNING
+      #------------------------------------------------------------------------------
+      effective_cache_size = ${toString (sharedBuffers * 2)}MB
+
+      random_page_cost = ${toString randomPageCost}
+      # version-specific resource settings for >=9.3
+      effective_io_concurrency = 100
+
+      #------------------------------------------------------------------------------
+      # WRITE AHEAD LOG
+      #------------------------------------------------------------------------------
+      wal_level = hot_standby
+      wal_buffers = ${toString walBuffers}MB
+      checkpoint_completion_target = 0.9
+      archive_mode = off
+
+      #------------------------------------------------------------------------------
+      # ERROR REPORTING AND LOGGING
+      #------------------------------------------------------------------------------
+      log_min_duration_statement = 1000
+      log_checkpoints = on
+      log_connections = on
+      log_line_prefix = 'user=%u,db=%d '
+      log_lock_waits = on
+      log_autovacuum_min_duration = 5000
+      log_temp_files = 1kB
+      shared_preload_libraries = 'auto_explain'
+      auto_explain.log_min_duration = '3s'
+
+      #------------------------------------------------------------------------------
+      # CLIENT CONNECTION DEFAULTS
+      #------------------------------------------------------------------------------
+      datestyle = 'iso, mdy'
+      lc_messages = 'en_US.utf8'
+      lc_monetary = 'en_US.utf8'
+      lc_numeric = 'en_US.utf8'
+      lc_time = 'en_US.utf8'
+
+      ${localConfig}
+    '';
+
+    environment.etc."local/postgresql/${cfg.majorVersion}/README.txt".text = ''
+        Put your local postgresql configuration here. This directory
+        is being included with include_dir.
+        '';
+
+    services.postgresql.authentication = ''
+      local postgres root       trust
+      # trusted access for Nagios
+      host    nagios          nagios          0.0.0.0/0               trust
+      host    nagios          nagios          ::/0                    trust
+      # authenticated access for others
+      host all  all  0.0.0.0/0  md5
+      host all  all  ::/0       md5
+    '';
+
+    flyingcircus.services = {
+
+      sensu-client.checks = 
+        lib.listToAttrs (
+        map (host:
+            let saneHost = replaceStrings [":"] ["_"] host;
+            in
+            { name = "postgresql-listen-${saneHost}-5432";
+              value = {
+                notification = "PostgreSQL listening on ${host}:5432";
+                command = "check-postgres-alive.rb -h ${host} -u nagios -d nagios -P 5432";
+                interval = 120;
+              };
+            })
+          listenAddresses);
+
+      telegraf.inputs = {
+        postgresql = [{
+          address = "host=/tmp user=root sslmode=disable dbname=postgres";
+        }];
+      };
+    };
+
+  }));
+}

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -38,6 +38,10 @@ in {
     ];
   };
 
+  rum = super.callPackage ./postgresql/rum { };
+  #postgis = super.callPackage ./postgis { };
+  temporal_tables = super.callPackage ./postgresql/temporal_tables { };
+
   # We use a (our) newer version than on upstream.
   vulnix = super.callPackage ./vulnix.nix {
     pythonPackages = self.python3Packages;

--- a/pkgs/postgresql/rum/default.nix
+++ b/pkgs/postgresql/rum/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub, postgresql }:
+
+let
+  version = "1.3.1";
+in
+stdenv.mkDerivation {
+  name = "rum-${version}";
+
+  src = fetchFromGitHub {
+    rev = "${version}";
+    owner = "postgrespro";
+    repo = "rum";
+    sha256 = "1d19r5mb78h0iapnqv5l59kgfcxlcyrvpk2bnnvj06brwzssghia";
+  };
+
+  buildInputs = [ postgresql ];
+
+  makeFlags = [
+    "USE_PGXS=1"
+  ];
+
+   installPhase =
+   ''
+     mkdir -p $out/{bin,lib}
+     cp ./rum.so $out/lib
+     mkdir -p $out/share/extension
+     echo .............
+     echo *
+     cp ./rum.control ./rum--1.0.sql ./rum--1.2.sql ./rum--1.3.sql $out/share/extension
+   '';
+ }

--- a/pkgs/postgresql/temporal_tables/default.nix
+++ b/pkgs/postgresql/temporal_tables/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchurl, pkgconfig, postgresql }:
+
+stdenv.mkDerivation rec {
+  name = "temporal_tables-${version}";
+  version = "1.2.0";
+
+  src = fetchurl {
+    url = "https://github.com/arkhipov/temporal_tables/archive/v1.2.0.tar.gz";
+    sha256 = "e6d1b31a124e8597f61b86f08b6a18168f9cd9da1db77f2a8dd1970b407b7610";
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ postgresql ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    install -D temporal_tables.so -t $out/lib/
+    install -D ./{temporal_tables-*.sql,temporal_tables.control} -t $out/share/extension
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A PostgreSQL extension for temporal tables";
+    longDescription = "This extension for PostgreSQL provides support for temporal tables. System-period data versioning (also known as transaction time or system time) allows you to specify that old rows are archived into another table (that is called the history table).";
+    homepage = https://pgxn.org/dist/temporal_tables/;
+    license = licenses.postgresql;
+    maintainers = with maintainers; [ frlan ];
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -26,6 +26,9 @@ in {
   mail = callSubTests ./mail.nix {};
   memcached = callTest ./memcached.nix {};
   network = callSubTests ./network {};
+  postgresql95 = callTest ./postgresql.nix { rolename = "postgresql95"; };
+  postgresql96 = callTest ./postgresql.nix { rolename = "postgresql96"; };
+  postgresql10 = callTest ./postgresql.nix { rolename = "postgresql10"; };
   prometheus = callTest ./prometheus.nix {};
   redis = callTest ./redis.nix {};
   statshost-master = callTest ./statshost-master.nix {};

--- a/tests/postgresql.nix
+++ b/tests/postgresql.nix
@@ -1,0 +1,75 @@
+import ./make-test.nix ({ rolename ? "postgresql10", lib, pkgs, ... }:
+let 
+  ipv4 = "192.168.101.1";
+  ipv6 = "2001:db8:f030:1c3::1";
+in {
+  name = "postgresql";
+  machine = 
+    { ... }:
+    {
+      imports = [ ../nixos ../nixos/roles ];
+      flyingcircus.roles.${rolename}.enable = true;
+
+      flyingcircus.enc.parameters = {
+        resource_group = "test";
+        interfaces.srv = {
+          mac = "52:54:00:12:34:56";
+          networks = {
+            "192.168.101.0/24" = [ ipv4 ];
+            "2001:db8:f030:1c3::/64" = [ ipv6 ];
+          };
+          gateways = {};
+        };
+      };
+    };
+
+  testScript =
+    let
+      insertSql = pkgs.writeText "insert.sql" ''
+        CREATE TABLE employee (
+          id INT PRIMARY KEY,
+          name TEXT
+        );
+        INSERT INTO employee VALUES (1, 'John Doe');
+      '';
+
+      selectSql = pkgs.writeText "select.sql" ''
+        SELECT * FROM employee WHERE id = 1;
+      '';
+
+      dataTest = pkgs.writeScript "postgresql-tests" ''
+        set -e
+        createdb employees
+        psql --echo-all -d employees < ${insertSql}
+        psql --echo-all -d employees < ${selectSql} | grep -5 "John Doe"
+      '';
+
+      createExtensions = pkgs.writeScript "extension-tests" ''
+        set -e
+        psql employees -c "CREATE EXTENSION postgis;"
+        psql employees -c "CREATE EXTENSION temporal_tables;"
+      '';
+    in
+    ''
+      $machine->waitForUnit("postgresql.service");
+      $machine->waitForOpenPort(5432);
+
+      # simple data round trip
+      $machine->succeed('sudo -u postgres -- sh ${dataTest}');
+
+      # connection tests with password
+      $machine->succeed('sudo -u postgres -- psql -c "CREATE USER test; ALTER USER test WITH PASSWORD \'test\'"');
+      $machine->succeed('sudo -u postgres -- psql postgresql://test:test@${ipv4}:5432/postgres -c "SELECT \'hello\'" | grep hello');
+      $machine->succeed('sudo -u postgres -- psql postgresql://test:test@[${ipv6}]:5432/postgres -c "SELECT \'hello\'" | grep hello');
+
+      # should not trust connections via TCP
+      $machine->fail('psql --no-password -h localhost -l');
+
+      # test extensions that work on all versions
+      $machine->succeed('sudo -u postgres -- sh ${createExtensions}');
+    '' +
+      lib.optionalString  (rolename != "postgresql95")
+    ''# Do the rum extension test. Rum is not available for 9.5.
+      $machine->succeed('sudo -u postgres -- psql employees -c "CREATE EXTENSION rum;"');
+    '';
+})


### PR DESCRIPTION
* supports versions 9.5, 9.6 and 10
* only one pg role may be enabled at a time
* uses upstream pg pkgs and postgis extension
* current version of rum extension, old one was incompatible with 10.7
* create root user instead of postgres because upstream creates a postgres user now


@flyingcircusio/release-managers

Impact:

Changelog:

* PostgreSQL roles (9.5, 9.6 and 10) for 18.09 