### PR TITLE
Update production VMs in maintenance.

### DIFF
--- a/nixos/infrastructure/testing.nix
+++ b/nixos/infrastructure/testing.nix
@@ -8,7 +8,7 @@
     networking.useDHCP = lib.mkForce false;
     users.users.root.password = "";
 
-    flyingcircus.agent.install = false;
+    flyingcircus.agent.enable = lib.mkOverride 200 false;
     flyingcircus.enc = {
       parameters.resource_group = "testrg";
       parameters.location = "testloc";

--- a/nixos/platform/agent.nix
+++ b/nixos/platform/agent.nix
@@ -29,8 +29,8 @@ in {
       };
 
       with-maintenance = mkOption {
-        default = false;
-        description = "Perform channel updates in scheduled maintenance.";
+        default = config.flyingcircus.enc.parameters.production;
+        description = "Perform channel updates in scheduled maintenance. Default: all production VMs";
         type = types.bool;
       };
 

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -20,6 +20,7 @@ let
   in discover (importTest fn args system);
 
 in {
+  fcagent = callTest ./fcagent.nix {};
   garbagecollect = callTest ./garbagecollect.nix {};
   login = callTest ./login.nix {};
   logrotate = callTest ./logrotate.nix {};

--- a/tests/fcagent.nix
+++ b/tests/fcagent.nix
@@ -1,0 +1,44 @@
+import ./make-test.nix ({ pkgs, ... }:
+let
+  agent_updates_channel_with_maintenance = pkgs.writeScript "agent-updates-channel-with-maintenance" ''
+      #!/bin/sh
+      set -ex
+      x=$(grep ExecStart /etc/systemd/system/fc-agent.service)
+      x=''${x/ExecStart=/}
+      cat $x
+      grep 'channel-with-maintenance' $x
+      '';
+in
+  {
+  name = "fc-agent";
+  nodes = {
+    prod =
+      { config, lib, ... }:
+      {
+        imports = [
+          ../nixos
+        ];
+        flyingcircus.agent.enable = true;
+        flyingcircus.enc.parameters.production = true;
+      };
+
+    nonprod =
+      { config, lib, ... }:
+      {
+        imports = [
+          ../nixos
+        ];
+        flyingcircus.agent.enable = true;
+        flyingcircus.enc.parameters.production = false;
+      };
+
+  };
+  testScript = ''
+    $nonprod->waitForUnit('multi-user.target');
+    $nonprod->fail('${agent_updates_channel_with_maintenance}');
+
+    $prod->waitForUnit('multi-user.target');
+    $prod->succeed('${agent_updates_channel_with_maintenance}');
+  '';
+})
+


### PR DESCRIPTION
This will reduce unexpected downtimes where our prediction model is missing
critical things that should go without downtime but then causes downtime.

Fixes #110759