### PR TITLE
Update my root ssh key (also: some whitespace)

### DIFF
--- a/nixos/platform/static.nix
+++ b/nixos/platform/static.nix
@@ -107,7 +107,7 @@ with lib;
 
       adminKeys = {
         directory = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDSejGFORJ7hlFraV3caVir3rWlo/QcsWptWrukk2C7eaGu/8tXMKgPtBHYdk4DYRi7EcPROllnFVzyVTLS/2buzfIy7XDjn7bwHzlHoBHZ4TbC9auqW3j5oxTDA4s2byP6b46Dh93aEP9griFideU/J00jWeHb27yIWv+3VdstkWTiJwxubspNdDlbcPNHBGOE+HNiAnRWzwyj8D0X5y73MISC3pSSYnXJWz+fI8IRh5LSLYX6oybwGX3Wu+tlrQjyN1i0ONPLxo5/YDrS6IQygR21j+TgLXaX8q8msi04QYdvnOqk1ntbY4fU8411iqoSJgCIG18tOgWTTOcBGcZX directory@directory.fcio.net";
-        ctheune = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIrMeeyMUiSfXGnhvdIk50RsW3VMAbmYAChOGmiKGMUc ctheune@thirteen.fritz.box";
+        ctheune = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHvjFPzQjaDFiBVW44hRbZvLNf1BCAXjfDENi1YO7W2R ctheune";
         ckauhaus = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIB6MKl9D9mzhuB6/sQXNCEW5qq4R7mXlpnxi+QZSGi57 root/ckauhaus@fcio.net";
         zagy = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKqKaOCYLUxtjAs9e3amnTRH5NM2j0kjLOE+5ZGy9/W4 zagy@drrr.local";
         flanitz = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAg5mbkbBk0dngSVmlZJEH0hAUqnu3maJzqEV9Su1Cff flanitz";
@@ -124,10 +124,10 @@ with lib;
       uchiwa = 31003;
       sensuclient = 31004;
       powerdns = 31005;
-      
+
       # removed by upstream, we want to keep it
       memcached = 177;
-      redis = 181; 
+      redis = 181;
     };
 
     ids.gids = {


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

## Security implications

- [X] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

Admins need to have emergency root ssh keys. I lost the passphrase for my current key, probably when we migrated 1Password to the EU account. I have deleted my old root key (public and private) and generated a new one.

- [X] Security requirements tested? (EVIDENCE)

n/a