### PR TITLE
Port antivirus role

### DIFF
--- a/nixos/roles/antivirus.nix
+++ b/nixos/roles/antivirus.nix
@@ -1,0 +1,66 @@
+{ config, lib, pkgs, ... }:
+
+with builtins;
+
+let
+  fclib = config.fclib;
+  listenAddresses =
+    fclib.listenAddresses "lo" ++
+    fclib.listenAddresses "ethsrv";
+
+in
+{
+  options = {
+    flyingcircus.roles.antivirus = {
+      enable = lib.mkEnableOption "ClamAV antivirus scanner";
+    };
+  };
+
+  config = lib.mkIf config.flyingcircus.roles.antivirus.enable {
+    services.clamav.daemon = {
+      enable = true;
+      extraConfig = ''
+        TCPSocket 3310
+      '' + lib.concatMapStringsSep "\n" (ip: "TCPAddr ${ip}") listenAddresses;
+
+    };
+
+    systemd.services.clamav-daemon.serviceConfig = {
+      PrivateTmp = lib.mkForce "no";
+      PrivateNetwork = lib.mkForce "no";
+      Restart = "always";
+    };
+
+    services.clamav.updater.enable = true;
+
+    systemd.services.clamav-freshclam.serviceConfig = {
+      # We monitor systemd process status for alerting, but this really
+      # isn't critical to wake up people. We'll catch errors when the
+      # file age check for the database update goes critical.
+      # The list is taken from the freshclam manpage.
+      SuccessExitStatus = lib.mkForce [ 40 50 51 52 53 54 55 56 57 58 59 60 61 62 ];
+    };
+
+    flyingcircus.services = {
+      sensu-client.checks = {
+
+        clamav-updater = {
+          notification = "ClamAV virus database up-to-date";
+          command = ''
+            check_file_age -w 86400 -c 172800 /var/lib/clamav/mirrors.dat
+          '';
+          interval = 300;
+          };
+
+        clamav-listen = {
+          notification = "clamd not reachable via TCP";
+          command = ''
+            ${pkgs.sensu-plugins-network-checks}/bin/check-ports.rb \
+              -h ${lib.concatStringsSep "," listenAddresses} -p 3310
+          '';
+        };
+
+      };
+    };
+  };
+}

--- a/nixos/roles/default.nix
+++ b/nixos/roles/default.nix
@@ -11,6 +11,7 @@ in {
   imports = [
     ./docker.nix
     ./external_net
+    ./antivirus.nix
     ./mailserver.nix
     ./memcached.nix
     ./mongodb

--- a/pkgs/sensuplugins-rb/sensu-plugins-network-checks/default.nix
+++ b/pkgs/sensuplugins-rb/sensu-plugins-network-checks/default.nix
@@ -2,5 +2,8 @@
 
 bundlerSensuPlugin {
   pname = "sensu-plugins-network-checks";
-  exes = [ "check-netstat-tcp.rb" ];
+  exes = [ 
+    "check-netstat-tcp.rb"
+    "check-ports.rb"
+  ];
 }

--- a/tests/antivirus.nix
+++ b/tests/antivirus.nix
@@ -1,0 +1,38 @@
+# It's hard to test the real functionality because the updater needs internet access
+# and the daemon need large binary files in order to run.
+# We just check the generated config.
+import ./make-test.nix ({ lib, ... }:
+let 
+  ipv4 = "192.168.101.1";
+  ipv6 = "2001:db8:f030:1c3::1";
+in {
+  name = "antivirus";
+  machine = 
+    { lib, pkgs, ... }:
+    {
+      imports = [ ../nixos ../nixos/roles ];
+      flyingcircus.roles.antivirus.enable = true;
+      flyingcircus.enc.parameters = {
+        resource_group = "test";
+        interfaces.srv = {
+          mac = "52:54:00:12:34:56";
+          networks = {
+            "192.168.101.0/24" = [ ipv4 ];
+            "2001:db8:f030:1c3::/64" = [ ipv6 ];
+          };
+          gateways = {};
+        };
+      };
+    };
+
+  testScript =
+  let
+    check = ipaddr: ''
+      $machine->succeed('grep ${ipaddr} /etc/clamav/clamd.conf');
+    '';
+  in ''
+    $machine->succeed('systemctl cat clamav-daemon.service');
+    $machine->succeed('systemctl cat clamav-freshclam.service');
+    $machine->succeed('systemctl cat clamav-freshclam.timer');
+  '' + lib.concatMapStringsSep "\n" check [ "127.0.0.1" "::1" ipv4 ipv6 ];
+})

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -20,6 +20,7 @@ let
   in discover (importTest fn args system);
 
 in {
+  antivirus = callTest ./antivirus.nix {};
   docker = callTest (nixpkgs + /nixos/tests/docker.nix) {};
   fcagent = callTest ./fcagent.nix {};
   garbagecollect = callTest ./garbagecollect.nix {};


### PR DESCRIPTION
* clamav package and service from upstream
* clamd listens on srv and lo addresses

Case 119631
Case 115501

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Port antivirus (clamav) role. Clamd listens on srv interfaces. (#119631, #115501).

## Security implications

- uses upstream service but disables private network because we want to listen to srv interfaces; disables private temp dir because we want to allow scanning files in /tmp

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - clamd listens on srv and lo interfaces
  - clamd find virus signatures
- [x] Security requirements tested? (EVIDENCE)
  - automatic test checks if correct listen addresses are set in the config
  - manual checks in dev if clamd listens to the correct interfaces and recognizes the EICAR virus test signature


