### PR TITLE
Statshost: remove unneeded PostgreSQL and InfluxDB labels

### DIFF
--- a/nixos/roles/postgresql.nix
+++ b/nixos/roles/postgresql.nix
@@ -42,6 +42,20 @@ with builtins;
     })
 
     {
+      flyingcircus.roles.statshost.prometheusMetricRelabel = [
+        {
+          source_labels = [ "__name__" "datname" ];
+          regex = "postgresql_.+;(.+)-[a-f0-9]{12}";
+          replacement = "$1";
+          target_label = "datname";
+        }
+        {
+          source_labels = [ "__name__" "db" ];
+          regex = "postgresql_.+;(.+)-[a-f0-9]{12}";
+          replacement = "$1";
+          target_label = "db";
+        }
+      ];
       flyingcircus.roles.statshost.globalAllowedMetrics = [ "postgresql" ];
     }
   ];

--- a/nixos/roles/statshost/default.nix
+++ b/nixos/roles/statshost/default.nix
@@ -426,6 +426,15 @@ in
         [ "influxdb" ] ++
         (attrNames config.flyingcircus.services.telegraf.inputs);
 
+      flyingcircus.roles.statshost.prometheusMetricRelabel = let
+        removeLabel = label: {
+          source_labels = [ "__name__" label ];
+          regex = "influxdb_(tsm1|shard)_.*;.+";
+          replacement = "";
+          target_label = label;
+        };
+        in map removeLabel [ "path" "walPath" "id" "url" ];
+
       services.influxdb = {
         enable = true;
         dataDir = "/srv/influxdb";


### PR DESCRIPTION
bugs id: #121869

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Statshost: remove unneeded PostgreSQL and InfluxDB labels (#121869).

## Security implications

n/a, just a manual test if the right metrics/labels are matched
