### PR TITLE
Update unstable, PostgreSQL 12 role, remove 9.5

### DIFF
--- a/nixos/roles/postgresql.nix
+++ b/nixos/roles/postgresql.nix
@@ -12,6 +12,7 @@ with builtins;
       postgresql96.enable = mkRole "9.6";
       postgresql10.enable = mkRole "10";
       postgresql11.enable = mkRole "11";
+      postgresql12.enable = mkRole "12";
     };
   };
 
@@ -22,6 +23,7 @@ with builtins;
       "9.6" = postgresql96.enable;
       "10" = postgresql10.enable;
       "11" = postgresql11.enable;
+      "12" = postgresql12.enable;
     };
     enabledRoles = lib.filterAttrs (n: v: v) pgroles;
     enabledRolesCount = length (lib.attrNames enabledRoles);

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -110,6 +110,8 @@ in {
   percona57 = super.callPackage ./percona/5.7.nix { boost = self.boost159; };
   percona80 = super.callPackage ./percona/8.0.nix { boost = self.boost169; };
 
+  inherit (pkgs-unstable) postgresql_12;
+
   inherit (pkgs-unstable) prometheus;
 
   prometheus-elasticsearch-exporter = super.callPackage ./prometheus-elasticsearch-exporter.nix { };
@@ -137,6 +139,7 @@ in {
   sensu-plugins-rabbitmq = super.callPackage ./sensuplugins-rb/sensu-plugins-rabbitmq { };
   sensu-plugins-redis = super.callPackage ./sensuplugins-rb/sensu-plugins-redis { };
   sensu-plugins-systemd = super.callPackage ./sensuplugins-rb/sensu-plugins-systemd { };
+
   temporal_tables = super.callPackage ./postgresql/temporal_tables { };
 
   inherit (pkgs-unstable) writeShellScript;

--- a/pkgs/postgresql/rum/default.nix
+++ b/pkgs/postgresql/rum/default.nix
@@ -1,16 +1,21 @@
-{ stdenv, fetchFromGitHub, postgresql }:
+{ stdenv, fetchFromGitHub, postgresql, postgresqlFromUnstable ? false }:
 
 let
-  version = "1.3.1";
-in
-stdenv.mkDerivation {
-  name = "rum-${version}";
+  # We use 12 from unstable which changed the location for extensions.
+  extPath =
+    if postgresqlFromUnstable
+    then "share/postgresql/extension"
+    else "share/extension";
+
+in stdenv.mkDerivation {
+  pname = "rum";
+  version = "2020-04-07";
 
   src = fetchFromGitHub {
-    rev = "${version}";
+    rev = "bc917c9f0d667432412df998a3fe6b6c935b3053";
     owner = "postgrespro";
     repo = "rum";
-    sha256 = "1d19r5mb78h0iapnqv5l59kgfcxlcyrvpk2bnnvj06brwzssghia";
+    sha256 = "185bmjd236qis5gqdv2vi52k5bg13cghs95ch5z0vqx59xqs17bm";
   };
 
   buildInputs = [ postgresql ];
@@ -23,9 +28,10 @@ stdenv.mkDerivation {
    ''
      mkdir -p $out/{bin,lib}
      cp ./rum.so $out/lib
-     mkdir -p $out/share/extension
+     ext_dir=$out/${extPath}
+     mkdir -p $ext_dir
      echo .............
      echo *
-     cp ./rum.control ./rum--1.0.sql ./rum--1.2.sql ./rum--1.3.sql $out/share/extension
+     cp ./rum.control ./rum--1.0.sql ./rum--1.2.sql ./rum--1.3.sql $ext_dir
    '';
  }

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -51,7 +51,7 @@ in {
   percona80 = callTest ./mysql.nix { rolename = "percona80"; };
   postgresql10 = callTest ./postgresql.nix { rolename = "postgresql10"; };
   postgresql11 = callTest ./postgresql.nix { rolename = "postgresql11"; };
-  postgresql95 = callTest ./postgresql.nix { rolename = "postgresql95"; };
+  postgresql12 = callTest ./postgresql.nix { rolename = "postgresql12"; };
   postgresql96 = callTest ./postgresql.nix { rolename = "postgresql96"; };
   prometheus = callTest ./prometheus.nix {};
   rabbitmq36_15 = callTest ./rabbitmq.nix { rolename = "rabbitmq36_15"; };

--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixos-unstable": {
     "owner": "NixOS",
     "repo": "nixpkgs",
-    "rev": "dc80d7bc4a244120b3d766746c41c0d9c5f81dfa",
-    "sha256": "0dy0mp7alc7m34zxall14x42qx9yjm7b0m6psgmw0lb6j1iy1pla"
+    "rev": "8d05772134f17180fb2711d0660702dae2a67313",
+    "sha256": "0pnyg26c1yhnp3ymzglc71pd9j0567ymqy6il5ywc82bbm1zy25a"
   },
   "nixpkgs": {
     "owner": "flyingcircusio",


### PR DESCRIPTION
* 9.5 is old, unused on 19.03 and doesn't support all extensions
* use periods extension instead of deprecated temporal_tables for 12
* use socket dir /run/postgresql for 12 (has been changed in nixpkgs)

Case 126897

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Provide PostgreSQL 12 role, remove unused 9.5 role. The new role for 12 uses /run/postgresql as socket dir and replaces the deprecated temporal_tables extension with the periods extension (#126897).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - use a recent version
  - TCP connections must require a password
  - should only listen on srv and localhost
- [x] Security requirements tested? (EVIDENCE)
  - 12.3 is the newest version
  - NixOS test checks basic functionality, extensions and that TCP requires a password
  - checked the release notes for 12.x for security changes https://www.postgresql.org/docs/release
  - checked open ports and basic functionality on dev vm