### PR TITLE
Extend firewall filter script to prohibit use of hostnames instead of…

### DIFF
--- a/nixos/platform/filter-rules.py
+++ b/nixos/platform/filter-rules.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+import fileinput
+import re
+import shlex
+import sys
+import os.path as p
+
+R_ALLOWED = re.compile(r'^(ip(6|46)?tables .*)?''$')
+
+ADDR_V4_ALLOWED = re.compile(r'^[0-9.\/\-]+$')
+ADDR_V6_ALLOWED = re.compile(r'^[0-9a-fA-F\/\-]+:[0-9a-fA-F\:\/\-]*$')
+
+
+# We currently only filter hostnames in the '-s' and '-d' options. There
+# are some more obscure candidates around but I'm leaving them out for now
+# because they don't imply that they are actually doing DNS resolution:
+#
+# [!] --ctorigsrc address[/mask]
+# [!] --ctorigdst address[/mask]
+# [!] --ctreplsrc address[/mask]
+# [!] --ctrepldst address[/mask]
+# [!] --src-range from[-to]
+# [!] --dst-range from[-to]
+# [!] --vaddr address[/mask]
+# [!] --tunnel-src addr[/mask]
+# [!] --tunnel-dst addr[/mask]
+# --rt-0-addrs addr[,addr...]
+# --to-destination [ipaddr[-ipaddr]][:port[-port]]
+# --hmark-src-prefix cidr
+# --hmark-dst-prefix cidr
+# --to address[/mask]
+# --to-source [ipaddr[-ipaddr]][:port[-port]]
+# --on-ip address
+
+def find_arguments_with_values(options, args):
+    for option in options:
+        if option not in args:
+            continue
+        value = args[args.index(option)+1]
+        yield option, value
+
+
+def exit_with_error(message, line):
+    fn = fileinput.filename()
+    ln = fileinput.lineno()
+    print('File "{fn}", line {ln}\n'
+          '  {line}\n\n'
+          'Error: {message}'.format(
+              message=message, line=line.strip(), fn=fn, ln=ln),
+          file=sys.stderr)
+    sys.exit(1)
+
+
+for line in fileinput.input():
+    line = line.strip()
+    if line.startswith('#'):
+        print(line)
+        continue
+    atoms = list(shlex.quote(s) for s in shlex.split(line.strip()))
+    m = R_ALLOWED.match(' '.join(atoms))
+
+    # Is this an iptables command?
+    if not (m and m.group(1)):
+        exit_with_error('only iptables statements or comments allowed', line)
+
+    # Are there any hostnames in there?
+    for option, value in find_arguments_with_values(
+            ['-s', '--source', '-d', '--destination'], atoms):
+        if ADDR_V4_ALLOWED.match(value):
+            continue
+        if ADDR_V6_ALLOWED.match(value):
+            continue
+        exit_with_error('hostnames are not allowed as addresses', line)
+
+    # Are we using a default chain? Don't.
+    for option, value in find_arguments_with_values(
+            ['-A', '-C', '-D', '-I', '-R', '-S', '-F', '-L', '-Z', '-N', '-X',
+            '-P', '-E'], atoms):
+        if value in ['INPUT', 'OUTPUT', 'FORWARD', 'PREROUTING', 'POSTROUTING'
+                      'SECMARK', 'CONNSECMARK']:
+            exit_with_error('builtin chains are not allowed here', line)
+
+    print(m.group(1))


### PR DESCRIPTION
… addresses and avoid interference with builtin chains.

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Revert our atomic firewall to the fine-grained reload/reconfiguration mechanism in baseline NixOS. This helps compatibility with dynamic rule systems like Docker, Kubernetes, etc. We also now filter custom rules in /etc/local/firewall to only interact with custom chains and prohibit interaction with the default chains. Existing configurations may become invalid but will not silently break as NixOS catches those errors without breaking the running configuration. We'll clean up customer installations that are affected by this manually.

## Security implications

- [X] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

The existing firewall rules should not be hurt. The change here reverts our way of assembling the firewall rules to the regular NixOS approach and limits the interactions that customers can have with custom rules to avoid reconfiguration conflicts with dynamic systems like docker. Those limits are more strict than previously and some customer configs might not work in the new system. However, existing configurations won't break and will just be kept until the config is cleaned up.

- [X] Security requirements tested? (EVIDENCE)

* Tested migration and manual changes on my dev VM test36. Firewall tests in hydra should still be running once merged.