### PR TITLE
Fix statshost metric relabeling config

### DIFF
--- a/nixos/roles/statshost/default.nix
+++ b/nixos/roles/statshost/default.nix
@@ -76,7 +76,7 @@ let
             refresh_interval = "10m";
           }
         ];
-        relabel_configs =
+        metric_relabel_configs =
           prometheusMetricRelabel ++
           (relabelConfiguration "${localDir}/metric-relabel.${relayNode.job_name}.yaml");
       } // relayNode)
@@ -396,7 +396,7 @@ in
                 files = [ "${localDir}/scrape-*.json" ];
                 refresh_interval = "10m";
               }];
-              relabel_configs =
+              metric_relabel_configs =
                 prometheusMetricRelabel ++
                 (relabelConfiguration
                   "${localDir}/metric-relabel.${job_name}.yaml");
@@ -413,7 +413,7 @@ in
                 files = [ "${localDir}/federate-*.json" ];
                 refresh_interval = "10m";
               }];
-              relabel_configs = prometheusMetricRelabel;
+              metric_relabel_configs = prometheusMetricRelabel;
             }
 
           ] ++ relayRGConfig ++ relayLocationConfig;

--- a/nixos/roles/statshost/global-relabel.nix
+++ b/nixos/roles/statshost/global-relabel.nix
@@ -13,7 +13,7 @@ let
       regex = "yes";
       action = "keep"; }
     { regex = "__tmp_globally_allowed";
-      action = "drop"; }
+      action = "labeldrop"; }
   ];
 
 in mkIf config.flyingcircus.roles.statshost.enable

--- a/nixos/services/prometheus.nix
+++ b/nixos/services/prometheus.nix
@@ -235,8 +235,12 @@ let
         List of labeled target groups for this job.
       '';
 
+      metric_relabel_configs = mkOpt (types.listOf promTypes.relabel_config) ''
+        List of metric relabel configurations (after scrape).
+      '';
+
       relabel_configs = mkOpt (types.listOf promTypes.relabel_config) ''
-        List of relabel configurations.
+        List of relabel configurations (before scrape).
       '';
 
       sample_limit = mkDefOpt types.int "0" ''
@@ -446,10 +450,12 @@ let
         regular expression matches.
       '';
 
-      action = mkDefOpt (types.enum ["replace" "keep" "drop"]) "replace" ''
-        Action to perform based on regex matching.
-      '';
-
+      action = mkDefOpt
+        (types.enum [
+          "replace" "keep" "drop" "hashmod" "labelmap" "labeldrop" "labelkeep"
+        ])
+        "replace"
+        "Action to perform based on regex matching.";
     };
   };
 


### PR DESCRIPTION
We used the wrong prometheus config attribute relabel_configs which is
run before scraping a target. We want metric_relabel_configs. That
option was missing from the service code from upstream, added it.
Also, in some places drop was used, but labeldrop was meant.
This adds action options that are missing upstream which includes
labeldrop.

bugs id: #122902

@flyingcircusio/release-managers

## Release process

Impact:

* Prometheus will be restarted

Changelog:

* Fix statshost metric relabeling config (#122902).

## Security implications

n/a

