### PR TITLE
Statshost: fix netstat_tcp metric relabeling

### DIFF
--- a/nixos/roles/statshost/default.nix
+++ b/nixos/roles/statshost/default.nix
@@ -129,6 +129,7 @@ in
   imports = [
     ./global-relabel.nix
     ./location-proxy.nix
+    ./relabel.nix
     ./rg-relay.nix
   ];
 

--- a/nixos/roles/statshost/global-relabel.nix
+++ b/nixos/roles/statshost/global-relabel.nix
@@ -20,28 +20,5 @@ in mkIf config.flyingcircus.roles.statshost.enable
 {
   flyingcircus.roles.statshost.prometheusMetricRelabel =
     markAllowedMetrics ++
-    dropUnmarkedMetrics ++
-    (let
-      rename_merge = options: [
-        {
-          source_labels = [ "__name__" ];
-          # Only if there is no command set.
-          regex = options.regex;
-          replacement = "\${1}";
-          target_label = options.target_label;
-        }
-        {
-          source_labels = [ "__name__" ];
-          regex = options.regex;
-          replacement = options.target_name;
-          target_label = "__name__";
-        }
-      ];
-    in
-    rename_merge {
-      regex = "netstat_tcp_(.*)";
-      target_label = "state";
-      target_name = "netstat_tcp";
-    }
-  );
+    dropUnmarkedMetrics;
 }

--- a/nixos/roles/statshost/relabel.nix
+++ b/nixos/roles/statshost/relabel.nix
@@ -1,0 +1,31 @@
+# Relabeling rules that do not fit elsewhere.
+# Role-specific rules should be put in the role definitions.
+
+{ config, pkgs, lib, ... }:
+with lib;
+let
+  renameMerge = options: [
+    {
+      source_labels = [ "__name__" ];
+      # Only if there is no command set.
+      regex = options.regex;
+      replacement = "\${1}";
+      target_label = options.targetLabel;
+    }
+    {
+      source_labels = [ "__name__" ];
+      regex = options.regex;
+      replacement = options.targetName;
+      target_label = "__name__";
+    }
+  ];
+
+in
+{
+  flyingcircus.roles.statshost.prometheusMetricRelabel =
+    renameMerge {
+      regex = "netstat_tcp_(.*)";
+      targetLabel = "state";
+      targetName = "netstat_tcp";
+    };
+}


### PR DESCRIPTION
The relabel rule was only effective if the statshost role was selected.
It's now working for statshost-master (per RG), too.

bugs id: #123713

@flyingcircusio/release-managers

## Release process

Impact:

[NixOS 19.03] Prometheus will be restarted.

Changelog:

* Statshost: fix TCP connection metric (#123713).

## Security implications

n/a