### PR TITLE
fc-agent: Remove next channel even if nixos-rebuild fails

### DIFF
--- a/pkgs/fc/agent/fc/manage/manage.py
+++ b/pkgs/fc/agent/fc/manage/manage.py
@@ -29,9 +29,9 @@ ACTIVATE = """\
 set -e
 nix-channel --add {url} nixos
 nix-channel --update nixos
+nix-channel --remove next
 # Retry once in case nixos-build fails e.g. due to updates to Nix itself
 nixos-rebuild switch || nixos-rebuild switch
-nix-channel --remove next
 """
 
 


### PR DESCRIPTION
Currently, the maintenance script stops after a failed nixos-rebuild
and keeps the next channel.
nixos channel is the same as the next channel in this case.
The next channel serves no purpose after nixos has been changed
and even breaks future updates.

Case 110203

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Fix problems with future platform release updates if the last update has failed (#110203). 

## Security implications

This just avoids manual cleanup after maintenance update failures.
