### PR TITLE
Randomization for some graylog, grafana and prometheus timers

### DIFF
--- a/nixos/roles/statshost/default.nix
+++ b/nixos/roles/statshost/default.nix
@@ -344,7 +344,7 @@ in
           timerConfig = {
             Unit = "fc-prometheus-update-relayed-nodes";
             OnUnitActiveSec = "11m";
-            RandomSec = "3m";
+            RandomizedDelaySec = "3m";
           };
         });
       }
@@ -621,8 +621,7 @@ in
         timerConfig = {
           Unit = "fc-grafana-load-dashboards.service";
           OnUnitActiveSec = "1h";
-          # Not yet supported by our systemd version.
-          # RandomSec = "3m";
+          RandomizedDelaySec = "3m";
         };
       };
 

--- a/nixos/services/graylog.nix
+++ b/nixos/services/graylog.nix
@@ -415,7 +415,7 @@ in {
         Unit = "graylog-update-geolite.service";
         OnStartupSec = "10m";
         OnUnitActiveSec = "30d";
-        RandomSec = "3m";
+        RandomizedDelaySec = "3m";
       };
     };
 


### PR DESCRIPTION
There's no timer unit option RandomSec, it's RandomizedDelaySec.
Two were wrong (ignored by systemd), one was commented out and had the wrong name.

bugs id: #123321

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Randomization for some graylog, grafana and prometheus timers (#123321).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - just timer randomization
- [x] Security requirements tested? (EVIDENCE)
  - manual check if warning message is gone
