### PR TITLE
Use new tideways daemon that fixes a crash in our test suite and when…

### DIFF
--- a/nixos/roles/lamp.nix
+++ b/nixos/roles/lamp.nix
@@ -149,10 +149,7 @@ Listen localhost:8001
           '';
           Restart = "always";
           RestartSec = "60s";
-          # The daemon currently crashes when run with the tideways user.
-          # We have a ticket with tideways, run with nobody until this is
-          # fixed.
-          User = "nobody";
+          User = "tideways";
           Type = "simple";
         };
       };

--- a/pkgs/tideways/daemon.nix
+++ b/pkgs/tideways/daemon.nix
@@ -2,7 +2,7 @@
 
 assert stdenv.hostPlatform.system == "x86_64-linux";
 
-let version = "1.6.14"; in
+let version = "1.6.16"; in
 
 stdenv.mkDerivation {
   name = "tideways-daemon-${version}";
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "https://s3-eu-west-1.amazonaws.com/tideways/daemon/${version}/tideways-daemon_linux_amd64-${version}.tar.gz";
-    sha256 = "1fnhi63h7nk80fbzz7vw3dsgdb0bg1fa3g0zj3jr4xcmp48fdrz3";
+    sha256 = "0b1i9n7916vis26d75f119hxr0q89vps9hw7cqbx8473f31l6my3";
   };
 
   meta = {

--- a/tests/lamp.nix
+++ b/tests/lamp.nix
@@ -16,11 +16,10 @@ import ./make-test.nix ({ ... }:
     $lamp->waitForUnit("httpd.service");
     $lamp->waitForOpenPort(8000);
 
-    # it crashes in the test but works in production. we are in touch with
-    # tideways to figure this out
-    #
-    # $lamp->waitForUnit("tideways-daemon.service");
-    # $lamp->waitForOpenPort(9135);
+    $lamp->waitForUnit("tideways-daemon.service");
+    $lamp->waitForOpenPort(9135);
+
+    $lamp->succeed('journalctl -u tideways.daemon');
 
     $lamp->succeed('mkdir -p /srv/docroot');
     $lamp->succeed('ln -s /srv/docroot /etc/local/lamp/docroot');


### PR DESCRIPTION
… running with the wrong user.

@flyingcircusio/release-managers

## Release process

Impact:

* Tideways daemons will be restarted.

Changelog:

* Update tideways to 1.6.6 so it doesn't crash in test suite now and can be run as a separate user (instead of nobody).

## Security implications

- [X] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

* restricting daemons to specific users reduces attack surface

- [X] Security requirements tested? (EVIDENCE)

* tideways daemon now tested in hydra tests

