### PR TITLE
Extra channels: 19.09 -> 20.03, drop 18.09

### DIFF
--- a/nixos/platform/garbagecollect/default.nix
+++ b/nixos/platform/garbagecollect/default.nix
@@ -76,7 +76,7 @@ in {
 
       # keep in sync with pkgs/overlay.nix
       environment.etc."nixos/garbagecollect-protect-references".text = ''
-        nixpkgs-19.09=${pkgs.nixpkgs-19_09-src}
+        nixpkgs-20.03=${pkgs.nixpkgs-20_03-src}
       '';
 
       flyingcircus.services.sensu-client.checks.fc-collect-garbage = {

--- a/nixos/roles/kubernetes/default.nix
+++ b/nixos/roles/kubernetes/default.nix
@@ -20,21 +20,22 @@ let
         '';
       };
 
-  # Pull in kubernetes modules from NixOS 19.09.
-  kubernetesModulesFrom1909 = [
+  # Pull in kubernetes modules from NixOS 20.03.
+  kubernetesModulesFrom2003 = [
+    "services/networking/flannel.nix"
+    "services/misc/etcd.nix"
+    "services/security/cfssl.nix"
+    "services/cluster/kubernetes/proxy.nix"
+    "services/cluster/kubernetes/controller-manager.nix"
     "services/cluster/kubernetes/addons/dns.nix"
     "services/cluster/kubernetes/addons/dashboard.nix"
     "services/cluster/kubernetes/addon-manager.nix"
     "services/cluster/kubernetes/apiserver.nix"
-    "services/cluster/kubernetes/controller-manager.nix"
     "services/cluster/kubernetes/default.nix"
     "services/cluster/kubernetes/flannel.nix"
     "services/cluster/kubernetes/kubelet.nix"
-    "services/cluster/kubernetes/proxy.nix"
     "services/cluster/kubernetes/scheduler.nix"
-    "services/networking/flannel.nix"
-    "services/misc/etcd.nix"
-    "services/security/cfssl.nix"
+    "services/cluster/kubernetes/default.nix"
   ];
 
   kubernetesModulesFromHere = [
@@ -42,19 +43,19 @@ let
     "services/cluster/kubernetes/pki.nix"
   ];
 
-  nixpkgs-19_09-src = (import ../../../versions.nix {}).nixos-19_09;
+  nixpkgs-20_03-src = (import ../../../versions.nix {}).nixos-20_03;
 
 in {
 
-  disabledModules = kubernetesModulesFrom1909 ++ kubernetesModulesFromHere;
+  disabledModules = kubernetesModulesFrom2003 ++ kubernetesModulesFromHere;
 
   imports = [
     ./frontend.nix
     ./master.nix
+    ./node.nix
     ./certmgr.nix
     ./pki.nix
-    ./node.nix
-  ] ++ map (m: "${nixpkgs-19_09-src}/nixos/modules/${m}") kubernetesModulesFrom1909;
+  ] ++ map (m: "${nixpkgs-20_03-src}/nixos/modules/${m}") kubernetesModulesFrom2003;
 
   options = with lib; {
     flyingcircus.kubernetes.lib = mkOption {

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -1,6 +1,6 @@
 # Collection of own packages
 { pkgs ? import <nixpkgs> {}
-, pkgs-19_09 ? import <nixpkgs> {}
+, pkgs-20_03 ? import <nixpkgs> {}
 }:
 
 let
@@ -9,7 +9,7 @@ let
 
     fc = import ./fc {
       inherit (self) callPackage;
-      inherit pkgs pkgs-19_09;
+      inherit pkgs pkgs-20_03;
     };
 
   };

--- a/pkgs/fc/default.nix
+++ b/pkgs/fc/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, pkgs-19_09, callPackage }:
+{ pkgs, pkgs-20_03, callPackage }:
 
 {
   recurseForDerivations = true;
@@ -7,13 +7,13 @@
   box = callPackage ./box { };
   check-haproxy = callPackage ./check-haproxy {};
   check-journal = callPackage ./check-journal.nix {};
-  check-postfix = pkgs-19_09.callPackage ./check-postfix {};
+  check-postfix = pkgs-20_03.callPackage ./check-postfix {};
   collectdproxy = callPackage ./collectdproxy {};
-  roundcube-chpasswd = pkgs-19_09.callPackage ./roundcube-chpasswd {};
+  roundcube-chpasswd = pkgs-20_03.callPackage ./roundcube-chpasswd {};
   fix-so-rpath = callPackage ./fix-so-rpath {};
   logcheckhelper = callPackage ./logcheckhelper { };
   multiping = callPackage ./multiping.nix {};
   sensuplugins = callPackage ./sensuplugins {};
   sensusyntax = callPackage ./sensusyntax {};
-  userscan = pkgs-19_09.callPackage ./userscan.nix {};
+  userscan = pkgs-20_03.callPackage ./userscan.nix {};
 }

--- a/pkgs/libpcap-1.8.nix
+++ b/pkgs/libpcap-1.8.nix
@@ -1,0 +1,54 @@
+{ stdenv, fetchurl, fetchpatch, flex, bison }:
+
+stdenv.mkDerivation rec {
+  name = "libpcap-1.8.1";
+
+  src = fetchurl {
+    url = "https://www.tcpdump.org/release/${name}.tar.gz";
+    sha256 = "07jlhc66z76dipj4j5v3dig8x6h3k6cb36kmnmpsixf3zmlvqgb7";
+  };
+
+  nativeBuildInputs = [ flex bison ];
+
+  # We need to force the autodetection because detection doesn't
+  # work in pure build enviroments.
+  configureFlags = [
+    ("--with-pcap=" + {
+      linux = "linux";
+      darwin = "bpf";
+    }.${stdenv.hostPlatform.parsed.kernel.name})
+  ] ++ stdenv.lib.optionals (stdenv.hostPlatform == stdenv.buildPlatform) [
+    "ac_cv_linux_vers=2"
+  ];
+
+  dontStrip = stdenv.hostPlatform != stdenv.buildPlatform;
+
+  prePatch = stdenv.lib.optionalString stdenv.isDarwin ''
+    substituteInPlace configure --replace " -arch i386" ""
+  '';
+
+  patches = [
+    (fetchpatch {
+      url    = "https://sources.debian.net/data/main/libp/libpcap/1.8.1-3/debian/patches/disable-remote.diff";
+      sha256 = "0dvjax9c0spvq8cdjnkbnm65wlzaml259yragf95kzg611vszfmj";
+    })
+    # See https://github.com/wjt/bustle/commit/f62cf6bfa662af4ae39effbbd4891bc619e3b4e9
+    (fetchpatch {
+      url    = "https://github.com/the-tcpdump-group/libpcap/commit/2be9c29d45fb1fab8e9549342a30c160b7dea3e1.patch";
+      sha256 = "1g8mh942vr0abn48g0bdvi4gmhq1bz0l80276603y7064qhy3wq5";
+    })
+    (fetchpatch {
+      url    = "https://github.com/the-tcpdump-group/libpcap/commit/1a6b088a88886eac782008f37a7219a32b86da45.patch";
+      sha256 = "1n5ylm7ch3i1lh4y2q16b0vabgym8g8mqiqxpqcdkjdn05c1wflr";
+    })
+  ];
+
+  preInstall = ''mkdir -p $out/bin'';
+
+  meta = with stdenv.lib; {
+    homepage = http://www.tcpdump.org;
+    description = "Packet Capture Library";
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ fpletz ];
+  };
+}

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -2,19 +2,18 @@ self: super:
 
 let
   versions = import ../versions.nix { pkgs = super; };
-  pkgs-18_09 = import versions.nixos-18_09 {};
-  pkgs-19_09 = import versions.nixos-19_09 {};
+  pkgs-20_03 = import versions.nixos-20_03 {};
 
 in {
   # keep in sync with nixos/platform/garbagecollect/default.nix
-  nixpkgs-19_09-src = versions.nixos-19_09;
+  nixpkgs-20_03-src = versions.nixos-20_03;
 
   #
   # == our own stuff
   #
   fc = (import ./default.nix {
     pkgs = self;
-    inherit pkgs-19_09;
+    inherit pkgs-20_03;
   });
 
   #
@@ -25,8 +24,8 @@ in {
       meta.priority = 10;
     });
 
-  certmgr = super.callPackage ./certmgr.nix { inherit (pkgs-19_09) buildGoPackage; };
-  cfssl = super.callPackage ./cfssl.nix { inherit (pkgs-19_09) buildGoPackage; };
+  certmgr = super.callPackage ./certmgr.nix { inherit (pkgs-20_03) buildGoPackage; };
+  cfssl = super.callPackage ./cfssl.nix { inherit (pkgs-20_03) buildGoPackage; };
 
   docsplit = super.callPackage ./docsplit { };
   grub2_full = super.callPackage ./grub/2.0x.nix { };
@@ -45,7 +44,9 @@ in {
   influxdb = super.callPackage ./influxdb { };
   innotop = super.callPackage ./percona/innotop.nix { };
 
-  inherit (pkgs-19_09) kubernetes;
+  inherit (pkgs-20_03) kubernetes;
+
+  libpcap_1_8 = super.callPackage ./libpcap-1.8.nix { };
 
   mailx = super.callPackage ./mailx.nix { };
   mc = super.callPackage ./mc.nix { };
@@ -53,7 +54,7 @@ in {
     sasl = super.cyrus_sasl;
     boost = super.boost160;
     # 3.2 is too old for the current libpcap version 1.9, use 1.8.1
-    inherit (pkgs-18_09) libpcap;
+    libpcap = self.libpcap_1_8;
   };
   mysql = super.mariadb;
 

--- a/versions.json
+++ b/versions.json
@@ -1,20 +1,14 @@
 {
-  "nixos-18.09": {
+  "nixos-20.03": {
     "owner": "NixOS",
     "repo": "nixpkgs",
-    "rev": "a7e559a5504572008567383c3dc8e142fa7a8633",
-    "sha256": "16j95q58kkc69lfgpjkj76gw5sx8rcxwi3civm0mlfaxxyw9gzp6"
-  },
-  "nixos-19.09": {
-    "owner": "NixOS",
-    "repo": "nixpkgs",
-    "rev": "c49da6435f314e04fc58ca29807221817ac2ac6b",
-    "sha256": "17zsqhaf098bvcfarnq0h9601z6smkfd1kz1px6xfg6xqfmr80r7"
+    "rev": "48723f48ab92381f0afd50143f38e45cf3080405",
+    "sha256": "0h3b3l867j3ybdgimfn76lw7w6yjhszd5x02pq5827l659ihcf53"
   },
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "92c7b4b23a60ad437bf501b86aa0ef5f493227ad",
-    "sha256": "1yyy1p6rfjinvhsl4rprfw40gckgcgjqcy3wq2klb3xg0zs260c3"
+    "rev": "fe0db4a6230502165054a3b423d7ec66e08e8a69",
+    "sha256": "043hf3gbkarhkks4ymnnyk76j4gl7q4iaykmlayhd86fvy34i7qd"
   }
 }


### PR DESCRIPTION
Replace packages and modules from 19.09 with the versions from 20.03.

Updates Kubernetes from 1.15 to 1.17 and uses the 20.03 rust toolchain for building our tools.

Our pinned nixpkgs needed an update to remove the Kubernetes options from rename.nix
that are already defined in the 20.03 modules.

18.09 is dropped. We only used libpcap 1.8 which is now included in the
overlay.

Case 124530

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Replace 19.09 channel with 20.03. Lowers RAM consumption of our periodic management task which should reduce swapping on VMs with only 1GB RAM. Updates Kubernetes to 1.17 (#124530).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - No changes from our side.
- [x] Security requirements tested? (EVIDENCE)
  - Automatic tests have been run
