### PR TITLE
Telegraf: increase timeouts, fix PostgreSQL 12, add show-config command

### DIFF
--- a/nixos/infrastructure/flyingcircus.nix
+++ b/nixos/infrastructure/flyingcircus.nix
@@ -4,6 +4,9 @@ with lib;
 
 let
   cfg = config.flyingcircus;
+  telegrafShowConfig = pkgs.writeScriptBin "telegraf-show-config" ''
+    cat $(systemctl cat telegraf | grep "ExecStart=" | cut -d" " -f3 | tr -d '"')
+  '';
 
 in
 mkIf (cfg.infrastructureModule == "flyingcircus") {
@@ -49,6 +52,7 @@ mkIf (cfg.infrastructureModule == "flyingcircus") {
 
   environment.systemPackages = with pkgs; [
     fc.userscan
+    telegrafShowConfig
   ];
 
   fileSystems = {

--- a/nixos/roles/rabbitmq.nix
+++ b/nixos/roles/rabbitmq.nix
@@ -176,6 +176,8 @@ with builtins;
 
         telegraf.inputs.rabbitmq = [
           {
+            client_timeout = "10s";
+            header_timeout = "10s";
             url = "http://${config.networking.hostName}:15672";
             username = "fc-telegraf";
             password = telegrafPassword;

--- a/nixos/roles/statshost/default.nix
+++ b/nixos/roles/statshost/default.nix
@@ -485,6 +485,7 @@ in
       flyingcircus.services.telegraf.inputs = {
         influxdb = [{
           urls = [ "http://localhost:8086/debug/vars" ];
+          timeout = "10s";
         }];
       };
 

--- a/nixos/services/postgresql.nix
+++ b/nixos/services/postgresql.nix
@@ -236,9 +236,16 @@ in {
           listenAddresses);
 
       telegraf.inputs = {
-        postgresql = [{
-          address = "host=/tmp user=root sslmode=disable dbname=postgres";
-        }];
+        postgresql = [
+          (if (lib.versionOlder cfg.majorVersion "12") then {
+            address = "host=/tmp user=root sslmode=disable dbname=postgres";
+          }
+          else {
+            address = "host=/run/postgresql user=root sslmode=disable dbname=postgres";
+            # Workaround for a telegraf bug: https://github.com/influxdata/telegraf/issues/6712
+            ignored_databases = [ "postgres" "template0" "template1" ];
+          })
+        ];
       };
     };
 


### PR DESCRIPTION
* 10s timeouts for rabbitmq and influxdb
* PostgreSQL 12 uses another socket dir and telegraf needs a workaround

Case 127644

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Telegraf metrics: increase read timeouts for rabbitmq and influxdb, fix for PostgreSQL 12 (#127644).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - reduce the number of unhelpful errors when services respond slowly to metrics requests
  - we want metrics from PostgreSQL 12
  - no further security impact
- [x] Security requirements tested? (EVIDENCE)
  - manual tests and config inspection on dev VMs
