### PR TITLE
Add RabbitMQ 3.8 role

### DIFF
--- a/nixos/roles/rabbitmq.nix
+++ b/nixos/roles/rabbitmq.nix
@@ -14,6 +14,7 @@ with builtins;
       rabbitmq36_5 = mkRole "3.6.5";
       rabbitmq36_15 = mkRole "3.6.15";
       rabbitmq37 = mkRole "3.7";
+      rabbitmq38 = mkRole "3.8";
     };
   };
 
@@ -33,6 +34,7 @@ with builtins;
       "3.6.5" = rabbitmq36_5.enable;
       "3.6.15" = rabbitmq36_15.enable;
       "3.7" = rabbitmq37.enable;
+      "3.8" = rabbitmq38.enable;
     };
     enabledRoles = lib.filterAttrs (n: v: v) rabbitRoles;
     enabledRolesCount = length (lib.attrNames enabledRoles);
@@ -55,8 +57,8 @@ with builtins;
       flyingcircus.services.rabbitmq36 = serviceConfig;
     })
 
-    (lib.mkIf (enabled && majorMinorVersion == "3.7") {
-      flyingcircus.services.rabbitmq37 = serviceConfig;
+    (lib.mkIf (enabled && majorMinorVersion != "3.6") {
+      flyingcircus.services.rabbitmq = serviceConfig;
     })
 
     (lib.mkIf enabled {

--- a/nixos/services/default.nix
+++ b/nixos/services/default.nix
@@ -16,7 +16,7 @@
     ./postgresql.nix
     ./prometheus.nix
     ./rabbitmq36.nix
-    ./rabbitmq37.nix
+    ./rabbitmq.nix
     ./redis.nix
     ./sensu.nix
     ./ssmtp.nix

--- a/nixos/services/rabbitmq.nix
+++ b/nixos/services/rabbitmq.nix
@@ -3,7 +3,7 @@
 with lib;
 
 let
-  cfg = config.flyingcircus.services.rabbitmq37;
+  cfg = config.flyingcircus.services.rabbitmq;
 
   inherit (builtins) concatStringsSep;
 
@@ -15,21 +15,21 @@ let
 in {
   ###### interface
   options = {
-    flyingcircus.services.rabbitmq37 = {
+    flyingcircus.services.rabbitmq = {
       enable = mkOption {
         default = false;
         description = ''
           Whether to enable the RabbitMQ server, an Advanced Message
-          Queuing Protocol (AMQP) broker (3.7.x series).
+          Queuing Protocol (AMQP) broker.
         '';
       };
 
       package = mkOption {
-        default = pkgs.rabbitmq_server_3_7;
+        default = pkgs.rabbitmq_server_3_8;
         type = types.package;
-        defaultText = "pkgs.rabbitmq_server_3_7";
+        defaultText = "pkgs.rabbitmq_server_3_8";
         description = ''
-          Which rabbitmq package (3.7.x) to use.
+          Which rabbitmq package (3.7.x or 3.8.x) to use.
         '';
       };
 
@@ -152,7 +152,7 @@ in {
 
     users.groups.rabbitmq.gid = config.ids.gids.rabbitmq;
 
-    flyingcircus.services.rabbitmq37.configItems = {
+    flyingcircus.services.rabbitmq.configItems = {
       "listeners.tcp.1" = mkDefault "${cfg.listenAddress}:${toString cfg.port}";
     };
 

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -92,6 +92,7 @@ in {
     erlang = self.erlangR19;
   };
   rabbitmq-server_3_7 = super.rabbitmq-server;
+  rabbitmq-server_3_8 = pkgs-20_03.rabbitmq-server;
 
   remarshal = super.callPackage ./remarshal.nix { };
   rum = super.callPackage ./postgresql/rum { };

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -51,6 +51,7 @@ in {
   rabbitmq36_15 = callTest ./rabbitmq.nix { rolename = "rabbitmq36_15"; };
   rabbitmq36_5 = callTest ./rabbitmq.nix { rolename = "rabbitmq36_5"; };
   rabbitmq37 = callTest ./rabbitmq.nix { rolename = "rabbitmq37"; };
+  rabbitmq38 = callTest ./rabbitmq.nix { rolename = "rabbitmq38"; };
   redis = callTest ./redis.nix {};
   rg-relay = callTest ./statshost/rg-relay.nix {};
   statshost-global = callTest ./statshost/statshost-global.nix {};

--- a/tests/rabbitmq.nix
+++ b/tests/rabbitmq.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ rolename ? "rabbitmq36_15", lib, pkgs, testlib, ... }:
+import ./make-test.nix ({ rolename ? "rabbitmq38", lib, pkgs, testlib, ... }:
 let
   ipv4 = "192.168.101.1";
   amqpPortCheck = "nc -z ${ipv4} 5672";
@@ -33,7 +33,6 @@ in {
 
     print($machine->succeed("$cli status"));
     $machine->succeed("$cli node_health_check");
-    $machine->succeed("$cli status | grep 'amqp,5672,\"${ipv4}\"'");
 
     # make sure this is run before continuing
     $machine->succeed("systemctl start fc-rabbitmq-settings");


### PR DESCRIPTION
Works with the existing service rabbitmq37 which is named just rabbitmq now.
Removed a test line that doesn't work with 3.8 and doesn't add real
value.

Case 126083

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Add RabbitMQ 3.8 role.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- minimise attack surface area: no additional ports are opened
- use a version that still gets security updates
- check that the new version doesn't introduce features that will harm security
- [x] Security requirements tested? (EVIDENCE)
- reviewed changelog and checked manually on test VM if no additional ports are opened
- 3.8 is the current version of RabbitMQ. It's from NixOS 20.03 which still gets security fixes.