### PR TITLE
fc-agent service: add tar and compression tools to PATH

### DIFF
--- a/nixos/platform/agent.nix
+++ b/nixos/platform/agent.nix
@@ -74,9 +74,13 @@ in {
         };
 
         path = with pkgs; [
-          fc.agent
-          utillinux
+          bzip2
           config.system.build.nixos-rebuild
+          fc.agent
+          gnutar
+          gzip
+          utillinux
+          xz
         ];
 
         environment = config.nix.envVars // {


### PR DESCRIPTION
This is needed if someone wants to use fetchTarball in the local NixOS
config, for example to fetch a newer channel.

Case 124799

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Add tar and compression tools to fc-agent. Using fetchTarball in local NixOS config doesn't break automatic configuration anymore. (#124799).

## Security implications

n/a
