### PR TITLE
Use unstable channel instead of 20.03 as extra channel

### DIFF
--- a/nixos/platform/garbagecollect/default.nix
+++ b/nixos/platform/garbagecollect/default.nix
@@ -76,7 +76,7 @@ in {
 
       # keep in sync with pkgs/overlay.nix
       environment.etc."nixos/garbagecollect-protect-references".text = ''
-        nixpkgs-20.03=${pkgs.nixpkgs-20_03-src}
+        nixpkgs-unstable=${pkgs.nixpkgs-unstable-src}
       '';
 
       flyingcircus.services.sensu-client.checks.fc-collect-garbage = {

--- a/nixos/roles/kubernetes/default.nix
+++ b/nixos/roles/kubernetes/default.nix
@@ -20,8 +20,8 @@ let
         '';
       };
 
-  # Pull in kubernetes modules from NixOS 20.03.
-  kubernetesModulesFrom2003 = [
+  # Pull in kubernetes modules from a newer NixOS version.
+  kubernetesModulesFromUnstable = [
     "services/networking/flannel.nix"
     "services/misc/etcd.nix"
     "services/security/cfssl.nix"
@@ -43,11 +43,11 @@ let
     "services/cluster/kubernetes/pki.nix"
   ];
 
-  nixpkgs-20_03-src = (import ../../../versions.nix {}).nixos-20_03;
+  nixpkgs-unstable-src = (import ../../../versions.nix {}).nixos-unstable;
 
 in {
 
-  disabledModules = kubernetesModulesFrom2003 ++ kubernetesModulesFromHere;
+  disabledModules = kubernetesModulesFromUnstable ++ kubernetesModulesFromHere;
 
   imports = [
     ./frontend.nix
@@ -55,7 +55,7 @@ in {
     ./node.nix
     ./certmgr.nix
     ./pki.nix
-  ] ++ map (m: "${nixpkgs-20_03-src}/nixos/modules/${m}") kubernetesModulesFrom2003;
+  ] ++ map (m: "${nixpkgs-unstable-src}/nixos/modules/${m}") kubernetesModulesFromUnstable;
 
   options = with lib; {
     flyingcircus.kubernetes.lib = mkOption {

--- a/nixos/services/default.nix
+++ b/nixos/services/default.nix
@@ -1,9 +1,18 @@
 { lib, ... }:
-{
-  disabledModules = [
+let
+  modulesFromHere = [
     "services/monitoring/prometheus.nix"
     "services/monitoring/prometheus/default.nix"
   ];
+
+  modulesFromUnstable = [
+    "services/monitoring/grafana.nix"
+  ];
+
+  nixpkgs-unstable-src = (import ../../versions.nix {}).nixos-unstable;
+
+in {
+  disabledModules = modulesFromUnstable ++ modulesFromHere;
 
   imports = with lib; [
     ./box/client.nix
@@ -24,5 +33,5 @@
     ./telegraf.nix
 
     (mkRemovedOptionModule [ "flyingcircus" "services" "percona" "rootPassword" ] "Change the root password via MySQL and modify secret files")
-  ];
+  ] ++ map (m: "${nixpkgs-unstable-src}/nixos/modules/${m}") modulesFromUnstable;
 }

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -1,6 +1,6 @@
 # Collection of own packages
 { pkgs
-, pkgs-20_03
+, pkgs-unstable
 }:
 
 let
@@ -9,7 +9,7 @@ let
 
     fc = import ./fc {
       inherit (self) callPackage;
-      inherit pkgs pkgs-20_03;
+      inherit pkgs pkgs-unstable;
     };
 
   };

--- a/pkgs/fc/check-postfix/default.nix
+++ b/pkgs/fc/check-postfix/default.nix
@@ -10,7 +10,7 @@ rustPlatform.buildRustPackage rec {
     filter = n: t: baseNameOf n != "target";
     src = cleanSource ./.;
   };
-  cargoSha256 = "1s771jlf0vlxqqhh5nzr8i3rpi57gkpjmiv82d06qzh6p4sgngl7";
+  cargoSha256 = "1zq8j25f61wz316sgpxbqqzq6sc8hn7divsdb0l365sfr0fz1p48";
 
   meta = {
     description = ''

--- a/pkgs/fc/default.nix
+++ b/pkgs/fc/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, pkgs-20_03, callPackage }:
+{ pkgs, pkgs-unstable, callPackage }:
 
 {
   recurseForDerivations = true;
@@ -7,13 +7,13 @@
   box = callPackage ./box { };
   check-haproxy = callPackage ./check-haproxy {};
   check-journal = callPackage ./check-journal.nix {};
-  check-postfix = pkgs-20_03.callPackage ./check-postfix {};
+  check-postfix = pkgs-unstable.callPackage ./check-postfix {};
   collectdproxy = callPackage ./collectdproxy {};
-  roundcube-chpasswd = pkgs-20_03.callPackage ./roundcube-chpasswd {};
+  roundcube-chpasswd = pkgs-unstable.callPackage ./roundcube-chpasswd {};
   fix-so-rpath = callPackage ./fix-so-rpath {};
   logcheckhelper = callPackage ./logcheckhelper { };
   multiping = callPackage ./multiping.nix {};
   sensuplugins = callPackage ./sensuplugins {};
   sensusyntax = callPackage ./sensusyntax {};
-  userscan = pkgs-20_03.callPackage ./userscan.nix {};
+  userscan = pkgs-unstable.callPackage ./userscan.nix {};
 }

--- a/pkgs/fc/roundcube-chpasswd/default.nix
+++ b/pkgs/fc/roundcube-chpasswd/default.nix
@@ -7,5 +7,5 @@ rustPlatform.buildRustPackage {
     filter = n: t: baseNameOf n != "target";
     src = lib.cleanSource ./.;
   };
-  cargoSha256 = "1fq49xvli5bpz3af5dyzizb1bmbz1fqw9z014fnb7g0snr8bls1a";
+  cargoSha256 = "1rpxgpfcc17m499mx2zww4n5absjhk747zs9sqs3x98dgzz1kx5w";
 }

--- a/pkgs/fc/userscan.nix
+++ b/pkgs/fc/userscan.nix
@@ -17,7 +17,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "172q2ywdpg3q7picbl99cv45rcca2vhl7pvb7d4ilc66mhq6b265";
   };
 
-  cargoSha256 = "0ma6ng94r963pn0bdnnmkq27khg031vrb4s3g17kk0kdl30yb9vn";
+  cargoSha256 = "0rb181fih70jmnpn9q5lhwhv2gk0rk58945g6j6gapapq4sf259m";
   nativeBuildInputs = [ docutils ];
   propagatedBuildInputs = [ lzo ];
 

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -2,18 +2,18 @@ self: super:
 
 let
   versions = import ../versions.nix { pkgs = super; };
-  pkgs-20_03 = import versions.nixos-20_03 {};
+  pkgs-unstable = import versions.nixos-unstable {};
 
 in {
   # keep in sync with nixos/platform/garbagecollect/default.nix
-  nixpkgs-20_03-src = versions.nixos-20_03;
+  nixpkgs-unstable-src = versions.nixos-unstable;
 
   #
   # == our own stuff
   #
   fc = (import ./default.nix {
     pkgs = self;
-    inherit pkgs-20_03;
+    inherit pkgs-unstable;
   });
 
   #
@@ -24,11 +24,13 @@ in {
       meta.priority = 10;
     });
 
-  certmgr = super.callPackage ./certmgr.nix { inherit (pkgs-20_03) buildGoPackage; };
-  cfssl = super.callPackage ./cfssl.nix { inherit (pkgs-20_03) buildGoPackage; };
+  certmgr = super.callPackage ./certmgr.nix { inherit (pkgs-unstable) buildGoPackage; };
+  cfssl = super.callPackage ./cfssl.nix { inherit (pkgs-unstable) buildGoPackage; };
 
   docsplit = super.callPackage ./docsplit { };
-  inherit (pkgs-20_03) grafana;
+
+  inherit (pkgs-unstable) grafana;
+
   grub2_full = super.callPackage ./grub/2.0x.nix { };
 
   linux_4_19 = super.linux_4_19.override {
@@ -45,7 +47,7 @@ in {
   influxdb = super.callPackage ./influxdb { };
   innotop = super.callPackage ./percona/innotop.nix { };
 
-  inherit (pkgs-20_03) kubernetes;
+  inherit (pkgs-unstable) kubernetes;
 
   libpcap_1_8 = super.callPackage ./libpcap-1.8.nix { };
 
@@ -82,7 +84,8 @@ in {
   percona57 = super.callPackage ./percona/5.7.nix { boost = self.boost159; };
   percona80 = super.callPackage ./percona/8.0.nix { boost = self.boost169; };
 
-  inherit (pkgs-20_03) prometheus;
+  inherit (pkgs-unstable) prometheus;
+
   prometheus-elasticsearch-exporter = super.callPackage ./prometheus-elasticsearch-exporter.nix { };
 
   rabbitmq-server_3_6_5 = super.callPackage ./rabbitmq-server/3.6.5.nix {
@@ -92,7 +95,7 @@ in {
     erlang = self.erlangR19;
   };
   rabbitmq-server_3_7 = super.rabbitmq-server;
-  rabbitmq-server_3_8 = pkgs-20_03.rabbitmq-server;
+  rabbitmq-server_3_8 = pkgs-unstable.rabbitmq-server;
 
   remarshal = super.callPackage ./remarshal.nix { };
   rum = super.callPackage ./postgresql/rum { };
@@ -109,6 +112,8 @@ in {
   sensu-plugins-redis = super.callPackage ./sensuplugins-rb/sensu-plugins-redis { };
   sensu-plugins-systemd = super.callPackage ./sensuplugins-rb/sensu-plugins-systemd { };
   temporal_tables = super.callPackage ./postgresql/temporal_tables { };
+
+  inherit (pkgs-unstable) writeShellScript;
 
   xtrabackup = super.callPackage ./percona/xtrabackup.nix {
     inherit (self) percona;

--- a/tests/kubernetes/default.nix
+++ b/tests/kubernetes/default.nix
@@ -173,7 +173,7 @@ in {
     };
 
     subtest "creating a deployment should work", sub {
-      $kubmaster->succeed("docker load < ${redis.image}");
+      $kubmaster->waitUntilSucceeds("docker load < ${redis.image}");
       $kubmaster->succeed("kubectl apply -f ${redis.deployment}");
       $kubmaster->succeed("kubectl apply -f ${redis.service}");
     };
@@ -184,7 +184,7 @@ in {
     };
 
     subtest "scaling the deployment should start 4 pods", sub {
-      $kubnode->succeed("docker load < ${redis.image}");
+      $kubnode->waitUntilSucceeds("docker load < ${redis.image}");
       $kubmaster->succeed("kubectl scale deployment redis --replicas=4");
       $kubmaster->waitUntilSucceeds("kubectl get deployment redis | grep -q 4/4");
     };

--- a/versions.json
+++ b/versions.json
@@ -1,9 +1,9 @@
 {
-  "nixos-20.03": {
+  "nixos-unstable": {
     "owner": "NixOS",
     "repo": "nixpkgs",
-    "rev": "2b417708c282d84316366f4125b00b29c49df10f",
-    "sha256": "0426qaxw09h0kkn5zwh126hfb2j12j5xan6ijvv2c905pqi401zq"
+    "rev": "dc80d7bc4a244120b3d766746c41c0d9c5f81dfa",
+    "sha256": "0dy0mp7alc7m34zxall14x42qx9yjm7b0m6psgmw0lb6j1iy1pla"
   },
   "nixpkgs": {
     "owner": "flyingcircusio",


### PR DESCRIPTION
* kubernetes test: retry docker load which seems to fail more often now

Affects these packages:

* prometheus: 2.15.2 -> 2.19.2
* rabbitmq: 3.8.2 -> 3.8.5
* grafana: 6.7.1 -> 7.0.4
* influxdb: 1.6.6 -> 1.8.0
* kubernetes: 1.17.5 -> 1.18.5

Case 126856 and Case 126663

@flyingcircusio/release-managers

## Release process

Impact:

* Prometheus, InfluxDB and Grafana will be restarted.

Changelog:

* Statshost: update Prometheus to 2.19.2, InfluxDB to 1.8.0 and Grafana to 7.0.4 (#126856, #126663).
* Update Kubernetes to 1.18.5 (#126856)

## Security implications

- [x] [Security requirements]
  - use a version that still gets security updates
  - check that the new version doesn't introduce features that can harm security
- [x] Security requirements tested? (EVIDENCE)
  - rabbitmq: checked changelog https://www.rabbitmq.com/changelog.html and release notes
  - prometheus: checked changelog https://github.com/prometheus/prometheus/blob/master/CHANGELOG.md
  - influxdb: checked changelog https://github.com/influxdata/influxdb/blob/1.8/CHANGELOG.md
  - grafana: checked release notes https://community.grafana.com/t/release-notes-v7-0-x/29381
  - kubernetes checked release notes https://kubernetes.io/docs/setup/release/notes/
  - checked open ports on dev VMs
  - all automatic tests are green
  - checked basic functionality of all updated services in dev
  - didn't check kubernetes manually for security aspects in dev, it's still experimental on our plattform and we need to review it properly
