### PR TITLE
Run postfix-queue-perms even if no mails are sent

### DIFF
--- a/nixos/services/mail/default.nix
+++ b/nixos/services/mail/default.nix
@@ -269,11 +269,16 @@ in {
         wantedBy = [ "multi-user.target" ];
         path = with pkgs; [ acl inotify-tools ];
         script = ''
-          while true; do
-            inotifywait -r -e create /var/lib/postfix/queue
+          fix() {
             setfacl -Rm u:telegraf:rX ${dirs}
             setfacl -Rdm u:telegraf:rX ${dirs}
             sleep 1
+          }
+
+          fix
+          while true; do
+            inotifywait -r -t 60 -e create /var/lib/postfix/queue
+            fix
           done
         '';
         serviceConfig = {


### PR DESCRIPTION
Telegraf fails to get metrics from Postfix queue directories since
Postfix resets permissions during startup. The postfix-queue-perms job
corrects these as soon as new queue files are generated.

In the time between Postfix startup and the first mail being processed,
no Telegraf metrics can be generated. This presents a problem for
low-volume mail servers.

Fix the script so that it runs occasionally even without mails being
processed.

Case 126332

@flyingcircusio/release-managers

## Release process

Impact:

Changelog: Fix Postfix permissions problem which lead to incomplete Telegraf metrics for low-volume mail servers (#126332).

## Security implications

- [ ] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

dunno

- [x] Security requirements tested? (EVIDENCE)

Missing metrics -> monitoring less useful