### PR TITLE
126611 wrap up lamp role

### DIFF
--- a/nixos/roles/lamp.nix
+++ b/nixos/roles/lamp.nix
@@ -123,6 +123,34 @@ Listen localhost:8001
 
       services.httpd.listen = [ { port = 8000;} ];
 
+      flyingcircus.services.sensu-client.checks = {
+        httpd_status = {
+          notification = "Apache status page";
+          command = "check_http -H localhost -p 8001 -u /server-status?auto -v";
+          timeout = 30;
+        };
+      };
+
+      flyingcircus.services.telegraf.inputs = {
+        apache  = [{
+          urls = [ "http://localhost:8001/server-status?auto" ];
+        }];
+      };
+
+      systemd.tmpfiles.rules = [
+        "d /var/log/httpd 0750 root service"
+        "a+ /var/log/httpd - - - - group:sudo-srv:r-x"
+      ];
+
+      services.logrotate.config = ''
+        /var/log/httpd/*.log {
+          create 0644 root root
+          postrotate
+            systemctl reload httpd
+          endscript
+        }
+      '';
+
       flyingcircus.localConfigDirs.lamp = {
         dir = "/etc/local/lamp";
         user = "nobody";

--- a/nixos/roles/lamp.nix
+++ b/nixos/roles/lamp.nix
@@ -92,7 +92,7 @@ Listen localhost:8001
     StartServers 5
     MinSpareServers 2
     MaxSpareServers 5
-    MaxRequestWorkers 10
+    MaxRequestWorkers 25
     MaxConnectionsPerChild 20
 </IfModule>
 


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

* Apache (in LAMP roles) will be reloaded/restarted.

Changelog:

* Polish our new LAMP role: add logrotation, detailed Sensu monitoring, metrics integration and grant access to service users to read the apache logs. (#126611)

## Security implications

- [X] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

Most changes are not security related, but read access to logs is now granted to service users and users with the 'sudo-srv' permission.

- [X] Security requirements tested? (EVIDENCE)

Manually tested on vmonitorstag00.

