### PR TITLE
Add wormhole CLI as alternative to our NFS box to allow using it ever…

### DIFF
--- a/nixos/platform/packages.nix
+++ b/nixos/platform/packages.nix
@@ -37,6 +37,7 @@
         links
         lsof
         lynx
+        magic-wormhole
         mailx
         mercurial
         mmv


### PR DESCRIPTION
…ywhere by default.

@flyingcircusio/release-managers

## Release process

Impact:

n/a

Changelog:

* Provide the `magic wormhole` utility as a potential replacement for our NFS box feature by default. No customization or deeper integration has happened yet, but this automates installation of the CLI utility and stops customers from having to install it manually all the time.

## Security implications

- [X] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

Zagy has already reviewed it and I went throught the documentation today. This looks sufficiently safe and customers can decide whether to use it or not at this stage. If we push this further then we should consider creating our own server and use it by default.

- [X] Security requirements tested? (EVIDENCE)

I don't pretend that I could actually test the encryption, it looks fine from an overall position.  Cafeat emptor applies at this point.