### PR TITLE
As we discussed: avoid swapping applications and aggressively drop ca…

### DIFF
--- a/nixos/infrastructure/flyingcircus.nix
+++ b/nixos/infrastructure/flyingcircus.nix
@@ -44,7 +44,7 @@ mkIf (cfg.infrastructureModule == "flyingcircus") {
       gfxmodeBios = "text";
     };
 
-    kernel.sysctl."vm.swappiness" = mkDefault 10;
+    kernel.sysctl."vm.swappiness" = mkDefault 1;
   };
 
   environment.systemPackages = with pkgs; [


### PR DESCRIPTION
…ches.

Filesystem caches are easier to rebuild as they don't have to work in 4k page sizes.
Applications going to swap should really be the absolute last resort as things then
can become unresponsive quite quickly.

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

- Reduce swappiness to 1. Our overall experience shows that applications in our environment
   really want to stay in RAM. The perfomance penalty of swapping applications also seems worse
   than thrashing VFS caches (under pressure). We now much more strongly recommend adding
   memory when applications start getting swapped as the performance penalties can become
   critical in undue situations.

## Security implications

- [ ] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

Improves availability.

- [ ] Security requirements tested? (EVIDENCE)

Used this setting in various situations under stress that became better and didn't create adverse effects.