### PR TITLE
Reduce I/O contention during garbage collection

### DIFF
--- a/nixos/infrastructure/flyingcircus.nix
+++ b/nixos/infrastructure/flyingcircus.nix
@@ -16,6 +16,7 @@ mkIf (cfg.infrastructureModule == "flyingcircus") {
     consoleLogLevel = mkDefault 7;
 
     initrd.kernelModules = [
+      "bfq"
       "i6300esb"
       "virtio_blk"
       "virtio_console"
@@ -90,10 +91,11 @@ mkIf (cfg.infrastructureModule == "flyingcircus") {
       in
       attrByPath [ "static" "ntpServers" loc ] [ "pool.ntp.org" ] cfg;
 
-    # installs /dev/disk/device-by-alias/*
     udev.extraRules = ''
-      # Select GRUB boot device
-      SUBSYSTEM=="block", KERNEL=="[vs]da", SYMLINK+="disk/device-by-alias/root"
+      # GRUB boot device should be device-by-alias/root
+      SUBSYSTEM=="block", KERNEL=="vda", SYMLINK+="disk/device-by-alias/root"
+      # Use BFQ for better fairness
+      SUBSYSTEM=="block", ACTION=="add|change", KERNEL=="vd[a-z]", ATTR{queue/scheduler}="bfq", ATTR{queue/rotational}="0"
     '';
 
   };

--- a/nixos/platform/agent.nix
+++ b/nixos/platform/agent.nix
@@ -75,6 +75,7 @@ in {
 
         path = with pkgs; [
           fc.agent
+          utillinux
           config.system.build.nixos-rebuild
         ];
 
@@ -88,7 +89,8 @@ in {
           let interval = toString cfg.agent.interval;
           in ''
             rc=0
-            timeout 14400 fc-manage -E ${cfg.encPath} -i ${interval} \
+            timeout 14400 ionice -c3 \
+              fc-manage -E ${cfg.encPath} -i ${interval} \
               ${cfg.agent.steps} || rc=$?
             timeout 900 fc-resize -E ${cfg.encPath} || rc=$?
             exit $rc

--- a/nixos/roles/mysql.nix
+++ b/nixos/roles/mysql.nix
@@ -8,8 +8,8 @@
 with builtins;
 
 {
-  options = with lib; 
-  let  
+  options = with lib;
+  let
     mkRole = v: lib.mkEnableOption
       "Enable the Flying Circus MySQL / Percona ${v} server role.";
   in {
@@ -38,7 +38,7 @@ with builtins;
 
   };
 
-  config = 
+  config =
   let
     mysqlRoles = with config.flyingcircus.roles; {
       "5.5" = mysql55.enable;
@@ -47,7 +47,7 @@ with builtins;
       "8.0" = percona80.enable;
     };
 
-    mysqlPackages = with pkgs; { 
+    mysqlPackages = with pkgs; {
       "5.5" = mysql55;
       "5.6" = percona56;
       "5.7" = percona57;
@@ -78,7 +78,7 @@ with builtins;
     enabledRoles = lib.filterAttrs (n: v: v) mysqlRoles;
     enabledRolesCount = length (lib.attrNames enabledRoles);
     version = head (lib.attrNames enabledRoles);
-    package = mysqlPackages.${version} or null; 
+    package = mysqlPackages.${version} or null;
 
     telegrafPassword = fclib.derivePasswordForHost "mysql-telegraf";
     sensuPassword = fclib.derivePasswordForHost "mysql-sensu";
@@ -92,13 +92,13 @@ with builtins;
   in lib.mkMerge [
 
   (lib.mkIf (enabledRolesCount > 0) {
-    assertions = 
-      [ 
-        { 
+    assertions =
+      [
+        {
           assertion = enabledRolesCount == 1;
           message = "MySQL / Percona roles are mutually exclusive. Only one may be enabled.";
         }
-      ]; 
+      ];
 
     services.percona = {
       enable = true;
@@ -281,15 +281,15 @@ with builtins;
         RemainAfterExit = true;
       };
 
-      script = 
+      script =
       let
-        ensureUserAndDatabase = username: password: 
+        ensureUserAndDatabase = username: password:
           if (lib.versionAtLeast version "8.0") then ''
             CREATE USER IF NOT EXISTS ${username}@localhost IDENTIFIED BY '${password}';
             ALTER USER ${username}@localhost IDENTIFIED BY '${password}';
             CREATE DATABASE IF NOT EXISTS ${username};
             GRANT SELECT ON ${username}.* TO ${username}@localhost;
-          '' 
+          ''
           else ''
             CREATE DATABASE IF NOT EXISTS ${username};
             GRANT SELECT ON ${username}.* TO ${username}@localhost IDENTIFIED BY '${password}';
@@ -323,7 +323,7 @@ with builtins;
 
     services.udev.extraRules = ''
       # increase readahead for mysql
-      SUBSYSTEM=="block", ATTR{queue/rotational}=="1", ACTION=="add|change", KERNEL=="vd[a-z]", ATTR{bdi/read_ahead_kb}="1024", ATTR{queue/read_ahead_kb}="1024"
+      SUBSYSTEM=="block", ACTION=="add|change", KERNEL=="vd[a-z]", ATTR{bdi/read_ahead_kb}="1024", ATTR{queue/read_ahead_kb}="1024"
     '';
 
     environment.systemPackages = with pkgs; [

--- a/nixos/roles/postgresql.nix
+++ b/nixos/roles/postgresql.nix
@@ -2,7 +2,7 @@
 
 with builtins;
 {
-  options = 
+  options =
   let
     mkRole = v: lib.mkEnableOption
       "Enable the Flying Circus PostgreSQL ${v} server role.";
@@ -15,7 +15,7 @@ with builtins;
     };
   };
 
-  config = 
+  config =
   let
     pgroles = with config.flyingcircus.roles; {
       "9.5" = postgresql95.enable;
@@ -25,19 +25,19 @@ with builtins;
     };
     enabledRoles = lib.filterAttrs (n: v: v) pgroles;
     enabledRolesCount = length (lib.attrNames enabledRoles);
-  
+
   in lib.mkMerge [
     (lib.mkIf (enabledRolesCount > 0) {
-      assertions = 
-        [ 
-          { 
+      assertions =
+        [
+          {
             assertion = enabledRolesCount == 1;
             message = "PostgreSQL roles are mutually exclusive. Only one may be enabled.";
           }
-        ]; 
+        ];
 
       flyingcircus.services.postgresql.enable = true;
-      flyingcircus.services.postgresql.majorVersion = 
+      flyingcircus.services.postgresql.majorVersion =
         head (lib.attrNames enabledRoles);
     })
 

--- a/nixos/services/postgresql.nix
+++ b/nixos/services/postgresql.nix
@@ -62,7 +62,7 @@ in {
 
   };
 
-  config = 
+  config =
   (lib.mkIf cfg.enable (
   let
     postgresqlPkg = getAttr cfg.majorVersion packages;
@@ -130,7 +130,7 @@ in {
 
     services.udev.extraRules = ''
       # increase readahead for postgresql
-      SUBSYSTEM=="block", ATTR{queue/rotational}=="1", ACTION=="add|change", KERNEL=="vd[a-z]", ATTR{bdi/read_ahead_kb}="1024", ATTR{queue/read_ahead_kb}="1024"
+      SUBSYSTEM=="block", ACTION=="add|change", KERNEL=="vd[a-z]", ATTR{bdi/read_ahead_kb}="1024", ATTR{queue/read_ahead_kb}="1024"
     '';
 
     # Custom postgresql configuration
@@ -207,7 +207,7 @@ in {
 
     flyingcircus.services = {
 
-      sensu-client.checks = 
+      sensu-client.checks =
         lib.listToAttrs (
         map (host:
             let saneHost = replaceStrings [":"] ["_"] host;

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -1,5 +1,7 @@
 # Collection of own packages
-{ pkgs ? import <nixpkgs> {} }:
+{ pkgs ? import <nixpkgs> {}
+, pkgs-19_09 ? import <nixpkgs> {}
+}:
 
 let
   self = {
@@ -7,7 +9,7 @@ let
 
     fc = import ./fc {
       inherit (self) callPackage;
-      inherit pkgs;
+      inherit pkgs pkgs-19_09;
     };
 
   };

--- a/pkgs/fc/default.nix
+++ b/pkgs/fc/default.nix
@@ -1,22 +1,16 @@
-{ pkgs, callPackage }:
+{ pkgs, pkgs-19_09, callPackage }:
 
 {
   recurseForDerivations = true;
 
   agent = callPackage ./agent {};
-  box = callPackage ./box {
-  };
-  check-journal = callPackage ./check-journal.nix {
-  };
+  box = callPackage ./box { };
+  check-journal = callPackage ./check-journal.nix { };
   collectdproxy = callPackage ./collectdproxy {};
   fix-so-rpath = callPackage ./fix-so-rpath {};
-  logcheckhelper = callPackage ./logcheckhelper {
-  };
-  multiping = callPackage ./multiping.nix {
-  };
-  sensusyntax = callPackage ./sensusyntax {
-  };
+  logcheckhelper = callPackage ./logcheckhelper { };
+  multiping = callPackage ./multiping.nix { };
+  sensusyntax = callPackage ./sensusyntax { };
   sensuplugins = callPackage ./sensuplugins {};
-  userscan = callPackage ./userscan.nix {
-  };
+  userscan = pkgs-19_09.callPackage ./userscan.nix { };
 }

--- a/pkgs/fc/userscan.nix
+++ b/pkgs/fc/userscan.nix
@@ -1,25 +1,24 @@
 { lib
 , docutils
 , fetchFromGitHub
-, git
 , lzo
 , rustPlatform
 }:
 
 rustPlatform.buildRustPackage rec {
   name = "fc-userscan-${version}";
-  version = "0.4.3";
+  version = "0.4.4";
 
   src = fetchFromGitHub {
     name = "fc-userscan-src-${version}";
     owner = "flyingcircusio";
     repo = "userscan";
     rev = version;
-    sha256 = "03jpkgzhlql4q1g3hhlkafk6q6q7cw2aqz2qcw4a8b37kpkidqi7";
+    sha256 = "172q2ywdpg3q7picbl99cv45rcca2vhl7pvb7d4ilc66mhq6b265";
   };
 
-  cargoSha256 = "0jnqkl4g5m2rdlijf6hvns52rxpqagz5d9vhyny6w9clz3ssd14w";
-  nativeBuildInputs = [ git docutils ];
+  cargoSha256 = "0ma6ng94r963pn0bdnnmkq27khg031vrb4s3g17kk0kdl30yb9vn";
+  nativeBuildInputs = [ docutils ];
   propagatedBuildInputs = [ lzo ];
 
   postBuild = ''
@@ -32,8 +31,8 @@ rustPlatform.buildRustPackage rec {
 
   meta = with lib; {
     description = "Scan and register Nix store references from arbitrary files";
-    homepage = https://github.com/flyingcircusio/userscan;
-    license = with licenses; [ bsd3 ];
+    homepage = "https://github.com/flyingcircusio/userscan";
+    license = licenses.bsd3;
     platforms = platforms.all;
   };
 }

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -3,12 +3,13 @@ self: super:
 let
   versions = import ../versions.nix { pkgs = super; };
   pkgs-18_09 = import versions.nixos-18_09 {};
+  pkgs-19_09 = import versions.nixos-19_09 {};
 
 in {
   #
   # == our own stuff
   #
-  fc = (import ./default.nix { pkgs = self; });
+  fc = (import ./default.nix { pkgs = self; inherit pkgs-19_09; });
 
   bundlerSensuPlugin = super.callPackage ./sensuplugins-rb/bundler-sensu-plugin.nix { };
   busybox = super.busybox.overrideAttrs (oldAttrs: {
@@ -67,6 +68,7 @@ in {
 
   remarshal = super.callPackage ./remarshal.nix { };
   rum = super.callPackage ./postgresql/rum { };
+
   sensu-plugins-elasticsearch = super.callPackage ./sensuplugins-rb/sensu-plugins-elasticsearch { };
   sensu-plugins-memcached = super.callPackage ./sensuplugins-rb/sensu-plugins-memcached { };
   sensu-plugins-mysql = super.callPackage ./sensuplugins-rb/sensu-plugins-mysql { };

--- a/versions.json
+++ b/versions.json
@@ -6,9 +6,15 @@
     "sha256": "1yh1swn4nvvf4imv1h25fzfwcdkr748nypycr5c1vzbc770v5rsb"
   },
   "nixos-18.09": {
-    "owner": "nixos",
+    "owner": "NixOS",
     "repo": "nixpkgs",
     "rev": "9f9806d63d4cf428c1e08ea4a9f3862a90b1b580",
     "sha256": "0sa5b02hrj0wsa4jxda2ylai7zqldfi27q35d2cdadkq1gyl1a7p"
+  },
+  "nixos-19.09": {
+    "owner": "NixOS",
+    "repo": "nixpkgs",
+    "rev": "8e4c9d15456fd3a35044bcea864d558fade4a021",
+    "sha256": "1v7cn9lj0p2vijyiqk2b1p7aa5s66qj4wy37fpxj007h00swpy5j"
   }
 }


### PR DESCRIPTION
Switch all VMs to BFQ so that ionice does the right thing.

Use fc-userscan 0.4.4 which manages load:
- Use Rust toolchain from 19.09 since our standard version is too old.
- Add pkgs-19.09 import to our overlay.

Also:
- Decrease fc-userscan verboseness so that errors and warnings can be
  spotted easily.
- Rewrite fc-userscan control script with Python.

Case 119463
Case 115735

@flyingcircusio/release-managers

## Release process

Impact:

Changelog: Use BFQ for I/O scheduling to reduce system load during OS garbage collection.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

Remove potential denial-of-service source.

- [x] Security requirements tested? (EVIDENCE)

Tried various I/O intensive operations during nix-collect-garbage: git checkout, Rust compilation, pkg installation.