### PR TITLE
Don't create a broken syslog unit when service is disabled

### DIFF
--- a/tests/default.nix
+++ b/tests/default.nix
@@ -40,6 +40,7 @@ in {
   redis = callTest ./redis.nix {};
   statshost-master = callTest ./statshost-master.nix {};
   sudo = callTest ./sudo.nix {};
+  syslog = callSubTests ./syslog.nix {};
   systemd-service-cycles = callTest ./systemd-service-cycles.nix {};
   vxlan = callTest ./vxlan.nix {};
   webproxy = callTest ./webproxy.nix {};

--- a/tests/make-test.nix
+++ b/tests/make-test.nix
@@ -1,3 +1,39 @@
+# Make a test, possibly with multiple test cases.
+# f can be a set or a function returning a set.
+# A single test case is defined by a name, test script and machine / nodes specification.
+# Multiple test cases can be defined in a set called 'testCases'.
+# When multiple cases are defined, the name attribute is used as prefix for the test case names.
+#
+# Single test case:
+#
+# import ./make-test.nix ({ ... }:
+# {
+#   name = "test";
+#   machine = ...
+#   testScript = ...
+# })
+#
+# This creates a single case called 'test'.
+#
+# Multiple:
+#
+# import ./make-test.nix ({ ... }:
+# {
+#   name = "test";
+#   testCases = {
+#     case1 = {
+#       machine = ...
+#       testScript = ...
+#     };
+#     case2 = {
+#       nodes = ...
+#       testScript = ...
+#     };
+#   };
+# })
+#
+# This will create two test cases called 'test-case1' and 'test-case2'.
+
 f: {
   system ? builtins.currentSystem
   , nixpkgs ? (import ../versions.nix {}).nixpkgs
@@ -11,12 +47,19 @@ with import "${nixpkgs}/nixos/lib/testing.nix" {
   inherit system minimal config;
 };
 
-makeTest (
-  if pkgs.lib.isFunction f
-  then f (args // { 
-    inherit pkgs;
-    inherit (pkgs) lib;
-    testlib = pkgs.callPackage ./testlib.nix {};
-  })
-  else f
-)
+let 
+  lib = pkgs.lib;
+  test =
+    if lib.isFunction f
+    then f (args // { 
+      inherit pkgs lib;
+      testlib = pkgs.callPackage ./testlib.nix {};
+    })
+    else f;
+
+in if test ? testCases 
+then lib.mapAttrs
+  (testCaseName: testCase: makeTest (
+    testCase // { name = "${test.name}-${testCaseName}"; }))
+  test.testCases
+else makeTest test

--- a/tests/syslog.nix
+++ b/tests/syslog.nix
@@ -1,0 +1,35 @@
+import ./make-test.nix ({ ... }:
+
+let
+  machine = 
+    {
+      imports = [ ../nixos ];
+    };
+
+in {
+  name = "syslog";
+
+  testCases = {
+    disabled = {
+      inherit machine;
+      testScript = ''
+        $machine->mustFail("systemctl list-unit-files | grep syslog.service");
+      '';
+    };
+
+    enabled = {
+      machine = machine // {
+        flyingcircus.syslog.separateFacilities = {
+          local2 = "/var/log/test.log";
+        };
+      };
+
+      testScript = ''
+        $machine->waitForUnit("syslog.service");
+        $machine->succeed("logger -p local2.info testlog");
+        $machine->sleep(0.5);
+        $machine->succeed("grep testlog /var/log/test.log");
+      '';
+    };
+  };
+})


### PR DESCRIPTION
Our syslog service tried to extend a nonexistent unit file
and created a broken new unit file instead. mkIf prevents that.
The log cleaning rule is always added because it makes sense
even without activated rsyslogd.

Use mkPlatform as a stronger default than mkDefault.