### PR TITLE
Fix fc-userscan permission problems

### DIFF
--- a/nixos/platform/garbagecollect/default.nix
+++ b/nixos/platform/garbagecollect/default.nix
@@ -10,8 +10,6 @@ let
   log = "/var/log/fc-collect-garbage.log";
 
   garbagecollect = pkgs.writeScript "fc-collect-garbage.py" ''
-    #! ${pkgs.python3.interpreter}
-
     import datetime
     import os
     import pwd
@@ -31,16 +29,16 @@ let
                     user.pw_dir + "/.cache/fc-userscan.cache", "-L10000000",
                     "--unzip=*.egg", "-E", EXCLUDE, user.pw_dir],
                 stdin=subprocess.DEVNULL,
-                preexec_fn=lambda: os.seteuid(user.pw_uid))
+                preexec_fn=lambda: os.setuid(user.pw_uid))
             rc.append(p.wait())
 
         status = max(rc)
         print('Overall status:', status)
         if status >= 2:
-            print('ERROR: fc-userscan had hard errors (see above). Aborting')
+            print('Aborting garbagecollect. See above for fc-userscan errors')
             sys.exit(2)
         if status >= 1:
-            print('WARNING: fc-userscan had soft errors (see above). Aborting')
+            print('Aborting garbagecollect. See above for fc-userscan warnings')
             sys.exit(1)
         print('Running nix-collect-garbage')
         rc = subprocess.run([

--- a/pkgs/fc/userscan.nix
+++ b/pkgs/fc/userscan.nix
@@ -7,17 +7,17 @@
 
 rustPlatform.buildRustPackage rec {
   name = "fc-userscan-${version}";
-  version = "0.4.4";
+  version = "0.4.7";
 
   src = fetchFromGitHub {
     name = "fc-userscan-src-${version}";
     owner = "flyingcircusio";
     repo = "userscan";
     rev = version;
-    sha256 = "172q2ywdpg3q7picbl99cv45rcca2vhl7pvb7d4ilc66mhq6b265";
+    sha256 = "19jk0x03i0glsn96a26inbf7mznxzcadxvcsp5g9bilp28c4ibj3";
   };
 
-  cargoSha256 = "0rb181fih70jmnpn9q5lhwhv2gk0rk58945g6j6gapapq4sf259m";
+  cargoSha256 = "0qvccpxgmk3pp35d9ivr4wwvfh4j6gi3ql04qb2icw19m93hna17";
   nativeBuildInputs = [ docutils ];
   propagatedBuildInputs = [ lzo ];
 

--- a/tests/garbagecollect.nix
+++ b/tests/garbagecollect.nix
@@ -29,17 +29,23 @@ import ./make-test.nix (
       $machine->startJob("fc-collect-garbage");
       $machine->fail("systemctl is-failed fc-collect-garbage.service");
 
-      # create some files containing Nix store references
-      # these should be found & registered by fc-userscan
+      # create a script containing a Nix store reference and run
+      # fc-collect-garbage again
       print($machine->succeed(<<_EOT_));
         set -e
         echo -e "#!${py}\nprint('hello world')" > ${home}/script.py
         chmod +x ${home}/script.py
         grep -r /nix/store/ ${home}
-        sudo -u u0 -- ${userscan} -rvc ${home}/.cache/fc-userscan.cache ${home}
-        test -s ${home}/.cache/fc-userscan.cache
-        test -n "$(find /nix/var/nix/gcroots/per-user/u0${home} -type l)"
       _EOT_
+      $machine->startJob("fc-collect-garbage");
+      print($machine->waitForFile("${home}/.cache/fc-userscan.cache"));
+
+      # check that a GC root has been registered
+      print($machine->succeed(<<_EOT_));
+        ls -lR /nix/var/nix/gcroots/per-user/u0${home} | grep ${py}
+        test `find /nix/var/nix/gcroots/per-user/u0${home} -type l | wc -l` = 1
+      _EOT_
+      $machine->fail("systemctl is-failed fc-collect-garbage.service");
     '';
   }
 )


### PR DESCRIPTION
- Be more forgiving w.r.t. problematic access permissions, i.e. when a
  user has non-readable files in its home directory.

- Use setuid() instead of seteuid()

Got the setup of setuid execution wrong in detail: The real uid stays
with the invoking user but the effective uid is set to 0. In our case,
when forking into a user context from root, we need to set the ruid not
the euid.

Case 124165

@flyingcircusio/release-managers

## Release process

Impact:

Changelog: Improve robustness of fc-userscan, the garbage collection scanner. It doesn't stop on unreadable files now. Also fix setuid-root invocation: GC roots and cache files are opened with dropped privileges.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

Principle of least privilege: fc-userscan makes use of its elevated privileges only when reading files, not when writing GC roots or cache files

- [x] Security requirements tested? (EVIDENCE)

Checking this fact explicitly via NixOS test.