### PR TITLE
Fix #114925: always restart redis

### DIFF
--- a/nixos/services/redis.nix
+++ b/nixos/services/redis.nix
@@ -57,7 +57,7 @@ in {
       services.redis.extraConfig = extraConfig;
 
 
-      flyingcircus.activationScripts.redis = 
+      flyingcircus.activationScripts.redis =
         lib.stringAfter [ "fc-local-config" ] ''
           if [[ ! -e /etc/local/redis/password ]]; then
             ( umask 007;
@@ -68,15 +68,16 @@ in {
           chmod 0660 /etc/local/redis/password
         '';
 
-      flyingcircus.localConfigDirs.redis = { 
+      flyingcircus.localConfigDirs.redis = {
         dir = "/etc/local/redis";
-        user = "redis"; 
+        user = "redis";
       };
 
       systemd.services.redis = rec {
         serviceConfig = {
           LimitNOFILE = 64000;
           PermissionsStartOnly = true;
+          Restart = "always";
         };
 
         after = [ "network.target" ];

--- a/tests/redis.nix
+++ b/tests/redis.nix
@@ -22,5 +22,11 @@ import ./make-test.nix ({ ... }:
 
     # service user should be able to write the password file
     $redis->succeed('sudo -u redis touch /etc/local/redis/password');
+
+    # killing the redis process should trigger an automatic restart
+    $redis->succeed("kill \$(systemctl show redis.service --property MainPID | sed -e 's/MainPID=//')");
+    $redis->waitForUnit("redis.service");
+    $redis->waitUntilSucceeds("$cli ping | grep PONG");
+
   '';
 })


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

- Redis will be restarted

Changelog:

## Security implications

- [n/a ] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [n/a ] Security requirements tested? (EVIDENCE)

