### PR TITLE
Exclude sock files from userscan.

### DIFF
--- a/nixos/platform/garbagecollect/userscan.exclude
+++ b/nixos/platform/garbagecollect/userscan.exclude
@@ -68,6 +68,7 @@ postgresql/*/pg_*
 redis/*.rdb
 *.rpm
 *.rss
+*.sock
 solr/data/
 *.spl
 *.sql


### PR DESCRIPTION
bugs id: #122944

@flyingcircusio/release-managers

## Release process

Impact:
n.a.
Changelog:
Exclude sock files from userscan.

## Security implications

- [ ] [Security requirements]
n.a.
- [ ] Security requirements tested? (EVIDENCE)
n.a.

