### PR TITLE
Pick up last upstream security updates

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -14,7 +14,7 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "fcdfb80bb662d56a1ebce343a535994d404e57fe",
-    "sha256": "1yh1swn4nvvf4imv1h25fzfwcdkr748nypycr5c1vzbc770v5rsb"
+    "rev": "92c7b4b23a60ad437bf501b86aa0ef5f493227ad",
+    "sha256": "1yyy1p6rfjinvhsl4rprfw40gckgcgjqcy3wq2klb3xg0zs260c3"
   }
 }


### PR DESCRIPTION
- aspell patch CVE-2019-17544
- fribidi patch CVE-2019-18397
- update openssl to 1.0.2u
- pyopenssl patch against 2019/2020 test bug

@flyingcircusio/release-managers

## Release process

Impact:

Changelog: Pick up last upstream security fixes for 19.03. Affected packages include: openssl, pyopenssl, aspell, fribidi.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

nothing changed

- [ ] Security requirements tested? (EVIDENCE)

