### PR TITLE
126523 central log host

### DIFF
--- a/nixos/platform/garbagecollect/default.nix
+++ b/nixos/platform/garbagecollect/default.nix
@@ -10,8 +10,6 @@ let
   log = "/var/log/fc-collect-garbage.log";
 
   garbagecollect = pkgs.writeScript "fc-collect-garbage.py" ''
-    #! ${pkgs.python3.interpreter}
-
     import datetime
     import os
     import pwd
@@ -31,16 +29,16 @@ let
                     user.pw_dir + "/.cache/fc-userscan.cache", "-L10000000",
                     "--unzip=*.egg", "-E", EXCLUDE, user.pw_dir],
                 stdin=subprocess.DEVNULL,
-                preexec_fn=lambda: os.seteuid(user.pw_uid))
+                preexec_fn=lambda: os.setuid(user.pw_uid))
             rc.append(p.wait())
 
         status = max(rc)
         print('Overall status:', status)
         if status >= 2:
-            print('ERROR: fc-userscan had hard errors (see above). Aborting')
+            print('Aborting garbagecollect. See above for fc-userscan errors')
             sys.exit(2)
         if status >= 1:
-            print('WARNING: fc-userscan had soft errors (see above). Aborting')
+            print('Aborting garbagecollect. See above for fc-userscan warnings')
             sys.exit(1)
         print('Running nix-collect-garbage')
         rc = subprocess.run([

--- a/nixos/roles/default.nix
+++ b/nixos/roles/default.nix
@@ -18,7 +18,7 @@ in {
     ./kibana.nix
     ./kubernetes
     ./lamp.nix
-    ./loghost.nix
+    ./loghost
     ./mailout.nix
     ./mailserver.nix
     ./memcached.nix

--- a/nixos/roles/loghost/default.nix
+++ b/nixos/roles/loghost/default.nix
@@ -1,0 +1,10 @@
+{ config, lib, pkgs, ... }:
+
+{
+
+  imports = [
+    ./location.nix
+    ./resourcegroup.nix
+  ];
+
+}

--- a/nixos/roles/loghost/location.nix
+++ b/nixos/roles/loghost/location.nix
@@ -1,0 +1,31 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.flyingcircus.roles.loghost-location;
+  fclib = config.fclib;
+
+in
+{
+
+  options = {
+
+    flyingcircus.roles.loghost-location.enable = lib.mkEnableOption ''
+      Flying Circus central Loghost role.
+
+      This role enables the full graylog stack at once (GL, ES, Mongo).
+
+      Used for location-central log hosts that aggregate system logs from
+      all systems in that location.
+    '';
+
+  };
+
+  config = lib.mkIf (cfg.enable) {
+
+    # Currently just a glorified alias.
+
+    flyingcircus.roles.loghost = fclib.mkPlatform { enable = true; };
+
+  };
+
+}

--- a/nixos/roles/loghost/resourcegroup.nix
+++ b/nixos/roles/loghost/resourcegroup.nix
@@ -24,14 +24,6 @@ in
       This role enables the full graylog stack at once (GL, ES, Mongo).
     '';
 
-    # flyingcircus.roles.loghost-location.enable = lib.mkEnableOption ''
-    #   Flying Circus central Loghost role.
-    #   This role enables the full graylog stack at once (GL, ES, Mongo).
-
-    #   Used for location-central log hosts that aggregate system logs from
-    #   all systems in that location.
-    # '';
-
   };
 
   config = lib.mkIf (cfg.enable) {

--- a/nixos/roles/loghost/resourcegroup.nix
+++ b/nixos/roles/loghost/resourcegroup.nix
@@ -6,11 +6,6 @@ let
   cfg = config.flyingcircus.roles.loghost;
   fclib = config.fclib;
 
-  loghostService = lib.findFirst
-    (s: s.service == "loghost-server")
-    null
-    config.flyingcircus.encServices;
-
   # It's common to have stathost and loghost on the same node. Each should
   # use half of the memory then. A general approach for this kind of
   # multi-service would be nice.
@@ -29,9 +24,17 @@ in
       This role enables the full graylog stack at once (GL, ES, Mongo).
     '';
 
+    # flyingcircus.roles.loghost-location.enable = lib.mkEnableOption ''
+    #   Flying Circus central Loghost role.
+    #   This role enables the full graylog stack at once (GL, ES, Mongo).
+
+    #   Used for location-central log hosts that aggregate system logs from
+    #   all systems in that location.
+    # '';
+
   };
 
-  config = lib.mkIf cfg.enable {
+  config = lib.mkIf (cfg.enable) {
 
     flyingcircus.roles.graylog = fclib.mkPlatform {
       enable = true;

--- a/nixos/services/graylog.nix
+++ b/nixos/services/graylog.nix
@@ -92,6 +92,9 @@ let
       root_password_sha2 = $(sha256sum ${rootPassword.file} | cut -f1 -d " ")
       password_secret = $(cat "${passwordSecret.file}")
 
+      # disable version check as its really annoying and obscures real errors
+      versionchecks = false
+
       # Settings here can be overridden by flyingcircus.services.graylog.config.
     '' + lib.concatStringsSep
             "\n"

--- a/pkgs/fc/userscan.nix
+++ b/pkgs/fc/userscan.nix
@@ -7,17 +7,17 @@
 
 rustPlatform.buildRustPackage rec {
   name = "fc-userscan-${version}";
-  version = "0.4.4";
+  version = "0.4.7";
 
   src = fetchFromGitHub {
     name = "fc-userscan-src-${version}";
     owner = "flyingcircusio";
     repo = "userscan";
     rev = version;
-    sha256 = "172q2ywdpg3q7picbl99cv45rcca2vhl7pvb7d4ilc66mhq6b265";
+    sha256 = "19jk0x03i0glsn96a26inbf7mznxzcadxvcsp5g9bilp28c4ibj3";
   };
 
-  cargoSha256 = "0rb181fih70jmnpn9q5lhwhv2gk0rk58945g6j6gapapq4sf259m";
+  cargoSha256 = "0qvccpxgmk3pp35d9ivr4wwvfh4j6gi3ql04qb2icw19m93hna17";
   nativeBuildInputs = [ docutils ];
   propagatedBuildInputs = [ lzo ];
 

--- a/pkgs/overlay-python.nix
+++ b/pkgs/overlay-python.nix
@@ -3,9 +3,10 @@ super:
 python-self: python-super:
 {
 
-  pytoml = python-super.zodbpickle.overrideAttrs (old: rec {
+  pytoml = python-super.pytoml.overrideAttrs (old: rec {
     pname = "pytoml";
     version = "0.1.20";
+    name = "${pname}-${version}";
     src = super.fetchFromGitHub {
       owner = "avakar";
       repo = "pytoml";

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -163,6 +163,8 @@ in {
   sensu-plugins-systemd = super.callPackage ./sensuplugins-rb/sensu-plugins-systemd { };
 
   temporal_tables = super.callPackage ./postgresql/temporal_tables { };
+  tideways_daemon = super.callPackage ./tideways/daemon.nix {};
+  tideways_module = super.callPackage ./tideways/module.nix {};
 
   inherit (pkgs-unstable) writeShellScript;
 
@@ -173,19 +175,25 @@ in {
 
   # === Python ===
 
-  python = super.python.override {
+  # python2
+  python27 = super.python27.override {
     packageOverrides = import ./overlay-python.nix super;
   };
+  python27Packages = self.python27.pkgs;
 
-  python3 = super.python3.override {
+  python35 = super.python35.override {
     packageOverrides = import ./overlay-python.nix super;
   };
+  python35Packages = self.python35.pkgs;
+
+  python36 = super.python36.override {
+    packageOverrides = import ./overlay-python.nix super;
+  };
+  python36Packages = self.python36.pkgs;
 
   python37 = super.python37.override {
     packageOverrides = import ./overlay-python.nix super;
   };
-
-  tideways_daemon = super.callPackage ./tideways/daemon.nix {};
-  tideways_module = super.callPackage ./tideways/module.nix {};
+  python37Packages = self.python37.pkgs;
 
 }

--- a/release/default.nix
+++ b/release/default.nix
@@ -83,11 +83,15 @@ let
 
   modifiedPkgNames = attrNames (import ../pkgs/overlay.nix pkgs pkgs);
 
-  modifiedPkgs =
-    listToAttrs (map (n: { name = n; value = pkgs.${n}; }) modifiedPkgNames);
+  testPkgNames = [
+    "wkhtmltopdf"
+  ] ++ modifiedPkgNames;
+
+  testPkgs =
+    listToAttrs (map (n: { name = n; value = pkgs.${n}; }) testPkgNames);
 
   jobs = {
-    pkgs = mapTestOn (packagePlatforms modifiedPkgs);
+    pkgs = mapTestOn (packagePlatforms testPkgs);
     tests = import ../tests { inherit system pkgs; nixpkgs = nixpkgs_; };
   };
 

--- a/tests/garbagecollect.nix
+++ b/tests/garbagecollect.nix
@@ -29,17 +29,23 @@ import ./make-test.nix (
       $machine->startJob("fc-collect-garbage");
       $machine->fail("systemctl is-failed fc-collect-garbage.service");
 
-      # create some files containing Nix store references
-      # these should be found & registered by fc-userscan
+      # create a script containing a Nix store reference and run
+      # fc-collect-garbage again
       print($machine->succeed(<<_EOT_));
         set -e
         echo -e "#!${py}\nprint('hello world')" > ${home}/script.py
         chmod +x ${home}/script.py
         grep -r /nix/store/ ${home}
-        sudo -u u0 -- ${userscan} -rvc ${home}/.cache/fc-userscan.cache ${home}
-        test -s ${home}/.cache/fc-userscan.cache
-        test -n "$(find /nix/var/nix/gcroots/per-user/u0${home} -type l)"
       _EOT_
+      $machine->startJob("fc-collect-garbage");
+      print($machine->waitForFile("${home}/.cache/fc-userscan.cache"));
+
+      # check that a GC root has been registered
+      print($machine->succeed(<<_EOT_));
+        ls -lR /nix/var/nix/gcroots/per-user/u0${home} | grep ${py}
+        test `find /nix/var/nix/gcroots/per-user/u0${home} -type l | wc -l` = 1
+      _EOT_
+      $machine->fail("systemctl is-failed fc-collect-garbage.service");
     '';
   }
 )

--- a/tests/mail/default.nix
+++ b/tests/mail/default.nix
@@ -135,7 +135,7 @@ in
     $mail->succeed('grep testmail5 /srv/mail/example.local/user2/new/*');
 
     # IMAP
-    $client->waitForOpenPort(143);
+    $mail->waitForOpenPort(143);
     $client->succeed('python3 ${./test_imap.py}');
 
     # SMTP outgoing

--- a/tests/mail/default.nix
+++ b/tests/mail/default.nix
@@ -135,6 +135,7 @@ in
     $mail->succeed('grep testmail5 /srv/mail/example.local/user2/new/*');
 
     # IMAP
+    $client->waitForOpenPort(143);
     $client->succeed('python3 ${./test_imap.py}');
 
     # SMTP outgoing

--- a/versions.json
+++ b/versions.json
@@ -8,7 +8,7 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "ec7f283e80a92a615ca980ea895b58da5e1b14c7",
-    "sha256": "0zha9znnr4iqqi9dsfrbscb7gml1bqh8vnapb3j0frkvaai9i1c1"
+    "rev": "990b75cc6a0b8d15a7cd84de9811b47539625e65",
+    "sha256": "1jq7278s3c152rbcbcj7miw478mkkv89yhk59rgqg8rjy6mzfdaq"
   }
 }

--- a/versions.json
+++ b/versions.json
@@ -8,7 +8,7 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "9d57ce89bae75371996c40481d39924309234d67",
-    "sha256": "0zwn31dy5jhxdg3yx6m4asxb69rdyllfybm1c8ghvmdpyrb72jsv"
+    "rev": "ec7f283e80a92a615ca980ea895b58da5e1b14c7",
+    "sha256": "0zha9znnr4iqqi9dsfrbscb7gml1bqh8vnapb3j0frkvaai9i1c1"
   }
 }

--- a/versions.json
+++ b/versions.json
@@ -8,7 +8,7 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "990b75cc6a0b8d15a7cd84de9811b47539625e65",
-    "sha256": "1jq7278s3c152rbcbcj7miw478mkkv89yhk59rgqg8rjy6mzfdaq"
+    "rev": "51f63f17056aed5c1482b3e8dee06b7f2dfbc098",
+    "sha256": "1npp209nm01169agjm0rwkk00nzfd93n6p1knifcpy9334pnwq61"
   }
 }

--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixos-unstable": {
     "owner": "NixOS",
     "repo": "nixpkgs",
-    "rev": "8d05772134f17180fb2711d0660702dae2a67313",
-    "sha256": "0pnyg26c1yhnp3ymzglc71pd9j0567ymqy6il5ywc82bbm1zy25a"
+    "rev": "8e2b14aceb1d40c7e8b84c03a7c78955359872bb",
+    "sha256": "0zzjpd9smr7rxzrdf6raw9kbj42fbvafxb5bz36lcxgv290pgsm8"
   },
   "nixpkgs": {
     "owner": "flyingcircusio",


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Disable "version check" for managed graylog instances to reduce annoying/superfluous warnings.

* Add logging syslog and journal to centralized loghosts for improved platform-wide analysis and security.

## Security implications

- [X] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

Operating a centralized log host has been established as a task in the most recent risk treatment plan. The security of the loghost itself is covered by the existing security practices around running graylog. To avoid additional complicated requirements for further encryption we decided to run log hosts per location and avoid shipping log data over the internet.

Also, we receive log data from all hosts within a DC freely so we expect those to be trustworthy "enough". However, we need to avoid shipping log data to the wrong hosts.

- [X] Security requirements tested? (EVIDENCE)

Log hosts are properly identified and logged to based on the new "non-customer-selectable" role "loghost_location" and this has been tested manually on all platforms (puppet/gentoo, nixos 15.09 and nixos 19.03)
