### PR TITLE
Add sensu-client test stub to cache sensu-client on Hydra

### DIFF
--- a/tests/sensu-client.nix
+++ b/tests/sensu-client.nix
@@ -1,0 +1,20 @@
+# This is just a stub to check if sensu-client builds and to cache the result.
+# We need to port sensu server for a real end-to-end test.
+import ./make-test-python.nix ({ pkgs, lib, ... }:
+{
+  name = "sensu-client";
+
+  machine = {
+    imports = [ ../nixos ];
+
+    flyingcircus.services.sensu-client = {
+      password = "sensu";
+      server = "127.0.0.1";
+      enable = true;
+    };
+  };
+
+  testScript = ''
+    start_all()
+  '';
+})


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

- Ensure we build sufficient sensu packages centrally on our Hydra to avoid building them on every machine locally.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - nothing
- [x] Security requirements tested? (EVIDENCE)
  - ran test stub on hydra

