### PR TITLE
Reload varnish on config changes instead of restarting

### DIFF
--- a/tests/webproxy.nix
+++ b/tests/webproxy.nix
@@ -6,25 +6,42 @@ import ./make-test.nix ({ pkgs, ... }:
       { lib, ... }:
       {
         imports = [ ../nixos ../nixos/roles ];
+        environment.etc."local/varnish/newconfig.vcl".text = ''
+          vcl 4.0;
+          backend test {
+            .host = "127.0.0.1";
+            .port = "8081";
+          }
+        '';
         flyingcircus.roles.webproxy.enable = true;
       };
   };
   testScript = ''
     $webproxy->waitForUnit("varnish.service");
+    $webproxy->waitForUnit("varnishncsa.service");
 
     $webproxy->execute(<<__SETUP__);
     echo 'Hello World!' > hello.txt
     ${pkgs.python3.interpreter} -m http.server 8080 &
     __SETUP__
 
-    my $curl = 'curl -s http://localhost:8008/hello.txt';
-    $webproxy->waitUntilSucceeds($curl);
-    $webproxy->succeed($curl) =~ /Hello World!/ or
-      die "expected output missing";
+    my $url = 'http://localhost:8008/hello.txt';
+    my $curl = "curl -s $url";
 
-    # check log file entry
-    $webproxy->waitUntilSucceeds(<<_EOT_);
-    grep "GET http://localhost:8008/hello.txt HTTP/" /var/log/varnish.log
-    _EOT_
+    $webproxy->waitUntilSucceeds($curl);
+
+    subtest "request should return expected output", sub {
+      $webproxy->succeed("$curl | grep -q 'Hello World!'");
+    };
+
+    subtest "varnishncsa should log requests", sub {
+      $webproxy->waitUntilSucceeds("$curl && grep -q 'GET $url HTTP/' /var/log/varnish.log");
+    };
+
+    subtest "changing config and reloading should activate new config", sub {
+      $webproxy->execute('ln -sf /etc/local/varnish/newconfig.vcl /etc/current-config/varnish.vcl');
+      $webproxy->execute('systemctl reload varnish');
+      $webproxy->succeed('varnishadm vcl.list | grep active | grep -q newconfig');
+    };
   '';
 })


### PR DESCRIPTION
Restarting empties the cache, we want to avoid that.
Restart code is from 15.09, with added testing and a check if the config
has really changed.

Case 124192

@flyingcircusio/release-managers

## Release process

Impact:

* [NixOS 19.03] Varnish will be restarted.

Changelog:

* Reload varnish on config changes instead of restarting (#124192).

## Security implications

n/a

