### PR TITLE
Avoid logrotate errors on fc-manage runs

### DIFF
--- a/nixos/services/nginx/default.nix
+++ b/nixos/services/nginx/default.nix
@@ -287,7 +287,7 @@ in
             rotate 92
             create 0644 nginx service
             postrotate
-                systemctl kill nginx -s USR1 --kill-who=main
+                systemctl kill nginx -s USR1 --kill-who=main || systemctl restart nginx
             endscript
         }
       '';


### PR DESCRIPTION
* try to restart nginx after log rotation if sending the signal fails
* remove logrotate from multi-user.target which avoids running logrotate
during fc-manage runs

Logrotate produced an error during a fc-manage run which caused the
maintenance task to fail. This happened because nginx was restarted at
the same time and logrotate tried to send a signal to the missing process.
Each one of the changes fixes the problem but it makes sense to include
both to avoid errors in similar situations.

bugs id: #119218

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Don't trigger logrotate on fc-manage runs. This avoids maintenance errors that are not really related to it. Also, make nginx log rotation more robust (#119218).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - n/a
- [x] Security requirements tested? (EVIDENCE)
  - tested in dev that it rotates nginx log files and restarts nginx if neccessary

