### PR TITLE
Vagrant: enable logrotate, add local config dir for vagrant user

### DIFF
--- a/nixos/infrastructure/vagrant.nix
+++ b/nixos/infrastructure/vagrant.nix
@@ -65,9 +65,14 @@ in {
     # FC specific customizations
     flyingcircus = {
       agent.enable = false;
+      logrotate.enable = true;
 
-      localConfigDirs = expandLocal
-        [ "logrotate" "nixos" "sensu-client" "telegraf" ];
+      localConfigDirs = {
+        logrotate-vagrant = {
+          user = "vagrant";
+          dir = "/etc/local/logrotate/vagrant";
+        };
+      } // expandLocal [ "nixos" "sensu-client" "telegraf" ];
 
       passwordlessSudoRules = [
         { # Grant unrestricted access to vagrant


### PR DESCRIPTION
Case 123879
Case 127092

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Vagrant: enable logrotate and add local config dir for vagrant user (#123879, #127092)

## Security implications

Just for convenience in vagrant dev VMs.

