### PR TITLE
Port loghost, graylog and elasticsearch roles.

### DIFF
--- a/nixos/lib/utils.nix
+++ b/nixos/lib/utils.nix
@@ -9,10 +9,6 @@ in
 with lib;
 rec {
 
-  # get the DN of this node for LDAP logins.
-  getLdapNodeDN = config:
-    "cn=${config.networking.hostName},ou=Nodes,dc=gocept,dc=com";
-
   # Derives a password from host data and a custom prefix
   derivePasswordForHost = prefix:
     builtins.hashString "sha256" (concatStringsSep "/" [
@@ -21,16 +17,22 @@ rec {
       config.networking.hostName
     ]);
 
+  getLdapNodePassword = derivePasswordForHost "ldap";
+
+  # get the DN of this node for LDAP logins.
+  getLdapNodeDN =
+    "cn=${config.networking.hostName},ou=Nodes,dc=gocept,dc=com";
+
   # Returns service from /etc/nixos/services.json
   # that matches the given name or null, if nothing matches.
   # If there are multiple matches, an error is thrown.
-  findOneService = name: 
-    let 
+  findOneService = name:
+    let
       found = filter (s: s.service == name) config.flyingcircus.encServices;
       len = length found;
     in if len == 0 then null
       else if len == 1 then head found
-      else throw ("Multiple matches for service ${name}: " 
+      else throw ("Multiple matches for service ${name}: "
         + lib.concatMapStringsSep "; " (s: s.address or "<no address>") found);
 
 

--- a/nixos/roles/default.nix
+++ b/nixos/roles/default.nix
@@ -12,6 +12,9 @@ in {
     ./docker.nix
     ./external_net
     ./antivirus.nix
+    ./elasticsearch.nix
+    ./graylog.nix
+    ./loghost.nix
     ./mailserver.nix
     ./memcached.nix
     ./mongodb

--- a/nixos/roles/elasticsearch.nix
+++ b/nixos/roles/elasticsearch.nix
@@ -1,0 +1,265 @@
+{ config, lib, pkgs, ... }:
+
+with builtins;
+
+let
+  cfg = config.flyingcircus.roles.elasticsearch;
+  cfg_service = config.services.elasticsearch;
+  fclib = config.fclib;
+
+  esVersion =
+    if config.flyingcircus.roles.elasticsearch6.enable
+    then "6"
+    else if config.flyingcircus.roles.elasticsearch5.enable
+    then "5"
+    else null;
+
+  package = versionConfiguration.${esVersion}.package;
+  enabled = esVersion != null;
+
+  versionConfiguration = {
+    "5" = {
+      package = pkgs.elasticsearch5;
+      serviceName = "elasticsearch5-node";
+    };
+    "6" = {
+      package = pkgs.elasticsearch6;
+      serviceName = "elasticsearch6-node";
+    };
+    null = {
+      package = null;
+      serviceName = null;
+    };
+  };
+
+  esNodes =
+    if cfg.esNodes == null
+    then map
+      (service: service.address)
+      (filter
+        (s: s.service == versionConfiguration.${esVersion}.serviceName)
+        config.flyingcircus.encServices)
+    else cfg.esNodes;
+
+  thisNode =
+    if config.networking.domain != null
+    then "${config.networking.hostName}.${config.networking.domain}"
+    else "localhost";
+
+  defaultClusterName = config.networking.hostName;
+
+  clusterName =
+    if cfg.clusterName == null
+    then (fclib.configFromFile /etc/local/elasticsearch/clusterName defaultClusterName)
+    else cfg.clusterName;
+
+  additionalConfig =
+    fclib.configFromFile /etc/local/elasticsearch/elasticsearch.yml "";
+
+  currentMemory = fclib.currentMemory 1024;
+
+  esHeap = fclib.min
+    [ (currentMemory * cfg.heapPercentage / 100)
+      (31 * 1024)];
+
+in
+{
+
+  options = with lib; {
+
+    flyingcircus.roles.elasticsearch = {
+
+      clusterName = mkOption {
+        type = types.nullOr types.string;
+        default = null;
+        description = ''
+          The clusterName elasticsearch will use.
+        '';
+      };
+
+      dataDir = mkOption {
+        type = types.path;
+        default = "/srv/elasticsearch";
+        description = ''
+          Data directory for elasticsearch.
+        '';
+      };
+
+      heapPercentage = mkOption {
+        type = types.int;
+        default = 50;
+        description = ''
+          Tweak amount of memory to use for ES heap
+          (systemMemory * heapPercentage / 100)
+        '';
+      };
+
+      esNodes = mkOption {
+        type = types.nullOr (types.listOf types.string);
+        default = null;
+      };
+
+    };
+
+    flyingcircus.roles.elasticsearch5.enable =
+      mkEnableOption "Enable the Flying Circus elasticsearch5 role.";
+
+    flyingcircus.roles.elasticsearch6.enable =
+      mkEnableOption "Enable the Flying Circus elasticsearch6 role.";
+
+  };
+
+  config = lib.mkMerge [
+    (lib.mkIf enabled {
+
+    services.elasticsearch = {
+      enable = true;
+      package = package;
+      listenAddress = thisNode;
+      dataDir = cfg.dataDir;
+      cluster_name = clusterName;
+      extraJavaOptions = [
+       "-Des.path.scripts=${cfg_service.dataDir}/scripts"
+       "-Des.security.manager.enabled=false"
+       # Xms and Xmx are already defined as cmdline args by config/jvm.options.
+       # Appending the next two lines overrides the former.
+       "-Xms${toString esHeap}m"
+       "-Xmx${toString esHeap}m"
+
+      ];
+      extraConf = ''
+        node.name: ${config.networking.hostName}
+        discovery.zen.ping.unicast.hosts: ${builtins.toJSON esNodes}
+        bootstrap.memory_lock: true
+        ${additionalConfig}
+      '';
+    };
+
+    systemd.services.elasticsearch = {
+      serviceConfig = {
+        LimitMEMLOCK = "infinity";
+        Restart = "always";
+        StartLimitInterval=480;
+        StartLimitBurst=3;
+      };
+      preStart = lib.mkAfter ''
+        # Install scripts
+        mkdir -p ${cfg_service.dataDir}/scripts
+      '';
+      postStart = let
+        url = "http://${thisNode}:9200/_cat/health";
+        in ''
+        # Wait until available for use
+        for count in {0..120}; do
+            ${pkgs.curl}/bin/curl -s ${url} && exit
+            echo "Trying to connect to ${url} for ''${count}s"
+            sleep 1
+        done
+        echo "No connection to ${url} for 120s, giving up"
+        exit 1
+      '';
+    };
+
+    flyingcircus.activationScripts.elasticsearch = ''
+      install -d -o ${toString config.ids.uids.elasticsearch} -g service -m 02775 \
+        /etc/local/elasticsearch/
+    '';
+
+    environment.etc."local/elasticsearch/README.txt".text = ''
+      Elasticsearch is running on this VM.
+
+      It is forming the cluster named ${clusterName}
+      To change the cluster name, add a file named "clusterName" here, with the
+      cluster name as its sole contents.
+
+      To add additional configuration options, create a file "elasticsearch.yml"
+      here. Its contents will be appended to the base configuration.
+    '';
+
+    flyingcircus.services.sensu-client.checks = {
+
+      es_circuit_breakers = {
+        notification = "ES: Circuit Breakers active";
+        command = ''
+          ${pkgs.sensu-plugins-elasticsearch}/bin/check-es-circuit-breakers.rb \
+            -h ${thisNode}
+        '';
+        interval = 300;
+      };
+
+      es_cluster_health = {
+        notification = "ES: Cluster Health";
+        command = ''
+        ${pkgs.sensu-plugins-elasticsearch}/bin/check-es-cluster-health.rb \
+          -h ${thisNode}
+        '';
+      };
+
+      es_file_descriptor = {
+        notification = "ES: File descriptors in use";
+        command = ''
+          ${pkgs.sensu-plugins-elasticsearch}/bin/check-es-file-descriptors.rb \
+            -h ${thisNode}
+        '';
+        interval = 300;
+      };
+
+      es_heap = {
+        notification = "ES: Heap too full";
+        command = ''
+          ${pkgs.sensu-plugins-elasticsearch}/bin/check-es-heap.rb \
+            -h ${thisNode} -w 80 -c 90 -P
+        '';
+        interval = 300;
+      };
+
+      es_node_status = {
+        notification = "ES: Node status";
+        command = ''
+          ${pkgs.sensu-plugins-elasticsearch}/bin/check-es-node-status.rb \
+            -h ${thisNode}
+        '';
+      };
+
+      es_shard_allocation_status = {
+        notification = "ES: Shard allocation status";
+        command = ''
+          ${pkgs.sensu-plugins-elasticsearch}/bin/check-es-shard-allocation-status.rb \
+            -s ${thisNode}
+        '';
+        interval = 300;
+      };
+
+    };
+
+    systemd.services.prometheus-elasticsearch-exporter = {
+      description = "Prometheus exporter for elasticsearch metrics";
+      wantedBy = [ "multi-user.target" ];
+      path = [ pkgs.prometheus-elasticsearch-exporter ];
+      script = ''
+        exec elasticsearch_exporter\
+            --es.uri http://${thisNode}:9200 \
+            --web.listen-address localhost:9108
+      '';
+      serviceConfig = {
+        User = "nobody";
+        Restart = "always";
+        PrivateTmp = true;
+        WorkingDirectory = /tmp;
+        ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
+      };
+    };
+
+    flyingcircus.services.telegraf.inputs = {
+      prometheus  = [{
+        urls = [ "http://localhost:9108/metrics" ];
+      }];
+    };
+  })
+
+  {
+    flyingcircus.roles.statshost.globalAllowedMetrics = [ "elasticsearch" ];
+  }
+
+  ];
+}

--- a/nixos/roles/graylog.nix
+++ b/nixos/roles/graylog.nix
@@ -1,0 +1,289 @@
+# NOTES:
+# * Mongo cluster setup requires manual intervention.
+# * Logstash lumberjack plugin doesn't exist for graylog 3.x.
+#   Use integrated beats support.
+
+{ config, options, lib, pkgs, ... }:
+
+with builtins;
+
+let
+  cfg = config.flyingcircus.roles.graylog;
+  fclib = config.fclib;
+  glAPIHAPort = 8002;
+  gelfTCPHAPort = 12201;
+  listenFQDN = "${config.networking.hostName}.${config.networking.domain}";
+  slash = addr: if fclib.isIp4 addr then "/32" else "/128";
+  syslogInputPort = config.flyingcircus.services.graylog.syslogInputPort;
+  gelfTCPGraylogPort = config.flyingcircus.services.graylog.gelfTCPGraylogPort;
+  glAPIPort = config.flyingcircus.services.graylog.apiPort;
+  replSetName = if cfg.cluster then "graylog" else "";
+
+  jsonConfig = (fromJSON
+    (fclib.configFromFile /etc/local/graylog/graylog.json "{}"));
+
+  # First graylog or loghost node becomes master
+  glNodes =
+    fclib.listServiceAddresses "loghost-server" ++
+    fclib.listServiceAddresses "graylog-server";
+
+  masterHostname =
+    (head
+      (lib.splitString
+        "."
+        (head glNodes)));
+in
+{
+
+  options = with lib; {
+
+    flyingcircus.roles.graylog = {
+
+      enable = mkEnableOption ''
+          Graylog (3.x) role.
+
+          Note: there can be multiple graylogs per RG, unlike loghost.
+        '';
+
+      cluster = mkOption {
+        type = types.bool;
+        default = true;
+        description = "Build a GL cluster. Usually disabled by loghost role.";
+      };
+
+      publicFrontend = {
+
+        enable = mkEnableOption "Configure Nginx for GL UI on FE at 80/443?";
+
+        ssl = mkOption {
+          type = types.bool;
+          default = true;
+          description = ''
+            Enable SSL via Let's Encrypt.
+          '';
+        };
+
+        hostName = mkOption {
+          type = types.nullOr types.str;
+          default = "graylog.${config.flyingcircus.enc.parameters.resource_group}.fcio.net";
+          description = "HTTP host name for the GL frontend.";
+          example = "graylog.example.com";
+        };
+      };
+    };
+  };
+
+  config = lib.mkMerge [
+
+    (lib.mkIf cfg.publicFrontend.enable {
+      services.nginx.virtualHosts."${cfg.publicFrontend.hostName}" = {
+        enableACME = cfg.publicFrontend.ssl;
+        forceSSL = cfg.publicFrontend.ssl;
+        locations = {
+          "/" = {
+            proxyPass = "http://${listenFQDN}:${toString glAPIHAPort}";
+            extraConfig = ''
+              proxy_set_header Remote-User "";
+              proxy_set_header X-Graylog-Server-URL https://${cfg.publicFrontend.hostName}/;
+            '';
+          };
+          "/admin" = {
+            proxyPass = "http://${listenFQDN}:${toString glAPIHAPort}";
+            extraConfig = ''
+              auth_basic "FCIO user";
+              auth_basic_user_file "/etc/local/nginx/htpasswd_fcio_users";
+            '';
+          };
+        };
+      };
+    })
+
+    (lib.mkIf (jsonConfig ? heapPercentage) {
+      flyingcircus.services.graylog.heapPercentage = jsonConfig.heapPercentage;
+    })
+
+    (lib.mkIf (jsonConfig ? publicFrontend) {
+      flyingcircus.roles.graylog.publicFrontend.enable = jsonConfig.publicFrontend;
+    })
+
+    (lib.mkIf (jsonConfig ? publicFrontendHostname) {
+      flyingcircus.roles.graylog.publicFrontend.hostName = jsonConfig.publicFrontendHostname;
+    })
+
+    (lib.mkIf cfg.enable {
+
+      networking.firewall.allowedTCPPorts = [ 9002 ];
+
+      flyingcircus.services.graylog = {
+
+        enable = true;
+        isMaster = masterHostname == config.networking.hostName;
+
+        mongodbUri = let
+          repl = if cfg.cluster then "?replicaSet=${replSetName}" else "";
+          mongodbNodes = concatStringsSep ","
+              (map (node: "${node}:27017") glNodes);
+          in
+            "mongodb://${mongodbNodes}/graylog${repl}";
+
+        config = jsonConfig.extraGraylogConfig or {};
+
+      };
+
+      flyingcircus.roles.mongodb34.enable = true;
+      services.mongodb.replSetName = replSetName;
+      services.mongodb.extraConfig = ''
+        storage.wiredTiger.engineConfig.cacheSizeGB: 1
+      '';
+
+      flyingcircus.roles.nginx.enable = true;
+
+      flyingcircus.localConfigDirs.graylog = {
+        dir = "/etc/local/graylog";
+        user = "graylog";
+      };
+
+      environment.etc."local/graylog/README.txt".text = ''
+        Graylog (${config.services.graylog.package.version}) is running on this machine.
+
+        If you need to set non-default configuration options, you can put a
+        file called `graylog.json` into this directory.
+        Have a look at graylog.json.example in this directory.
+
+        Available options:
+
+        * publicFrontend: set to true to serve the Graylog dashboard on
+          the public interface via HTTPS.
+        * publicFrontendHostname: set hostname for Graylog dashboard,
+          default is ${options.flyingcircus.roles.graylog.publicFrontend.hostName.default}.
+        * heapPercentage (int): Fraction of system memory that is used for
+          Graylog, in percent.
+        * extraGraylogConfig (object): Addional config params supported by
+          Graylog's server config file.
+          See https://docs.graylog.org/en/3.0/pages/configuration/server.conf.html.
+
+        '';
+
+      environment.etc."local/graylog/graylog.json.example".text = ''
+        {
+          "publicFrontend": true,
+          "heapPercentage": 70,
+          "extraGraylogConfig": {
+            "processbuffer_processors": 4,
+            "trusted_proxies": "127.0.0.1/32, 0:0:0:0:0:0:0:1/128"
+          }
+        }
+      '';
+
+      services.nginx.virtualHosts."${cfg.publicFrontend.hostName}:9002" =
+      let
+        mkListen = addr: { inherit addr; port = 9002; };
+      in {
+        listen = map mkListen (fclib.listenAddressesQuotedV6 "ethsrv");
+        locations = {
+          "/" = {
+            proxyPass = "http://${listenFQDN}:${toString glAPIHAPort}";
+            extraConfig = ''
+              # Direct access w/o prior authentication. This is useful for API access.
+              # Strip Remote-User as there is nothing in between the user and us.
+              proxy_set_header Remote-User "";
+              proxy_set_header X-Graylog-Server-URL http://${listenFQDN}:9002/;
+            '';
+          };
+        };
+      };
+      # HAProxy load balancer.
+      # Since haproxy is rather lightweight we just fire up one on each graylog
+      # node, talking to all known graylog nodes.
+      flyingcircus.services.haproxy.enable = true;
+
+      services.haproxy.config = lib.mkForce (let
+        backendConfig = node_config: lib.concatStringsSep "\n"
+          (map
+            (node: "    " + (node_config node))
+            glNodes);
+        listenConfig = port: lib.concatStringsSep "\n"
+          (map
+            (addr: "    bind ${addr}:${toString port}")
+            (fclib.listenAddresses "ethsrv"));
+      in ''
+        global
+            daemon
+            chroot /var/empty
+            user haproxy
+            group haproxy
+            maxconn 4096
+            log localhost local2
+            stats socket ${config.flyingcircus.services.haproxy.statsSocket} mode 660 group nogroup level operator
+
+        defaults
+            mode http
+            log global
+            option dontlognull
+            option http-keep-alive
+            option redispatch
+
+            timeout connect 5s
+            timeout client 30s    # should be equal to server timeout
+            timeout server 30s    # should be equal to client timeout
+            timeout queue 30s
+
+        frontend gelf-tcp-in
+        ${listenConfig gelfTCPHAPort}
+            mode tcp
+            option tcplog
+            timeout client 10s # should be equal to server timeout
+
+            default_backend gelf_tcp
+
+        frontend graylog_http
+        ${listenConfig glAPIHAPort}
+            use_backend stats if { path_beg /admin/stats }
+            option httplog
+            timeout client 121s    # should be equal to server timeout
+            default_backend graylog
+
+        backend gelf_tcp
+            mode tcp
+            balance leastconn
+            option httpchk HEAD /api/system/lbstatus
+            timeout server 10s
+            timeout tunnel 61s
+        ${backendConfig (node:
+            "server ${node}  ${node}:${toString gelfTCPGraylogPort} check port ${toString glAPIPort} inter 10s rise 2 fall 1")}
+
+        backend graylog
+            balance roundrobin
+            option httpchk GET /
+            timeout server 121s    # should be equal to client timeout
+        ${backendConfig (node:
+            "server ${node}  ${node}:${toString glAPIPort} check fall 1 rise 2 inter 10s maxconn 20")}
+
+        backend stats
+            stats uri /
+            stats refresh 5s
+      '');
+    })
+
+    (lib.mkIf (length glNodes > 0) {
+      # Forward all syslog to graylog, if there is one in the RG.
+      flyingcircus.syslog.extraRules = ''
+        *.* @${head glNodes}:${toString syslogInputPort};RSYSLOG_SyslogProtocol23Format
+      '';
+    })
+
+    {
+
+      flyingcircus.roles.statshost.prometheusMetricRelabel = [
+        {
+          source_labels = [ "__name__" ];
+          regex = "(org_graylog2)_(.*)$";
+          replacement = "graylog_\${2}";
+          target_label = "__name__";
+        }
+      ];
+      flyingcircus.roles.statshost.globalAllowedMetrics = [ "graylog" ];
+    }
+
+  ];
+}

--- a/nixos/services/default.nix
+++ b/nixos/services/default.nix
@@ -7,6 +7,7 @@
   imports = [
     ./box/client.nix
     ./collectdproxy.nix
+    ./graylog.nix
     ./haproxy.nix
     ./logrotate
     ./nginx

--- a/nixos/services/graylog.nix
+++ b/nixos/services/graylog.nix
@@ -1,0 +1,506 @@
+{ config, lib, pkgs, ... }:
+
+with builtins;
+
+let
+  cfg = config.flyingcircus.services.graylog;
+  fclib = config.fclib;
+
+  listenFQDN = "${config.networking.hostName}.${config.networking.domain}";
+  # graylog listens on first srv ipv6 address
+  listenIP = (head config.networking.interfaces.ethsrv.ipv6.addresses).address;
+  # FQDN doesn't work here
+  httpBindAddress = "[${listenIP}]:${toString cfg.apiPort}";
+  webListenUri = "http://${listenFQDN}:${toString cfg.apiPort}";
+  restListenUri = "${webListenUri}/api";
+
+  glNodes =
+    fclib.listServiceAddresses "loghost-server" ++
+    fclib.listServiceAddresses "graylog-server";
+
+  glPlugins = pkgs.buildEnv {
+    name = "graylog-plugins";
+    paths = cfg.plugins;
+  };
+
+  # Secrets can be set in advance (for example, to share a password across nodes).
+  # Missing files will be generated when the graylog service starts.
+
+  # This password can be used to login with the admin user.
+  rootPasswordFile = "/etc/local/graylog/password";
+  passwordSecretFile = "/etc/local/graylog/password_secret";
+
+  rootPassword = fclib.servicePassword {
+    user = cfg.user;
+    file = rootPasswordFile;
+    token = config.networking.hostName;
+  };
+
+  passwordSecret = fclib.servicePassword {
+    user = cfg.user;
+    file = passwordSecretFile;
+    token = config.networking.hostName;
+  };
+
+  graylogShowConfig = pkgs.writeScriptBin "graylog-show-config" ''
+    cat /run/graylog/graylog.conf
+  '';
+
+  defaultGraylogConfig = let
+    slash = addr: if fclib.isIp4 addr then "/32" else "/128";
+    otherGraylogNodes =
+      filter
+        (a: elem "${a.name}.${config.networking.domain}" glNodes)
+        config.flyingcircus.encAddresses;
+
+  in {
+    http_bind_address = httpBindAddress;
+    http_publish_uri = webListenUri;
+    timezone = config.time.timeZone;
+
+    processbuffer_processors =
+      fclib.max [
+        ((fclib.currentCores 1) - 2)
+        5
+      ];
+
+    outputbuffer_processors =
+      fclib.max [
+        ((fclib.currentCores 1) / 2)
+        3
+      ];
+  } //
+  lib.optionalAttrs (otherGraylogNodes != []) {
+    trusted_proxies =
+      concatMapStringsSep
+        ", "
+        (a: (fclib.stripNetmask a.ip) + (slash a.ip))
+        otherGraylogNodes;
+  };
+
+  graylogConf = let
+      mkLine = name: value: "${name} = ${toString value}";
+    in ''
+      is_master = ${lib.boolToString cfg.isMaster}
+      node_id_file = ${cfg.nodeIdFile}
+      elasticsearch_hosts = ${lib.concatStringsSep "," cfg.elasticsearchHosts}
+      message_journal_dir = ${cfg.messageJournalDir}
+      mongodb_uri = ${cfg.mongodbUri}
+      plugin_dir = /var/lib/graylog/plugins
+
+      # secrets
+      root_password_sha2 = $(sha256sum ${rootPassword.file} | cut -f1 -d " ")
+      password_secret = $(cat "${passwordSecret.file}")
+
+      # Settings here can be overridden by flyingcircus.services.graylog.config.
+    '' + lib.concatStringsSep
+            "\n"
+            (lib.mapAttrsToList
+              mkLine
+                (defaultGraylogConfig // cfg.config));
+
+  graylogConfPath = "/run/graylog/graylog.conf";
+
+  telegrafPassword = fclib.derivePasswordForHost "graylog-telegraf";
+
+in {
+
+  options = with lib; {
+
+    flyingcircus.services.graylog = {
+
+      enable = mkEnableOption "Preconfigured Graylog (3.x).";
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.graylog;
+        defaultText = "pkgs.graylog";
+        example = literalExample "pkgs.graylog";
+        description = "Graylog package to use.";
+      };
+
+      user = mkOption {
+        type = types.str;
+        default = "graylog";
+        example = literalExample "graylog";
+        description = "User account under which graylog runs";
+      };
+
+      isMaster = mkOption {
+        type = types.bool;
+        default = true;
+        description = "Use this graylog node as master. Only one master per cluster is allowed.";
+      };
+
+      nodeIdFile = mkOption {
+        type = types.str;
+        default = "/var/lib/graylog/server/node-id";
+        description = "Path of the file containing the graylog node-id";
+      };
+
+      elasticsearchHosts = mkOption {
+        type = types.listOf types.str;
+        example = literalExample ''[ "http://node1:9200" "http://user:password@node2:19200" ]'';
+        description = "List of valid URIs of the http ports of your elastic nodes. If one or more of your elasticsearch hosts require authentication, include the credentials in each node URI that requires authentication";
+      };
+
+      messageJournalDir = mkOption {
+        type = types.str;
+        default = "/var/lib/graylog/data/journal";
+        description = "The directory which will be used to store the message journal. The directory must be exclusively used by Graylog and must not contain any other files than the ones created by Graylog itself";
+      };
+
+      mongodbUri = mkOption {
+        type = types.str;
+        default = "mongodb://localhost/graylog";
+        description = "MongoDB connection string. See http://docs.mongodb.org/manual/reference/connection-string/ for details";
+      };
+
+      plugins = mkOption {
+        description = "Extra graylog plugins";
+        default = with pkgs.graylogPlugins; [ slack ];
+        type = types.listOf types.package;
+      };
+
+      heapPercentage = mkOption {
+        type = types.int;
+        default = 70;
+        description = "How much RAM should go to graylog heap.";
+      };
+
+      gelfTCPGraylogPort = mkOption {
+        type = types.int;
+        default = 12202;
+      };
+
+      apiPort = mkOption {
+        type = types.int;
+        default = 9001;
+      };
+
+      syslogInputPort = mkOption {
+        type = types.int;
+        default = 5140;
+        description = "UDP Port for the Graylog syslog input.";
+      };
+
+      config = mkOption {
+        type = types.attrs;
+        default = {};
+        description = ''
+          Additional config params for the Graylog server config file.
+          They override default settings defined by this service with the same name.
+        '';
+      };
+    };
+  };
+
+
+  config = lib.mkIf cfg.enable {
+
+    users.users = lib.mkIf (cfg.user == "graylog") {
+      graylog = {
+        uid = config.ids.uids.graylog;
+        description = "Graylog server daemon user";
+      };
+    };
+
+    systemd.tmpfiles.rules = [
+      "d '${cfg.messageJournalDir}' - ${cfg.user} - - -"
+      "d '/run/graylog' - ${cfg.user} - - -"
+    ];
+
+    environment.etc."local/graylog/api_url".text = restListenUri;
+
+    environment.systemPackages = [ graylogShowConfig ];
+
+    systemd.services.graylog = {
+
+      description = "Graylog Server";
+      wantedBy = [ "multi-user.target" ];
+      environment = let
+        pkg = config.services.graylog.package;
+        javaHeap = ''${toString
+          (fclib.max [
+            ((fclib.currentMemory 1024) * cfg.heapPercentage / 100)
+            768
+            ])}m'';
+
+        javaOpts = [
+          "-Djava.library.path=${pkg}/lib/sigar"
+          "-Xms${javaHeap}"
+          "-Xmx${javaHeap}"
+          "-XX:NewRatio=1"
+          "-server"
+          "-XX:+ResizeTLAB"
+          "-XX:+UseConcMarkSweepGC"
+          "-XX:+CMSConcurrentMTEnabled"
+          "-XX:+CMSClassUnloadingEnabled"
+          "-XX:+UseParNewGC"
+          "-XX:-OmitStackTraceInFastThrow"
+        ];
+
+      in {
+        JAVA_HOME = pkgs.jre_headless;
+        GRAYLOG_CONF = graylogConfPath;
+        JAVA_OPTS = lib.concatStringsSep " " javaOpts;
+      };
+
+      path = [ pkgs.jre_headless pkgs.which pkgs.procps ];
+
+      preStart = ''
+        rm -rf /var/lib/graylog/plugins || true
+        mkdir -p /var/lib/graylog/plugins -m 755
+
+        mkdir -p "$(dirname ${cfg.nodeIdFile})"
+        chown -R ${cfg.user} "$(dirname ${cfg.nodeIdFile})"
+
+        for declarativeplugin in `ls ${glPlugins}/bin/`; do
+          ln -sf ${glPlugins}/bin/$declarativeplugin /var/lib/graylog/plugins/$declarativeplugin
+        done
+        for includedplugin in `ls ${cfg.package}/plugin/`; do
+          ln -s ${cfg.package}/plugin/$includedplugin /var/lib/graylog/plugins/$includedplugin || true
+        done
+
+        # Generate secrets if missing and write config file
+
+        ${rootPassword.generate}
+        ${passwordSecret.generate}
+
+        cat > ${graylogConfPath} << EOF
+        ${graylogConf}
+        EOF
+
+        chown ${cfg.user}:service ${graylogConfPath}
+        chmod 440 ${graylogConfPath}
+      '';
+
+      postStart = ''
+        # Wait until GL is available for use
+        for count in {0..120}; do
+            ${pkgs.curl}/bin/curl -s ${webListenUri} && exit
+            echo "Trying to connect to ${webListenUri} for ''${count}s"
+            sleep 1
+        done
+        echo "No connection to ${webListenUri} for 120s, giving up"
+        exit 1
+      '';
+
+      serviceConfig = {
+        Restart = "always";
+        # Starting just takes a long time...
+        TimeoutStartSec = 240;
+        PermissionsStartOnly = true;
+        User = "${cfg.user}";
+        StateDirectory = "graylog";
+        ExecStart = "${cfg.package}/bin/graylogctl run";
+      };
+
+    };
+
+    systemd.services.fc-graylog-config = {
+      description = "Configure Graylog FCIO settings";
+      requires = [ "graylog.service" ];
+      after = [ "graylog.service" "mongodb.service" "elasticsearch.service" ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        Type = "oneshot";
+        User = config.services.graylog.user;
+        RemainAfterExit = true;
+      };
+      script = let
+
+        syslogUdpConfiguration = {
+          configuration = {
+            bind_address = "0.0.0.0";
+            port = cfg.syslogInputPort;
+          };
+          title = "Syslog UDP"; # be careful changing it, it's used as
+                                # a primary key for identifying the config
+                                # object
+          type = "org.graylog2.inputs.syslog.udp.SyslogUDPInput";
+          global = true;
+        };
+
+        gelfTcpConfiguration = {
+          configuration = {
+            bind_address = "0.0.0.0";
+            port = cfg.gelfTCPGraylogPort;
+          };
+          title = "GELF TCP";
+          type = "org.graylog2.inputs.gelf.tcp.GELFTCPInput";
+          global = true;
+        };
+
+        geodbConfiguration = {
+          enabled = true;
+          db_type = "MAXMIND_CITY";
+          db_path = "/var/lib/graylog/GeoLite2-City.mmdb";
+        };
+
+        ldapConfiguration = {
+            enabled = true;
+            system_username = fclib.getLdapNodeDN;
+            system_password = fclib.getLdapNodePassword;
+            ldap_uri = "ldaps://ldap.rzob.gocept.net:636/";
+            trust_all_certificates = true;
+            use_start_tls = false;
+            active_directory = false;
+            search_base = "ou=People,dc=gocept,dc=com";
+            search_pattern = "(&(&(objectClass=inetOrgPerson)(uid={0}))(memberOf=cn=${config.flyingcircus.enc.parameters.resource_group},ou=GroupOfNames,dc=gocept,dc=com))";
+            display_name_attribute = "displayName";
+            default_group = "Admin";
+        };
+
+        metricsRole = {
+          description = "Provides read access to all system metrics";
+          permissions = ["metrics:*"];
+          read_only = false;
+        };
+
+        telegrafUser = {
+          password = telegrafPassword;
+          roles = [ "Metrics" ];
+        };
+
+        callApi = what: "${pkgs.fc.agent}/bin/fc-graylog ${what}";
+
+        configureInput = input:
+          callApi "configure --input '${toJSON input}'";
+      in ''
+        ${configureInput syslogUdpConfiguration}
+        ${configureInput gelfTcpConfiguration}
+
+        ${callApi ''
+          call \
+          -s 202 \
+          /system/cluster_config/org.graylog.plugins.map.config.GeoIpResolverConfig \
+          '${toJSON geodbConfiguration}'
+        ''}
+
+        ${callApi ''
+          call \
+          -s 204 \
+          /system/ldap/settings \
+          '${toJSON ldapConfiguration}'
+        ''}
+
+        ${callApi "ensure-role Metrics '${toJSON metricsRole}'"}
+
+        ${callApi "ensure-user telegraf '${toJSON telegrafUser}'"}
+      '';
+    };
+
+    systemd.services.graylog-update-geolite = {
+      description = "Update geolite db for graylog";
+      restartIfChanged = false;
+      after = [ "graylog.service" ];
+      path = with pkgs; [ gzip curl ];
+      serviceConfig = {
+        User = config.services.graylog.user;
+        Type = "oneshot";
+      };
+
+      script = ''
+        cd /var/lib/graylog
+        curl -O http://geolite.maxmind.com/download/geoip/database/GeoLite2-City.mmdb.gz
+        gunzip -f GeoLite2-City.mmdb.gz
+      '';
+    };
+
+    systemd.timers.graylog-update-geolite = {
+      description = "Timer for updating the geolite db for graylog";
+      wantedBy = [ "timers.target" ];
+      timerConfig = {
+        Unit = "graylog-update-geolite.service";
+        OnStartupSec = "10m";
+        OnUnitActiveSec = "30d";
+        RandomSec = "3m";
+      };
+    };
+
+    systemd.services.graylog-collect-journal-age-metric = rec {
+      description = "Collect journal age and report to Telegraf";
+      wantedBy = [ "graylog.service" "telegraf.service" "fc-graylog-config.service" ];
+      after = wantedBy;
+      serviceConfig = {
+        User = "telegraf";
+        Restart = "always";
+        RestartSec = "10";
+        ExecStart = ''
+          ${pkgs.fc.agent}/bin/fc-graylog \
+            -u telegraf \
+            -p '${telegrafPassword}' \
+            collect-journal-age-metric --socket-path /run/telegraf/influx.sock
+
+        '';
+      };
+    };
+
+    services.collectd.extraConfig = ''
+      LoadPlugin curl_json
+      <Plugin curl_json>
+        <URL "${restListenUri}/system/journal">
+          User "admin"
+          Password "${rootPassword.value}"
+          Header "Accept: application/json"
+          Instance "graylog"
+          <Key "uncommitted_journal_entries">
+            Type "gauge"
+          </Key>
+          <Key "append_events_per_second">
+            Type "gauge"
+          </Key>
+          <Key "read_events_per_second">
+            Type "gauge"
+          </Key>
+        </URL>
+        <URL "${restListenUri}/system/throughput">
+          User "admin"
+          Password "${rootPassword.value}"
+          Header "Accept: application/json"
+          Instance "graylog"
+          <Key "throughput">
+            Type "gauge"
+          </Key>
+        </URL>
+      </Plugin>
+    '';
+
+    flyingcircus.services.sensu-client.checks = {
+
+      graylog_ui = {
+        notification = "Graylog UI alive";
+        command = ''
+          ${pkgs.monitoring-plugins}/bin/check_http \
+            -H ${listenFQDN} -p ${toString cfg.apiPort} \
+            -u /
+        '';
+      };
+
+    };
+
+    flyingcircus.services.telegraf.inputs.graylog = [
+      {
+        servers = [ "${restListenUri}/system/metrics/multiple" ];
+        metrics = [ "jvm.memory.total.committed"
+                    "jvm.memory.total.used"
+                    "jvm.threads.count"
+                    "org.graylog2.buffers.input.size"
+                    "org.graylog2.buffers.input.usage"
+                    "org.graylog2.buffers.output.size"
+                    "org.graylog2.buffers.output.usage"
+                    "org.graylog2.buffers.process.size"
+                    "org.graylog2.buffers.process.usage"
+                    "org.graylog2.journal.oldest-segment"
+                    "org.graylog2.journal.size"
+                    "org.graylog2.journal.size-limit"
+                    "org.graylog2.throughput.input"
+                    "org.graylog2.throughput.output" ];
+        username = "telegraf";
+        password = telegrafPassword;
+      }
+    ];
+  };
+
+}

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -54,6 +54,7 @@ in {
   percona57 = super.callPackage ./percona/5.7.nix { boost = self.boost159; };
   percona80 = super.callPackage ./percona/8.0.nix { boost = self.boost169; };
 
+  prometheus-elasticsearch-exporter = super.callPackage ./prometheus-elasticsearch-exporter.nix { };
   qpress = super.callPackage ./percona/qpress.nix { };
 
   rabbitmq-server_3_6_5 = super.callPackage ./rabbitmq-server/3.6.5.nix {

--- a/pkgs/prometheus-elasticsearch-exporter.nix
+++ b/pkgs/prometheus-elasticsearch-exporter.nix
@@ -1,0 +1,27 @@
+{ stdenv, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "elasticsearch_exporter-${version}";
+  version = "1.0.2";
+  rev = "v${version}";
+
+  goPackagePath = "github.com/justwatchcom/elasticsearch_exporter";
+
+  src = fetchFromGitHub {
+    inherit rev;
+    owner = "justwatchcom";
+    repo = "elasticsearch_exporter";
+    sha256 = "0ms23hqgz5xvzc74ysc5d43v3rvv4hbg6p3zcg84cimfqhg4ilcy";
+  };
+
+  # # FIXME: megacli test fails
+  # doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Prometheus exporter for elasticsearch";
+    homepage = https://github.com/justwatchcom/elasticsearch_exporter;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ zagy ];
+    platforms = platforms.unix;
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -24,6 +24,7 @@ in {
   docker = callTest (nixpkgs + /nixos/tests/docker.nix) {};
   fcagent = callTest ./fcagent.nix {};
   garbagecollect = callTest ./garbagecollect.nix {};
+  graylog = callTest ./graylog.nix {};
   login = callTest ./login.nix {};
   logrotate = callTest ./logrotate.nix {};
   mail = callSubTests ./mail.nix {};

--- a/tests/graylog.nix
+++ b/tests/graylog.nix
@@ -1,0 +1,96 @@
+import ./make-test.nix ({ pkgs, lib, ... }:
+let
+  ipv4 = "192.168.101.1";
+  ipv6 = "2001:db8:f030:1c3::1";
+in {
+  name = "graylog";
+  machine =
+    { config, ... }:
+    {
+      imports = [
+        ../nixos
+        ../nixos/roles
+      ];
+
+      virtualisation.memorySize = 4096;
+
+      flyingcircus.roles.loghost.enable = true;
+      networking.domain = "fcio.net";
+
+      services.telegraf.enable = true;  # set in infra/fc but not in infra/testing
+
+      flyingcircus.enc.parameters = {
+        directory_password = "asdf";
+        resource_group = "test";
+        interfaces.srv = {
+          mac = "52:54:00:12:34:56";
+          networks = {
+            "192.168.101.0/24" = [ ipv4 ];
+            "2001:db8:f030:1c3::/64" = [ ipv6 ];
+          };
+          gateways = {};
+        };
+      };
+
+      users.groups.login = {
+        members = [];
+      };
+
+      flyingcircus.encServices = [
+        { service = "loghost-server";
+          address = "machine.fcio.net";
+        }
+      ];
+      networking.extraHosts = ''
+        ${ipv4} machine.fcio.net
+        ${ipv6} machine.fcio.net
+      '';
+
+    };
+  testScript = { nodes, ... }:
+  let
+    config = nodes.machine.config;
+    sensuChecks = config.flyingcircus.services.sensu-client.checks;
+    graylogCheck = lib.replaceChars ["\n"] [" "] sensuChecks.graylog_ui.command;
+    graylogApi = "${pkgs.fc.agent}/bin/fc-graylog --api http://machine.fcio.net:9001/api get -l";
+  in ''
+    $machine->waitForUnit("haproxy.service");
+    $machine->waitForUnit("mongodb.service");
+    $machine->waitForUnit("elasticsearch.service");
+    $machine->waitForUnit("graylog.service");
+    $machine->waitForUnit("nginx.service");
+
+    subtest "elasticsearch should have a graylog index", sub {
+      $machine->succeed("curl http://machine.fcio.net:9200/_cat/indices?v | grep -q graylog_0");
+    };
+
+    subtest "graylog API should respond", sub {
+      $machine->succeed("${graylogApi} / | grep -q cluster_id");
+    };
+
+    subtest "config script must create telegraf user", sub {
+      $machine->waitForUnit("fc-graylog-config.service");
+      $machine->succeed("${graylogApi} /users | grep -q telegraf");
+    };
+
+    subtest "sensu check should be green", sub {
+      $machine->succeed("${graylogCheck}");
+    };
+
+    subtest "sensu check should be red after shutting down graylog", sub {
+      $machine->stopJob("graylog.service");
+      $machine->waitUntilFails("${graylogApi} / | grep -q cluster_id");
+      $machine->mustFail("${graylogCheck}");
+    };
+
+    subtest "service user should be able to write to local config dir", sub {
+      $machine->succeed('sudo -u graylog touch /etc/local/graylog/graylog.json');
+    };
+
+    subtest "secret files should have correct permissions", sub {
+      $machine->succeed("stat /etc/local/graylog/password -c %a:%U:%G | grep '660:graylog:service'");
+      $machine->succeed("stat /etc/local/graylog/password_secret -c %a:%U:%G | grep '660:graylog:service'");
+      $machine->succeed("stat /run/graylog/graylog.conf -c %a:%U:%G | grep '440:graylog:service'");
+    };
+  '';
+})


### PR DESCRIPTION
* graylog frontend uses SSL with automated letsencrypt certs by default
* logstash plugin not available anymore, use beats input instead
* uses upstream graylog 3 and elasticsearch 5 & 6
* upgrade from graylog 2.5 (NixOS 15.09 platform) works
* local JSON config can add/override graylog settings
* better fc-graylog that can be used to interact with the graylog API

bugs id: #119556

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Add loghost, graylog (3.x) and elasticsearch (5.x, 6.x) roles (#119556).

## Security implications

Improves security compared to the old platform by using a more recent graylog version and removing the admin pw from the nix store.

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Nginx only listens on fe when public dashboard is enabled, other services listen only on srv/loopback.
  - no admin password in the nix store
  - secrets only accessible by graylog and service users
- [x] Security requirements tested?
  - manual checks in dev that the admin pw is not in the nix store and that the services listen on the correct interfaces (compared with old platform)
  - automated tests check permissions of secrets and if elasticsearch and graylog listen on the correct interfaces

