### PR TITLE
Change sudo default to require a password

### DIFF
--- a/nixos/platform/agent.nix
+++ b/nixos/platform/agent.nix
@@ -105,7 +105,8 @@ in {
 
       security.sudo.extraRules = [
         {
-          commands = [ "${pkgs.fc.agent}/bin/fc-manage" ];
+          commands = [ { command = "${pkgs.fc.agent}/bin/fc-manage"; 
+                         options = [ "NOPASSWD" ]; } ];
           groups = [ "sudo-srv" "service" ];
         }
       ];

--- a/nixos/platform/firewall.nix
+++ b/nixos/platform/firewall.nix
@@ -154,11 +154,12 @@ in
       let ipt = x: "${pkgs.iptables}/bin/ip${x}tables";
       in [
         {
-          commands = [ "${ipt ""} -L*" "${ipt "6"} -L*" ];
+          commands = [ { command = "${ipt ""} -L*"; options = [ "NOPASSWD" ]; }
+                       { command = "${ipt "6"} -L*"; options = [ "NOPASSWD" ]; } ];
           groups = [ "users" "service" ];
         }
         {
-          commands = [ "${checkIPTables}" ];
+          commands = [ { command = "${checkIPTables}"; options = [ "NOPASSWD" ]; } ];
           users = [ "sensuclient" ];
         }
       ];

--- a/nixos/platform/packages.nix
+++ b/nixos/platform/packages.nix
@@ -74,8 +74,10 @@
     lib.optional (!config.services.postgresql.enable) pkgs.postgresql;
 
     security.sudo.extraRules = [
-      { groups = [ "sudo-srv" "service" ];
-        commands = [ "${pkgs.iotop}/bin/iotop" ];
+      { 
+        commands = [ { command = "${pkgs.iotop}/bin/iotop"; 
+                       options = [ "NOPASSWD" ]; } ];
+        groups = [ "sudo-srv" "service" ];
       }
     ];
 

--- a/nixos/services/postfix.nix
+++ b/nixos/services/postfix.nix
@@ -86,7 +86,7 @@ in
     flyingcircus.services.sensu-client.checks = {
       postfix_mailq = {
         command = ''
-          sudo ${checkMailq} -w 200 -c 400
+          /run/wrappers/bin/sudo ${checkMailq} -w 200 -c 400
         '';
         notification = "Too many undelivered mails in Postfix mail queue.";
       };
@@ -108,8 +108,9 @@ in
 
     security.sudo.extraRules = [
       {
-        commands = [ checkMailq ];
+        commands = [ { command = checkMailq; options = [ "NOPASSWD" ]; } ];
         groups = [ "sensuclient" ];
+        
       }
     ];
 

--- a/nixos/services/sensu.nix
+++ b/nixos/services/sensu.nix
@@ -246,8 +246,8 @@ in {
     security.sudo.extraRules = [
       {
         commands = with pkgs; [
-          "${fc.multiping}/bin/multiping"
-          "${fc.sensuplugins}/bin/check_disk"
+          { command = "${fc.multiping}/bin/multiping"; options = [ "NOPASSWD" ]; }
+          { command = "${fc.sensuplugins}/bin/check_disk"; options = [ "NOPASSWD" ]; }
         ];
         groups = [ "sensuclient" ];
       }

--- a/tests/sudo.nix
+++ b/tests/sudo.nix
@@ -16,21 +16,23 @@ let
       uid = "u${id}";
     })
     {
-      "1000" = [];
+      "1000" = [ ];
       "1001" = [ "admins" ];
       "1002" = [ "sudo-srv" ];
+      "1003" = [ "wheel" ];
     }) ++ [
       {
         class = "service";
         gid = 101;
-        home_directory = "/home/test1";
+        home_directory = "/home/s-service";
         id = 1074;
         login_shell = "/bin/bash";
-        name = "test1";
-        password = "*";
+        name = "s-service";
+        # password = hum1pass
+        password = "$6$tCkMUKawIO9w90qR$e0v.8fedV8mm.kLs7M9zN6z0tYG9YLpuJxCM.KiB4P4Nf7lU1l9P7HSbTuziLzjRR/qBrcf.BJRjajrAid1sl.";
         permissions.test = [];
         ssh_pubkey = [];
-        uid = "test1";
+        uid = "s-service";
       }
     ];
 
@@ -74,46 +76,118 @@ in
       $out = $machine->succeed("id u1002");
       $out eq "uid=1002(u1002) gid=100(users) groups=503(sudo-srv),100(users)\n"
         or die $out;
-      $out = $machine->succeed("id test1");
-      $out eq "uid=1074(test1) gid=900(service) groups=900(service)\n"
+      $out = $machine->succeed("id s-service");
+      $out eq "uid=1074(s-service) gid=900(service) groups=900(service)\n"
         or die $out;
     };
 
     sub login {
-      my ($user) = @_;
+      my ($user, $tty) = @_;
+      $machine->sendKeys("alt-f$tty");
       $machine->sleep(1);
-      $machine->waitUntilTTYMatches(1, "login:");
+      $machine->waitUntilTTYMatches($tty, "login:");
       $machine->sendChars($user . "\n");
-      $machine->waitUntilTTYMatches(1, "Password:");
+      $machine->waitUntilTTYMatches($tty, "Password:");
       $machine->sendChars("hum1pass\n");
-      $machine->waitUntilTTYMatches(1, "\$");
+      $machine->waitUntilTTYMatches($tty, "\$");
     };
 
-    subtest "unpriviledged user should not be able to sudo", sub {
-      login("u1000");
+    # Each user gets its own tty. 
+    # Avoids strange logout problems and keeps the output for interactive inspection.
+    # Inspect tty contents in the interactive test driver with: 
+    # print($machine->getTTYText(1));
+
+    login("u1000", 1);
+
+    subtest "unprivileged user should not be able to sudo", sub {
       $machine->sendChars("sudo -l -u root id || echo failed1\n");
       $machine->waitUntilTTYMatches(1, "failed1");
-      $machine->sendChars("sudo -l -u test1 id || echo failed2\n");
+      $machine->sendChars("sudo -l -u s-service id || echo failed2\n");
       $machine->waitUntilTTYMatches(1, "failed2");
-      $machine->sendKeys("ctrl-d");
     };
 
-    subtest "admin should be able to sudo", sub {
-      login("u1001");
-      $machine->sendChars("sudo -l -u root id || echo failed3\n");
-      $machine->waitUntilTTYMatches(1, "/run/current-system/sw/bin/id");
-      $machine->sendChars("sudo -l -u test1 id || echo failed4\n");
-      $machine->waitUntilTTYMatches(1, "/run/current-system/sw/bin/id");
-      $machine->sendKeys("ctrl-d");
+    subtest "unprivileged user should be able to run ipXtables without password", sub {
+      $machine->sendChars("sudo -n iptables && echo 'pw not required iptables'\n");
+      $machine->waitUntilTTYMatches(1, "pw not required iptables");
+
+      $machine->sendChars("sudo -n ip6tables && echo 'pw not required ip6tables'\n");
+      $machine->waitUntilTTYMatches(1, "pw not required ip6tables");
     };
+
+    login("u1001", 2);
+
+    subtest "admins should be able to sudo", sub {
+      $machine->sendChars("sudo -l -u root id || echo failed3\n");
+      $machine->waitUntilTTYMatches(2, "/run/current-system/sw/bin/id");
+      $machine->sendChars("sudo -l -u s-service id || echo failed4\n");
+      $machine->waitUntilTTYMatches(2, "/run/current-system/sw/bin/id");
+    };
+
+    subtest "admins sudo should require a password", sub {
+      $machine->sendChars("sudo -n true || echo 'pw required admins'\n");
+      $machine->waitUntilTTYMatches(2, "pw required admins");
+    };
+
+    login("u1002", 3);
 
     subtest "sudo-srv should grant restricted sudo", sub {
-      login("u1002");
       $machine->sendChars("sudo -l -u root id || echo failed5\n");
-      $machine->waitUntilTTYMatches(1, "failed5");
-      $machine->sendChars("sudo -l -u test1 id || echo failed6\n");
-      $machine->waitUntilTTYMatches(1, "/run/current-system/sw/bin/id");
-      $machine->sendKeys("ctrl-d");
+      $machine->waitUntilTTYMatches(3, "failed5");
+      $machine->sendChars("sudo -l -u s-service id || echo failed6\n");
+      $machine->waitUntilTTYMatches(3, "/run/current-system/sw/bin/id");
     };
+
+    subtest "sudo-srv should be able to become service user without password", sub {
+      $machine->sendChars("sudo -niu s-service\n");
+      $machine->waitUntilTTYMatches(3, 's-service@machine');
+    };
+    
+    subtest "sudo-srv should be able to run systemctl without password", sub {
+      $machine->sendChars("sudo -n systemctl --no-pager && echo 'pw not required systemctl'\n");
+      $machine->waitUntilTTYMatches(3, "pw not required systemctl");
+    };
+
+    subtest "sudo-srv should be able to run fc-manage without password", sub {
+      $machine->sendChars("sudo -n fc-manage && echo 'pw not required fc-manage'\n");
+      $machine->waitUntilTTYMatches(3, "pw not required fc-manage");
+    };
+
+    subtest "sudo-srv user should be able to run iotop without password", sub {
+      $machine->sendChars("sudo -n iotop -n1 && echo 'pw not required iotop'\n");
+      $machine->waitUntilTTYMatches(3, "pw not required iotop");
+    };
+
+    login("u1003", 4);
+
+    subtest "wheel sudo should require a password", sub {
+      $machine->sendChars("sudo -n true || echo 'pw required wheel'\n");
+      $machine->waitUntilTTYMatches(4, "pw required wheel");
+    };
+
+    login("s-service", 5);
+
+    subtest "service user should be able to run systemctl without password", sub {
+      $machine->sendChars("sudo -n systemctl --no-pager && echo 'pw not required systemctl'\n");
+      $machine->waitUntilTTYMatches(5, "pw not required systemctl");
+    };
+
+    subtest "service user should be able to run fc-manage without password", sub {
+      $machine->sendChars("sudo -n fc-manage  && echo 'pw not required fc-manage'\n");
+      $machine->waitUntilTTYMatches(5, "pw not required fc-manage");
+    };
+
+    subtest "service user should be able to run iotop without password", sub {
+      $machine->sendChars("sudo -n iotop -n1 && echo 'pw not required iotop'\n");
+      $machine->waitUntilTTYMatches(5, "pw not required iotop");
+    };
+
+    subtest "service user should be able to run ipXtables without password", sub {
+      $machine->sendChars("sudo -n iptables && echo 'pw not required iptables'\n");
+      $machine->waitUntilTTYMatches(5, "pw not required iptables");
+
+      $machine->sendChars("sudo -n ip6tables && echo 'pw not required ip6tables'\n");
+      $machine->waitUntilTTYMatches(5, "pw not required ip6tables");
+    };
+
   '';
 })


### PR DESCRIPTION
Sudo normally requires a password, but we changed the default to not
require a password. This also applied to the wheel rule defined by
NixOS. Users in wheel shouldn't have passwordless sudo.

* Change default in sudoers to "authenticate"
* Add NOPASSWD to all sudo rules that used the old default
* Fix sudo call in postfix sensu check

Case 114332

@flyingcircusio/release-managers

Impact:

Changelog:

* Change sudo default to require a password. NOPASSWD must be set explicitly now (#114332).