### PR TITLE
Statshost: increase influxdb startup timeout to one hour

### DIFF
--- a/nixos/roles/statshost/default.nix
+++ b/nixos/roles/statshost/default.nix
@@ -450,6 +450,7 @@ in
       systemd.services.influxdb = {
         serviceConfig = {
           LimitNOFILE = 65535;
+          TimoutStartSec = "1h";
           Restart = "always";
         };
         postStart =


### PR DESCRIPTION
InfluxDB can take a long time to start.

Case 126604

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Statshost: increase influxdb startup timeout (#126604).

## Security implications

n/a