### PR TITLE
Nginx: JSON config and reload production-ready

### DIFF
--- a/nixos/lib/attrsets.nix
+++ b/nixos/lib/attrsets.nix
@@ -1,0 +1,19 @@
+{ lib, ...}:
+
+with lib;
+
+rec {
+  # Returns a list of attribute names that appear in more than one attrset.
+  # Useful for checking if merging the attrsets would overwrite a previous value.
+  # 
+  # duplicateAttrNames [ { a = 1; } { b = 2; } { a = 3; } ]
+  # => [ "a" ]
+  duplicateAttrNames = listOfAttrs:
+    attrNames
+      (filterAttrs
+        (n: a: a > 1)
+        (foldAttrs
+          (n: acc: acc + 1)
+          0
+          listOfAttrs));
+}

--- a/nixos/lib/default.nix
+++ b/nixos/lib/default.nix
@@ -1,7 +1,8 @@
 { config, pkgs, lib, ... }:
 
 let
-  files = import ./files.nix { inherit pkgs lib; };
+  attrsets = import ./attrsets.nix { inherit config lib; };
+  files = import ./files.nix { inherit config pkgs lib; };
   math = import ./math.nix { inherit pkgs lib; };
   network = import ./network.nix { inherit config pkgs lib; };
   system = import ./system.nix { inherit config pkgs lib; };
@@ -19,7 +20,7 @@ in
 
   config = {
     fclib =
-      { inherit files math network system utils; }
-      // files // math // network // system // utils;
+      { inherit attrsets files math network system utils; }
+      // attrsets // files // math // network // system // utils;
   };
 }

--- a/nixos/services/nginx/README.txt
+++ b/nixos/services/nginx/README.txt
@@ -1,38 +1,33 @@
 Nginx is enabled on this machine.
 
-Manual configuration
---------------------
+We provide basic config. You can use two ways to add custom configuration.
 
-Put your site configuration into this directory as `*.conf`. You may
-add other files, like SSL keys, as well.
+Changes to your custom config will cause nginx to reload without downtime on 
+the next fc-manage run if the config is valid. It will display a warning if
+invalid settings are found in the nginx config.
 
-If you want to authenticate against the Flying Circus users with login permission,
-use the following snippet, and *USE SSL*:
-
-auth_basic "FCIO user";
-auth_basic_user_file "/etc/local/nginx/htpasswd_fcio_users";
-
-There is also an `example-configuration` here. Copy to some file ending with
-*.conf and adapt.
-
-Changes to *.conf will cause nginx only to reload, not to restart, on the next
-nixos-rebuild run.
-
+The combined nginx config file can be shown with: `nginx-show-config`
 
 Structured configuration
 ------------------------
 
-Alternatively, you can place virtual host definition in
-`/etc/local/nginx/vhosts.json` which resembles NixOS nginx virtualHosts options
+You can place virtual host definitions in `/etc/local/nginx/*.json`
+that are managed by NixOS. They are built into the combined config file by
+running fc-manage.
 
-Example vhosts.json containing a virtual with static root directory, a bit of
-custom configuration, and Let's encrypt SSL:
+You may add other files to the directory, like SSL keys, as well.
+
+The config snippets must contain a single JSON object that defines one or
+more virtual hosts. Multiple JSON config files will be merged into one object.
+It's a good idea to use one config file per virtual host.
+
+example.json containing a virtual with static root directory, a bit of
+custom configuration, and SSL with a default certificate from Let's Encrypt:
 
 ```
 {
   "www.example.org": {
     "serverAliases": ["example.org"],
-    "acmeEmail"
     "forceSSL": true,
     "root": "/srv/webroot",
     "extraConfig": "add_header Strict-Transport-Security max-age=31536000; rewrite ^/old_url /new_url redirect;",
@@ -45,9 +40,31 @@ custom configuration, and Let's encrypt SSL:
 }
 ```
 
-All options are documented in
-https://nixos.org/nixos/options.html#services.nginx.virtualhosts. Note that an
-non-standard attribute "acmeEmail" must be set to a contact mail address
-in order to activate Let's encrypt.
+All options are documented at
+https://nixos.org/nixos/options.html#services.nginx.virtualhosts.%3Cname%3E 
 
-Changes to *.json will cause nginx to restart on the next nixos-rebuild run.
+For SSL support with redirection from HTTP to HTTPS, use `forceSSL`.
+Let's Encrypt (`enableACME`) is activated automatically if one of `forceSSL`, `onlySSL` or `addSSL`
+is set to true.
+To use a custom certificate, set the certificate options and set `"enableACME" = false`.
+
+We support the custom option `emailACME` to set the contact address for Let's Encrypt.
+
+Manual configuration
+--------------------
+
+You can also use plain nginx config files /etc/local/nginx/*.conf for configuration. 
+The contents are included verbatim into the combined config by running fc-manage.
+
+You may add other files to the directory, like SSL keys, as well.
+
+If you want to authenticate against the Flying Circus users with login permission,
+use the following snippet, and *USE SSL*:
+
+auth_basic "FCIO user";
+auth_basic_user_file "/etc/local/nginx/htpasswd_fcio_users";
+
+There is also an `example-configuration` here. Copy to some file ending with
+*.conf and adapt.
+
+You can check if the config is valid with: `nginx-check-config`

--- a/nixos/services/sensu.nix
+++ b/nixos/services/sensu.nix
@@ -108,7 +108,7 @@ let
   sensu-check-env = with pkgs; buildEnv {
     name = "sensu-check-env";
     paths = [
-      "/run/wrappers"
+      "/run/wrappers/sudo"
       bash
       coreutils
       glibc
@@ -116,6 +116,7 @@ let
       monitoring-plugins
       nix
       openssl
+      procps
       sensu
       sysstat
     ];

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -30,6 +30,7 @@ in {
   mongodb34 = callTest ./mongodb.nix { rolename = "mongodb34"; };
   network = callSubTests ./network {};
   nginx = callTest ./nginx.nix {};
+  nginx_reload = callTest (nixpkgs + /nixos/tests/nginx.nix) {};
   openvpn = callTest ./openvpn.nix {};
   postgresql95 = callTest ./postgresql.nix { rolename = "postgresql95"; };
   postgresql96 = callTest ./postgresql.nix { rolename = "postgresql96"; };

--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "fd0aff0181edef0bad830af8e70f664e85838f19",
-    "sha256": "0j25wbr00hzqvv3pnji1qif3w6f8wqmp7lw8a9ih5xxrcwzf1sgw"
+    "rev": "9bc51a466db15db1d791a066981538d556f135b8",
+    "sha256": "0hz5bpihckghjdq30bcwxwb5x7i41gpaywi8gbhq17v7xv7h2cjh"
   },
   "nixos-18.09": {
     "owner": "nixos",


### PR DESCRIPTION
* make emailACME optional in json config
* enableACME is activated automatically if one of forceSSL, onlySSL or addSSL
  is set to true.
* JSON config can be now be split into multiple files
  * merge all snippets into a single set
  * prevents and reports duplicate vhost names
* use nginx reload code from upstream PR https://github.com/NixOS/nixpkgs/pull/24476
  * our reload code is superseded by the changes in nixpkgs
  * reloading on fc-manage now works for json config
  * changes in /etc/local/nginx are picked up by fc-manage
* add nginx config helper commands
  * nginx-show-config shows the currently activated nginx config
  * nginx-check-config runs nginx -t for the current config
* update readme, json config is preferred now
* include modified nginx test from nixpkgs

Case 110209

Changelog:

* Nginx: Improve structured JSON config and reloading (#110209).