### PR TITLE
Provide ES+Kibana 7 roles

### DIFF
--- a/nixos/roles/default.nix
+++ b/nixos/roles/default.nix
@@ -37,6 +37,7 @@ in {
     (mkRenamedOptionModule [ "flyingcircus" "roles" "statshost" "enable" ] [ "flyingcircus" "roles" "statshost-global" "enable" ])
     (mkRenamedOptionModule [ "flyingcircus" "roles" "statshost" "globalAllowedMetrics" ] [ "flyingcircus" "roles" "statshost-global" "allowedMetricPrefixes" ])
     (mkRenamedOptionModule [ "flyingcircus" "roles" "statshostproxy" ] [ "flyingcircus" "roles" "statshost-location-proxy" ])
+    (mkRenamedOptionModule [ "flyingcircus" "roles" "kibana" "enable" ] [ "flyingcircus" "roles" "kibana6" "enable" ])
   ];
 
   options = {

--- a/nixos/services/default.nix
+++ b/nixos/services/default.nix
@@ -7,6 +7,8 @@ let
 
   modulesFromUnstable = [
     "services/monitoring/grafana.nix"
+    "services/search/elasticsearch.nix"
+    "services/search/kibana.nix"
   ];
 
   nixpkgs-unstable-src = (import ../../versions.nix {}).nixos-unstable;

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -3,6 +3,7 @@ self: super:
 let
   versions = import ../versions.nix { pkgs = super; };
   pkgs-unstable = import versions.nixos-unstable {};
+  elk7Version = "7.8.0";
 
 in {
   # keep in sync with nixos/platform/garbagecollect/default.nix
@@ -28,6 +29,28 @@ in {
   cfssl = super.callPackage ./cfssl.nix { inherit (pkgs-unstable) buildGoPackage; };
 
   docsplit = super.callPackage ./docsplit { };
+
+  elasticsearch7 = pkgs-unstable.elasticsearch7.overrideAttrs(_: rec {
+    version = elk7Version;
+    name = "elasticsearch-${version}";
+
+    src = super.fetchurl {
+      url = "https://artifacts.elastic.co/downloads/elasticsearch/${name}-linux-x86_64.tar.gz";
+      sha256 = "1vy3z5f3zn9a2caa9jq1w4iagqrdmd27wr51bl6yf8v74169vpr4";
+    };
+    meta.license = null;
+  });
+
+  kibana7 = pkgs-unstable.kibana7.overrideAttrs(_: rec {
+    version = elk7Version;
+    name = "kibana-${version}";
+
+    src = super.fetchurl {
+      url = "https://artifacts.elastic.co/downloads/kibana/${name}-linux-x86_64.tar.gz";
+      sha256 = "0xnh07n894f170ahawcg03jm3xk4qpjjbfwkvd955vdgihpy60gh";
+    };
+    meta.license = null;
+  });
 
   inherit (pkgs-unstable) grafana;
 

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -22,11 +22,16 @@ let
 in {
   antivirus = callTest ./antivirus.nix {};
   docker = callTest (nixpkgs + /nixos/tests/docker.nix) {};
+  elasticsearch5 = callTest ./elasticsearch.nix { version = "5"; };
+  elasticsearch6 = callTest ./elasticsearch.nix { version = "6"; };
+  elasticsearch7 = callTest ./elasticsearch.nix { version = "7"; };
   fcagent = callTest ./fcagent.nix {};
   garbagecollect = callTest ./garbagecollect.nix {};
   graylog = callTest ./graylog.nix {};
   haproxy = callTest ./haproxy.nix {};
   journal = callTest ./journal.nix {};
+  kibana6 = callTest ./kibana.nix { version = "6"; };
+  kibana7 = callTest ./kibana.nix { version = "7"; };
   kubernetes = callTest ./kubernetes {};
   login = callTest ./login.nix {};
   logrotate = callTest ./logrotate.nix {};

--- a/tests/elasticsearch.nix
+++ b/tests/elasticsearch.nix
@@ -1,0 +1,36 @@
+import ./make-test.nix ({ version ? "7", pkgs, ... }:
+let
+  ipv4 = "192.168.1.1";
+in
+{
+  name = "elasticsearch";
+
+  machine =
+    { pkgs, config, ... }:
+    {
+
+      imports = [ ../nixos ../nixos/roles ];
+
+      flyingcircus.enc.parameters = {
+        resource_group = "test";
+        interfaces.srv = {
+          mac = "52:54:00:12:34:56";
+          networks = {
+            "192.168.1.0/24" = [ ipv4 ];
+          };
+          gateways = {};
+        };
+      };
+
+      networking.domain = "test";
+      virtualisation.memorySize = 3072;
+      virtualisation.qemu.options = [ "-smp 2" ];
+      flyingcircus.roles."elasticsearch${version}".enable = true;
+      flyingcircus.roles.elasticsearch.esNodes = [ "machine" ];
+    };
+
+  testScript = ''
+    $machine->waitForUnit("elasticsearch");
+    $machine->waitUntilSucceeds("curl ${ipv4}:9200");
+  '';
+})

--- a/tests/kibana.nix
+++ b/tests/kibana.nix
@@ -1,6 +1,6 @@
-import ./make-test.nix ({ pkgs, ... }:
+import ./make-test.nix ({ version ? "6", pkgs, ... }:
 let
-  ipv4 = "192.168.101.1";
+  ipv4 = "192.168.1.1";
 in
 {
   name = "kibana";
@@ -16,16 +16,18 @@ in
         interfaces.srv = {
           mac = "52:54:00:12:34:56";
           networks = {
-            "192.168.101.0/24" = [ ipv4 ];
+            "192.168.1.0/24" = [ ipv4 ];
           };
           gateways = {};
         };
       };
 
+      networking.domain = "test";
       virtualisation.memorySize = 3072;
       virtualisation.qemu.options = [ "-smp 2" ];
-      flyingcircus.roles.elasticsearch6.enable = true;
-      flyingcircus.roles.kibana.enable = true;
+      flyingcircus.roles."elasticsearch${version}".enable = true;
+      flyingcircus.roles.elasticsearch.esNodes = [ "machine" ];
+      flyingcircus.roles."kibana${version}".enable = true;
     };
 
   testScript = ''


### PR DESCRIPTION
* esNodes uses just the hostnames now because inital_master_nodes
  must use the same format as node.name for ES7.
* add nodeName option

Case 126877

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Provide roles for Elasticsearch and Kibana 7, currently version 7.8.0. Machines using ES5 at the moment must first reindex with ES6 before upgrading to ES7 (#126877).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- ES and Kibana should only listen on SRV addresses
- New versions shouldn't introduce unnecessary security risks
- We should use up-to-date versions
- [x] Security requirements tested? (EVIDENCE)
  - 7.8.0 is the newest version of the elk stack
  - manually tested on a dev VM, checked open ports
  - automated tests check basic functionality for all versions 5-7
  - checked breaking changes of Kibana since 6.7 for security-related items: https://www.elastic.co/guide/en/kibana/7.8/breaking-changes-7.8.html
  - checked breaking changes of Elasticsearch since 6.7 for security-related items:   https://www.elastic.co/guide/en/elasticsearch/reference/7.8/breaking-changes-7.8.html



