### PR TITLE
Fix sudo ordering (passwordless access, vagrant)

### DIFF
--- a/nixos/infrastructure/vagrant.nix
+++ b/nixos/infrastructure/vagrant.nix
@@ -44,15 +44,13 @@
 	    ];
 	};
 
-    security.sudo = {
-      extraRules = lib.mkBefore [
-        # Allow unrestricted access to vagrant
-        {
-          commands = [ { command = "ALL"; options = [ "NOPASSWD" ]; } ];
-          users = [ "vagrant" ];
-        }
-      ];
-    };
+    flyingcircus.passwordlessSudoRules = [
+      # Allow unrestricted access to vagrant
+      {
+        commands = [ "ALL" ];
+        users = [ "vagrant" ];
+      }
+    ];
 
     # General vagrant optimizations
 

--- a/nixos/platform/agent.nix
+++ b/nixos/platform/agent.nix
@@ -103,10 +103,9 @@ in {
         "d /var/spool/maintenance/archive - - - 90d"
       ];
 
-      security.sudo.extraRules = [
+      flyingcircus.passwordlessSudoRules = [
         {
-          commands = [ { command = "${pkgs.fc.agent}/bin/fc-manage"; 
-                         options = [ "NOPASSWD" ]; } ];
+          commands = [ "${pkgs.fc.agent}/bin/fc-manage" ];
           groups = [ "sudo-srv" "service" ];
         }
       ];

--- a/nixos/platform/firewall.nix
+++ b/nixos/platform/firewall.nix
@@ -7,7 +7,7 @@ let
 
   fclib = config.fclib;
 
-  localCfgDir = cfg.localConfigPath + "/firewall"; 
+  localCfgDir = cfg.localConfigPath + "/firewall";
 
   # Technically, snippets in /etc/local/firewall are plain shell scripts. We
   # don't want to support full (root) shell expressiveness here, so restrict
@@ -144,17 +144,17 @@ in
           in rg + local;
       };
 
-    security.sudo.extraRules =
+    flyingcircus.passwordlessSudoRules =
       let ipt = x: "${pkgs.iptables}/bin/ip${x}tables";
       in [
         {
-          commands = [ { command = "${ipt ""} -L*"; options = [ "NOPASSWD" ]; }
-                       { command = "${ipt "6"} -L*"; options = [ "NOPASSWD" ]; } ];
+          commands = [ "${ipt ""} -L*"
+                       "${ipt "6"} -L*" ];
           groups = [ "users" "service" ];
         }
         {
-          commands = [ { command = "${checkIPTables}"; options = [ "NOPASSWD" ]; } ];
-          users = [ "sensuclient" ];
+          commands = [ "${checkIPTables}" ];
+          groups = [ "sensuclient" ];
         }
       ];
 

--- a/nixos/platform/packages.nix
+++ b/nixos/platform/packages.nix
@@ -73,10 +73,9 @@
     ] ++
     lib.optional (!config.services.postgresql.enable) pkgs.postgresql;
 
-    security.sudo.extraRules = [
+    flyingcircus.passwordlessSudoRules = [
       { 
-        commands = [ { command = "${pkgs.iotop}/bin/iotop"; 
-                       options = [ "NOPASSWD" ]; } ];
+        commands = [ "${pkgs.iotop}/bin/iotop" ];
         groups = [ "sudo-srv" "service" ];
       }
     ];

--- a/nixos/platform/users.nix
+++ b/nixos/platform/users.nix
@@ -172,6 +172,20 @@ in
       adminsGroup = mkDefault (fclib.jsonFromFile cfg.adminsGroupPath "{}");
     };
 
+    flyingcircus.passwordlessSudoRules = [
+      # Allow sudo-srv users to become service user
+      { 
+        commands = [ "ALL" ];
+        groups = [ "sudo-srv" ]; 
+        runAs = "%service";
+      }
+      # Allow applying config and restarting services to service users
+      {
+        commands = [ "${pkgs.systemd}/bin/systemctl" ];
+        groups = [ "sudo-srv" "service" ];
+      }
+    ];
+
     security.pam.services.sshd.showMotd = true;
 
     security.sudo = {
@@ -188,18 +202,6 @@ in
         {
           commands = [ { command = "ALL"; options = [ "PASSWD" ]; } ];
           groups = [ "admins" ];
-        }
-        # Allow sudo-srv users to become service user
-        { 
-          commands = [ { command = "ALL"; options = [ "NOPASSWD" ]; } ];
-          groups = [ "sudo-srv" ]; 
-          runAs = "%service";
-        }
-        # Allow applying config and restarting services to service users
-        {
-          commands = [ { command = "${pkgs.systemd}/bin/systemctl"; 
-                         options = [ "NOPASSWD" ]; } ];
-          groups = [ "sudo-srv" "service" ];
         }
       ];
     };

--- a/nixos/roles/rabbitmq.nix
+++ b/nixos/roles/rabbitmq.nix
@@ -72,10 +72,10 @@ with builtins;
         shell = "/run/current-system/sw/bin/bash";
       };
 
-      security.sudo.extraRules = [
+      flyingcircus.passwordlessSudoRules = [
         # Service users may switch to the rabbitmq system user
         {
-          commands = [ { command = "ALL"; options = [ "NOPASSWD" ]; } ];
+          commands = [ "ALL" ];
           groups = [ "sudo-srv" "service" ];
           runAs = "rabbitmq";
         }

--- a/nixos/services/nginx/default.nix
+++ b/nixos/services/nginx/default.nix
@@ -246,11 +246,10 @@ in
 
       security.acme.certs = acmeSettings;
 
-      security.sudo.extraRules = [
+      flyingcircus.passwordlessSudoRules = [
         # sensuclient can run config check script as nginx user
         {
-          commands = [ { command = "${nginxCheckConfig}/bin/nginx-check-config"; 
-                         options = [ "NOPASSWD" ]; } ];
+          commands = [ "${nginxCheckConfig}/bin/nginx-check-config" ];
           groups = [ "sensuclient" ];
         }
       ];

--- a/nixos/services/postfix.nix
+++ b/nixos/services/postfix.nix
@@ -106,9 +106,9 @@ in
       };
     };
 
-    security.sudo.extraRules = [
+    flyingcircus.passwordlessSudoRules = [
       {
-        commands = [ { command = checkMailq; options = [ "NOPASSWD" ]; } ];
+        commands = [ checkMailq ];
         groups = [ "sensuclient" ];
       }
     ];

--- a/nixos/services/postgresql.nix
+++ b/nixos/services/postgresql.nix
@@ -113,10 +113,10 @@ in {
       user = "postgres";
     };
 
-    security.sudo.extraRules = [
+    flyingcircus.passwordlessSudoRules = [
       # Service users may switch to the postgres system user
       {
-        commands = [ { command = "ALL"; options = [ "NOPASSWD" ]; } ];
+        commands = [ "ALL" ];
         groups = [ "sudo-srv" "service" ];
         runAs = "postgres";
       }

--- a/nixos/services/sensu.nix
+++ b/nixos/services/sensu.nix
@@ -243,17 +243,17 @@ in {
         }
     '';
 
-    security.sudo.extraRules = [
+    flyingcircus.passwordlessSudoRules = [
       {
         commands = with pkgs; [
-          { command = "${fc.multiping}/bin/multiping"; options = [ "NOPASSWD" ]; }
-          { command = "${fc.sensuplugins}/bin/check_disk"; options = [ "NOPASSWD" ]; }
+          "${fc.multiping}/bin/multiping"
+          "${fc.sensuplugins}/bin/check_disk"
         ];
         groups = [ "sensuclient" ];
       }
       # Allow sensuclient group to become service user for running custom checks
       { 
-        commands = [ { command = "ALL"; options = [ "NOPASSWD" ]; } ];
+        commands = [ "ALL" ];
         groups = [ "sensuclient" ]; 
         runAs = "%service";
       }


### PR DESCRIPTION
* add an option flyingcircus.passwordlessSudoRules that does the right thing
  for common passwordless sudo rules.
* fix vagrant rule placement
* use group instead of user for sensuclient check-iptables

Case 120150

@flyingcircusio/release-managers

## Release process

Impact:

* Correct sudo rules ordering; fixes passwordless sudo access for users with sudo-srv + wheel group (#120150).

Changelog:

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Passwordless access for users with sudo-srv + wheel group should be possible as before on 15.09.
- [x] Security requirements tested? (EVIDENCE)
  - case added to automated test; I looked at the resulting /etc/sudoers in dev
