### PR TITLE
Remove misleading inotifywait messages

### DIFF
--- a/nixos/services/mail/default.nix
+++ b/nixos/services/mail/default.nix
@@ -277,7 +277,7 @@ in {
 
           fix
           while true; do
-            inotifywait -r -t 60 -e create /var/lib/postfix/queue
+            inotifywait -q -r -e create /var/lib/postfix/queue
             fix
           done
         '';


### PR DESCRIPTION

Case 126796

@flyingcircusio/release-managers

## Release process

Impact:

Changelog: Silence misleading journal messages from `postfix-queue-perms.service` (#126796)

## Security implications

Improve diagnostic abilities by reducing amount of unnecessary error messages in the journal.