### PR TITLE
Port Kibana role, fix es6 license problem and deprecation warning

### DIFF
--- a/nixos/roles/default.nix
+++ b/nixos/roles/default.nix
@@ -14,6 +14,7 @@ in {
     ./antivirus.nix
     ./elasticsearch.nix
     ./graylog.nix
+    ./kibana.nix
     ./loghost.nix
     ./mailserver.nix
     ./memcached.nix

--- a/nixos/roles/kibana.nix
+++ b/nixos/roles/kibana.nix
@@ -1,0 +1,88 @@
+{ config, lib, pkgs, ... }:
+
+with builtins;
+
+let
+  cfg = config.flyingcircus.roles.kibana;
+  fclib = config.fclib;
+  esUrlFile = "/etc/local/kibana/elasticSearchUrl";
+  esCfg = config.services.elasticsearch;
+
+  # Determine the Elasticsearch URL, in order:
+  # 1. elasticSearchUrl option
+  # 2. URL from local config
+  # 3. Local Elasticsearch service
+  # 4. no URL, don't activate Kibana
+  elasticSearchUrl =
+    if cfg.elasticSearchUrl == null
+    then
+      if pathExists esUrlFile
+      then
+        (lib.removeSuffix "\n" (readFile esUrlFile))
+      else
+        if esCfg.enable
+        then "http://${esCfg.listenAddress}:${toString esCfg.port}"
+        else null
+    else cfg.elasticSearchUrl;
+
+  kibanaShowConfig = pkgs.writeScriptBin "kibana-show-config" ''
+    cat $(systemctl cat kibana | grep "ExecStart" | cut -d" " -f3)
+  '';
+
+in
+{
+  options = {
+
+    flyingcircus.roles.kibana = with lib; {
+      enable = mkEnableOption "Enable the Flying Circus Kibana server role.";
+
+      elasticSearchUrl = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        example = "http://elasticsearchhost:9200";
+      };
+
+    };
+
+  };
+
+  config = lib.mkMerge [
+    (lib.mkIf (cfg.enable && elasticSearchUrl != null) {
+
+      environment.systemPackages = [
+        kibanaShowConfig
+      ];
+
+      services.kibana = {
+        enable = true;
+        # Unlike elasticsearch, kibana cannot listen to both IPv4 and IPv6.
+        # We choose to use IPv4 here.
+        listenAddress = head (fclib.listenAddresses "ethsrv");
+        elasticsearch.url = elasticSearchUrl;
+      };
+
+      systemd.services.kibana.serviceConfig = {
+        Restart = "always";
+      };
+    })
+
+    (lib.mkIf cfg.enable {
+      environment.etc."local/kibana/README.txt".text = ''
+        Kibana local configuration
+
+        To configure the ElasticSearch Kibana connects to, add a file `elasticSearchUrl`
+        here, and put the URL in.
+
+        If no URL has been set and ElasticSearch is running on this machine the local
+        ElasticSearch is used automatically.
+
+        Run `sudo fc-manage --build` to activate the configuration.
+      '';
+
+      flyingcircus.localConfigDirs.systemd = {
+        dir = "/etc/local/kibana";
+      };
+    })
+
+  ];
+}

--- a/tests/kibana.nix
+++ b/tests/kibana.nix
@@ -1,0 +1,58 @@
+import ./make-test.nix ({ pkgs, ... }:
+let
+  ipv4 = "192.168.101.1";
+in
+{
+  name = "kibana";
+
+  machine =
+    { pkgs, config, ... }:
+    {
+
+      imports = [ ../nixos ../nixos/roles ];
+
+      flyingcircus.enc.parameters = {
+        resource_group = "test";
+        interfaces.srv = {
+          mac = "52:54:00:12:34:56";
+          networks = {
+            "192.168.101.0/24" = [ ipv4 ];
+          };
+          gateways = {};
+        };
+      };
+
+      virtualisation.memorySize = 3072;
+      virtualisation.qemu.options = [ "-smp 2" ];
+      flyingcircus.roles.elasticsearch6.enable = true;
+      flyingcircus.roles.kibana.enable = true;
+    };
+
+  testScript = ''
+    startAll;
+
+    $machine->waitForUnit("elasticsearch");
+    $machine->waitForUnit("kibana");
+
+    my $statusCheck = <<'END';
+      for count in {0..100}; do
+        echo "Checking..." | logger -t kibana-status
+        curl -s "${ipv4}:5601/api/status" | grep -q '"state":"green' && exit
+        sleep 5
+      done
+      echo "Failed" | logger -t kibana-status
+      curl -s "${ipv4}:5601/api/status"
+      exit 1
+    END
+
+    subtest "cluster healthy?", sub {
+      $machine->succeed($statusCheck);
+    };
+
+    subtest "killing the kibana process should trigger an automatic restart", sub {
+      $machine->succeed("kill -9 \$(systemctl show kibana.service --property MainPID --value)");
+      $machine->waitForUnit("kibana");
+      $machine->succeed($statusCheck);
+    };
+  '';
+})


### PR DESCRIPTION
* Uses an elasticsearch node that is running locally automatically now.
* ES6 uses an unfree license, we have to enable allowUnfree.
* Fix deprecation warning by using the new publish address format.
* Add show config scripts for es and kibana.

bugs id: #124025

@flyingcircusio/release-managers

## Release process

Impact:

* [NixOS 19.03] Elasticsearch 6 will be restarted.

Changelog:

* Fix Elasticsearch 6 role and avoid deprecation warning by using the new publish address format from ES7 (#123942).
* Port Kibana role (#124025).


## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Kibana server listens only on srv.
  - nonFree license allows us to use ES in the intended way
- [x] Security requirements tested? (EVIDENCE)
  - Automatic test confirms that kibana is listening on srv; manual checks on test VM for open ports.
  - https://github.com/elastic/elasticsearch/blob/6.8/licenses/ELASTIC-LICENSE.txt prohibits SAAS offerings where the _main_ motivation is ES. That's not the case here. ES is always only part of a customer application.