### PR TITLE
Allow sensu checks to sudo run as a service user

### DIFF
--- a/nixos/services/sensu.nix
+++ b/nixos/services/sensu.nix
@@ -252,6 +252,12 @@ in {
         ];
         groups = [ "sensuclient" ];
       }
+      # Allow sensuclient group to become service user for running custom checks
+      { 
+        commands = [ { command = "ALL"; options = [ "NOPASSWD" ]; } ];
+        groups = [ "sensuclient" ]; 
+        runAs = "%service";
+      }
     ];
 
     flyingcircus.activationScripts = {


### PR DESCRIPTION
Case 115283

Changelog

* Allow sensu checks to switch to a service user without password (#115283).