### PR TITLE
Fix extreme Prometheus RAM consumption, limitNOFile, Grafana 6.7

### DIFF
--- a/nixos/roles/rabbitmq.nix
+++ b/nixos/roles/rabbitmq.nix
@@ -178,6 +178,9 @@ with builtins;
             username = "fc-telegraf";
             password = telegrafPassword;
             nodes = [ "rabbit@${config.networking.hostName}" ];
+            # Drop string fields. They are converted to labels in Prometheus
+            # which blows up the number of metrics.
+            fielddrop = [ "idle_since" ];
           }
         ];
 
@@ -188,10 +191,8 @@ with builtins;
     {
       flyingcircus.roles.statshost.prometheusMetricRelabel = [
         {
-          source_labels = [ "__name__" "idle_since" ];
-          regex = "rabbitmq_.*;idle_since";
-          target_label = "idle_since";
-          replacement = "";
+          regex = "idle_since";
+          action = "labeldrop";
         }
       ];
     }

--- a/nixos/roles/redis.nix
+++ b/nixos/roles/redis.nix
@@ -19,7 +19,7 @@ in {
     flyingcircus.roles.statshost.prometheusMetricRelabel = [
       {
         regex = "aof_last_bgrewrite_status|aof_last_write_status|maxmemory_policy|rdb_last_bgsave_status|used_memory_dataset_perc|used_memory_peak_perc";
-        action = "drop";
+        action = "labeldrop";
       }
     ];
   }

--- a/nixos/roles/statshost/default.nix
+++ b/nixos/roles/statshost/default.nix
@@ -19,9 +19,8 @@ let
   cfgProxyLocation = config.flyingcircus.roles.statshost-location-proxy;
   cfgProxyRG = config.flyingcircus.roles.statshost-relay;
 
-  retentionHours = cfgStats.prometheusRetention * 3600;
   promFlags = [
-    "--storage.tsdb.retention ${toString retentionHours}h"
+    "--storage.tsdb.retention.time ${toString cfgStats.prometheusRetention}d"
   ];
   prometheusListenAddress = cfgStats.prometheusListenAddress;
 
@@ -366,6 +365,8 @@ in
         # Prometheus can take a few minutes to shut down. If it is forcefully
         # killed, a crash recovery process is started, which takes even longer.
         TimeoutStopSec = "10m";
+        # Prometheus uses a lot of connections, 1024 is not enough.
+        LimitNOFILE = 65536;
       };
 
       services.prometheus =

--- a/nixos/roles/statshost/relabel.nix
+++ b/nixos/roles/statshost/relabel.nix
@@ -20,15 +20,17 @@ let
     }
   ];
 
+  removeLabel = prefix: label: {
+    source_labels = [ "__name__" label ];
+    regex = "${prefix}.*;.+";
+    replacement = "";
+    target_label = label;
+  };
+
   # Drop unwanted labels from InfluxDB metrics.
   influxdbRelabel = let
-    removeLabel = label: {
-      source_labels = [ "__name__" label ];
-      regex = "influxdb_(tsm1|shard)_.*;.+";
-      replacement = "";
-      target_label = label;
-    };
-    in map removeLabel [ "path" "walPath" "id" "url" ];
+    removeInfluxLabel = removeLabel "influxdb_(tsm1|shard)_";
+    in map removeInfluxLabel [ "path" "walPath" "id" "url" ];
 
 in
 {

--- a/nixos/services/prometheus.nix
+++ b/nixos/services/prometheus.nix
@@ -690,8 +690,8 @@ in {
 
       package = mkOption {
         type = types.package;
-        default = pkgs.prometheus_2;
-        defaultText = "pkgs.prometheus_2";
+        default = pkgs.prometheus;
+        defaultText = "pkgs.prometheus";
         description = ''
           The prometheus package that should be used.
         '';

--- a/nixos/services/redis.nix
+++ b/nixos/services/redis.nix
@@ -100,6 +100,16 @@ in {
             servers = [
               "tcp://:${password}@localhost:${toString config.services.redis.port}"
             ];
+            # Drop string fields. They are converted to labels in Prometheus
+            # which blows up the number of metrics.
+            fielddrop = [
+              "aof_last_bgrewrite_status"
+              "aof_last_write_status"
+              "maxmemory_policy"
+              "rdb_last_bgsave_status"
+              "used_memory_dataset_perc"
+              "used_memory_peak_perc"
+            ];
           }
         ];
       };

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -28,6 +28,7 @@ in {
   cfssl = super.callPackage ./cfssl.nix { inherit (pkgs-20_03) buildGoPackage; };
 
   docsplit = super.callPackage ./docsplit { };
+  inherit (pkgs-20_03) grafana;
   grub2_full = super.callPackage ./grub/2.0x.nix { };
 
   linux_4_19 = super.linux_4_19.override {
@@ -81,6 +82,7 @@ in {
   percona57 = super.callPackage ./percona/5.7.nix { boost = self.boost159; };
   percona80 = super.callPackage ./percona/8.0.nix { boost = self.boost169; };
 
+  inherit (pkgs-20_03) prometheus;
   prometheus-elasticsearch-exporter = super.callPackage ./prometheus-elasticsearch-exporter.nix { };
 
   rabbitmq-server_3_6_5 = super.callPackage ./rabbitmq-server/3.6.5.nix {


### PR DESCRIPTION
* add limitNOFile=65536 from 15.09 role
* reduce retention time which was way too long because of an unit mistake
* fix various relabel mistakes caused by labeldrop/drop confusion
* drop labels for rabbitmq/redis filtered by Prometheus directly in Telegraf
* Prometheus 2.8.1 -> 2.15.2
* Grafana 6.3 -> 6.7

Reducing the number of active metrics and updating lowered
RAM consumption of Prometheus dramatically.

Case 126199

@flyingcircusio/release-managers

## Release process

Impact:

* Prometheus will be restarted.

Changelog:

* Statshost: Update Prometheus to 2.15.2, Grafana to 6.7, fix problems with too many open connections and correct wrong label dropping rules. The new Prometheus version uses significantly less RAM on our central statshost. (#126199)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - No changes; Prometheus should only listen on srv.
- [x] Security requirements tested? (EVIDENCE)
  - Ran automatic tests and checked open ports on a dev VM.
