### PR TITLE
Rotate all logs in /var/log/nginx

### DIFF
--- a/nixos/services/nginx/default.nix
+++ b/nixos/services/nginx/default.nix
@@ -280,9 +280,7 @@ in
       };
 
       services.logrotate.config = ''
-        /var/log/nginx/*access*log
-        /var/log/nginx/*error*log
-        /var/log/nginx/performance.log
+        /var/log/nginx/*.log
         {
             rotate 92
             create 0644 nginx service


### PR DESCRIPTION
There can be custom log files for nginx which should not grow indefinitely.

Case 126707

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Rotate all logs in /var/log/nginx periodically (#126707).

## Security implications

n/a
