### PR TITLE
Update fc-userscan to 0.4.5

### DIFF
--- a/nixos/platform/garbagecollect/default.nix
+++ b/nixos/platform/garbagecollect/default.nix
@@ -10,8 +10,6 @@ let
   log = "/var/log/fc-collect-garbage.log";
 
   garbagecollect = pkgs.writeScript "fc-collect-garbage.py" ''
-    #! ${pkgs.python3.interpreter}
-
     import datetime
     import os
     import pwd
@@ -37,10 +35,10 @@ let
         status = max(rc)
         print('Overall status:', status)
         if status >= 2:
-            print('ERROR: fc-userscan had hard errors (see above). Aborting')
+            print('Aborting garbagecollect. See above for fc-userscan errors')
             sys.exit(2)
         if status >= 1:
-            print('WARNING: fc-userscan had soft errors (see above). Aborting')
+            print('Aborting garbagecollect. See above for fc-userscan warnings')
             sys.exit(1)
         print('Running nix-collect-garbage')
         rc = subprocess.run([

--- a/tests/garbagecollect.nix
+++ b/tests/garbagecollect.nix
@@ -29,17 +29,23 @@ import ./make-test.nix (
       $machine->startJob("fc-collect-garbage");
       $machine->fail("systemctl is-failed fc-collect-garbage.service");
 
-      # create some files containing Nix store references
-      # these should be found & registered by fc-userscan
+      # create a script containing a Nix store reference and run
+      # fc-collect-garbage again
       print($machine->succeed(<<_EOT_));
         set -e
         echo -e "#!${py}\nprint('hello world')" > ${home}/script.py
         chmod +x ${home}/script.py
         grep -r /nix/store/ ${home}
-        sudo -u u0 -- ${userscan} -rvc ${home}/.cache/fc-userscan.cache ${home}
-        test -s ${home}/.cache/fc-userscan.cache
-        test -n "$(find /nix/var/nix/gcroots/per-user/u0${home} -type l)"
       _EOT_
+      $machine->startJob("fc-collect-garbage");
+      print($machine->waitForFile("${home}/.cache/fc-userscan.cache"));
+
+      # check that a GC root has been registered
+      print($machine->succeed(<<_EOT_));
+        ls -lR /nix/var/nix/gcroots/per-user/u0${home} | grep ${py}
+        test `find /nix/var/nix/gcroots/per-user/u0${home} -type l | wc -l` = 1
+      _EOT_
+      $machine->fail("systemctl is-failed fc-collect-garbage.service");
     '';
   }
 )


### PR DESCRIPTION
This makes fc-collect-garbage more forgiving to problematic file permissions/file ownership, i.e. when a user has non-readable files in its home directory.

Also improve test.

Case 124165

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

  - Improved reliability of fc-userscan
  - But: 3rd-party install procedures may dump code owned by root or other privileged accounts into service users' homes. These may contain references into the Nix store. fc-userscan now skips these files with warnings. This may lead to unwanted cleanups in the Nix store and may affect application reliability.

- [x] Security requirements tested? (EVIDENCE)

  - NixOS test provide
  - The effect outlined above must be watched and adjusted if this presents problems in practice.