### PR TITLE
Allow vagrant user to interact with the docker daemon

### DIFF
--- a/nixos/infrastructure/vagrant.nix
+++ b/nixos/infrastructure/vagrant.nix
@@ -38,7 +38,7 @@
     users.users.vagrant = {
     	description = "Vagrant user";
     	group = "users";
-    	extraGroups = [ "login" "service" ];
+    	extraGroups = [ "login" "service" "docker" ];
     	password = "vagrant";
     	home = "/home/vagrant";
     	isNormalUser = true;


### PR DESCRIPTION
Case 126517

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Allow vagrant user to interact with the docker daemon (#126517).

## Security implications

Only affects the vagrant environment for testing

