### PR TITLE
mailstub: handle unset "domain" option

### DIFF
--- a/nixos/roles/mailserver.nix
+++ b/nixos/roles/mailserver.nix
@@ -23,7 +23,7 @@ let
       type = types.str;
       default = with config.networking; if hasFE
         then "${hostName}.fe.${params.location}.${domain}"
-        else "${hostName}.${domain}";
+        else if domain != null then "${hostName}.${domain}" else hostName;
       description = ''
         FQDN of the mail server's frontend address. IP adresses and
         forward/reverse DNS must match exactly.

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -37,6 +37,7 @@ in {
   login = callTest ./login.nix {};
   logrotate = callTest ./logrotate.nix {};
   mail = callTest ./mail {};
+  mailstub = callTest ./mail/stub.nix {};
   memcached = callTest ./memcached.nix {};
   mongodb32 = callTest ./mongodb.nix { version = "3.2"; };
   mongodb34 = callTest ./mongodb.nix { version = "3.4"; };

--- a/tests/mail/stub.nix
+++ b/tests/mail/stub.nix
@@ -1,0 +1,19 @@
+import ../make-test.nix ({pkgs, lib, ...}:
+{
+  name = "mailstub";
+  nodes = {
+    mail =
+      { lib, ... }: {
+        imports = [ ../../nixos ../../nixos/roles ];
+        config = {
+          flyingcircus.roles.mailstub.enable = true;
+          networking.domain = null;
+        };
+      };
+  };
+  testScript = ''
+    startAll;
+    # basic smoke test, should be expanded
+    $mail->waitForOpenPort(25);
+  '';
+})


### PR DESCRIPTION
This is needed in Vagrant for example, where `domain == null`

Case 127577

@flyingcircusio/release-managers

## Release process

Impact:

Changelog: Vagrant: Fix bug with caused the "mailstub" role to fail when mailHost is not explicitly set.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

Code does sensible stuff in unusual environments.

- [x] Security requirements tested? (EVIDENCE)

NixOS test in tests/mail/stub.nix