### PR TITLE
fix missing routes after address unit restart

### DIFF
--- a/nixos/platform/network.nix
+++ b/nixos/platform/network.nix
@@ -189,7 +189,7 @@ in
               after = [ "network-addresses-eth${vlan}.service" ];
               before = [ "network-local-commands.service" ];
               wantedBy = after;
-              bindsTo = [ "sys-subsystem-net-devices-eth${vlan}.device" ];
+              bindsTo = [ "sys-subsystem-net-devices-eth${vlan}.device" ] ++ after;
               path = [ relaxedIp ];
               script = startStopScript {
                 vlan = "${vlan}";


### PR DESCRIPTION
Restarting the address setup unit for an interface drops the routes.
Binding the route setup unit to the address unit automatically re-adds
routes if the address unit is restarted.

Case 113315

Changelog:

* Fix missing network routes after address unit restart. (#113315)