### PR TITLE
MongoDB 3.6 and 4.0 roles

### DIFF
--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -79,12 +79,34 @@ in {
 
   mailx = super.callPackage ./mailx.nix { };
   mc = super.callPackage ./mc.nix { };
-  mongodb_3_2 = super.callPackage ./mongodb/3.2.nix {
+
+  mongodb-3_2 = super.callPackage ./mongodb/3.2.nix {
     sasl = super.cyrus_sasl;
     boost = super.boost160;
     # 3.2 is too old for the current libpcap version 1.9, use 1.8.1
     libpcap = self.libpcap_1_8;
   };
+  mongodb_3_2 = self.mongodb-3_2;
+  mongodb-3_4 = super.mongodb;
+  mongodb-3_6 = pkgs-unstable.mongodb-3_6.overrideAttrs(_: rec {
+    meta.license = null;
+    version = "3.6.19";
+    name = "mongodb-${version}";
+    src = super.fetchurl {
+      url = "https://fastdl.mongodb.org/src/mongodb-src-r${version}.tar.gz";
+      sha256 = "0y0k5lc2czvg8zirvqfnmpv9z0xz2slp2zfacp0hm0kzcnq82m51";
+    };
+  });
+  mongodb-4_0 = pkgs-unstable.mongodb-4_0.overrideAttrs(_: rec {
+    meta.license = null;
+    version = "4.0.19";
+    name = "mongodb-${version}";
+    src = super.fetchurl {
+      url = "https://fastdl.mongodb.org/src/mongodb-src-r${version}.tar.gz";
+      sha256 = "1kbw8vjbwlh94y58am0cxdz92mpb4amf575x0p456h1k3kh87rjg";
+    };
+  });
+
   mysql = super.mariadb;
 
   nginx = super.nginx.override {

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -38,8 +38,10 @@ in {
   logrotate = callTest ./logrotate.nix {};
   mail = callTest ./mail {};
   memcached = callTest ./memcached.nix {};
-  mongodb32 = callTest ./mongodb.nix { rolename = "mongodb32"; };
-  mongodb34 = callTest ./mongodb.nix { rolename = "mongodb34"; };
+  mongodb32 = callTest ./mongodb.nix { version = "3.2"; };
+  mongodb34 = callTest ./mongodb.nix { version = "3.4"; };
+  mongodb36 = callTest ./mongodb.nix { version = "3.6"; };
+  mongodb40 = callTest ./mongodb.nix { version = "4.0"; };
   mysql55 = callTest ./mysql.nix { rolename = "mysql55"; };
   mysql56 = callTest ./mysql.nix { rolename = "mysql56"; };
   mysql57 = callTest ./mysql.nix { rolename = "mysql57"; };


### PR DESCRIPTION
* uses current versions 3.6.19 and 4.0.19

Case 126656

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Add MongoDB roles for 3.6 and 4.0. We support upgrades from 3.2 to 4.0 which must include every major version in between (#126656).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - listens only on srv and localhost
  - use recent versions that include all security updates
  - new versions should not introduce features that harm security
- [x] Security requirements tested? (EVIDENCE)
  - automatic test checks basic functionality
  - manually checked open ports on a dev VM and ran some test inserts in the cli
  - checked release notes for security-related changes: https://docs.mongodb.com/manual/release-notes
  - 3.6.19 and 4.0.19 are the newest minor versions

