### PR TITLE
firewall: Accept empty lines and POSTROUTING rules

### DIFF
--- a/nixos/platform/filter-rules.py
+++ b/nixos/platform/filter-rules.py
@@ -3,7 +3,6 @@ import fileinput
 import re
 import shlex
 import sys
-import os.path as p
 
 R_ALLOWED = re.compile(r'^(ip(6|46)?tables .*)?''$')
 
@@ -53,7 +52,7 @@ def exit_with_error(message, line):
 
 for line in fileinput.input():
     line = line.strip()
-    if line.startswith('#'):
+    if line.startswith('#') or line.strip() == '':
         print(line)
         continue
     atoms = list(shlex.quote(s) for s in shlex.split(line.strip()))
@@ -75,9 +74,9 @@ for line in fileinput.input():
     # Are we using a default chain? Don't.
     for option, value in find_arguments_with_values(
             ['-A', '-C', '-D', '-I', '-R', '-S', '-F', '-L', '-Z', '-N', '-X',
-            '-P', '-E'], atoms):
-        if value in ['INPUT', 'OUTPUT', 'FORWARD', 'PREROUTING', 'POSTROUTING'
-                      'SECMARK', 'CONNSECMARK']:
+             '-P', '-E'], atoms):
+        if value in ['INPUT', 'OUTPUT', 'FORWARD', 'PREROUTING',
+                     'SECMARK', 'CONNSECMARK']:
             exit_with_error('builtin chains are not allowed here', line)
 
     print(m.group(1))

--- a/tests/network/open-fe-80/firewall/firewall.conf
+++ b/tests/network/open-fe-80/firewall/firewall.conf
@@ -1,1 +1,3 @@
+# comment
+
 ip46tables -A nixos-fw -p tcp -i ethfe --dport 80 -j nixos-fw-accept


### PR DESCRIPTION
Not allowing empty lines is a nuisance at least and does not work well
with rule files generated from templates.

We need to accept POSTROUTING rules to express masquerading.

Case 126819
Case 126822

@flyingcircusio/release-managers

## Release process

Impact:

Changelog: Accept empty lines and POSTROUTING rules in `/etc/local/firewall` (#126819, #126822).

## Security implications

- The empty lines change is functionally transparent
- POSTROUTING is necessary to prevent breakage of Docker installation which need to set up masquerading. Being able to install own POSTROUTING rules includes the possibility to create outgoing packets with non-local IP sender addresses. But the additional risk is low since this is already possible by other means. This issue needs to be addressed in the new overlay/underlay based network architecture.
