### PR TITLE
Remove wrong or redundant Unit setting in systemd timer units

### DIFF
--- a/nixos/infrastructure/flyingcircus.nix
+++ b/nixos/infrastructure/flyingcircus.nix
@@ -110,7 +110,6 @@ mkIf (cfg.infrastructureModule == "flyingcircus") {
       description = "Timer for Serial console liveness marker";
       requiredBy = [ "serial-getty@ttyS0.service" ];
       timerConfig = {
-        Unit = "serial-console-liveness.service";
         OnBootSec = "10m";
         OnUnitActiveSec = "10m";
       };

--- a/nixos/roles/statshost/default.nix
+++ b/nixos/roles/statshost/default.nix
@@ -343,7 +343,6 @@ in
           description = "Timer for updating relayed targets";
           wantedBy = [ "timers.target" ];
           timerConfig = {
-            Unit = "fc-prometheus-update-relayed-nodes";
             OnUnitActiveSec = "11m";
             RandomizedDelaySec = "3m";
           };
@@ -620,7 +619,6 @@ in
         description = "Timer for updating the grafana dashboards";
         wantedBy = [ "timers.target" ];
         timerConfig = {
-          Unit = "fc-grafana-load-dashboards.service";
           OnUnitActiveSec = "1h";
           RandomizedDelaySec = "3m";
         };


### PR DESCRIPTION
The default is to activate the service with the same name as the timer.
Specifying the service name without ending causes a warning.

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Fix warning for ignored setting in fc-prometheus-update-relayed-nodes timer (#124132).

## Security implications

n/a
