### PR TITLE
Fix derivePasswordForHost in case of missing enc parameters (broken mysql on vagrant)

### DIFF
--- a/nixos/lib/utils.nix
+++ b/nixos/lib/utils.nix
@@ -17,7 +17,7 @@ rec {
   derivePasswordForHost = prefix:
     builtins.hashString "sha256" (concatStringsSep "/" [
       prefix
-      (lib.attrByPath ["directory_password"] "" config.flyingcircus.enc.parameters)
+      (lib.attrByPath ["parameters" "directory_password"] "" config.flyingcircus.enc)
       config.networking.hostName
     ]);
 


### PR DESCRIPTION
On vagrant, the parameters set is missing which broke some roles.

bugs id: #122228

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Fix MySQL, RabbitMQ and OpenVPN roles on Vagrant (#122228).

## Security implications

not relevant
