### PR TITLE
Enable nixos-nat-pre and nixos-nat-post chains

### DIFF
--- a/nixos/platform/filter-rules.py
+++ b/nixos/platform/filter-rules.py
@@ -52,7 +52,7 @@ def exit_with_error(message, line):
 
 for line in fileinput.input():
     line = line.strip()
-    if line.startswith('#') or line.strip() == '':
+    if line.startswith('#') or line == '':
         print(line)
         continue
     atoms = list(shlex.quote(s) for s in shlex.split(line.strip()))
@@ -75,7 +75,7 @@ for line in fileinput.input():
     for option, value in find_arguments_with_values(
             ['-A', '-C', '-D', '-I', '-R', '-S', '-F', '-L', '-Z', '-N', '-X',
              '-P', '-E'], atoms):
-        if value in ['INPUT', 'OUTPUT', 'FORWARD', 'PREROUTING',
+        if value in ['INPUT', 'OUTPUT', 'FORWARD', 'PREROUTING', 'POSTROUTING',
                      'SECMARK', 'CONNSECMARK']:
             exit_with_error('builtin chains are not allowed here', line)
 

--- a/nixos/platform/firewall.nix
+++ b/nixos/platform/firewall.nix
@@ -68,21 +68,13 @@ in
 
       Activating the rules listed here by calling `fc-manage`.
 
+      Standard chains:
 
-      Examples
-      --------
+      - nixos-fw: normal accept/reject rules
+      - nixos-nat-pre: prerouting rules, e.g. port redirects (-t nat)
+      - nixos-nat-post: postrouting rules, e.g. masquerding (-t nat)
 
-      Accept TCP traffic from ethfe to port 32542:
-
-      ip46tables -A nixos-fw -p tcp -i ethfe --dport 32542 -j nixos-fw-accept
-
-
-      Reject traffic from certain networks in separate chain:
-
-      ip46tables -N blackhole
-      iptables -A blackhole -s 192.0.2.0/24 -j DROP
-      ip6tables -A blackhole -s 2001:db8::/32 -j DROP
-      ip46tables -A nixos-fw -j blackhole
+      See also https://flyingcircus.io/doc/guide/platform_nixos_2/firewall.html
     '';
 
     flyingcircus.services.sensu-client.checks = {
@@ -98,6 +90,11 @@ in
         command = "/run/wrappers/bin/sudo ${checkIPTables}";
       };
     };
+
+    # This is just to create nixos-nat-(pre|post) ruleset. No further
+    # configuration on the NixOS side. Users may set additional networking.nat.*
+    # options in /etc/local/nixos.
+    networking.nat.enable = true;
 
     networking.firewall =
       # our code generally assumes IPv6


### PR DESCRIPTION
PREROUTING/POSTROUTING actions can now specified in /etc/local/firewall.
They must go into nixos-nat-(pre|post) chains.

Case 126879
Case 126936
Case 127007

@flyingcircusio/release-managers

## Release process

Impact:

Changelog: Firewall: Allow specification of prerouting and postrouting rules in nixos-nat-pre and nixos-nat-post chains.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

Structured approach for pre-/postrouting in contrast to ad-hoc solutions found in the field now. Rules are now properly filtered and direct additions to the system chains are prohibited.

- [x] Security requirements tested? (EVIDENCE)

Extensive manual testing on test21, including all examples found in the docs.