### PR TITLE
Reset maintenance flag every time

### DIFF
--- a/nixos/platform/agent.nix
+++ b/nixos/platform/agent.nix
@@ -106,7 +106,7 @@ in {
         "f /etc/nixos/local.nix 644"
         "d /var/lib/fc-manage"
         "r /var/lib/fc-manage/stamp-channel-update"
-        "d /var/spool/maintenance/archive - - - 90d"
+        "d /var/spool/maintenance/archive - - - 180d"
       ];
 
       flyingcircus.passwordlessSudoRules = [

--- a/pkgs/fc/agent/fc/maintenance/reqmanager.py
+++ b/pkgs/fc/agent/fc/maintenance/reqmanager.py
@@ -188,8 +188,6 @@ class ReqManager:
             LOG.error('failed to set "out of service" directory flag')
 
     def leave_maintenance(self):
-        if not self.in_maintenance:
-            return
         try:
             LOG.debug('marking node as "in service"')
             self.directory.mark_node_service_status(socket.gethostname(),


### PR DESCRIPTION
Every time fc-agent is called with '--maintenance', the "in maintenance"
directory flag gets reset at the end of the run unconditionally.

The maintenance client used to reset the "in maintenance" directory flag
only if a maintenance job actually has been run. This meant that in case
a maintenance job aborts, the flag does not get reset until another
maintenance job is created. This may take a long time on VMs not running
updates in maintenance.

Also increase maintenance archive retention time to assist debugging of
old cases.

Case 119218

@flyingcircusio/release-managers

## Release process

Impact: -

Changelog: Automatically recover from stuck "VM in maintenance" directory flags (119218).

## Security implications

- [ ] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [ ] Security requirements tested? (EVIDENCE)

