### PR TITLE
Port mysql / percona roles and additional packages

### DIFF
--- a/nixos/rename.nix
+++ b/nixos/rename.nix
@@ -4,5 +4,7 @@
     # old -> new
     # redis and redis4 roles do the same
     (mkRenamedOptionModule [ "flyingcircus" "roles" "redis4" ] [ "flyingcircus" "roles" "redis" ])
+    (mkRemovedOptionModule [ "flyingcircus" "services" "percona" "rootPassword" ] "Change the root password via MySQL and modify secret files")
+    (mkRemovedOptionModule [ "flyingcircus" "roles" "mysql" "rootPassword" ] "Change the root password via MySQL and modify secret files")
   ];
 }

--- a/nixos/roles/default.nix
+++ b/nixos/roles/default.nix
@@ -13,6 +13,7 @@ in {
     ./mailserver.nix
     ./memcached.nix
     ./mongodb
+    ./mysql.nix
     ./nfs.nix
     ./postgresql.nix
     ./rabbitmq.nix

--- a/nixos/roles/mysql.nix
+++ b/nixos/roles/mysql.nix
@@ -1,0 +1,406 @@
+{ config, lib, pkgs, ... }:
+
+# Root password is stored in /root/.my.cnf and /etc/local/mysql/mysql.password
+# These files must be modified manually if the root password is changed in MySQL.
+# TODO:
+# consistency check / automatic maintenance?
+
+with builtins;
+
+{
+  options = with lib; 
+  let  
+    mkRole = v: lib.mkEnableOption
+      "Enable the Flying Circus MySQL / Percona ${v} server role.";
+  in {
+
+    flyingcircus.roles = {
+
+      mysql = {
+
+        extraConfig = mkOption {
+          type = types.lines;
+          default = "";
+          description =
+          ''
+            Extra MySQL configuration to append at the end of the
+            configuration file. Do not assume this to be located
+            in any specific section.
+          '';
+        };
+      };
+
+      mysql55.enable = mkRole "5.5";
+      mysql56.enable = mkRole "5.6";
+      mysql57.enable = mkRole "5.7";
+      percona80.enable = mkRole "8.0";
+    };
+
+  };
+
+  config = 
+  let
+    mysqlRoles = with config.flyingcircus.roles; {
+      "5.5" = mysql55.enable;
+      "5.6" = mysql56.enable;
+      "5.7" = mysql57.enable;
+      "8.0" = percona80.enable;
+    };
+
+    mysqlPackages = with pkgs; { 
+      "5.5" = mysql55;
+      "5.6" = percona56;
+      "5.7" = percona57;
+      "8.0" = percona80;
+    };
+
+    cfg = config.flyingcircus.roles.mysql;
+    fclib = config.fclib;
+
+    current_memory = fclib.currentMemory 256;
+    cores = fclib.currentCores 1;
+
+    listenAddresses =
+      fclib.listenAddresses "lo" ++
+      fclib.listenAddresses "ethsrv";
+
+    localConfigPath = /etc/local/mysql;
+
+    rootPasswordFile = "${toString localConfigPath}/mysql.passwd";
+
+    isCnf = path: t: lib.hasSuffix ".cnf" path;
+
+    localConfig =
+      if pathExists localConfigPath
+      then "!includedir ${filterSource isCnf localConfigPath}"
+      else "";
+
+    enabledRoles = lib.filterAttrs (n: v: v) mysqlRoles;
+    enabledRolesCount = length (lib.attrNames enabledRoles);
+    version = head (lib.attrNames enabledRoles);
+    package = mysqlPackages.${version} or null; 
+
+    telegrafPassword = fclib.derivePasswordForHost "mysql-telegraf";
+    sensuPassword = fclib.derivePasswordForHost "mysql-sensu";
+
+    mysqlCheck = ''
+      ${pkgs.sensu-plugins-mysql}/bin/check-mysql-alive.rb \
+        -s /run/mysqld/mysqld.sock -d fc_sensu \
+        --user fc_sensu --pass ${sensuPassword}
+    '';
+
+  in lib.mkMerge [
+
+  (lib.mkIf (enabledRolesCount > 0) {
+    assertions = 
+      [ 
+        { 
+          assertion = enabledRolesCount == 1;
+          message = "MySQL / Percona roles are mutually exclusive. Only one may be enabled.";
+        }
+      ]; 
+
+    services.percona = {
+      enable = true;
+      inherit package rootPasswordFile;
+      dataDir = "/srv/mysql";
+      extraOptions =
+        let
+          charset = if (lib.versionAtLeast package.version "8.0")
+                    then "utf8mb4"
+                    else "utf8";
+          collation = if (lib.versionAtLeast package.version "8.0")
+                      then "utf8mb4_unicode_ci"
+                      else "utf8_unicode_ci";
+        in ''
+        [mysqld]
+        default-storage-engine  = innodb
+        skip-external-locking
+        skip-name-resolve
+        max_allowed_packet         = 512M
+        bulk_insert_buffer_size    = 128M
+        tmp_table_size             = 512M
+        max_heap_table_size        = 512M
+        lower-case-table-names     = 0
+        max_connect_errors         = 20
+        default_storage_engine     = InnoDB
+        table_definition_cache     = 512
+        open_files_limit           = 65535
+        sysdate-is-now             = 1
+        sql_mode                   = NO_ENGINE_SUBSTITUTION
+
+        init-connect               = 'SET NAMES ${charset} COLLATE ${collation}'
+        character-set-server       = ${charset}
+        collation-server           = ${collation}
+        character_set_server       = ${charset}
+        collation_server           = ${collation}
+
+        interactive_timeout        = 28800
+        wait_timeout               = 28800
+        connect_timeout            = 10
+
+        ${ # versions before 8.0.13 don't support binding to multiple IPs
+           # so we must bind to 0.0.0.0
+          if (lib.versionAtLeast package.version "8.0")
+          then
+          "bind-address               = ${lib.concatStringsSep "," listenAddresses}"
+          else
+          "bind-address               = 0.0.0.0"
+        }
+        max_connections            = 1000
+        thread_cache_size          = 128
+        myisam-recover-options     = FORCE
+        key_buffer_size            = 64M
+        table_open_cache           = 1000
+        # myisam-recover           = FORCE
+        thread_cache_size          = 8
+
+        ${# For 8.0 we still use native password because there are
+          # too many non 8.0 client libs out there, which cannot
+          # connect otherwise.
+          lib.optionalString
+          (lib.versionAtLeast package.version "8.0")
+          "default_authentication_plugin = mysql_native_password"}
+
+        ${# Query cache is gone in 8.0
+          # https://mysqlserverteam.com/mysql-8-0-retiring-support-for-the-query-cache/
+          lib.optionalString
+          (lib.versionOlder package.version "8.0")
+          ''query_cache_type           = 1
+            query_cache_min_res_unit   = 2k
+            query_cache_size           = 80M
+          ''}
+
+        # * InnoDB
+        innodb_buffer_pool_size         = ${toString (current_memory * 70 / 100)}M
+        innodb_log_buffer_size          = 64M
+        innodb_file_per_table           = 1
+        innodb_read_io_threads          = ${toString (cores * 4)}
+        innodb_write_io_threads         = ${toString (cores * 4)}
+        # Percentage. Probably needs local tuning depending on the workload.
+        ${lib.optionalString
+          (lib.versionAtLeast package.mysqlVersion "5.6")
+          "innodb_change_buffer_max_size   = 50"}
+        innodb_doublewrite              = 1
+        innodb_log_file_size            = 512M
+        innodb_log_files_in_group       = 4
+        innodb_flush_method             = O_DSYNC
+        innodb_open_files               = 800
+        innodb_stats_on_metadata        = 0
+        innodb_lock_wait_timeout        = 120
+
+        [mysqldump]
+        quick
+        quote-names
+        max_allowed_packet    = 512M
+
+        [xtrabackup]
+        target_dir                      = /opt/backup/xtrabackup
+        compress-threads                = ${toString (cores * 2)}
+        compress
+        parallel            = 3
+
+        [isamchk]
+        key_buffer        = 16M
+
+        # flyingcircus.roles.mysql.extraConfig
+        ${cfg.extraConfig}
+
+        # /etc/local/mysql/*
+        ${localConfig}
+      '';
+    };
+
+    flyingcircus.localConfigDirs.mysql = {
+      dir = (toString localConfigPath);
+      user = "mysql";
+    };
+
+    flyingcircus.activationScripts.mysql =
+    let
+      mysql = config.services.percona.package;
+    in
+      lib.stringAfter
+        [ "fc-local-config" ]
+        ''
+          # Configure initial root password for mysql.
+          # * set password
+          # * write password to /etc/mysql/mysql.passwd
+          # * write /root/.my.cnf
+
+          umask 0066
+          if [[ ! -f ${rootPasswordFile} ]]; then
+            pw=`${pkgs.apg}/bin/apg -a 1 -M lnc -n 1 -m 12`
+            echo -n "''${pw}" > ${rootPasswordFile}
+          fi
+          chown root:service ${rootPasswordFile}
+          chmod 640 ${rootPasswordFile}
+
+          if [[ ! -f /root/.my.cnf ]]; then
+            touch /root/.my.cnf
+            chmod 640 /root/.my.cnf
+            pw=$(<${rootPasswordFile})
+            cat > /root/.my.cnf <<__EOT__
+          # The following options will be passed to all MySQL clients
+          [client]
+          password = ''${pw}
+          user = root
+          __EOT__
+          fi
+        '';
+
+    environment.etc."local/mysql/README.txt".text = ''
+      MySQL / Percona (${package.name}) is running on this machine.
+
+      You can find the password for the mysql root user in the file `mysql.passwd`.
+      Service users can read the password file.
+
+      To connect as root, run:
+
+      $ mysql -h localhost -uroot -p$(< /etc/local/mysql/mysql.passwd)
+
+      This directory (/etc/local/mysql) is included in the mysql configuration.
+      To set custom options, add a `local.cnf` (or any other *.cnf) file here, and
+      run `sudo fc-manage --build`.
+
+      ATTENTION: Changes in this directory will restart MySQL to activate the
+      new configuration.
+
+      For more information, see our documentation at
+      https://flyingcircus.io/doc/guide/platform_nixos2/mysql.html.
+    '';
+
+    systemd.services.fc-mysql-post-init = {
+      description = "Prepare mysql for monitoring.";
+      partOf = [ "mysql.service" ];
+      requiredBy = [ "mysql.service" ];
+      after = [ "mysql.service" ];
+      path = [ package ];
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+      };
+
+      script = 
+      let
+        ensureUserAndDatabase = username: password: 
+          if (lib.versionAtLeast version "8.0") then ''
+            CREATE USER IF NOT EXISTS ${username}@localhost IDENTIFIED BY '${password}';
+            ALTER USER ${username}@localhost IDENTIFIED BY '${password}';
+            CREATE DATABASE IF NOT EXISTS ${username};
+            GRANT SELECT ON ${username}.* TO ${username}@localhost;
+          '' 
+          else ''
+            CREATE DATABASE IF NOT EXISTS ${username};
+            GRANT SELECT ON ${username}.* TO ${username}@localhost IDENTIFIED BY '${password}';
+          '';
+        mysqlCmd = sql: ''mysql --defaults-extra-file=/root/.my.cnf -e "${sql}"'';
+      in ''
+          # Wait until the MySQL server is available for use
+          count=0
+          running=0
+          while [ $running -eq 0 ]
+          do
+              if [ $count -eq 60 ]
+              then
+                  echo "Tried 60 times, giving up..."
+                  exit 1
+              fi
+
+              echo "No MySQL server contact after $count attempts. Waiting..."
+              count=$((count+1))
+              ${mysqlCmd "SELECT 'MySQL is working!'"} && running=1
+              sleep 3
+          done
+
+          # Create user and database for sensu, if they do not exist and make sure that the password is set
+          ${mysqlCmd (ensureUserAndDatabase "fc_sensu" sensuPassword)}
+
+          # Create user and database for telegraf, if they do not exist and make sure that the password is set
+          ${mysqlCmd (ensureUserAndDatabase "fc_telegraf" telegrafPassword)}
+        '';
+    };
+
+    services.udev.extraRules = ''
+      # increase readahead for mysql
+      SUBSYSTEM=="block", ATTR{queue/rotational}=="1", ACTION=="add|change", KERNEL=="vd[a-z]", ATTR{bdi/read_ahead_kb}="1024", ATTR{queue/read_ahead_kb}="1024"
+    '';
+
+    environment.systemPackages = with pkgs; [
+      innotop
+      qpress
+      xtrabackup
+    ];
+
+    flyingcircus.services = {
+      sensu-client.checks = {
+        mysql = {
+          notification = "MySQL alive";
+          command = mysqlCheck;
+        };
+      };
+
+      telegraf.inputs = {
+        mysql = [{
+          servers = ["fc_telegraf:${telegrafPassword}@unix(/run/mysqld/mysqld.sock)/?tls=false"];
+        }];
+      };
+    };
+  })
+
+  {
+    flyingcircus.roles.statshost.prometheusMetricRelabel = [
+      {
+        source_labels = [ "__name__" "command" ];
+        # Only if there is no command set.
+        regex = "(mysql_commands)_(.+);$";
+        replacement = "\${2}";
+        target_label = "command";
+      }
+      {
+        source_labels = [ "__name__" ];
+        regex = "(mysql_commands)_(.+)";
+        replacement = "\${1}_total";
+        target_label = "__name__";
+      }
+      {
+        source_labels = [ "__name__" ];
+        regex = "(mysql_handler)_(.+)";
+        replacement = "\${2}";
+        target_label = "handler";
+      }
+      {
+        source_labels = [ "__name__" ];
+        regex = "(mysql_handler)_(.+)";
+        replacement = "mysql_handlers_total";
+        target_label = "__name__";
+      }
+      {
+        source_labels = [ "__name__" ];
+        regex = "(mysql_innodb_rows)_(.+)";
+        replacement = "\${2}";
+        target_label = "operation";
+      }
+      {
+        source_labels = [ "__name__" ];
+        regex = "(mysql_innodb_rows)_(.+)";
+        replacement = "mysql_innodb_row_ops_total";
+        target_label = "__name__";
+      }
+      {
+        source_labels = [ "__name__" ];
+        regex = "(mysql_innodb_buffer_pool_pages)_(.+)";
+        replacement = "\${2}";
+        target_label = "state";
+      }
+      {
+        source_labels = [ "__name__" ];
+        regex = "(mysql_innodb_buffer_pool_pages)_(.+)";
+        replacement = "mysql_buffer_pool_pages";
+        target_label = "__name__";
+      }
+    ];
+    flyingcircus.roles.statshost.globalAllowedMetrics = [ "mysql" ];
+  }
+  ];
+}

--- a/nixos/services/default.nix
+++ b/nixos/services/default.nix
@@ -10,6 +10,7 @@
     ./haproxy.nix
     ./logrotate
     ./nginx
+    ./percona.nix
     ./postfix.nix
     ./postgresql.nix
     ./prometheus.nix

--- a/nixos/services/percona.nix
+++ b/nixos/services/percona.nix
@@ -1,0 +1,269 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.percona;
+
+  mysql = cfg.package;
+
+  pidFile = "${cfg.pidDir}/mysqld.pid";
+
+  mysqldOptions =
+    "--user=${cfg.user} --datadir=${cfg.dataDir} --basedir=${mysql}";
+
+  myCnf = pkgs.writeText "my.cnf"
+  ''
+    [mysqld]
+    port = ${toString cfg.port}
+    ${optionalString
+      (cfg.replication.role == "master" || cfg.replication.role == "slave")
+      "log-bin=mysql-bin"}
+    ${optionalString
+      (cfg.replication.role == "master" || cfg.replication.role == "slave")
+      "server-id = ${toString cfg.replication.serverId}"}
+    ${cfg.extraOptions}
+  '';
+
+  mysqlInit =
+    if versionAtLeast mysql.mysqlVersion "5.7" then
+      "${mysql}/bin/mysqld --initialize-insecure ${mysqldOptions}"
+    else
+      "${pkgs.perl}/bin/perl ${mysql}/bin/mysql_install_db ${mysqldOptions}";
+in
+
+{
+  ###### interface
+
+  options = {
+    services.percona = {
+
+      enable = mkOption {
+        default = false;
+        description = "
+          Whether to enable the MySQL server.
+        ";
+      };
+
+      package = mkOption {
+        type = types.package;
+        example = literalExample "pkgs.percona";
+        description = "
+          Which MySQL derivation to use.
+        ";
+      };
+
+      port = mkOption {
+        default = "3306";
+        description = "Port of MySQL";
+      };
+
+      user = mkOption {
+        default = "mysql";
+        description = "User account under which MySQL runs";
+      };
+
+      dataDir = mkOption {
+        default = "/srv/mysql";
+        description = "Location where MySQL stores its table files";
+      };
+
+      rootPasswordFile = mkOption {
+        description = "Location of the root password file";
+      };
+
+      pidDir = mkOption {
+        default = "/run/mysqld";
+        description = "Location of the file which stores the PID of the MySQL server";
+      };
+
+      extraOptions = mkOption {
+        default = "";
+        example = ''
+          key_buffer_size = 6G
+          table_cache = 1600
+          log-error = /var/log/mysql_err.log
+        '';
+        description = ''
+          Provide extra options to the MySQL configuration file.
+
+          Please note, that these options are added to the
+          <literal>[mysqld]</literal> section so you don't need to explicitly
+          state it again.
+        '';
+      };
+
+      initialDatabases = mkOption {
+        default = [];
+        description = ''
+          List of database names and their initial schemas that should be used
+          to create databases on the first startup of MySQL
+        '';
+        example = [
+          { name = "foodatabase"; schema = literalExample "./foodatabase.sql"; }
+          { name = "bardatabase"; schema = literalExample "./bardatabase.sql"; }
+        ];
+      };
+
+      initialScript = mkOption {
+        default = null;
+        description = ''
+          A file containing SQL statements to be executed on the first startup.
+          Can be used for granting certain permissions on the database
+        '';
+      };
+
+      replication = {
+        role = mkOption {
+          default = "none";
+          description = ''
+            Role of the MySQL server instance. Can be either: master, slave or
+            none
+          '';
+        };
+
+        serverId = mkOption {
+          default = 1;
+          description = ''
+            Id of the MySQL server instance. This number must be unique for each
+            instance
+          '';
+        };
+
+        masterHost = mkOption {
+          description = "Hostname of the MySQL master server";
+        };
+
+        masterUser = mkOption {
+          description = "Username of the MySQL replication user";
+        };
+
+        masterPassword = mkOption {
+          description = "Password of the MySQL replication user";
+        };
+
+        masterPort = mkOption {
+          default = 3306;
+          description = "Port number on which the MySQL master server runs";
+        };
+      };
+    };
+
+  };
+
+
+  ###### implementation
+
+  config = mkIf config.services.percona.enable {
+
+    users.extraUsers.mysql = {
+      description = "MySQL server user";
+      group = "mysql";
+      uid = config.ids.uids.mysql;
+    };
+
+    users.extraGroups.mysql.gid = config.ids.gids.mysql;
+
+    environment.systemPackages = [ mysql ];
+
+    systemd.services.mysql = {
+      description = "MySQL Server";
+      wantedBy = [ "multi-user.target" ];
+      unitConfig.RequiresMountsFor = "${cfg.dataDir}";
+      preStart =
+        ''
+          if ! test -e ${cfg.dataDir}/mysql; then
+              mkdir -m 0700 -p ${cfg.dataDir}
+              chown -R ${cfg.user} ${cfg.dataDir}
+              ${mysqlInit}
+              touch /run/mysql_init
+          fi
+
+          mkdir -m 0755 -p ${cfg.pidDir}
+          chown -R ${cfg.user} ${cfg.pidDir}
+
+          # Make the socket directory
+          mkdir -p /run/mysqld
+          chmod 0755 /run/mysqld
+          chown -R ${cfg.user} /run/mysqld
+        '';
+      serviceConfig = {
+        ExecStart = "${mysql}/bin/mysqld --defaults-extra-file=${myCnf} ${mysqldOptions}";
+        Restart = "always";
+        TimeoutSec = 300;
+      };
+      postStart =
+        ''
+          # Wait until the MySQL server is available for use
+          count=0
+          while [ ! -e /run/mysqld/mysqld.sock ]
+          do
+              if [ $count -eq 60 ]
+              then
+                  echo "Tried 60 times, giving up..."
+                  exit 1
+              fi
+
+              echo "No MySQL server contact after $count attempts. Waiting..."
+              count=$((count+1))
+              sleep 3
+          done
+
+          if [ -f /run/mysql_init ]
+          then
+              ${concatMapStrings (database:
+                ''
+                  # Create initial databases
+                  if ! test -e "${cfg.dataDir}/${database.name}"; then
+                      echo "Creating initial database: ${database.name}"
+                      ( echo "create database ${database.name};"
+                        echo "use ${database.name};"
+
+                        if [ -f "${database.schema}" ]
+                        then
+                            cat ${database.schema}
+                        elif [ -d "${database.schema}" ]
+                        then
+                            cat ${database.schema}/mysql-databases/*.sql
+                        fi
+                      ) | ${mysql}/bin/mysql -u root -N
+                  fi
+                '') cfg.initialDatabases}
+
+              ${optionalString (cfg.replication.role == "slave")
+                ''
+                  # Set up the replication master
+
+                  ( echo "stop slave;"
+                    echo "change master to master_host='${cfg.replication.masterHost}', master_user='${cfg.replication.masterUser}', master_password='${cfg.replication.masterPassword}';"
+                    echo "start slave;"
+                  ) | ${mysql}/bin/mysql -u root -N
+                ''}
+
+              ${optionalString (cfg.initialScript != null)
+                ''
+                  # Execute initial script
+                  cat ${cfg.initialScript} | ${mysql}/bin/mysql -u root -N
+                ''}
+
+                  # Change root password
+                  ${# For 8.0 we still use native password because there are
+                    # too many non 8.0 client libs out there, which cannot
+                    # connect otherwise.
+                    if versionAtLeast mysql.version "8.0"
+                    then ''
+                      (echo "ALTER USER 'root'@'localhost' "
+                       echo "IDENTIFIED WITH mysql_native_password "
+                       echo "BY '$(< ${cfg.rootPasswordFile})';") |\
+                        ${mysql}/bin/mysql -u root -N
+                    ''
+                    else ''
+                    ${mysql}/bin/mysqladmin --no-defaults password "$(< ${cfg.rootPasswordFile})"
+                  ''}
+            rm /run/mysql_init
+          fi
+        '';  # */
+      };
+  };
+}

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -37,6 +37,14 @@ in {
     ];
   };
 
+  percona = self.percona80;
+  percona-toolkit = super.callPackage ./percona/toolkit.nix { };
+  percona56 = super.callPackage ./percona/5.6.nix { boost = self.boost159; };
+  percona57 = super.callPackage ./percona/5.7.nix { boost = self.boost159; };
+  percona80 = super.callPackage ./percona/8.0.nix { boost = self.boost169; };
+
+  qpress = super.callPackage ./percona/qpress.nix { };
+
   rabbitmq-server_3_6_5 = super.callPackage ./rabbitmq-server/3.6.5.nix { 
     erlang = self.erlangR19; 
   };
@@ -61,6 +69,11 @@ in {
   # We use a (our) newer version than on upstream.
   vulnix = super.callPackage ./vulnix.nix {
     pythonPackages = self.python3Packages;
+  };
+
+  xtrabackup = super.callPackage ./percona/xtrabackup.nix {
+    inherit (self) percona;
+    boost = self.boost169;
   };
 
 }

--- a/pkgs/percona/5.6.nix
+++ b/pkgs/percona/5.6.nix
@@ -1,0 +1,65 @@
+{ stdenv, fetchurl, cmake, boost, bison, ncurses, openssl, readline, zlib, perl }:
+
+# Note: zlib is not required; MySQL can use an internal zlib.
+
+stdenv.mkDerivation rec {
+  name = "percona-${version}";
+  version = "5.6.45-86.1";
+
+  src = fetchurl {
+    url = "https://www.percona.com/downloads/Percona-Server-5.6/Percona-Server-${version}/source/tarball/percona-server-${version}.tar.gz";
+    sha256 = "1306db0l8vvp7mlv96qgxddshikckbrsf9gyz542sag4ni0iak8c";
+  };
+
+  preConfigure = stdenv.lib.optional stdenv.isDarwin ''
+    ln -s /bin/ps $TMPDIR/ps
+    export PATH=$PATH:$TMPDIR
+  '';
+
+  buildInputs = [
+      cmake bison ncurses openssl readline zlib boost.out boost.dev
+    ] ++ stdenv.lib.optional stdenv.isDarwin perl;
+
+  enableParallelBuilding = true;
+
+  cmakeFlags = [
+    "-DWITH_SSL=yes"
+    "-DWITH_EMBEDDED_SERVER=no"
+    "-DWITH_ZLIB=yes"
+    "-DWITH_EDITLINE=bundled"
+    "-DHAVE_IPV6=yes"
+    "-DMYSQL_UNIX_ADDR=/run/mysqld/mysqld.sock"
+    "-DMYSQL_DATADIR=/var/lib/mysql"
+    "-DINSTALL_SYSCONFDIR=etc/mysql"
+    "-DINSTALL_INFODIR=share/mysql/docs"
+    "-DINSTALL_MANDIR=share/man"
+    "-DINSTALL_PLUGINDIR=lib/mysql/plugin"
+    "-DINSTALL_SCRIPTDIR=bin"
+    "-DINSTALL_INCLUDEDIR=include/mysql"
+    "-DINSTALL_DOCREADMEDIR=share/mysql"
+    "-DINSTALL_SUPPORTFILESDIR=share/mysql"
+    "-DINSTALL_MYSQLSHAREDIR=share/mysql"
+    "-DINSTALL_DOCDIR=share/mysql/docs"
+    "-DINSTALL_SHAREDIR=share/mysql"
+  ];
+
+  NIX_LDFLAGS = stdenv.lib.optionalString stdenv.isLinux "-lgcc_s";
+
+  prePatch = ''
+    sed -i -e "s|/usr/bin/libtool|libtool|" cmake/libutils.cmake
+  '';
+  postInstall = ''
+    sed -i -e "s|basedir=\"\"|basedir=\"$out\"|" $out/bin/mysql_install_db
+    rm -r $out/mysql-test $out/sql-bench $out/data "$out"/lib/*.a
+  '';
+
+  passthru.mysqlVersion = "5.6";
+
+  meta = {
+    homepage = http://www.percona.com/;
+    description = ''
+      Is a free, fully compatible, enhanced, open source drop-in replacement for
+      MySQL® that provides superior performance, scalability and instrumentation.
+    '';
+  };
+}

--- a/pkgs/percona/5.7.nix
+++ b/pkgs/percona/5.7.nix
@@ -1,0 +1,81 @@
+{ stdenv, fetchurl, cmake, curl, boost, bison, ncurses, libaio, pkgconfig, openssl, readline, zlib, perl }:
+
+# Note: zlib is not required; MySQL can use an internal zlib.
+
+stdenv.mkDerivation rec {
+  name = "percona-${version}";
+  version = "5.7.27-30";
+
+  src = fetchurl {
+    url = "https://www.percona.com/downloads/Percona-Server-5.7/Percona-Server-${version}/source/tarball/percona-server-${version}.tar.gz";
+    sha256 = "09m2cn7qp1zfk3xa57bwc81i3a14vx9cca7kix348r1c48yzy3dm";
+
+  };
+
+  preConfigure = stdenv.lib.optional stdenv.isDarwin ''
+    ln -s /bin/ps $TMPDIR/ps
+    export PATH=$PATH:$TMPDIR
+  '';
+
+  buildInputs = [
+      cmake curl bison ncurses openssl readline pkgconfig zlib boost libaio
+    ] ++ stdenv.lib.optional stdenv.isDarwin perl;
+
+  enableParallelBuilding = true;
+
+  cmakeFlags = [
+    "-DCMAKE_SKIP_BUILD_RPATH=OFF" # To run libmysql/libmysql_api_test during build.
+    "-DBUILD_CONFIG=mysql_release"
+    "-DWITH_SSL=system"
+    "-DWITH_EMBEDDED_SERVER=no"
+    "-DWITH_ZLIB=system"
+    "-DWITH_EDITLINE=bundled"
+    "-DHAVE_IPV6=yes"
+    "-DMYSQL_UNIX_ADDR=/run/mysqld/mysqld.sock"
+    "-DMYSQL_DATADIR=/var/lib/mysql"
+    "-DINSTALL_SYSCONFDIR=etc/mysql"
+    "-DINSTALL_INFODIR=share/mysql/docs"
+    "-DINSTALL_MANDIR=share/man"
+    "-DINSTALL_PLUGINDIR=lib/mysql/plugin"
+    "-DINSTALL_SCRIPTDIR=bin"
+    "-DINSTALL_INCLUDEDIR=include/mysql"
+    "-DINSTALL_DOCREADMEDIR=share/mysql"
+    "-DINSTALL_SUPPORTFILESDIR=share/mysql"
+    "-DINSTALL_MYSQLSHAREDIR=share/mysql"
+    "-DINSTALL_DOCDIR=share/mysql/docs"
+    "-DINSTALL_SHAREDIR=share/mysql"
+  ];
+
+  NIX_LDFLAGS = stdenv.lib.optionalString stdenv.isLinux "-lgcc_s";
+
+  prePatch = ''
+    sed -i -e "s|/usr/bin/libtool|libtool|" cmake/libutils.cmake
+
+    patchShebangs .
+
+    sed -i "s|COMMAND env -i |COMMAND env -i PATH=$PATH |" \
+      storage/rocksdb/CMakeLists.txt
+
+    # Disable ABI check. See case #108154
+    sed -i "s/SET(RUN_ABI_CHECK 1)/SET(RUN_ABI_CHECK 0)/" cmake/abi_check.cmake
+
+  '';
+  postInstall = ''
+    sed -i -e "s|basedir=\"\"|basedir=\"$out\"|" $out/bin/mysql_install_db
+    rm -r $out/mysql-test $out/lib/*.a
+  '';
+
+  preBuild = ''
+    export LD_LIBRARY_PATH=$(pwd)/library_output_directory
+  '';
+
+  passthru.mysqlVersion = "5.7";
+
+  meta = {
+    homepage = http://www.percona.com/;
+    description = ''
+      Is a free, fully compatible, enhanced, open source drop-in replacement for
+      MySQL® that provides superior performance, scalability and instrumentation.
+    '';
+  };
+}

--- a/pkgs/percona/8.0.nix
+++ b/pkgs/percona/8.0.nix
@@ -1,0 +1,93 @@
+{ stdenv, fetchurl, fetchFromGitHub, cmake, pkgconfig, ncurses, zlib, xz, lzo, lz4, bzip2, snappy
+, libiconv, openssl, pcre, boost, judy, bison, libxml2
+, libaio, jemalloc, cracklib, systemd, numactl
+, asio, buildEnv, check, scons, curl, perl
+}:
+
+stdenv.mkDerivation rec {
+  name = "percona-${version}";
+  version = "8.0.16-7";
+
+  src = fetchurl {
+    url = "https://www.percona.com/downloads/Percona-Server-8.0/Percona-Server-${version}/source/tarball/percona-server-${version}.tar.gz";
+    sha256 = "1677jm271l8jy7566r7lb5z1bfbfrc50yfkvggs58w4i4df6i3wg";
+  };
+
+  preConfigure = stdenv.lib.optional stdenv.isDarwin ''
+    ln -s /bin/ps $TMPDIR/ps
+    export PATH=$PATH:$TMPDIR
+  '';
+
+  nativeBuildInputs = [ cmake pkgconfig ];
+  buildInputs = [
+    ncurses openssl zlib pcre jemalloc libiconv libaio systemd boost curl perl
+  ];
+
+  enableParallelBuilding = true;
+
+  cmakeFlags = [
+
+    "-DBUILD_CONFIG=mysql_release"
+    "-DDEFAULT_CHARSET=utf8mb4"
+    "-DDEFAULT_COLLATION=utf8mb4_unicode_ci"
+
+    "-DWITH_ZLIB=system"
+    "-DWITH_SSL=system"
+    "-DWITH_EDITLINE=bundled"
+
+    # https://www.percona.com/blog/2013/03/08/mysql-performance-impact-of-memory-allocators-part-2/
+    "-DWITH_JEMALLOC=1"
+    "-DWITH_SYSTEMD=1"
+
+    "-DMYSQL_UNIX_ADDR=/run/mysqld/mysqld.sock"
+    "-DMYSQL_DATADIR=/var/lib/mysql"
+    "-DINSTALL_INFODIR=share/mysql/docs"
+    "-DINSTALL_MANDIR=share/man"
+    "-DINSTALL_PLUGINDIR=lib/mysql/plugin"
+    "-DINSTALL_INCLUDEDIR=include/mysql"
+    "-DINSTALL_DOCREADMEDIR=share/mysql"
+    "-DINSTALL_SUPPORTFILESDIR=share/mysql"
+    "-DINSTALL_MYSQLSHAREDIR=share/mysql"
+    "-DINSTALL_DOCDIR=share/mysql/docs"
+    "-DINSTALL_SHAREDIR=share/mysql"
+
+    "-DENABLED_LOCAL_INFILE=ON"
+    "-DWITH_ARCHIVE_STORAGE_ENGINE=1"
+    "-DWITH_BLACKHOLE_STORAGE_ENGINE=1"
+    "-DWITH_INNOBASE_STORAGE_ENGINE=1"
+    "-DWITHOUT_EXAMPLE_STORAGE_ENGINE=1"
+  ];
+
+  NIX_LDFLAGS = stdenv.lib.optionalString stdenv.isLinux "-lgcc_s";
+  CXXFLAGS = stdenv.lib.optionalString stdenv.isi686 "-fpermissive";
+
+  prePatch = ''
+    sed -i -e "s|/usr/bin/libtool|libtool|" cmake/libutils.cmake
+    patchShebangs .
+    sed -i "s|COMMAND env -i |COMMAND env -i PATH=$PATH |" \
+      storage/rocksdb/CMakeLists.txt
+
+    # Disable ABI check. See case #108154
+    sed -i "s/SET(RUN_ABI_CHECK 1)/SET(RUN_ABI_CHECK 0)/" cmake/abi_check.cmake
+
+  '';
+
+  preBuild = ''
+    export LD_LIBRARY_PATH=$(pwd)/library_output_directory
+  '';
+
+  postInstall = ''
+    rm -r $out/mysql-test
+    chmod g-w $out
+  '';
+
+  passthru.mysqlVersion = "8.0";
+
+  meta = {
+    homepage = http://www.percona.com/;
+    description = ''
+      Is a free, fully compatible, enhanced, open source drop-in replacement for
+      MySQL® that provides superior performance, scalability and instrumentation.
+    '';
+  };
+}

--- a/pkgs/percona/innotop.nix
+++ b/pkgs/percona/innotop.nix
@@ -11,6 +11,8 @@ pkgs.buildPerlPackage rec {
     sha256 = "0l284mmjzkadb17yrj9avyhbh5dqgdx3f5kj0yldlid28n1mx0kd";
   };
 
+  patches = [ ./innotop.patch ];
+
   outputs = [ "out" ];
 
   propagatedBuildInputs = [

--- a/pkgs/percona/innotop.patch
+++ b/pkgs/percona/innotop.patch
@@ -1,0 +1,13 @@
+diff --git a/innotop.spec b/innotop.spec
+index 61155bc..8bcdf4c 100644
+--- a/innotop.spec
++++ b/innotop.spec
+@@ -99,7 +99,7 @@ find %{buildroot}%{_prefix}             \
+         $d = $_;
+         /\Q$d\E/ && return for reverse sort @INC;
+         $d =~ /\Q$_\E/ && return
+-            for qw|/etc %_prefix/man %_prefix/bin %_prefix/share|;
++            for qw|/etc %_prefix/man1 %_prefix/bin %_prefix/share|;
+
+         $dirs[@dirs] = $_;
+         }

--- a/pkgs/percona/qpress-builder.sh
+++ b/pkgs/percona/qpress-builder.sh
@@ -1,0 +1,8 @@
+source $stdenv/setup
+
+echo "unpacking $src..."
+mkdir -p $out/bin
+tar xvfa $src -C $out/bin
+
+patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+    $out/bin/qpress

--- a/pkgs/percona/qpress.nix
+++ b/pkgs/percona/qpress.nix
@@ -1,0 +1,19 @@
+{ stdenv, fetchurl, pkgs, ... }:
+
+stdenv.mkDerivation rec {
+  name = "qpress-${version}";
+  version = "11";
+
+  src = fetchurl {
+    url = "http://www.quicklz.com/qpress-${version}-linux-x64.tar";
+    sha256 = "bf4d4201ce51ec902f06043f1a835056b106d88b901939c507353a00d8fd65dc";
+  };
+
+  builder = ./qpress-builder.sh;
+
+  meta = {
+    homepage = http://www.quicklz.com;
+    description = "qpress file archiver";
+  };
+}
+

--- a/pkgs/percona/toolkit.nix
+++ b/pkgs/percona/toolkit.nix
@@ -1,0 +1,17 @@
+{ buildPerlPackage, fetchurl, perlPackages, }:
+with perlPackages;
+
+buildPerlPackage rec {
+  name = "percona-toolkit-${version}";
+  version = "3.0.8";
+
+  src = fetchurl {
+    url = "https://www.percona.com/downloads/percona-toolkit/${version}/binary/tarball/percona-toolkit-${version}_x86_64.tar.gz";
+    sha256 = "73aa2a77d58f8f3584f930ea587f24c79c506d73db015bf0c6aebe3d541feae6";
+  };
+
+  propagatedBuildInputs = [
+    DBDmysql
+    TimeHiRes
+  ];
+}

--- a/pkgs/percona/xtrabackup.nix
+++ b/pkgs/percona/xtrabackup.nix
@@ -1,0 +1,53 @@
+{ stdenv, fetchurl, pkgs, boost, percona, ... }:
+
+stdenv.mkDerivation rec {
+  name = "xtrabackup-${version}";
+  version = "8.0.7";
+
+  src = fetchurl {
+    # warning: strange naming, multiple version strings in the URL...
+    url = "https://www.percona.com/downloads/Percona-XtraBackup-8.0/Percona-XtraBackup-8.0-7/source/tarball/percona-xtrabackup-${version}.tar.gz";
+    sha256 = "1qiwynlrs63fwbrmrl6gv5q86zyh5fgyv6w0vjnahwry18gnjk52";
+
+  };
+
+  buildInputs = with pkgs; [
+     bison
+     boost
+     cmake
+     curl
+     libaio
+     libev
+     libgcrypt
+     libgpgerror
+     ncurses
+     percona
+     vim
+     ];
+
+  enableParallelBuilding = true;
+  cmakeFlags = [
+    "-DBUILD_CONFIG=xtrabackup_release"
+    "-DGCRYPT_LIB_PATH=${pkgs.libgcrypt}/lib:${pkgs.libgpgerror}/lib"
+    "-DWITH_MAN_PAGES=OFF"
+  ];
+
+  prePatch = ''
+    # Disable ABI check. See case #108154
+    sed -i "s/SET(RUN_ABI_CHECK 1)/SET(RUN_ABI_CHECK 0)/" cmake/abi_check.cmake
+
+  '';
+
+  preBuild = ''
+    export LD_LIBRARY_PATH=$(pwd)/library_output_directory
+  '';
+
+  postInstall = ''
+    chmod g-w $out
+  '';
+
+  meta = {
+    homepage = https://www.percona.com/;
+    description = "Percona XtraBackup";
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -29,10 +29,14 @@ in {
   mongodb32 = callTest ./mongodb.nix { rolename = "mongodb32"; };
   mongodb34 = callTest ./mongodb.nix { rolename = "mongodb34"; };
   network = callSubTests ./network {};
+  mysql55 = callTest ./mysql.nix { rolename = "mysql55"; };
+  mysql56 = callTest ./mysql.nix { rolename = "mysql56"; };
+  mysql57 = callTest ./mysql.nix { rolename = "mysql57"; };
   nfs = callTest ./nfs.nix {};
   nginx = callTest ./nginx.nix {};
   nginx_reload = callTest (nixpkgs + /nixos/tests/nginx.nix) {};
   openvpn = callTest ./openvpn.nix {};
+  percona80 = callTest ./mysql.nix { rolename = "percona80"; };
   postgresql95 = callTest ./postgresql.nix { rolename = "postgresql95"; };
   postgresql96 = callTest ./postgresql.nix { rolename = "postgresql96"; };
   postgresql10 = callTest ./postgresql.nix { rolename = "postgresql10"; };

--- a/tests/mysql.nix
+++ b/tests/mysql.nix
@@ -1,0 +1,126 @@
+import ./make-test.nix ({ rolename ? "percona80", lib, pkgs, ... }:
+let 
+  net6Fe = "2001:db8:1::";
+  net6Srv = "2001:db8:2::";
+
+  master6Fe = net6Fe + "1";
+  master6Srv = net6Srv + "1";
+
+  net4Fe = "10.0.1";
+  net4Srv = "10.0.2";
+
+  master4Fe = net4Fe + ".1";
+  master4Srv = net4Srv + ".1";
+
+in
+{
+  name = "mysql-${rolename}";
+  nodes = {
+    master =
+    { pkgs, config, ... }:
+    {
+      imports = [ ../nixos ../nixos/roles ];
+      virtualisation.memorySize = 2048;
+
+      flyingcircus.roles.${rolename}.enable = true;
+
+      # Tune those arguments as we'd like to run this on Hydra
+      # in a rather small VM.
+      flyingcircus.roles.mysql.extraConfig = ''
+        [mysqld]
+        innodb-buffer-pool-size         = 10M
+        innodb_log_file_size            = 10M
+      '';
+
+      flyingcircus.enc.parameters = {
+        resource_group = "test";
+        interfaces.srv = {
+          mac = "52:54:00:12:02:01";
+          networks = {
+            "${net4Srv}.0/24" = [ master4Srv ];
+            "${net6Srv}/64" = [ master6Srv ];
+          };
+          gateways = {};
+        };
+        interfaces.fe = {
+          mac = "52:54:00:12:01:01";
+          networks = {
+            "${net4Fe}.0/24" = [ master4Fe ];
+            "${net6Fe}/64" = [ master6Fe ];
+          };
+          gateways = {};
+        };
+      };
+    };
+  };
+
+  testScript = { nodes, ... }: 
+  let 
+    config = nodes.master.config;
+    sensuChecks = config.flyingcircus.services.sensu-client.checks;
+    mysqlCheck = sensuChecks.mysql.command;
+    version = config.services.percona.package.version;
+    expectedAddresses = if lib.versionAtLeast version "8.0" then [
+      # 8.0 binds to lo and srv with port 3306
+      "${master4Srv}:3306"
+      "127.0.0.1:3306"
+      ":::33060"
+      "${master6Srv}:3306"
+      "::1:3306"
+    ] 
+    else [
+      # older versions listen on all ipv4 interfaces
+      "0.0.0.0:3306"
+    ];
+
+    expectedAddressesExpr = lib.concatStringsSep " |" expectedAddresses;
+
+  in ''
+    startAll;
+    $master->waitForUnit("mysql");
+
+    subtest "mysql works", sub {
+      $master->succeed("mysqladmin ping");
+    };
+
+    subtest "can login with root password", sub {
+      $master->succeed("mysql mysql -u root -p\$(< /etc/local/mysql/mysql.passwd) -e 'select 1'");
+    };
+
+    $master->sleep(3);
+
+    subtest "mysql only opens expected ports", sub {
+      # check for expected ports
+      ${lib.concatMapStringsSep 
+         "\n"
+          (a: ''  $master->succeed("netstat -tlpn | grep mysqld | grep '${a}'");'')
+          expectedAddresses
+      }
+      # check for unexpected ports
+      $master->mustFail("netstat -tlpn | grep mysqld | egrep -v '${expectedAddressesExpr}'");
+    };
+
+    subtest "killing the mysql process should trigger an automatic restart", sub {
+      $master->succeed("kill -9 \$(systemctl show mysql.service --property MainPID --value)");
+      $master->waitForUnit("mysql");
+      $master->sleep(1);
+      $master->succeed("mysqladmin ping");
+    };
+
+    subtest "all sensu checks should be green", sub {
+      $master->waitForUnit("fc-mysql-post-init.service");
+      $master->succeed('${mysqlCheck}');
+    };
+
+    subtest "status check should be red after shutting down mysql", sub {
+      $master->succeed('systemctl stop mysql');
+      $master->mustFail('${mysqlCheck}');
+    };
+
+    subtest "secret files should have correct permissions", sub {
+      $master->succeed("stat /etc/local/mysql/mysql.passwd -c %a:%U:%G | grep '640:root:service'");
+      $master->succeed("stat /root/.my.cnf -c %a:%U:%G | grep '640:root:root'");
+    };
+  '';
+
+})


### PR DESCRIPTION
- Percona packages from fc-15.09, but with current percona versions
  for 5.6, 5.7 and 8.0
- mysql package for 5.5
- Use sensu plugin instead of nagios monitoring script
- use non-root user for monitoring
- xtrabackup: 8.0.5 -> 8.0.7
- systemd now always restarts mysql when it dies
- percona 8.0: bind to srv and lo addresses only
- remove stuff for versions before 5.5
- refactor role options / package selection
- remove maintenance timer
  - has never worked on NixOS because of a typo (onCalendar -> OnCalendar)

Case 25409

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - ported from 15.09 with some improvements
  - no root password in the Nix store
  - 8.0: mysql listens only on lo and srv addresses, older versions don't support that
  - monitoring is done with separate db users that can only access their own database with read permissions from localhost
- [x] Security requirements tested? (EVIDENCE)
  - Test checks that exactly the expected ports are opened by mysql and secret files have the correct permissions
  - Manual checks in dev that root pw is not in the nix store and that monitoring users have the correct permissions