### PR TITLE
Add verbose logging and debugging for ClamD. (assists 120637)

### DIFF
--- a/nixos/roles/antivirus.nix
+++ b/nixos/roles/antivirus.nix
@@ -20,6 +20,13 @@ in
     services.clamav.daemon = {
       enable = true;
       extraConfig = ''
+        LogTime yes
+        LogClean yes
+        LogVerbose yes
+        ExtendedDetectionInfo yes
+        ExitOnOOM yes
+        Debug yes
+
         TCPSocket 3310
       '' + lib.concatMapStringsSep "\n" (ip: "TCPAddr ${ip}") listenAddresses;
 


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

- ClamD instances will be restarted.

Changelog:

- Generally increase ClamD logging to assist in debugging. (120637)

## Security implications

- [X] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

Logs to systemd journal, subsumed under general logging security requirements.

- [X] Security requirements tested? (EVIDENCE)

Seen logging to journal.