### PR TITLE
Fix & refactor activation scripts for /etc/local permissions

### DIFF
--- a/nixos/lib/utils.nix
+++ b/nixos/lib/utils.nix
@@ -21,6 +21,9 @@ rec {
       config.networking.hostName
     ]);
 
+  installDirWithPermissions = { user, group, permissions, dir }:
+    "install -d -o ${user} -g ${group} -m ${permissions} ${dir}";
+
   mkPlatform = lib.mkOverride 900;
 
   coalesce = list: findFirst (el: el != null) null list;

--- a/nixos/platform/default.nix
+++ b/nixos/platform/default.nix
@@ -23,8 +23,21 @@ in {
   ];
 
   options = with lib.types; {
-    flyingcircus.roles.generic.enable =
-      mkEnableOption "Generic role, which does nothing";
+
+    flyingcircus.activationScripts = mkOption {
+      description = ''
+        This does the same as system.activationScripts, 
+        but script / attribute names are prefixed with "fc-" automatically:
+
+        flyingcircus.activationScripts.script-name becomes
+        system.activationScripts.fc-script-name
+
+        Dependencies specified with lib.stringAfter must include the prefix.
+      '';
+      default = {};
+      # like in system.activationScripts, can be a string or a set (lib.stringAfter)
+      type = types.attrsOf types.unspecified; 
+    };
 
     flyingcircus.enc_services = mkOption {
       default = [];
@@ -37,6 +50,62 @@ in {
       type = path;
       description = "Where to find the ENC services json file.";
     };
+
+    flyingcircus.localConfigDirs = mkOption {
+      description = ''
+        Create a directory where local config files for a service can be placed.
+        The attribute path, for example flyingcircus.localConfigDirs.myservice
+        is echoed in the activation script for debugging purposes.
+
+        Other activation scripts that need a local config dir
+        can create a dependency on fc-local-config with stringAfter:
+
+        flyingcircus.activationScripts.needsCfg = lib.stringAfter ["fc-local-config"] "script..."
+      '';
+      default = {};
+
+      example = { myservice = { dir = "/etc/local/myservice"; user = "myservice"; }; };
+
+      type = types.attrsOf (types.submodule {
+
+        options = {
+
+          dir = mkOption {
+            description = "Path to the directory, typically starting with /etc/local.";
+            type = types.string;
+          };
+
+          user = mkOption {
+            default = "root";
+            description = ''
+              Name of the user owning the config directory,
+              typically the name of the service or root.
+            '';
+            type = types.string;
+          };
+
+          group = mkOption {
+            default = "service";
+            description = "Name of the group.";
+            type = types.string;
+          };
+
+          permissions = mkOption {
+            default = "02775";
+            description = ''
+              Directory permissions.
+              By default, owner and group can write to the directory and the sticky bit is set.
+            '';
+            type = types.string;
+          };
+
+        };
+
+      });
+    };
+
+    flyingcircus.roles.generic.enable =
+      mkEnableOption "Generic role, which does nothing";
 
   };
 
@@ -85,6 +154,34 @@ in {
       nscd.enable = true;
       openssh.enable = mkDefault true;
     };
+
+    system.activationScripts = let
+
+      cfgDirs = cfg.localConfigDirs;
+
+      snippet = name: ''
+        # flyingcircus.localConfigDirs.${name}
+        ${fclib.installDirWithPermissions { 
+          inherit (cfgDirs.${name}) user group permissions dir; 
+        }}
+      '';
+
+      # concat script snippets for all local config dirs
+      cfgScript = lib.fold 
+                    (name: acc: acc + "\n" + (snippet name)) 
+                    ""
+                    (lib.attrNames cfgDirs);
+
+      fromCfgDirs = { 
+        fc-local-config = lib.stringAfter ["users" "groups"] cfgScript; 
+      };
+
+      # prefix our activation scripts with "fc-"
+      fromActivationScripts = lib.mapAttrs' 
+                                (name: value: lib.nameValuePair ("fc-" + name) value) 
+                                cfg.activationScripts;
+
+    in fromCfgDirs // fromActivationScripts;
 
     systemd.tmpfiles.rules = [
       # d instead of r to a) respect the age rule and b) allow exclusion

--- a/nixos/platform/firewall.nix
+++ b/nixos/platform/firewall.nix
@@ -164,10 +164,9 @@ in
         }
       ];
 
-    system.activationScripts.local-firewall =
-      lib.stringAfter [ "users" "groups" ] ''
-        install -d -o root -g service -m 02775 ${cfg.firewall.localDir}
-      '';
+    flyingcircus.localConfigDirs.firewall = {
+      dir = cfg.firewall.localDir; 
+    };
 
   };
 }

--- a/nixos/platform/systemd.nix
+++ b/nixos/platform/systemd.nix
@@ -2,6 +2,10 @@
 { config, lib, pkgs, ... }:
 
 with lib;
+
+let
+  fclib = config.fclib;
+in
 {
   config = {
 
@@ -11,14 +15,18 @@ with lib;
       ForwardToSyslog=true
     '';
 
-    system.activationScripts.systemd-journal-acl = ''
-      # Ensure journal access for all users.
-      chmod -R a+rX /var/log/journal
-    '';
+    flyingcircus.activationScripts = {
 
-    system.activationScripts.systemd-local = ''
-      install -d -o root -g service -m 02775 /etc/local/systemd
-    '';
+      systemd-journal-acl = lib.stringAfter [ "systemd" ] ''
+        # Ensure journal access for all users.
+        chmod -R a+rX /var/log/journal
+      '';
+
+    };
+
+    flyingcircus.localConfigDirs.systemd = {
+      dir = "/etc/local/systemd";
+    };
 
     systemd.extraConfig = ''
       DefaultRestartSec=3

--- a/nixos/platform/users.nix
+++ b/nixos/platform/users.nix
@@ -223,7 +223,7 @@ in
         ];
     };
 
-    system.activationScripts.fc-homedir-permissions =
+    flyingcircus.activationScripts.homedir-permissions =
       lib.stringAfter [ "users" ]
       (concatStringsSep "\n" (homeDirPermissions cfg.userData));
 

--- a/nixos/roles/external_net/openvpn.nix
+++ b/nixos/roles/external_net/openvpn.nix
@@ -279,7 +279,7 @@ in
 
     services.openvpn.servers.access.config = serverConfig;
 
-    system.activationScripts.openvpn-pki =
+    flyingcircus.activationScripts.openvpn-pki =
       lib.stringAfter [] ''
         # generate pki / certificates
         ${pki.generate}

--- a/nixos/roles/memcached.nix
+++ b/nixos/roles/memcached.nix
@@ -41,10 +41,10 @@ in
 
   (mkIf cfg.enable {
 
-    system.activationScripts.fcio-memcached = ''
-      install -d -o ${toString config.ids.uids.memcached} -g service -m 02775 \
-        /etc/local/memcached
-    '';
+    flyingcircus.localConfigDirs.memcached = { 
+      dir = "/etc/local/memcached";
+      user = "memcached"; 
+    };
 
     environment.etc = {
       "local/memcached/README.txt".text = ''
@@ -78,6 +78,10 @@ in
         }
       ];
     };
+
+    # We want a fixed uid that is compatible with older releases.
+    # Upstream doesn't set the uid.
+    users.users.memcached.uid = config.ids.uids.memcached;
   })
 
   {

--- a/nixos/roles/mongodb/default.nix
+++ b/nixos/roles/mongodb/default.nix
@@ -104,14 +104,19 @@ in {
         home = "/srv/mongodb";
       };
 
-      system.activationScripts.flyingcircus-mongodb =
-      let
-        uid = toString config.ids.uids.mongodb;
-      in ''
-        install -d -o ${uid} /{srv,var/log}/mongodb
-        install -d -o ${uid} -g service -m 02775 /etc/local/mongodb
-      '';
+      flyingcircus.activationScripts = {
 
+        mongodb-dirs = lib.stringAfter [ "users" "groups" ] ''
+          install -d -o mongodb /{srv,var/log}/mongodb
+        '';
+
+      };      
+
+      flyingcircus.localConfigDirs.mongodb = {
+        dir = "/etc/local/mongodb";
+        user = "mongodb"; 
+      };
+      
       security.sudo.extraConfig = ''
         # Service users may switch to the mongodb system user
         %sudo-srv ALL=(mongodb) ALL

--- a/nixos/roles/rabbitmq.nix
+++ b/nixos/roles/rabbitmq.nix
@@ -78,12 +78,10 @@ with builtins;
         %service ALL=(rabbitmq) ALL
       '';
 
-      # We use this in this way in favor of setting PermissionsStartOnly to
-      # true as other script expect running as rabbitmq user
-      system.activationScripts.fcio-rabbitmq = ''
-        install -d -o ${toString config.ids.uids.rabbitmq} -g service -m 02775 \
-          /etc/local/rabbitmq/
-      '';
+      flyingcircus.localConfigDirs.rabbitmq = {
+        dir = "/etc/local/rabbitmq";
+        user = "rabbitmq";
+      };
 
       environment.etc."local/rabbitmq/README.txt".text = ''
         RabbitMQ (${package.version}) is running on this machine.

--- a/nixos/roles/statshost/default.nix
+++ b/nixos/roles/statshost/default.nix
@@ -479,9 +479,8 @@ in
         }];
       };
 
-      system.activationScripts.statshost = {
-        text = "install -d -g service -m 2775 ${localDir}";
-        deps = [];
+      flyingcircus.localConfigDirs.statshost = {
+        dir = localDir;
       };
 
       flyingcircus.services.sensu-client.checks = {

--- a/nixos/services/haproxy.nix
+++ b/nixos/services/haproxy.nix
@@ -109,6 +109,11 @@ in
         reloadIfChanged = true;
       };
 
+      flyingcircus.localConfigDirs.haproxy = {
+        dir = "/etc/local/haproxy";
+        user = "haproxy";
+      };
+
       systemd.services.prometheus-haproxy-exporter = {
         description = "Prometheus exporter for haproxy metrics";
         wantedBy = [ "multi-user.target" ];

--- a/nixos/services/logrotate/default.nix
+++ b/nixos/services/logrotate/default.nix
@@ -72,13 +72,13 @@ in
       # We create one directory for each service user. I decided not to remove
       # old directories as this may be manually placed data that I don't want
       # to delete accidentally.
-      system.activationScripts.logrotate-user =
-        let
-          installDir = u: ''
-            install -d -m 0755 -o ${u.name} -g service ${localDir}/${u.name}
-          '';
-        in
-        stringAfter [ "users" ] (concatStrings (map installDir serviceUsers));
+      flyingcircus.localConfigDirs = let 
+        cfgDir = u: 
+          lib.nameValuePair
+            "logrotate-${u.name}"
+            { dir = "${localDir}/${u.name}"; user = u.name; permissions = "0755"; };
+
+        in listToAttrs (map cfgDir serviceUsers);
 
       systemd.services =
         listToAttrs (

--- a/nixos/services/postgresql.nix
+++ b/nixos/services/postgresql.nix
@@ -67,6 +67,7 @@ in {
     postgresqlPkg = getAttr cfg.majorVersion packages;
 
   in {
+
     services.postgresql.enable = true;
     services.postgresql.package = postgresqlPkg;
     services.postgresql.extraPlugins = [
@@ -98,11 +99,18 @@ in {
       home = lib.mkForce "/srv/postgresql";
     };
 
-    system.activationScripts.flyingcircus_postgresql = ''
-      install -d -o ${toString config.ids.uids.postgres} /srv/postgresql
-      install -d -o ${toString config.ids.uids.postgres} -g service -m 02775 \
-        /etc/local/postgresql/${cfg.majorVersion}
-    '';
+    flyingcircus.activationScripts = {
+
+      postgresql-srv = lib.stringAfter [ "users" "groups" ] ''
+        install -d -o postgres /srv/postgresql
+      '';
+
+    };
+
+    flyingcircus.localConfigDirs.postgresql = {
+      dir = (toString localConfigPath);
+      user = "postgres";
+    };
 
     security.sudo.extraConfig = ''
       # Service users may switch to the postgres system user

--- a/nixos/services/sensu.nix
+++ b/nixos/services/sensu.nix
@@ -253,13 +253,22 @@ in {
       }
     ];
 
-    system.activationScripts.sensu-client = ''
-      ${ifJsonSyntaxError}
-        echo "Errors in /etc/local/sensu-client, aborting"
-        exit 3
-      fi
-      unset sensu_json_present
-    '';
+    flyingcircus.activationScripts = {
+      
+      sensu-client = ''
+        ${ifJsonSyntaxError}
+          echo "Errors in /etc/local/sensu-client, aborting"
+          exit 3
+        fi
+        unset sensu_json_present
+      '';
+
+    };
+
+    flyingcircus.localConfigDirs.sensu-client = {
+      dir = "/etc/local/sensu-client";
+      user = "sensuclient";
+    };
 
     systemd.services.sensu-client = {
       wantedBy = [ "multi-user.target" ];
@@ -293,7 +302,6 @@ in {
     };
 
     systemd.tmpfiles.rules = [
-      "d /etc/local/sensu-client 0775 sensuclient service"
       "d /var/cache/vulnix 0775 sensuclient service"
       "d /var/tmp/sensu 0775 sensuclient service"
     ];

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -29,6 +29,7 @@ in {
   mongodb32 = callTest ./mongodb.nix { rolename = "mongodb32"; };
   mongodb34 = callTest ./mongodb.nix { rolename = "mongodb34"; };
   network = callSubTests ./network {};
+  nginx = callTest ./nginx.nix {};
   openvpn = callTest ./openvpn.nix {};
   postgresql95 = callTest ./postgresql.nix { rolename = "postgresql95"; };
   postgresql96 = callTest ./postgresql.nix { rolename = "postgresql96"; };

--- a/tests/haproxy.nix
+++ b/tests/haproxy.nix
@@ -51,5 +51,8 @@ import ./make-test.nix ({ pkgs, ... }:
     $haproxyVM->succeed(<<_EOT_);
     grep "haproxy.* http-in server/python .* /hello.txt" /var/log/haproxy.log
     _EOT_
+
+    # service user should be able to write to local config dir
+    $machine->succeed('sudo -u haproxy touch /etc/local/haproxy/haproxy.cfg');
   '';
 })

--- a/tests/memcached.nix
+++ b/tests/memcached.nix
@@ -32,5 +32,8 @@ in {
     $machine->succeed("echo -e 'add my_key 0 60 11\\r\\nhello world\\r\\nquit' | nc ::1 11211 | grep STORED");
     $machine->succeed("echo -e 'get my_key\\r\\nquit' | nc ${ipv4} 11211 | grep 'hello world'");
     $machine->succeed("echo -e 'get my_key\\r\\nquit' | nc ${ipv6} 11211 | grep 'hello world'");
+
+    # service user should be able to write to local config dir
+    $machine->succeed('sudo -u memcached touch /etc/local/memcached/memcached.json');
   '';
 })

--- a/tests/mongodb.nix
+++ b/tests/mongodb.nix
@@ -40,5 +40,10 @@ in {
       $machine->waitForUnit("mongodb.service");
       $machine->waitForOpenPort(27017);
       $machine->waitUntilSucceeds('mongo --eval db');
-    '' + lib.concatMapStringsSep "\n" check [ "127.0.0.1" "[::1]" ipv4 "[${ipv6}]" ];
+    '' + lib.concatMapStringsSep "\n" check [ "127.0.0.1" "[::1]" ipv4 "[${ipv6}]" ]
+    + '' 
+      # service user should be able to write to local config dir
+      $machine->succeed('sudo -u mongodb touch /etc/local/mongodb/mongodb.yaml');
+    '';
+
 })

--- a/tests/network/default.nix
+++ b/tests/network/default.nix
@@ -30,6 +30,12 @@ let
             ];
           })));
       };
+
+      users.users.s-test = {
+        isNormalUser = true;
+        extraGroups = [ "service" ]; 
+      };
+
     };
 
   encInterfaces = id: {
@@ -158,6 +164,9 @@ let
             $router->fail("curl http://10.51.2.13/default.nix");
             $router->fail("curl http://[2001:db8:2::13]/default.nix");
           };
+
+          # service user should be able to write to its local config dir
+          $router->succeed('sudo -u s-test touch /etc/local/firewall/test');
         '';
       };
 

--- a/tests/nginx.nix
+++ b/tests/nginx.nix
@@ -25,5 +25,8 @@ import ./make-test.nix ({ ... }:
       grep "server accepts handled requests"
     _EOT_
     $machine->succeed('grep mysite.conf /var/log/nginx/access.log');
+
+    # service user should be able to write to local config dir
+    $machine->succeed('sudo -u nginx touch /etc/local/nginx/vhosts.json');
   '';
 })

--- a/tests/postgresql.nix
+++ b/tests/postgresql.nix
@@ -65,6 +65,9 @@ in {
       # should not trust connections via TCP
       $machine->fail('psql --no-password -h localhost -l');
 
+      # service user should be able to write to local config dir
+      $machine->succeed('sudo -u postgres touch `echo /etc/local/postgresql/*`/test');
+
       # test extensions that work on all versions
       $machine->succeed('sudo -u postgres -- sh ${createExtensions}');
     '' +
@@ -72,4 +75,5 @@ in {
     ''# Do the rum extension test. Rum is not available for 9.5.
       $machine->succeed('sudo -u postgres -- psql employees -c "CREATE EXTENSION rum;"');
     '';
+
 })

--- a/tests/rabbitmq.nix
+++ b/tests/rabbitmq.nix
@@ -55,5 +55,8 @@ in {
     # sensu checks should be red when service has stopped
     $machine->mustFail("${amqpAliveCheck}");
     $machine->mustFail("${nodeHealthCheck}");
+
+    # service user should be able to write to local config dir
+    $machine->succeed('sudo -u rabbitmq touch /etc/local/rabbitmq/rabbitmq.config');
   '';
 })

--- a/tests/redis.nix
+++ b/tests/redis.nix
@@ -16,5 +16,11 @@ import ./make-test.nix ({ ... }:
     $redis->waitUntilSucceeds("$cli ping | grep PONG");
     $redis->succeed("$cli set msg 'hello world'");
     $redis->succeed("$cli get msg | grep 'hello world'");
+
+    # service user should be able to local config dir
+    $redis->succeed('sudo -u redis touch /etc/local/redis/custom.conf');
+
+    # service user should be able to write the password file
+    $redis->succeed('sudo -u redis touch /etc/local/redis/password');
   '';
 })

--- a/tests/statshost-master.nix
+++ b/tests/statshost-master.nix
@@ -32,6 +32,12 @@ import ./make-test.nix ({ pkgs, ... }:
       '';
 
       services.telegraf.enable = true;  # set in infra/fc but not in infra/testing
+
+      users.users.s-test = {
+        isNormalUser = true;
+        extraGroups = [ "service" ]; 
+      };
+
     };
 
   testScript =
@@ -62,5 +68,8 @@ import ./make-test.nix ({ pkgs, ... }:
         curl -s ${api}/query?query='my_custom_metric' | \
          jq -e '.data.result[].value[1] == "42"'
       EOF
+
+      # service user should be able to write to local config dir
+      $machine->succeed('sudo -u s-test touch /etc/local/statshost/test');
     '';
 })


### PR DESCRIPTION
* add missing dir permissions for haproxy
* set static uids for memcached and redis users
* include nginx test
* add an option for fc-prefixed activation scripts
* add an option for creating local config dirs
* tests

Case 114332

Changelog:

* Fix permissions in /etc/local and user ids for redis and memcached. (#114432)