### PR TITLE
Retry nixos-rebuild switch if the first run fails

### DIFF
--- a/pkgs/fc/agent/fc/manage/manage.py
+++ b/pkgs/fc/agent/fc/manage/manage.py
@@ -29,9 +29,11 @@ ACTIVATE = """\
 set -e
 nix-channel --add {url} nixos
 nix-channel --update nixos
-nixos-rebuild switch
+# Retry once in case nixos-build fails e.g. due to updates to Nix itself
+nixos-rebuild switch || nixos-rebuild switch
 nix-channel --remove next
 """
+
 
 class Channel:
 


### PR DESCRIPTION
Case 126172

@flyingcircusio/release-managers

## Release process

Impact:

Changelog: Retry system update on failure if update in maintenance is enabled. This is expected to avoid failed maintenance jobs (#126172).

## Security implications

- [ ] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

* unchanged

- [ ] Security requirements tested? (EVIDENCE)