### PR TITLE
Adapt memcached check to configured listen addresses

### DIFF
--- a/nixos/roles/memcached.nix
+++ b/nixos/roles/memcached.nix
@@ -41,9 +41,9 @@ in
 
   (mkIf cfg.enable {
 
-    flyingcircus.localConfigDirs.memcached = { 
+    flyingcircus.localConfigDirs.memcached = {
       dir = "/etc/local/memcached";
-      user = "memcached"; 
+      user = "memcached";
     };
 
     environment.etc = {
@@ -62,11 +62,17 @@ in
     } // localConfig;
 
     flyingcircus.services = {
-      sensu-client.checks.memcached = {
+      sensu-client.checks.memcached =
+      let
+        host =
+          if localConfig ? listen
+          then elemAt (lib.splitString "," localConfig.listen) 0
+          else "localhost";
+      in {
         notification = "memcached alive";
         command = ''
           ${pkgs.sensu-plugins-memcached}/bin/check-memcached-stats.rb \
-            -h localhost -p ${toString port}
+          -h ${host} -p ${toString port}
         '';
       };
 


### PR DESCRIPTION
The memcached check used to connect always to 'localhost' but memcached allows for arbitrary listen addresses. Now the check uses the first configured listen address.

Case 122074

@flyingcircusio/release-managers

## Release process

Impact:

Changelog: Improve memcached check so that locally configured listen addresses will be honoured.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

Improve monitoring visibility.

- [x] Security requirements tested? (EVIDENCE)

 Tested manually with and without /etc/local/memcached/memcached.json
