### PR TITLE
Grant journal access to wheel, sudo-srv, admins and service groups

### DIFF
--- a/tests/default.nix
+++ b/tests/default.nix
@@ -25,6 +25,7 @@ in {
   fcagent = callTest ./fcagent.nix {};
   garbagecollect = callTest ./garbagecollect.nix {};
   graylog = callTest ./graylog.nix {};
+  login = callTest ./journal.nix {};
   login = callTest ./login.nix {};
   logrotate = callTest ./logrotate.nix {};
   mail = callSubTests ./mail.nix {};

--- a/tests/journal.nix
+++ b/tests/journal.nix
@@ -1,0 +1,64 @@
+import ./make-test.nix ({ lib, ... }:
+
+{
+  name = "journal";
+  machine =
+    { pkgs, lib, config, ... }:
+    {
+      imports = [
+        ../nixos
+      ];
+
+      users.groups = {
+        admins = {};
+        sudo-srv = {};
+        service = {};
+      };
+
+      users.users =
+        lib.mapAttrs'
+          (id: groups:
+            lib.nameValuePair
+              "u${id}"
+              {
+                uid = builtins.fromJSON id;
+                extraGroups = groups;
+                isNormalUser = true;
+              }
+          )
+          {
+            "1000" = [ ];
+            "1001" = [ "admins" ];
+            "1002" = [ "sudo-srv" ];
+            "1003" = [ "wheel" ];
+            "1004" = [ "service" ];
+            "1005" = [ "systemd-journal" ];
+          };
+    };
+
+  testScript = ''
+    $machine->waitForUnit('multi-user.target');
+
+    subtest "user without allowed groups should not see the journal", sub {
+      $machine->mustFail('sudo -iu \#1000 journalctl');
+    };
+
+    subtest "admin user should see the journal", sub {
+      $machine->succeed('sudo -iu \#1001 journalctl');
+    };
+
+    subtest "admin user should see the journal", sub {
+      $machine->succeed('sudo -iu \#1002 journalctl');
+    };
+
+    subtest "wheel user should see the journal", sub {
+      $machine->succeed('sudo -iu \#1003 journalctl');
+    };
+
+    subtest "service user should see the journal", sub {
+      $machine->succeed('sudo -iu \#1004 journalctl');
+    };
+
+    print($machine->succeed('getfacl /var/log/journal'));
+  '';
+})


### PR DESCRIPTION
Removes read permission for other users and grants access to the
mentioned groups by using ACL. This is recommended in the journald
docs and journalctl even produces a sensible error message if the
user is not in the allowed groups.

bugs id: #106521

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

Grant journal access to wheel, sudo-srv, admins and service groups (#106521).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - The groups systemd-journal, adm, wheel, sudo-srv, admins and service have access to system journal, no access for other users.
- [x] Security requirements tested? (EVIDENCE)
  - Automated test verifies that users with the allowed groups have journal access and a user without any of them gets an error when using journalctl. Also tested manually on a test VM.

