### PR TITLE
Fix cron mail issues

### DIFF
--- a/nixos/roles/mailserver.nix
+++ b/nixos/roles/mailserver.nix
@@ -10,13 +10,61 @@ let
   listenFe = fclib.listenAddresses "ethfe";
   listenFe4 = filter fclib.isIp4 listenFe;
   listenFe6 = filter fclib.isIp6 listenFe;
+  listenSrv = fclib.listenAddresses "ethsrv";
+  listenSrv4 = filter fclib.isIp4 listenSrv;
+  listenSrv6 = filter fclib.isIp6 listenSrv;
+  hasFE = (params ? location &&
+    lib.hasAttrByPath [ "interfaces" "fe" ] params &&
+    listenFe4 != [] && listenFe6 != []);
 
-  defaultFQDN =
-    if (params ? location &&
-        lib.hasAttrByPath [ "interfaces" "fe" ] params &&
-        (length listenFe > 0))
-    then "${config.networking.hostName}.fe.${params.location}.fcio.net"
-    else "${config.networking.hostName}.fcio.net";
+  stdOptions = with lib; {
+
+    mailHost = mkOption {
+      type = types.str;
+      default = with config.networking; if hasFE
+        then "${hostName}.fe.${params.location}.${domain}"
+        else "${hostName}.${domain}";
+      description = ''
+        FQDN of the mail server's frontend address. IP adresses and
+        forward/reverse DNS must match exactly.
+      '';
+      example = "mail.example.com";
+    };
+
+    rootAlias = mkOption {
+      type = types.str;
+      description = "Address to receive all mail to root@localhost.";
+      default = "admin@flyingcircus.io";
+    };
+
+    smtpBind4 = mkOption {
+      type = types.str;
+      description = ''
+        IPv4 address for outgoing connections. Must match forward/reverse DNS.
+      '';
+      default = if hasFE then head listenFe4 else head listenSrv4;
+    };
+
+    smtpBind6 = mkOption {
+      type = types.str;
+      description = ''
+        IPv6 address for outgoing connections. Must match forward/reverse DNS.
+      '';
+      default = if hasFE then head listenFe6 else head listenSrv6;
+    };
+
+    explicitSmtpBind = mkOption {
+      type = types.bool;
+      description = ''
+        Whether to include smtp_bind_address* statements explicitely in
+        main.cf or not. Set to false in case mail must be relayed both to the
+        public Internet and to other nodes inside the RG via srv.
+      '';
+      default = (length (listenFe4 ++ listenSrv4) > 1)
+             || (length (listenFe6 ++ listenSrv6) > 1);
+    };
+
+  };
 
 in
 {
@@ -26,7 +74,7 @@ in
 
   options = {
 
-    flyingcircus.roles.mailserver = with lib; {
+    flyingcircus.roles.mailserver = with lib; stdOptions // {
       enable = mkEnableOption ''
         Flying Circus mailserver role with web mail.
         Mailout on all nodes in this RG/location.
@@ -41,16 +89,6 @@ in
           is the canonical domain used to construct internal addresses in
           various places.
         '';
-      };
-
-      mailHost = mkOption {
-        type = types.str;
-        default = defaultFQDN;
-        description = ''
-          FQDN of the mail server's frontend address. IP adresses and
-          forward/reverse DNS must match exactly.
-        '';
-        example = "mail.example.com";
       };
 
       webmailHost = mkOption {
@@ -69,98 +107,19 @@ in
         default = 5;
       };
 
-      rootAlias = mkOption {
-        type = types.str;
-        description = "Address to receive all mail to root@localhost.";
-        default = "admin@flyingcircus.io";
-      };
-
-      smtpBind4 = mkOption {
-        type = types.str;
-        description = ''
-          IPv4 address for outgoing connections. Must match forward/reverse DNS.
-        '';
-        default =
-          if listenFe4 != [] then lib.head listenFe4 else "";
-      };
-
-      smtpBind6 = mkOption {
-        type = types.str;
-        description = ''
-          IPv6 address for outgoing connections. Must match forward/reverse DNS.
-        '';
-        default =
-          if listenFe6 != [] then lib.head listenFe6 else "";
-      };
-
-      explicitSmtpBind = mkOption {
-        type = types.bool;
-        description = ''
-          Whether to include smtp_bind_address* statements explicitely in
-          main.cf or not. Set to false in case mail must be relayed both to the
-          public Internet and to other nodes inside the RG via srv.
-        '';
-        default = (length listenFe4 > 1) || (length listenFe6 > 1);
-      };
-
       passwdFile = mkOption {
         type = types.str;
         description = "Virtual mail user passwd file (shared Postfix/Dovecot)";
         default = "/var/lib/dovecot/passwd";
       };
+
     };
 
-    flyingcircus.roles.mailstub = with lib; {
+    flyingcircus.roles.mailstub = with lib; stdOptions // {
       enable = mkEnableOption ''
         Flying Circus mail stub role which creates a simple Postfix instance for
         manual configuration.
       '';
-
-      mailHost = mkOption {
-        type = types.str;
-        default = defaultFQDN;
-        description = ''
-          FQDN of the mail server's frontend address. IP adresses and
-          forward/reverse DNS must match exactly.
-        '';
-        example = "mail.example.com";
-      };
-
-      rootAlias = mkOption {
-        type = types.str;
-        description = "Address to receive all mail to root@localhost.";
-        default = "admin@flyingcircus.io";
-      };
-
-      smtpBind4 = mkOption {
-        type = types.str;
-        description = ''
-          Select IPv4 FE address for outgoing connections. Must match
-          forward/reverse DNS.
-        '';
-        default =
-          if listenFe4 != [] then lib.head listenFe4 else "";
-      };
-
-      smtpBind6 = mkOption {
-        type = types.str;
-        description = ''
-          Select IPv6 FE address for outgoing connections. Must match
-          forward/reverse DNS.
-        '';
-        default =
-          if listenFe6 != [] then lib.head listenFe6 else "";
-      };
-
-      explicitSmtpBind = mkOption {
-        type = types.bool;
-        description = ''
-          Whether to include smtp_bind_address* statements explicitely in
-          main.cf or not. Set to false in case mail must be relayed both to the
-          public Internet and to other nodes inside the RG via SRV.
-        '';
-        default = (length listenFe4 > 1) || (length listenFe6 > 1);
-      };
     };
   };
 


### PR DESCRIPTION
Case 123375

@flyingcircusio/release-managers

## Release process

Impact:

Changelog: mailstub: fix handling of system mails emitted on other nodes of the same resource group (e.g., cron job output) (#123375)

## Security implications

- Improved diagnostics due to system mails being actually delivered.
- More consistent handling of smtpd_bind parameters reduces unexpected behaviour and thus improves operability.

Tested both mailstub and mailserver interactively.
