### PR TITLE
Case #127964: Ensure we build wkhtmltopdf on Hydra.

### DIFF
--- a/release/default.nix
+++ b/release/default.nix
@@ -83,11 +83,15 @@ let
 
   modifiedPkgNames = attrNames (import ../pkgs/overlay.nix pkgs pkgs);
 
-  modifiedPkgs =
-    listToAttrs (map (n: { name = n; value = pkgs.${n}; }) modifiedPkgNames);
+  testPkgNames = [
+    "wkhtmltopdf"
+  ] ++ modifiedPkgNames;
+
+  testPkgs =
+    listToAttrs (map (n: { name = n; value = pkgs.${n}; }) testPkgNames);
 
   jobs = {
-    pkgs = mapTestOn (packagePlatforms modifiedPkgs);
+    pkgs = mapTestOn (packagePlatforms testPkgs);
     tests = import ../tests { inherit system pkgs; nixpkgs = nixpkgs_; };
   };
 


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Prebuild wkhtmltopdf on Hydra to avoid expensive local compilation.

## Security implications

- [X] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

Nothing special. wkhtmltopdf is already widely used and this just speeds up compliation.

- [X ] Security requirements tested? (EVIDENCE)

n/a
