### PR TITLE
Provide coturn role

### DIFF
--- a/nixos/lib/utils.nix
+++ b/nixos/lib/utils.nix
@@ -115,4 +115,9 @@ rec {
         config.flyingcircus.users.userData
       );
 
+  writePrettyJSON = name: x:
+  let json = pkgs.writeText "write-pretty-json-input" (toJSON x);
+  in pkgs.runCommand name { preferLocalBuild = true; } ''
+      ${pkgs.jq}/bin/jq . < ${json} > $out
+    '';
 }

--- a/nixos/roles/coturn.nix
+++ b/nixos/roles/coturn.nix
@@ -1,0 +1,141 @@
+{ config, lib, pkgs, ... }:
+
+with builtins;
+
+let
+  fclib = config.fclib;
+  listenAddresses =
+    fclib.listenAddresses "lo" ++
+    fclib.listenAddresses "ethsrv" ++
+    fclib.listenAddresses "ethfe";
+
+  serviceCfg = config.services.coturn;
+  localDir = config.flyingcircus.localConfigDirs.coturn.dir;
+
+  coturnShowConfig = pkgs.writeScriptBin "coturn-show-config" ''
+    cat $(systemctl cat coturn.service | grep "ExecStart" | cut -d" " -f3)
+  '';
+
+  domain = config.networking.domain;
+  location = lib.attrByPath [ "parameters" "location" ] "standalone" config.flyingcircus.enc;
+  feFQDN = "${config.networking.hostName}.fe.${location}.${domain}";
+  cfg = config.flyingcircus.roles.coturn;
+
+  ourSettings = [
+    "extraConfig"
+    "hostname"
+    ];
+
+  defaultConfig = {
+    hostname = feFQDN;
+    alt-listening-port = 3479;
+    alt-tls-listening-port = 5350;
+    listening-ips = listenAddresses;
+    listening-port = 3478;
+    lt-cred-mech = false;
+    no-cli = true;
+    realm = feFQDN;
+    tls-listening-port = 5349;
+    use-auth-secret = true;
+    extraConfig = [];
+  };
+
+  jsonConfig = fromJSON
+    (fclib.configFromFile /etc/local/coturn/config.json "{}");
+
+
+  hostname = jsonConfig.hostname or defaultConfig.hostname;
+  kill = "${pkgs.coreutils}/bin/kill";
+in
+{
+  options = with lib; {
+    flyingcircus.roles.coturn = {
+      enable = lib.mkEnableOption "Coturn TURN server";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    services.coturn = {
+      enable = true;
+      cert = "/var/lib/acme/${hostname}/fullchain.pem";
+      pkey = "/var/lib/acme/${hostname}/key.pem";
+      extraConfig = lib.concatStringsSep "\n" jsonConfig.extraConfig or [];
+    } // (mapAttrs (name: value: lib.mkDefault value) (removeAttrs defaultConfig ourSettings))
+      // (removeAttrs jsonConfig ourSettings);
+
+    networking.firewall.allowedTCPPorts = [ 80 ];
+
+    # We need this only for the Letsencrypt HTTP challenge.
+    services.nginx = {
+      enable = true;
+      virtualHosts."${hostname}" = {
+        enableACME = true;
+      };
+    };
+
+    systemd.services.coturn = rec {
+      requires = [ "acme-selfsigned-${hostname}.service" ];
+      after = requires;
+      serviceConfig = {
+        Restart = lib.mkForce "always";
+      };
+    };
+
+    security.acme.certs."${hostname}" = {
+      allowKeysForGroup = true;
+      user = lib.mkForce "root";
+      group = "turnserver";
+      postRun = "systemctl kill -s USR2 coturn.service";
+    };
+
+    flyingcircus.services = {
+      sensu-client.checks = {
+
+        coturn = {
+          notification = "coturn not reachable via TCP";
+          command = ''
+            ${pkgs.sensu-plugins-network-checks}/bin/check-ports.rb \
+              -h ${lib.concatStringsSep "," serviceCfg.listening-ips} \
+              -p ${toString serviceCfg.tls-listening-port}
+          '';
+        };
+
+      };
+    };
+
+    flyingcircus.localConfigDirs.coturn = {
+      dir = "/etc/local/coturn";
+      user = "turnserver";
+    };
+
+    environment.systemPackages = [
+      coturnShowConfig
+    ];
+
+    environment.etc."local/coturn/README.txt".text = ''
+    Coturn (Turnserver)
+    -------------------
+
+    Put your config in ${localDir}/config.json.
+    Default settings are shown in ${localDir}/config.json.example.
+    Options defined in config.json override these.
+
+    The JSON config supports all options defined by NixOS:
+
+    https://nixos.org/nixos/options.html#coturn
+
+    In addition to that, hostname must be set for the Letsencrypt SSL cert.
+    Unsupported options can be added to extraConfig which is a list of strings
+    that are put as lines at the end of the configuration file.
+
+    The default config sets use-auth-secret but no secret.
+    You have to add static-auth-secret to config.json.
+
+    By default, coturn listens on all interfaces but ports are firewalled.
+    Add custom rules to /etc/local/firewall if you want public access.
+    '';
+
+    environment.etc."local/coturn/config.json.example".source =
+      fclib.writePrettyJSON "config.json.example" defaultConfig;
+  };
+}

--- a/nixos/roles/default.nix
+++ b/nixos/roles/default.nix
@@ -9,9 +9,10 @@ let
 
 in {
   imports = with lib; [
+    ./antivirus.nix
+    ./coturn.nix
     ./docker.nix
     ./external_net
-    ./antivirus.nix
     ./elasticsearch.nix
     ./graylog.nix
     ./kibana.nix

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -27,6 +27,8 @@ in {
   certmgr = super.callPackage ./certmgr.nix { inherit (pkgs-unstable) buildGoPackage; };
   cfssl = super.callPackage ./cfssl.nix { inherit (pkgs-unstable) buildGoPackage; };
 
+  inherit (pkgs-unstable) coturn;
+
   docsplit = super.callPackage ./docsplit { };
 
   inherit (pkgs-unstable) grafana;

--- a/tests/coturn.nix
+++ b/tests/coturn.nix
@@ -1,0 +1,124 @@
+import ./make-test.nix ({ pkgs, lib, ... }:
+let
+
+  netLoc4Srv = "10.0.1";
+  turnserver4Srv = netLoc4Srv + ".2";
+
+  netLoc6Srv = "2001:db8:1::";
+  turnserver6Srv = netLoc6Srv + "2";
+
+  net4Fe = "10.0.3";
+  client4Fe = net4Fe + ".1";
+  turnserver4Fe = net4Fe + ".2";
+
+  net6Fe = "2001:db8:3::";
+  client6Fe = net6Fe + "1";
+  turnserver6Fe = net6Fe + "2";
+
+  turnserverFe = "turnserver.fe.loc.fcio.net";
+
+  hosts = ''
+    127.0.0.1 localhost
+    ::1 localhost
+
+    ${turnserver6Fe} ${turnserverFe}
+    ${turnserver4Fe} ${turnserverFe}
+  '';
+
+in {
+  name = "coturn";
+  nodes = {
+    client = {
+      imports = [ ../nixos ../nixos/roles ];
+      environment.systemPackages = [ pkgs.curl ];
+
+      flyingcircus.enc.parameters = {
+        resource_group = "test";
+        interfaces.fe = {
+          mac = "52:54:00:12:02:01";
+          networks = {
+            "${net4Fe}.0/24" = [ client4Fe ];
+            "${net6Fe}/64" = [ client6Fe ];
+          };
+          gateways = {};
+        };
+      };
+      virtualisation.vlans = [ 1 2 ];
+    };
+
+    turnserver =
+      { config, ... }:
+      {
+        imports = [ ../nixos ../nixos/roles ];
+        flyingcircus.roles.coturn.enable = true;
+
+        flyingcircus.enc.parameters = {
+          resource_group = "test";
+          interfaces.srv = {
+            mac = "52:54:00:12:01:02";
+            networks = {
+              "${netLoc4Srv}.0/24" = [ turnserver4Srv ];
+              "${netLoc6Srv}/64" = [ turnserver6Srv ];
+            };
+            gateways = {};
+          };
+          interfaces.fe = {
+            mac = "52:54:00:12:02:02";
+            networks = {
+              "${net4Fe}.0/24" = [ turnserver4Fe ];
+              "${net6Fe}/64" = [ turnserver6Fe ];
+            };
+            gateways = {};
+          };
+        };
+
+        environment.etc.hosts.text = lib.mkForce hosts;
+        networking.domain = "fcio.net";
+        networking.firewall.allowedTCPPorts = [ 5349 ];
+        virtualisation.vlans = [ 1 2 ];
+      };
+  };
+
+  testScript = { nodes, ... }:
+  let
+    config = nodes.turnserver.config;
+    sensuChecks = config.flyingcircus.services.sensu-client.checks;
+    coturnCheck = lib.replaceChars ["\n"] [" "] sensuChecks.coturn.command;
+  in ''
+    $turnserver->waitForUnit("coturn.service");
+    $turnserver->waitForOpenPort(3478);
+    $turnserver->waitForOpenPort(3479);
+    $turnserver->waitForOpenPort(5349);
+    $turnserver->waitForOpenPort(5350);
+
+    subtest "coturn should be reachable on fe (IPv4)", sub {
+      $client->waitUntilSucceeds('nc -z ${turnserver4Fe} 5349');
+    };
+
+    subtest "coturn should be reachable on fe (IPv6)", sub {
+      $client->waitUntilSucceeds('nc -z ${turnserver6Fe} 5349');
+    };
+
+    subtest "sensu check should be green", sub {
+      $turnserver->succeed("${coturnCheck}");
+    };
+
+    subtest "sensu check should be red after shutting down coturn", sub {
+      $turnserver->stopJob("coturn.service");
+      $turnserver->waitUntilFails("nc -z localhost 5349");
+      $turnserver->mustFail("${coturnCheck}");
+    };
+
+    subtest "service user should be able to write to local config dir", sub {
+      $turnserver->succeed('sudo -u turnserver touch /etc/local/coturn/config.json');
+    };
+
+    # look for coturn's 4 default ports. Order is:
+    # (listening-port, alt-listening-port, tls-listening-port, alt-tls-listening-port)
+
+    subtest "coturn opens no unexpected ports", sub {
+      $turnserver->mustFail("netstat -tlpn | grep turnserver | egrep -qv ':3478 |:3479 |:5349 |:5350 '");
+    };
+
+  '';
+})

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -21,6 +21,7 @@ let
 
 in {
   antivirus = callTest ./antivirus.nix {};
+  coturn = callTest ./coturn.nix {};
   docker = callTest (nixpkgs + /nixos/tests/docker.nix) {};
   fcagent = callTest ./fcagent.nix {};
   garbagecollect = callTest ./garbagecollect.nix {};


### PR DESCRIPTION
Uses current coturn 4.5.13 from unstable.

Case 126406

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Provide coturn (STUN/TURN server) role (#126406).

## Security implications

Using coturn can have very different security implications depending on the configuration. We provide a base config that is quite locked-down. Users must configure coturn for their needs and think about security implications for their use case.

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- use current version
- secure defaults: firewalled by default, should not open unexpected ports
- [x] Security requirements tested? (EVIDENCE)
  - automated test checks basic functionality and that no unexpected ports are opened
  - manual checks on dev VM, checked open ports
  - checked default settings of the NixOS service
  - had a look at the configuration docs for coturn: https://github.com/coturn/coturn/blob/master/README.turnserver
