### PR TITLE
Update kernel to 4.19.94

### DIFF
--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -19,6 +19,17 @@ in {
 
   grub2_full = super.callPackage ./grub/2.0x.nix { };
 
+  linux_4_19 = super.linux_4_19.override {
+    argsOverride = rec {
+      src = super.fetchurl {
+            url = "mirror://kernel/linux/kernel/v4.x/linux-${version}.tar.xz";
+            sha256 = "0rvlz94mjl7ygpmhz0yn2whx9dq9fmy0w1472bj16hkwbaki0an6";
+      };
+      version = "4.19.94";
+      modDirVersion = "4.19.94";
+      };
+  };
+
   influxdb = super.callPackage ./influxdb { };
   innotop = super.callPackage ./percona/innotop.nix { };
 


### PR DESCRIPTION
bugs id: #122779

@flyingcircusio/release-managers

## Release process

Impact:

* [NixOS 19.03] VM will be rebooted.

Changelog:

* Update kernel to 4.19.94 (#122779).

## Security implications

- [x] [Security requirements]
This update is part of our patch effort. New kernels are expected to not increase the attack vector and thus don’t need to pass additional requirements.
- [x] Security requirements tested? (EVIDENCE)
  n/a, I have verified that it boots on a dev VM and that tests work