### PR TITLE
Fix rabbitmq settings timer execution and warning

### DIFF
--- a/nixos/roles/rabbitmq.nix
+++ b/nixos/roles/rabbitmq.nix
@@ -101,7 +101,7 @@ with builtins;
         '';
 
       systemd.services.fc-rabbitmq-settings = {
-        description = "Prepare rabbitmq for operation in FC.";
+        description = "Check/update FCIO rabbitmq settings (for monitoring)";
         requires = [ "rabbitmq.service" ];
         after = [ "rabbitmq.service" ];
         wantedBy = [ "multi-user.target" ];
@@ -110,7 +110,6 @@ with builtins;
           Type = "oneshot";
           User = "rabbitmq";
           Group = "rabbitmq";
-          RemainAfterExit = true;
         };
 
         script =
@@ -150,7 +149,6 @@ with builtins;
         description = "Runs the FC RabbitMQ preparation script regularly.";
         wantedBy = [ "timers.target" ];
         timerConfig = {
-          Unit = "fc-rabbitmq-settings";
           OnUnitActiveSec = "1h";
           AccuracySec = "10m";
         };


### PR DESCRIPTION
The service had RemainAfterExit=true set which means that it stays
active all the time. Timers don't reactivate active units, so it only
ran once and not hourly as intended.

The executed unit must be specified with extension, for example .service.
Systemd complained about that (no valid unit type) and ignored the line.
The default service name is the same as the timer name, so we don't have
to specify it at all.

bugs id: #123236
bugs id: #123185

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Fix RabbitMQ settings timer execution and warning (#123236).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined?
  - timer must run to remove the insecure guest user and set up monitoring permissions
- [x] Security requirements tested? (EVIDENCE)
  - I have checked that the timer runs periodically 
