### PR TITLE
add roles for multiple RabbitMQ versions

### DIFF
--- a/nixos/lib/utils.nix
+++ b/nixos/lib/utils.nix
@@ -13,11 +13,11 @@ rec {
   getLdapNodeDN = config:
     "cn=${config.networking.hostName},ou=Nodes,dc=gocept,dc=com";
 
-  # Compute LDAP password for this node.
-  getLdapNodePassword = config:
+  # Derives a password from host data and a custom prefix
+  derivePasswordForHost = prefix:
     builtins.hashString "sha256" (concatStringsSep "/" [
-      "ldap"
-      config.flyingcircus.enc.parameters.directory_password
+      prefix
+      (lib.attrByPath ["directory_password"] "" config.flyingcircus.enc.parameters)
       config.networking.hostName
     ]);
 

--- a/nixos/roles/default.nix
+++ b/nixos/roles/default.nix
@@ -13,6 +13,7 @@ in {
     ./memcached.nix
     ./mongodb
     ./postgresql.nix
+    ./rabbitmq.nix
     ./redis.nix
     ./statshost
     ./webgateway.nix

--- a/nixos/roles/rabbitmq.nix
+++ b/nixos/roles/rabbitmq.nix
@@ -1,0 +1,197 @@
+{ config, lib, pkgs, ... }:
+
+with builtins;
+
+{
+  options = 
+  let
+    mkRole = v: { 
+      enable = lib.mkEnableOption
+        "Enable the Flying Circus RabbitMQ ${v} server role.";
+    };
+  in {
+    flyingcircus.roles = {
+      rabbitmq36_5 = mkRole "3.6.5";
+      rabbitmq36_15 = mkRole "3.6.15";
+      rabbitmq37 = mkRole "3.7";
+    };
+  };
+
+  config = 
+  let
+    # XXX: We choose the first IP of ethsrv here, as the 3.6 service is not capable
+    # of handling more than one IP.
+    listenAddress = head (fclib.listenAddresses "ethsrv");
+
+    roles = config.flyingcircus.roles;
+    fclib = config.fclib;
+
+    telegrafPassword = fclib.derivePasswordForHost "telegraf";
+    sensuPassword = fclib.derivePasswordForHost "sensu";
+
+    rabbitRoles = with config.flyingcircus.roles; {
+      "3.6.5" = rabbitmq36_5.enable;
+      "3.6.15" = rabbitmq36_15.enable;
+      "3.7" = rabbitmq37.enable;
+    };
+    enabledRoles = lib.filterAttrs (n: v: v) rabbitRoles;
+    enabledRolesCount = length (lib.attrNames enabledRoles);
+    enabled = enabledRolesCount > 0;
+    roleVersion = head (lib.attrNames enabledRoles);
+    majorMinorVersion = lib.concatStringsSep "." (lib.take 2 (splitVersion roleVersion));
+    package = pkgs."rabbitmq_server_${replaceStrings ["."] ["_"] roleVersion}";
+  
+    extraConfig = fclib.configFromFile /etc/local/rabbitmq/rabbitmq.config "";
+
+    serviceConfig = {
+      inherit listenAddress package;
+      enable = true;
+      plugins = [ "rabbitmq_management" ];
+      config = extraConfig;
+    };
+  
+  in lib.mkMerge [
+    (lib.mkIf (enabled && majorMinorVersion == "3.6") {
+      flyingcircus.services.rabbitmq36 = serviceConfig;
+    })
+
+    (lib.mkIf (enabled && majorMinorVersion == "3.7") {
+      flyingcircus.services.rabbitmq37 = serviceConfig;
+    })
+
+    (lib.mkIf enabled {
+      assertions = 
+        [ 
+          { 
+            assertion = enabledRolesCount == 1;
+            message = "RabbitMQ roles are mutually exclusive. Only one may be enabled.";
+          }
+        ]; 
+
+      users.extraUsers.rabbitmq = {
+        shell = "/run/current-system/sw/bin/bash";
+      };
+
+      security.sudo.extraConfig = ''
+        # Service users may switch to the rabbitmq system user
+        %sudo-srv ALL=(rabbitmq) ALL
+        %service ALL=(rabbitmq) ALL
+      '';
+
+      # We use this in this way in favor of setting PermissionsStartOnly to
+      # true as other script expect running as rabbitmq user
+      system.activationScripts.fcio-rabbitmq = ''
+        install -d -o ${toString config.ids.uids.rabbitmq} -g service -m 02775 \
+          /etc/local/rabbitmq/
+      '';
+
+      environment.etc."local/rabbitmq/README.txt".text = ''
+        RabbitMQ (${package.version}) is running on this machine.
+
+        If you need to set non-default configuration options, you can put a
+        file called `rabbitmq.config` into this directory. The content of this
+        file will be added the configuration of the RabbitMQ service.
+
+        To access rabbitmqctl and other management tools, change into rabbitmq's
+        user and run your command(s). Example:
+
+          $ sudo -iu rabbitmq
+          % rabbitmqctl status
+        '';
+
+      systemd.services.fc-rabbitmq-settings = {
+        description = "Prepare rabbitmq for operation in FC.";
+        requires = [ "rabbitmq.service" ];
+        after = [ "rabbitmq.service" ];
+        wantedBy = [ "multi-user.target" ];
+        path = [ package ];
+        serviceConfig = {
+          Type = "oneshot";
+          User = "rabbitmq";
+          Group = "rabbitmq";
+          RemainAfterExit = true;
+        };
+
+        script = 
+        let
+          # 3.7 returns table headers in list_* results, we must suppress that with -s
+          quietParam = if (lib.versionOlder package.version "3.7") then "-q" else "-s"; 
+        in ''
+            # Delete user guest, if it's there with default password, and
+            # administrator privileges.
+            rabbitmqctl list_users | grep guest && \
+              rabbitmqctl delete_user guest
+
+            # Create user for telegraf, if it does not exist and make sure that the password is set
+            rabbitmqctl list_users | grep fc-telegraf || \
+              rabbitmqctl add_user fc-telegraf ${telegrafPassword}
+
+            rabbitmqctl change_password fc-telegraf ${telegrafPassword}
+
+            # Create user for sensu, if it does not exist and make sure that the password is set
+            rabbitmqctl list_users | grep fc-sensu || \
+              rabbitmqctl add_user fc-sensu ${sensuPassword}
+
+            rabbitmqctl change_password fc-sensu ${sensuPassword}
+
+            rabbitmqctl set_user_tags fc-telegraf monitoring || true
+            rabbitmqctl set_user_tags fc-sensu monitoring || true
+
+            for vhost in $(rabbitmqctl list_vhosts ${quietParam}); do
+              rabbitmqctl set_permissions fc-telegraf -p "$vhost" "" "" ".*"
+            done
+
+            rabbitmqctl set_permissions fc-sensu "^aliveness-test$" "^amq\.default$" "^(amq\.default|aliveness-test)$"
+          '';
+      };
+
+      systemd.timers.fc-rabbitmq-settings = {
+        description = "Runs the FC RabbitMQ preparation script regularly.";
+        wantedBy = [ "timers.target" ];
+        timerConfig = {
+          Unit = "fc-rabbitmq-settings";
+          OnUnitActiveSec = "1h";
+          AccuracySec = "10m";
+        };
+      };
+
+      flyingcircus.services = {
+
+        sensu-client.checks.rabbitmq-alive = {
+          notification = "rabbitmq amqp alive";
+          command = ''
+            ${pkgs.sensu-plugins-rabbitmq}/bin/check-rabbitmq-amqp-alive.rb \
+              -u fc-sensu -w ${listenAddress} -p ${sensuPassword}
+          '';
+        };
+
+        sensu-client.checks.rabbitmq-node-health = {
+          notification = "rabbitmq node healthy";
+          command = ''
+            ${pkgs.sensu-plugins-rabbitmq}/bin/check-rabbitmq-node-health.rb \
+              -u fc-sensu -w ${listenAddress} -p ${sensuPassword}
+          '';
+        };
+
+        telegraf.inputs.rabbitmq = [
+          {
+            url = "http://${config.networking.hostName}:15672";
+            username = "fc-telegraf";
+            password = telegrafPassword;
+            nodes = [ "rabbit@${config.networking.hostName}" ];
+          }
+        ];
+
+      };
+
+    })
+
+    {
+      flyingcircus.roles.statshost.globalAllowedMetrics = [ "rabbitmq" ];
+      flyingcircus.roles.statshost.prometheusMetricRelabel = [
+        { regex = "idle_since";
+          action = "labeldrop"; }
+      ];
+    }
+  ];
+}

--- a/nixos/services/default.nix
+++ b/nixos/services/default.nix
@@ -13,6 +13,8 @@
     ./postfix.nix
     ./postgresql.nix
     ./prometheus.nix
+    ./rabbitmq36.nix
+    ./rabbitmq37.nix
     ./redis.nix
     ./sensu.nix
     ./ssmtp.nix

--- a/nixos/services/rabbitmq36.nix
+++ b/nixos/services/rabbitmq36.nix
@@ -1,0 +1,149 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.flyingcircus.services.rabbitmq36;
+  config_file = pkgs.writeText "rabbitmq.config" cfg.config;
+  config_file_wo_suffix = builtins.substring 0 ((builtins.stringLength config_file) - 7) config_file;
+
+in {
+  ###### interface
+  options = {
+    flyingcircus.services.rabbitmq36 = {
+
+      enable = mkOption {
+        default = false;
+        description = ''
+          Whether to enable the RabbitMQ server, an Advanced Message
+          Queuing Protocol (AMQP) broker (3.6.x series).
+        '';
+      };
+
+      package = mkOption {
+        default = pkgs.rabbitmq_server;
+        type = types.package;
+        defaultText = "pkgs.rabbitmq_server";
+        description = ''
+          Which rabbitmq package (3.6.x) to use.
+        '';
+      };
+
+      listenAddress = mkOption {
+        default = "127.0.0.1";
+        example = "";
+        description = ''
+          IP address on which RabbitMQ will listen for AMQP
+          connections.  Set to the empty string to listen on all
+          interfaces.  Note that RabbitMQ creates a user named
+          <literal>guest</literal> with password
+          <literal>guest</literal> by default, so you should delete
+          this user if you intend to allow external access.
+        '';
+        type = types.str;
+      };
+
+      port = mkOption {
+        default = 5672;
+        description = ''
+          Port on which RabbitMQ will listen for AMQP connections.
+        '';
+        type = types.int;
+      };
+
+      dataDir = mkOption {
+        type = types.path;
+        default = "/var/lib/rabbitmq";
+        description = ''
+          Data directory for rabbitmq.
+        '';
+      };
+
+      cookie = mkOption {
+        default = "";
+        type = types.str;
+        description = ''
+          Erlang cookie is a string of arbitrary length which must
+          be the same for several nodes to be allowed to communicate.
+          Leave empty to generate automatically.
+        '';
+      };
+
+      config = mkOption {
+        default = "";
+        type = types.str;
+        description = ''
+          Verbatim configuration file contents.
+          See http://www.rabbitmq.com/configure.html
+        '';
+      };
+
+      plugins = mkOption {
+        default = [];
+        type = types.listOf types.str;
+        description = "The names of plugins to enable";
+      };
+    };
+  };
+
+
+  ###### implementation
+  config = mkIf cfg.enable {
+
+    environment.systemPackages = [ cfg.package ];
+
+    users.users.rabbitmq = {
+      description = "RabbitMQ server user";
+      home = "${cfg.dataDir}";
+      createHome = true;
+      group = "rabbitmq";
+      uid = config.ids.uids.rabbitmq;
+    };
+
+    users.groups.rabbitmq.gid = config.ids.gids.rabbitmq;
+
+    systemd.services.rabbitmq = {
+      description = "RabbitMQ Server";
+
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+
+      path = [ cfg.package pkgs.procps ];
+
+      environment = {
+        RABBITMQ_MNESIA_BASE = "${cfg.dataDir}/mnesia";
+        RABBITMQ_NODE_IP_ADDRESS = cfg.listenAddress;
+        RABBITMQ_NODE_PORT = toString cfg.port;
+        RABBITMQ_LOGS = "-";
+        RABBITMQ_SASL_LOGS = "-";
+        RABBITMQ_PID_FILE = "${cfg.dataDir}/pid";
+        SYS_PREFIX = "";
+        RABBITMQ_ENABLED_PLUGINS_FILE = pkgs.writeText "enabled_plugins" ''
+          [ ${concatStringsSep "," cfg.plugins} ].
+        '';
+      } //  optionalAttrs (cfg.config != "") { RABBITMQ_CONFIG_FILE = config_file_wo_suffix; };
+
+      serviceConfig = {
+        ExecStart = "${cfg.package}/sbin/rabbitmq-server";
+        ExecStop = "${cfg.package}/sbin/rabbitmqctl stop";
+        LimitNOFILE = "100000";
+        User = "rabbitmq";
+        Group = "rabbitmq";
+        WorkingDirectory = cfg.dataDir;
+      };
+
+      postStart = ''
+        rabbitmqctl wait ${cfg.dataDir}/pid
+      '';
+
+      preStart = ''
+        ${optionalString (cfg.cookie != "") ''
+            echo -n ${cfg.cookie} > ${cfg.dataDir}/.erlang.cookie
+            chmod 600 ${cfg.dataDir}/.erlang.cookie
+        ''}
+      '';
+    };
+
+  };
+
+}

--- a/nixos/services/rabbitmq37.nix
+++ b/nixos/services/rabbitmq37.nix
@@ -1,0 +1,209 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.flyingcircus.services.rabbitmq37;
+
+  inherit (builtins) concatStringsSep;
+
+  config_file_content = lib.generators.toKeyValue {} cfg.configItems;
+  config_file = pkgs.writeText "rabbitmq.conf" config_file_content;
+
+  advanced_config_file = pkgs.writeText "advanced.config" cfg.config;
+
+in {
+  ###### interface
+  options = {
+    flyingcircus.services.rabbitmq37 = {
+      enable = mkOption {
+        default = false;
+        description = ''
+          Whether to enable the RabbitMQ server, an Advanced Message
+          Queuing Protocol (AMQP) broker (3.7.x series).
+        '';
+      };
+
+      package = mkOption {
+        default = pkgs.rabbitmq_server_3_7;
+        type = types.package;
+        defaultText = "pkgs.rabbitmq_server_3_7";
+        description = ''
+          Which rabbitmq package (3.7.x) to use.
+        '';
+      };
+
+      listenAddress = mkOption {
+        default = "127.0.0.1";
+        example = "";
+        description = ''
+          IP address on which RabbitMQ will listen for AMQP
+          connections.  Set to the empty string to listen on all
+          interfaces.  Note that RabbitMQ creates a user named
+          <literal>guest</literal> with password
+          <literal>guest</literal> by default, so you should delete
+          this user if you intend to allow external access.
+
+          Together with 'port' setting it's mostly an alias for
+          configItems."listeners.tcp.1" and it's left for backwards
+          compatibility with previous version of this module.
+        '';
+        type = types.str;
+      };
+
+      port = mkOption {
+        default = 5672;
+        description = ''
+          Port on which RabbitMQ will listen for AMQP connections.
+        '';
+        type = types.int;
+      };
+
+      dataDir = mkOption {
+        type = types.path;
+        default = "/var/lib/rabbitmq";
+        description = ''
+          Data directory for rabbitmq.
+        '';
+      };
+
+      cookie = mkOption {
+        default = "";
+        type = types.str;
+        description = ''
+          Erlang cookie is a string of arbitrary length which must
+          be the same for several nodes to be allowed to communicate.
+          Leave empty to generate automatically.
+        '';
+      };
+
+      configItems = mkOption {
+        default = {};
+        type = types.attrsOf types.str;
+        example = ''
+          {
+            "auth_backends.1.authn" = "rabbit_auth_backend_ldap";
+            "auth_backends.1.authz" = "rabbit_auth_backend_internal";
+          }
+        '';
+        description = ''
+          Configuration options in RabbitMQ's new config file format,
+          which is a simple key-value format that can not express nested
+          data structures. This is known as the <literal>rabbitmq.conf</literal> file,
+          although outside NixOS that filename may have Erlang syntax, particularly
+          prior to RabbitMQ 3.7.0.
+
+          If you do need to express nested data structures, you can use
+          <literal>config</literal> option. Configuration from <literal>config</literal>
+          will be merged into these options by RabbitMQ at runtime to
+          form the final configuration.
+
+          See http://www.rabbitmq.com/configure.html#config-items
+          For the distinct formats, see http://www.rabbitmq.com/configure.html#config-file-formats
+        '';
+      };
+
+      config = mkOption {
+        default = "";
+        type = types.str;
+        description = ''
+          Verbatim advanced configuration file contents using the Erlang syntax.
+          This is also known as the <literal>advanced.config</literal> file or the old config format.
+
+          <literal>configItems</literal> is preferred whenever possible. However, nested
+          data structures can only be expressed properly using the <literal>config</literal> option.
+
+          The contents of this option will be merged into the <literal>configItems</literal>
+          by RabbitMQ at runtime to form the final configuration.
+
+          See the second table on http://www.rabbitmq.com/configure.html#config-items
+          For the distinct formats, see http://www.rabbitmq.com/configure.html#config-file-formats
+        '';
+      };
+
+      plugins = mkOption {
+        default = [];
+        type = types.listOf types.str;
+        description = "The names of plugins to enable";
+      };
+
+      pluginDirs = mkOption {
+        default = [];
+        type = types.listOf types.path;
+        description = "The list of directories containing external plugins";
+      };
+    };
+  };
+
+
+  ###### implementation
+  config = mkIf cfg.enable {
+
+    # This is needed so we will have 'rabbitmqctl' in our PATH
+    environment.systemPackages = [ cfg.package ];
+
+    users.users.rabbitmq = {
+      description = "RabbitMQ server user";
+      home = "${cfg.dataDir}";
+      createHome = true;
+      group = "rabbitmq";
+      uid = config.ids.uids.rabbitmq;
+    };
+
+    users.groups.rabbitmq.gid = config.ids.gids.rabbitmq;
+
+    flyingcircus.services.rabbitmq37.configItems = {
+      "listeners.tcp.1" = mkDefault "${cfg.listenAddress}:${toString cfg.port}";
+    };
+
+    systemd.services.rabbitmq = {
+      description = "RabbitMQ Server";
+
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+      wants = [ "network.target" ];
+
+      path = [ cfg.package pkgs.procps ];
+
+      environment = {
+        RABBITMQ_MNESIA_BASE = "${cfg.dataDir}/mnesia";
+        RABBITMQ_LOGS = "-";
+        SYS_PREFIX = "";
+        RABBITMQ_CONFIG_FILE = config_file;
+        RABBITMQ_PLUGINS_DIR = concatStringsSep ":" cfg.pluginDirs;
+        RABBITMQ_PID_FILE = "${cfg.dataDir}/pid";
+        RABBITMQ_ENABLED_PLUGINS_FILE = pkgs.writeText "enabled_plugins" ''
+          [ ${concatStringsSep "," cfg.plugins} ].
+        '';
+      } //  optionalAttrs (cfg.config != "") { RABBITMQ_ADVANCED_CONFIG_FILE = advanced_config_file; };
+
+      serviceConfig = {
+        ExecStart = "${cfg.package}/sbin/rabbitmq-server";
+        ExecStop = "${cfg.package}/sbin/rabbitmqctl shutdown";
+        User = "rabbitmq";
+        Group = "rabbitmq";
+        LogsDirectory = "rabbitmq";
+        WorkingDirectory = cfg.dataDir;
+        UMask = "0027";
+        LimitNOFILE = "100000";
+        Restart = "on-failure";
+        RestartSec = "10";
+        TimeoutStartSec = "3600";
+      };
+
+      preStart = ''
+        ${optionalString (cfg.cookie != "") ''
+            echo -n ${cfg.cookie} > ${cfg.dataDir}/.erlang.cookie
+            chmod 600 ${cfg.dataDir}/.erlang.cookie
+        ''}
+      '';
+
+      postStart = ''
+        rabbitmqctl wait ${cfg.dataDir}/pid
+      '';
+
+    };
+
+  };
+
+}

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -43,8 +43,13 @@ in {
     ];
   };
 
+  rabbitmq_server_3_6_5 = super.callPackage ./rabbitmq-server/3.6.5.nix { 
+    erlang = self.erlangR18; 
+  };
+  rabbitmq_server_3_6_15 = super.rabbitmq_server;
+  rabbitmq_server_3_7 = super.callPackage ./rabbitmq-server/3.7.nix { };
+
   rum = super.callPackage ./postgresql/rum { };
-  #postgis = super.callPackage ./postgis { };
   sensu-plugins-elasticsearch = super.callPackage ./sensuplugins-rb/sensu-plugins-elasticsearch { };
   sensu-plugins-memcached = super.callPackage ./sensuplugins-rb/sensu-plugins-memcached { };
   sensu-plugins-mysql = super.callPackage ./sensuplugins-rb/sensu-plugins-mysql { };

--- a/pkgs/rabbitmq-server/3.6.5.nix
+++ b/pkgs/rabbitmq-server/3.6.5.nix
@@ -1,0 +1,43 @@
+{ stdenv, fetchurl, erlang, python, libxml2, libxslt, xmlto
+, docbook_xml_dtd_45, docbook_xsl, zip, unzip, rsync }:
+
+stdenv.mkDerivation rec {
+  name = "rabbitmq-server-${version}";
+
+  version = "3.6.5";
+
+  src = fetchurl {
+    url = "http://www.rabbitmq.com/releases/rabbitmq-server/v${version}/${name}.tar.xz";
+    sha256 = "1v48ay4z8n9q9c8rg7fhrfa4cg2dqiwbjnr3yl5i7xdam0y46l4m";
+  };
+
+  buildInputs =
+    [ erlang python libxml2 libxslt xmlto docbook_xml_dtd_45 docbook_xsl zip unzip rsync ];
+
+  preBuild =
+    ''
+      # Fix the "/usr/bin/env" in "calculate-relative".
+      patchShebangs .
+    '';
+
+  installFlags = "PREFIX=$(out) RMQ_ERLAPP_DIR=$(out)";
+
+  preInstall =
+    ''
+      sed -i \
+        -e 's|SYS_PREFIX=|SYS_PREFIX=''${SYS_PREFIX-''${HOME}/.rabbitmq/${version}}|' \
+        -e 's|CONF_ENV_FILE=''${SYS_PREFIX}\(.*\)|CONF_ENV_FILE=\1|' \
+        scripts/rabbitmq-defaults
+    '';
+
+  postInstall =
+    ''
+      echo 'PATH=${erlang}/bin:${PATH:+:}$PATH' >> $out/sbin/rabbitmq-env
+    '';
+
+  meta = {
+    homepage = http://www.rabbitmq.com/;
+    description = "An implementation of the AMQP messaging protocol";
+    platforms = stdenv.lib.platforms.unix;
+  };
+}

--- a/pkgs/rabbitmq-server/3.7.nix
+++ b/pkgs/rabbitmq-server/3.7.nix
@@ -1,0 +1,47 @@
+{ stdenv, fetchurl, erlang, elixir, python, libxml2, libxslt, xmlto
+, docbook_xml_dtd_45, docbook_xsl, zip, unzip, rsync, getconf, socat
+}:
+
+stdenv.mkDerivation rec {
+  name = "rabbitmq-server-${version}";
+
+  version = "3.7.15";
+
+  src = fetchurl {
+    url = "https://github.com/rabbitmq/rabbitmq-server/releases/download/v${version}/${name}.tar.xz";
+    sha256 = "14ipnvcrwln9mwr4r32461js2gdlrr4h4hy92393ixbkscf9wdir";
+  };
+
+  buildInputs =
+    [ erlang elixir python libxml2 libxslt xmlto docbook_xml_dtd_45 docbook_xsl zip unzip rsync ];
+
+  outputs = [ "out" "man" "doc" ];
+
+  installFlags = "PREFIX=$(out) RMQ_ERLAPP_DIR=$(out)";
+  installTargets = "install install-man";
+
+  runtimePath = stdenv.lib.makeBinPath [ getconf erlang socat ];
+  postInstall = ''
+    echo 'PATH=${runtimePath}:''${PATH:+:}$PATH' >> $out/sbin/rabbitmq-env
+
+    # we know exactly where rabbitmq is gonna be,
+    # so we patch that into the env-script
+    substituteInPlace $out/sbin/rabbitmq-env \
+      --replace 'RABBITMQ_SCRIPTS_DIR=`dirname $SCRIPT_PATH`' \
+                "RABBITMQ_SCRIPTS_DIR=$out/sbin"
+
+    # there’s a few stray files that belong into share
+    mkdir -p $doc/share/doc/rabbitmq-server
+    mv $out/LICENSE* $doc/share/doc/rabbitmq-server
+
+    # and an unecessarily copied INSTALL file
+    rm $out/INSTALL
+  '';
+
+  meta = {
+    homepage = http://www.rabbitmq.com/;
+    description = "An implementation of the AMQP messaging protocol";
+    license = stdenv.lib.licenses.mpl11;
+    platforms = stdenv.lib.platforms.unix;
+  };
+}

--- a/pkgs/sensuplugins-rb/sensu-plugins-rabbitmq/default.nix
+++ b/pkgs/sensuplugins-rb/sensu-plugins-rabbitmq/default.nix
@@ -2,5 +2,10 @@
 
 bundlerSensuPlugin {
   pname = "sensu-plugins-rabbitmq";
-  exes = [ "check-rabbitmq-alive.rb" ];
+  exes = [ 
+    "check-rabbitmq-alive.rb"
+    "check-rabbitmq-amqp-alive.rb"
+    "check-rabbitmq-node-health.rb"
+    "check-rabbitmq-messages.rb"
+  ];
 }

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -32,6 +32,9 @@ in {
   postgresql96 = callTest ./postgresql.nix { rolename = "postgresql96"; };
   postgresql10 = callTest ./postgresql.nix { rolename = "postgresql10"; };
   prometheus = callTest ./prometheus.nix {};
+  rabbitmq36_5 = callTest ./rabbitmq.nix { rolename = "rabbitmq36_5"; };
+  rabbitmq36_15 = callTest ./rabbitmq.nix { rolename = "rabbitmq36_15"; };
+  rabbitmq37 = callTest ./rabbitmq.nix { rolename = "rabbitmq37"; };
   redis = callTest ./redis.nix {};
   statshost-master = callTest ./statshost-master.nix {};
   sudo = callTest ./sudo.nix {};

--- a/tests/make-test.nix
+++ b/tests/make-test.nix
@@ -13,6 +13,10 @@ with import "${nixpkgs}/nixos/lib/testing.nix" {
 
 makeTest (
   if pkgs.lib.isFunction f
-  then f (args // { inherit pkgs; inherit (pkgs) lib; })
+  then f (args // { 
+    inherit pkgs;
+    inherit (pkgs) lib;
+    testlib = pkgs.callPackage ./testlib.nix {};
+  })
   else f
 )

--- a/tests/rabbitmq.nix
+++ b/tests/rabbitmq.nix
@@ -1,0 +1,59 @@
+import ./make-test.nix ({ rolename ? "rabbitmq36_15", lib, pkgs, testlib, ... }:
+let 
+  ipv4 = "192.168.101.1";
+  amqpPortCheck = "nc -z ${ipv4} 5672";
+  sensuOpts = "-u fc-sensu -w ${ipv4} -p ${testlib.derivePasswordForHost "sensu"}";
+  amqpAliveCheck = "${pkgs.sensu-plugins-rabbitmq}/bin/check-rabbitmq-amqp-alive.rb ${sensuOpts}";
+  nodeHealthCheck = "${pkgs.sensu-plugins-rabbitmq}/bin/check-rabbitmq-node-health.rb ${sensuOpts}";
+
+in {
+  name = "rabbitmq";
+  machine = 
+    { ... }:
+    {
+      imports = [ ../nixos ../nixos/roles ];
+      flyingcircus.roles.${rolename}.enable = true;
+
+      flyingcircus.enc.parameters = {
+        resource_group = "test";
+        interfaces.srv = {
+          mac = "52:54:00:12:34:56";
+          networks = {
+            "192.168.101.0/24" = [ ipv4 ];
+          };
+          gateways = {};
+        };
+      };
+    };
+
+  testScript = ''
+    my $cli = 'sudo -u rabbitmq rabbitmqctl';
+    $machine->waitForUnit("rabbitmq.service");
+    $machine->waitUntilSucceeds("${amqpPortCheck}");
+
+    print($machine->succeed("$cli status"));
+    $machine->succeed("$cli node_health_check");
+    $machine->succeed("$cli status | grep 'amqp,5672,\"${ipv4}\"'");
+
+    # user setup takes a while...
+    $machine->waitForUnit("fc-rabbitmq-settings.service");
+
+    # settings script must create monitoring users and set their monitoring tag
+    $machine->succeed("$cli list_users | grep fc-telegraf | grep monitoring");
+    $machine->succeed("$cli list_users | grep fc-sensu | grep monitoring");
+
+    # settings script must delete default guest user
+    $machine->mustFail("$cli list_users | grep guest");
+
+    # sensu checks should be green
+    $machine->succeed("${amqpAliveCheck}");
+    $machine->succeed("${nodeHealthCheck}");
+
+    $machine->stopJob("rabbitmq.service");
+    $machine->waitUntilFails("${amqpPortCheck}");
+
+    # sensu checks should be red when service has stopped
+    $machine->mustFail("${amqpAliveCheck}");
+    $machine->mustFail("${nodeHealthCheck}");
+  '';
+})

--- a/tests/testlib.nix
+++ b/tests/testlib.nix
@@ -1,0 +1,9 @@
+{ lib }:
+{ 
+  derivePasswordForHost = prefix:
+    builtins.hashString "sha256" (lib.concatStringsSep "/" [
+      prefix
+      ""
+      "machine"
+    ]);
+}


### PR DESCRIPTION
* 3 roles for versions 3.6.5, 3.6.15 and 3.7.15
* vendored 3.6 service from 18.09
* vendored 3.7 service taken from 19.03 with some modifications
* packages for 3.6.5 and 3.7.15
* vendored packages for 3.6.5 and 3.7.15
* sensu checks for node health and amqp connectivity
* test checks node health and if monitoring users are present