### PR TITLE
Install tmux by default

### DIFF
--- a/nixos/platform/packages.nix
+++ b/nixos/platform/packages.nix
@@ -64,6 +64,7 @@
         sysstat
         tcpdump
         telnet
+        tmux
         tree
         unzip
         vim


### PR DESCRIPTION
Case 126628

@flyingcircusio/release-managers

## Release process

Impact:

Changelog: Provide `tmux` on all VMs by default (#126628).

## Security implications

- [ ] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

n/a

- [ ] Security requirements tested? (EVIDENCE)

n/a