### PR TITLE
Generate all locales

### DIFF
--- a/nixos/platform/default.nix
+++ b/nixos/platform/default.nix
@@ -151,8 +151,6 @@ in {
     documentation.dev.enable = mkDefault false;
     documentation.doc.enable = mkDefault false;
 
-    i18n.supportedLocales = [ (config.i18n.defaultLocale + "/UTF-8") ];
-
     nix = {
       nixPath = [
         "/nix/var/nix/profiles/per-user/root/channels/nixos"

--- a/tests/locale.nix
+++ b/tests/locale.nix
@@ -1,0 +1,15 @@
+import ./make-test.nix ({ ... }:
+{
+  name = "locale";
+  machine =
+    { ... }:
+    {
+      imports = [ ../nixos ../nixos/roles ];
+    };
+
+  testScript = ''
+    $machine->succeed("locale -a | grep -q de_DE.utf8");
+    $machine->succeed("locale -a | grep -q en_US.utf8");
+    $machine->succeed('(($(locale -a | wc -l) > 100))');
+  '';
+})


### PR DESCRIPTION
Case 126182

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Generate all locales instead of just en_US.utf8 (#126182).

## Security implications

n/a