### PR TITLE
127617 Security updates

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -8,7 +8,7 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "a7bcbf6a5e77b77be2e53145bb9636bca924499f",
-    "sha256": "0zhpjn6bd7ry43wnshvvgavrb57kg01cr3cwx5iaj8p1mchlhd9q"
+    "rev": "9d57ce89bae75371996c40481d39924309234d67",
+    "sha256": "0zwn31dy5jhxdg3yx6m4asxb69rdyllfybm1c8ghvmdpyrb72jsv"
   }
 }

--- a/versions.json
+++ b/versions.json
@@ -8,7 +8,7 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "0a92f12c2f6462c5843ce325a1d47116e6a030eb",
-    "sha256": "1kh7b3pg3mqd86w5r3fxbyvzg2q2l5885ipwfs76d5j5056x521y"
+    "rev": "a7bcbf6a5e77b77be2e53145bb9636bca924499f",
+    "sha256": "0zhpjn6bd7ry43wnshvvgavrb57kg01cr3cwx5iaj8p1mchlhd9q"
   }
 }


### PR DESCRIPTION
@flyingcircusio/release-managers

Case 127617

https://github.com/flyingcircusio/nixpkgs/issues/921 sysstat
https://github.com/flyingcircusio/nixpkgs/issues/923 tcpdump

## Release process

Impact:

Changelog: Security: update sysstat 12.1.2 -> 12.2.0, tcpdump: 4.9.2 -> 4.9.3

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

Security update process

- [x] Security requirements tested? (EVIDENCE)

Checked related CVEs