### PR TITLE
Link htpasswd file back to original location

### DIFF
--- a/nixos/services/nginx/README.txt
+++ b/nixos/services/nginx/README.txt
@@ -73,7 +73,7 @@ If you want to authenticate against the Flying Circus users with login permissio
 use the following snippet, and *USE SSL*:
 
 auth_basic "FCIO user";
-auth_basic_user_file "/etc/local/nginx/htpasswd_fcio_users";
+auth_basic_user_file "/etc/local/htpasswd_fcio_users";
 
 There is also an `example-configuration` here. Copy to some file ending with
 *.conf and adapt.

--- a/nixos/services/nginx/default.nix
+++ b/nixos/services/nginx/default.nix
@@ -175,6 +175,11 @@ in
           source = "${package}/conf/uwsgi_params";
         };
 
+        # file has moved; link back to the old location for compatibility reasons
+        "local/nginx/htpasswd_fcio_users" = { 
+          source = "/etc/local/htpasswd_fcio_users";
+        };
+
         "local/nginx/example-configuration".text =
           import ./example-config.nix { inherit config lib; };
 


### PR DESCRIPTION
* file moved from /etc/local/nginx to /etc/local earlier
* document new location

Case 115470

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Link htpasswd file which has moved earlier back to original location in /etc/local/nginx and document change (#115470).

## Security implications

none