### PR TITLE
Fix nginx worker age check, test sensu checks

### DIFF
--- a/tests/nginx.nix
+++ b/tests/nginx.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ ... }:
+import ./make-test.nix ({ lib, ... }:
 {
   name = "nginx";
   machine =
@@ -7,14 +7,33 @@ import ./make-test.nix ({ ... }:
       imports = [ ../nixos ];
       flyingcircus.services.nginx.enable = true;
     };
-  testScript = ''
-    $machine->waitForUnit('nginx.service');
-    $machine->succeed(<<_EOT_);
-      curl -v http://localhost/nginx_status | \
-      grep "server accepts handled requests"
-    _EOT_
+  testScript = { nodes, ... }: 
+  let 
+    sensuChecks = nodes.machine.config.flyingcircus.services.sensu-client.checks;
+    nginxConfigCheck = sensuChecks.nginx_config.command;
+    nginxWorkerAgeCheck = sensuChecks.nginx_worker_age.command;
+    nginxStatusCheck = sensuChecks.nginx_status.command;
 
-    # service user should be able to write to local config dir
-    $machine->succeed('sudo -u nginx touch /etc/local/nginx/vhosts.json');
+  in ''
+    $machine->waitForUnit('nginx.service');
+
+    subtest "nginx works", sub {
+      $machine->succeed("curl -v http://localhost/nginx_status | grep 'server accepts handled requests'");
+    };
+
+    subtest "service user should be able to write to local config dir", sub {
+      $machine->succeed('sudo -u nginx touch /etc/local/nginx/vhosts.json');
+    };
+
+    subtest "all sensu checks should be green", sub {
+      $machine->succeed('${nginxConfigCheck}');
+      $machine->succeed('${nginxWorkerAgeCheck}');
+      $machine->succeed('${nginxStatusCheck}');
+    };
+
+    subtest "status check should be red after shutting down nginx", sub {
+      $machine->succeed('systemctl stop nginx.service');
+      $machine->mustFail('${nginxStatusCheck}');
+    };
   '';
 })


### PR DESCRIPTION
Workers that are already in the shutdown state are ignored now because
they cause noise when connections are still open.
We don't care about them because they don't accept new
connections and will be killed by Nginx after the worker shutdown
timeout.

Using the worker shutdown timeout for comparing the agediff
didn't make any sense, it just checks if the worker is older
than the config file now.

Nginx Sensu checks are tested now.

Case 117042