### PR TITLE
Docker role

### DIFF
--- a/nixos/roles/default.nix
+++ b/nixos/roles/default.nix
@@ -9,6 +9,7 @@ let
 
 in {
   imports = [
+    ./docker.nix
     ./external_net
     ./mailserver.nix
     ./memcached.nix

--- a/nixos/roles/docker.nix
+++ b/nixos/roles/docker.nix
@@ -1,0 +1,14 @@
+{ config, lib, ... }:
+{
+  options = {
+    flyingcircus.roles.docker = {
+      enable = lib.mkEnableOption "Enable Docker";
+    };
+  };
+
+  config = lib.mkIf config.flyingcircus.roles.docker.enable {
+    virtualisation.docker.enable = true;
+    flyingcircus.users.serviceUsers.extraGroups = [ "docker" ];
+  };
+
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -20,6 +20,7 @@ let
   in discover (importTest fn args system);
 
 in {
+  docker = callTest (nixpkgs + /nixos/tests/docker.nix) {};
   fcagent = callTest ./fcagent.nix {};
   garbagecollect = callTest ./garbagecollect.nix {};
   login = callTest ./login.nix {};


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Add docker role.

## Security implications

We just activate standard docker support on NixOS and don't change the settings.

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Only users in the docker group are allowed to use docker commands.
- [x] Security requirements tested? (EVIDENCE)
  - We rely on upstream, we run a NixOS test that checks if docker works and if permissions are correct.
