### PR TITLE
Allow service users to write the mysql password for root

### DIFF
--- a/nixos/services/percona.nix
+++ b/nixos/services/percona.nix
@@ -53,7 +53,7 @@ let
       echo -n "''${pw}" > ${cfg.rootPasswordFile}
     fi
     chown root:service ${cfg.rootPasswordFile}
-    chmod 640 ${cfg.rootPasswordFile}
+    chmod 660 ${cfg.rootPasswordFile}
 
     pw=$(<${cfg.rootPasswordFile})
     cat > /root/.my.cnf <<__EOT__

--- a/tests/mysql.nix
+++ b/tests/mysql.nix
@@ -117,7 +117,7 @@ in
     };
 
     subtest "secret files should have correct permissions", sub {
-      $master->succeed("stat /etc/local/mysql/mysql.passwd -c %a:%U:%G | grep '640:root:service'");
+      $master->succeed("stat /etc/local/mysql/mysql.passwd -c %a:%U:%G | grep '660:root:service'");
       $master->succeed("stat /root/.my.cnf -c %a:%U:%G | grep '440:root:root'");
       $master->succeed("stat /run/mysqld/init_set_root_password.sql -c %a:%U:%G | grep '440:mysql:root'");
     };


### PR DESCRIPTION
We need that for automated deployments.

Case 126845

@flyingcircusio/release-managers

## Release process

Impact:

* MySQL will be restarted.
Changelog:

* MySQL root password can now be set by service users before MySQL starts by changing the password file. That is helpful for automated deployments (#126845). 

## Security implications

Service users can already read and change the root password at runtime. Allowing them to change to root password before mysql starts doesn't create new security risks.

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - mysql root password only readable and writable by service users and root
- [x] Security requirements tested? (EVIDENCE)
  - automated test checks root pw file permissions

