### PR TITLE
Add PostgreSQL 11 role

### DIFF
--- a/nixos/roles/postgresql.nix
+++ b/nixos/roles/postgresql.nix
@@ -11,6 +11,7 @@ with builtins;
       postgresql95.enable = mkRole "9.5";
       postgresql96.enable = mkRole "9.6";
       postgresql10.enable = mkRole "10";
+      postgresql11.enable = mkRole "11";
     };
   };
 
@@ -20,6 +21,7 @@ with builtins;
       "9.5" = postgresql95.enable;
       "9.6" = postgresql96.enable;
       "10" = postgresql10.enable;
+      "11" = postgresql11.enable;
     };
     enabledRoles = lib.filterAttrs (n: v: v) pgroles;
     enabledRolesCount = length (lib.attrNames enabledRoles);

--- a/nixos/services/postgresql.nix
+++ b/nixos/services/postgresql.nix
@@ -9,6 +9,7 @@ let
     "9.5" = pkgs.postgresql95;
     "9.6" = pkgs.postgresql96;
     "10" = pkgs.postgresql_10;
+    "11" = pkgs.postgresql_11;
   };
 
   listenAddresses =
@@ -54,7 +55,7 @@ in {
       majorVersion = mkOption {
           type = types.string;
           description = ''
-            The major version of PostgreSQL to use (9.5, 9.6, 10).
+            The major version of PostgreSQL to use (9.5, 9.6, 10, 11).
           '';
         };
     };

--- a/pkgs/postgresql/temporal_tables/default.nix
+++ b/pkgs/postgresql/temporal_tables/default.nix
@@ -1,12 +1,14 @@
-{ stdenv, fetchurl, pkgconfig, postgresql }:
+{ stdenv, fetchFromGitHub, pkgconfig, postgresql }:
 
 stdenv.mkDerivation rec {
   name = "temporal_tables-${version}";
-  version = "1.2.0";
+  version = "20190530-6cc86eb-git";
 
-  src = fetchurl {
-    url = "https://github.com/arkhipov/temporal_tables/archive/v1.2.0.tar.gz";
-    sha256 = "e6d1b31a124e8597f61b86f08b6a18168f9cd9da1db77f2a8dd1970b407b7610";
+  src = fetchFromGitHub {
+    owner = "mlt";
+    repo = "temporal_tables";
+    rev = "6cc86eb03d618d6b9fc09ae523f1a1e5228d22b5";
+    sha256 = "0ykv37rm511n5955mbh9dcp7pgg88z1nwgszav7z6pziaj3nba8x";
   };
 
   nativeBuildInputs = [ pkgconfig ];

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -34,6 +34,7 @@ in {
   postgresql95 = callTest ./postgresql.nix { rolename = "postgresql95"; };
   postgresql96 = callTest ./postgresql.nix { rolename = "postgresql96"; };
   postgresql10 = callTest ./postgresql.nix { rolename = "postgresql10"; };
+  postgresql11 = callTest ./postgresql.nix { rolename = "postgresql11"; };
   prometheus = callTest ./prometheus.nix {};
   rabbitmq36_5 = callTest ./rabbitmq.nix { rolename = "rabbitmq36_5"; };
   rabbitmq36_15 = callTest ./rabbitmq.nix { rolename = "rabbitmq36_15"; };

--- a/tests/postgresql.nix
+++ b/tests/postgresql.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ rolename ? "postgresql10", lib, pkgs, ... }:
+import ./make-test.nix ({ rolename ? "postgresql11", lib, pkgs, ... }:
 let 
   ipv4 = "192.168.101.1";
   ipv6 = "2001:db8:f030:1c3::1";


### PR DESCRIPTION
* temporal_tables had to be updated for pg 11 compatibility

Case 114598

Changelog

* Add PostgreSQL 11 role (#114598). 