### PR TITLE
Fix Grafana 7 login when stale cookies are present

### DIFF
--- a/nixos/roles/statshost/default.nix
+++ b/nixos/roles/statshost/default.nix
@@ -523,6 +523,9 @@ in
         extraOptions = {
           AUTH_LDAP_ENABLED = "true";
           AUTH_LDAP_CONFIG_FILE = toString grafanaLdapConfig;
+          # Grafana 7 changed the cookie path, so login fails if old session cookies are present.
+          # Changing the cookie name helps.
+          AUTH_LOGIN_COOKIE_NAME = "grafana7_session";
           LOG_LEVEL = "info";
           PATHS_PROVISIONING = grafanaProvisioningPath;
         };


### PR DESCRIPTION
Changing the name creates a new cookie.

Case 127083

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

## Security implications

Currently logged in users will be forced to log in again, no further consequences.

