### PR TITLE
Nginx: new packages, master process reload and various fixes

### DIFF
--- a/nixos/services/default.nix
+++ b/nixos/services/default.nix
@@ -3,6 +3,7 @@ let
   modulesFromHere = [
     "services/monitoring/prometheus.nix"
     "services/monitoring/prometheus/default.nix"
+    "services/web-servers/nginx/default.nix"
   ];
 
   modulesFromUnstable = [

--- a/nixos/services/nginx/README.txt
+++ b/nixos/services/nginx/README.txt
@@ -2,9 +2,13 @@ Nginx is enabled on this machine.
 
 We provide basic config. You can use two ways to add custom configuration.
 
-Changes to your custom config will cause nginx to reload without downtime on 
+Changes to your custom config will cause nginx to reload without downtime on
 the next fc-manage run if the config is valid. It will display a warning if
 invalid settings are found in the nginx config.
+
+Note that changes to listen directives that are incompatible with the running config
+require a manual Ngnix restart that drops connections. This happens when changing
+`listenAddress` from 0.0.0.0 to a single IP address 123.123.123.123, for example.
 
 The combined nginx config file can be shown with: `nginx-show-config`
 
@@ -21,8 +25,9 @@ The config snippets must contain a single JSON object that defines one or
 more virtual hosts. Multiple JSON config files will be merged into one object.
 It's a good idea to use one config file per virtual host.
 
-example.json containing a virtual with static root directory, a bit of
-custom configuration, and SSL with a default certificate from Let's Encrypt:
+This example.json defines a virtual host listening on all frontend IP addresses.
+Requests to Port 80 are redirected to 443 which serves SSL using a managed
+certificate from Let's Encrypt:
 
 ```
 {
@@ -43,12 +48,19 @@ custom configuration, and SSL with a default certificate from Let's Encrypt:
 ### Available Options
 
 Options provided by NixOS are documented at
-https://nixos.org/nixos/options.html#services.nginx.virtualhosts.%3Cname%3E 
+https://search.nixos.org/options?query=services.nginx.virtualHosts.&from=0&size=50&sort=relevance&channel=19.09
 
 We support the following custom options:
 * `emailACME`: set the contact address for Let's Encrypt, defaults to none.
-* `listenAddress`: IPv4 address for vhost, defaults to `0.0.0.0`.
-* `listenAddress6`: IPv6 address for vhost, defaults to `[::]`.
+* `listenAddress`: Single IPv4 address for vhost.
+* `listenAddress6`: Single IPv6 address for vhost.
+
+If only one of the listenAddress* options is given, the vhost listens only on IPv4 or IPv6.
+If none of the `listenAddress*` options is given, all frontend IPs are used.
+
+The `listen` option overrides our defaults: the `listenAddress*` options have
+no effect and no IP is used automatically in this case.
+
 
 ### HTTPS and Let's Encrypt
 
@@ -64,7 +76,7 @@ To use a custom certificate, set the certificate options and set `"enableACME" =
 Manual configuration
 --------------------
 
-You can also use plain nginx config files /etc/local/nginx/*.conf for configuration. 
+You can also use plain nginx config files /etc/local/nginx/*.conf for configuration.
 The contents are included verbatim into the combined config by running fc-manage.
 
 You may add other files to the directory, like SSL keys, as well.

--- a/nixos/services/nginx/base-module.nix
+++ b/nixos/services/nginx/base-module.nix
@@ -151,8 +151,8 @@ let
 
       ${optionalString cfg.statusPage ''
         server {
-          listen 80;
-          ${optionalString enableIPv6 "listen [::]:80;" }
+          listen 127.0.0.1:80;
+          ${optionalString enableIPv6 "listen [::1]:80;" }
 
           server_name localhost;
 

--- a/nixos/services/nginx/base-module.nix
+++ b/nixos/services/nginx/base-module.nix
@@ -1,0 +1,751 @@
+# This replaces the NixOS nginx module.
+# Taken from upstream nixos-19.03.
+# Modifications:
+# * Support config reloading without restart.
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.nginx;
+  certs = config.security.acme.certs;
+  vhostsConfigs = mapAttrsToList (vhostName: vhostConfig: vhostConfig) virtualHosts;
+  acmeEnabledVhosts = filter (vhostConfig: vhostConfig.enableACME && vhostConfig.useACMEHost == null) vhostsConfigs;
+  virtualHosts = mapAttrs (vhostName: vhostConfig:
+    let
+      serverName = if vhostConfig.serverName != null
+        then vhostConfig.serverName
+        else vhostName;
+    in
+    vhostConfig // {
+      inherit serverName;
+    } // (optionalAttrs vhostConfig.enableACME {
+      sslCertificate = "${certs.${serverName}.directory}/fullchain.pem";
+      sslCertificateKey = "${certs.${serverName}.directory}/key.pem";
+      sslTrustedCertificate = "${certs.${serverName}.directory}/full.pem";
+    }) // (optionalAttrs (vhostConfig.useACMEHost != null) {
+      sslCertificate = "${certs.${vhostConfig.useACMEHost}.directory}/fullchain.pem";
+      sslCertificateKey = "${certs.${vhostConfig.useACMEHost}.directory}/key.pem";
+      sslTrustedCertificate = "${certs.${vhostConfig.useACMEHost}.directory}/fullchain.pem";
+    })
+  ) cfg.virtualHosts;
+  enableIPv6 = config.networking.enableIPv6;
+
+  recommendedProxyConfig = pkgs.writeText "nginx-recommended-proxy-headers.conf" ''
+    proxy_set_header        Host $host;
+    proxy_set_header        X-Real-IP $remote_addr;
+    proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header        X-Forwarded-Proto $scheme;
+    proxy_set_header        X-Forwarded-Host $host;
+    proxy_set_header        X-Forwarded-Server $host;
+    proxy_set_header        Accept-Encoding "";
+  '';
+
+  upstreamConfig = toString (flip mapAttrsToList cfg.upstreams (name: upstream: ''
+    upstream ${name} {
+      ${toString (flip mapAttrsToList upstream.servers (name: server: ''
+        server ${name} ${optionalString server.backup "backup"};
+      ''))}
+      ${upstream.extraConfig}
+    }
+  ''));
+
+  awkFormat = builtins.toFile "awkFormat-nginx.awk" ''
+    awk -f
+    {sub(/^[ \t]+/,"");idx=0}
+    /\{/{ctx++;idx=1}
+    /\}/{ctx--}
+    {id="";for(i=idx;i<ctx;i++)id=sprintf("%s%s", id, "\t");printf "%s%s\n", id, $0}
+  '';
+
+  configFile = pkgs.runCommand "nginx.conf" {} (''
+    awk -f ${awkFormat} ${pre-configFile} | sed '/^\s*$/d' > $out
+  '');
+
+  pre-configFile = pkgs.writeText "pre-nginx.conf" ''
+    user ${cfg.user} ${cfg.group};
+    error_log ${cfg.logError};
+    daemon off;
+
+    ${cfg.config}
+
+    ${optionalString (cfg.eventsConfig != "" || cfg.config == "") ''
+    events {
+      ${cfg.eventsConfig}
+    }
+    ''}
+
+    ${optionalString (cfg.httpConfig == "" && cfg.config == "") ''
+    http {
+      include ${cfg.package}/conf/mime.types;
+      include ${cfg.package}/conf/fastcgi.conf;
+      include ${cfg.package}/conf/uwsgi_params;
+
+      ${optionalString (cfg.resolver.addresses != []) ''
+        resolver ${toString cfg.resolver.addresses} ${optionalString (cfg.resolver.valid != "") "valid=${cfg.resolver.valid}"};
+      ''}
+      ${upstreamConfig}
+
+      ${optionalString (cfg.recommendedOptimisation) ''
+        # optimisation
+        sendfile on;
+        tcp_nopush on;
+        tcp_nodelay on;
+        keepalive_timeout 65;
+        types_hash_max_size 2048;
+      ''}
+
+      ssl_protocols ${cfg.sslProtocols};
+      ssl_ciphers ${cfg.sslCiphers};
+      ${optionalString (cfg.sslDhparam != null) "ssl_dhparam ${cfg.sslDhparam};"}
+
+      ${optionalString (cfg.recommendedTlsSettings) ''
+        ssl_session_cache shared:SSL:42m;
+        ssl_session_timeout 23m;
+        ssl_ecdh_curve secp384r1;
+        ssl_prefer_server_ciphers on;
+        ssl_stapling on;
+        ssl_stapling_verify on;
+      ''}
+
+      ${optionalString (cfg.recommendedGzipSettings) ''
+        gzip on;
+        gzip_disable "msie6";
+        gzip_proxied any;
+        gzip_comp_level 5;
+        gzip_types
+          application/atom+xml
+          application/javascript
+          application/json
+          application/xml
+          application/xml+rss
+          image/svg+xml
+          text/css
+          text/javascript
+          text/plain
+          text/xml;
+        gzip_vary on;
+      ''}
+
+      ${optionalString (cfg.recommendedProxySettings) ''
+        proxy_redirect          off;
+        proxy_connect_timeout   90;
+        proxy_send_timeout      90;
+        proxy_read_timeout      90;
+        proxy_http_version      1.0;
+        include ${recommendedProxyConfig};
+      ''}
+
+      # $connection_upgrade is used for websocket proxying
+      map $http_upgrade $connection_upgrade {
+          default upgrade;
+          '''      close;
+      }
+      client_max_body_size ${cfg.clientMaxBodySize};
+
+      server_tokens ${if cfg.serverTokens then "on" else "off"};
+
+      ${cfg.commonHttpConfig}
+
+      ${vhosts}
+
+      ${optionalString cfg.statusPage ''
+        server {
+          listen 80;
+          ${optionalString enableIPv6 "listen [::]:80;" }
+
+          server_name localhost;
+
+          location /nginx_status {
+            stub_status on;
+            access_log off;
+            allow 127.0.0.1;
+            ${optionalString enableIPv6 "allow ::1;"}
+            deny all;
+          }
+        }
+      ''}
+
+      ${cfg.appendHttpConfig}
+    }''}
+
+    ${optionalString (cfg.httpConfig != "") ''
+    http {
+      include ${cfg.package}/conf/mime.types;
+      include ${cfg.package}/conf/fastcgi.conf;
+      include ${cfg.package}/conf/uwsgi_params;
+      ${cfg.httpConfig}
+    }''}
+
+    ${cfg.appendConfig}
+  '';
+
+  vhosts = concatStringsSep "\n" (mapAttrsToList (vhostName: vhost:
+    let
+        onlySSL = vhost.onlySSL || vhost.enableSSL;
+        hasSSL = onlySSL || vhost.addSSL || vhost.forceSSL;
+
+        defaultListen =
+          if vhost.listen != [] then vhost.listen
+          else ((optionals hasSSL (
+            singleton                    { addr = vhost.listenAddress; port = 443; ssl = true; }
+            ++ optional enableIPv6 { addr = vhost.listenAddress6;    port = 443; ssl = true; }
+          )) ++ optionals (!onlySSL) (
+            singleton                    { addr = vhost.listenAddress; port = 80;  ssl = false; }
+            ++ optional enableIPv6 { addr = vhost.listenAddress6;    port = 80;  ssl = false; }
+          ));
+
+        hostListen =
+          if vhost.forceSSL
+            then filter (x: x.ssl) defaultListen
+            else defaultListen;
+
+        listenString = { addr, port, ssl, extraParameters ? [], ... }:
+          "listen ${addr}:${toString port} "
+          + optionalString ssl "ssl "
+          + optionalString (ssl && vhost.http2) "http2 "
+          + optionalString vhost.default "default_server "
+          + optionalString (extraParameters != []) (concatStringsSep " " extraParameters)
+          + ";";
+
+        redirectListen = filter (x: !x.ssl) defaultListen;
+
+        acmeLocation = optionalString (vhost.enableACME || vhost.useACMEHost != null) ''
+          location /.well-known/acme-challenge {
+            ${optionalString (vhost.acmeFallbackHost != null) "try_files $uri @acme-fallback;"}
+            root ${vhost.acmeRoot};
+            auth_basic off;
+          }
+          ${optionalString (vhost.acmeFallbackHost != null) ''
+            location @acme-fallback {
+              auth_basic off;
+              proxy_pass http://${vhost.acmeFallbackHost};
+            }
+          ''}
+        '';
+
+      in ''
+        ${optionalString vhost.forceSSL ''
+          server {
+            ${concatMapStringsSep "\n" listenString redirectListen}
+
+            server_name ${vhost.serverName} ${concatStringsSep " " vhost.serverAliases};
+            ${acmeLocation}
+            location / {
+              return 301 https://$host$request_uri;
+            }
+          }
+        ''}
+
+        server {
+          ${concatMapStringsSep "\n" listenString hostListen}
+          server_name ${vhost.serverName} ${concatStringsSep " " vhost.serverAliases};
+          ${acmeLocation}
+          ${optionalString (vhost.root != null) "root ${vhost.root};"}
+          ${optionalString (vhost.globalRedirect != null) ''
+            return 301 http${optionalString hasSSL "s"}://${vhost.globalRedirect}$request_uri;
+          ''}
+          ${optionalString hasSSL ''
+            ssl_certificate ${vhost.sslCertificate};
+            ssl_certificate_key ${vhost.sslCertificateKey};
+          ''}
+          ${optionalString (hasSSL && vhost.sslTrustedCertificate != null) ''
+            ssl_trusted_certificate ${vhost.sslTrustedCertificate};
+          ''}
+
+          ${optionalString (vhost.basicAuthFile != null || vhost.basicAuth != {}) ''
+            auth_basic secured;
+            auth_basic_user_file ${if vhost.basicAuthFile != null then vhost.basicAuthFile else mkHtpasswd vhostName vhost.basicAuth};
+          ''}
+
+          ${mkLocations vhost.locations}
+
+          ${vhost.extraConfig}
+        }
+      ''
+  ) virtualHosts);
+  mkLocations = locations: concatStringsSep "\n" (map (config: ''
+    location ${config.location} {
+      ${optionalString (config.proxyPass != null && !cfg.proxyResolveWhileRunning)
+        "proxy_pass ${config.proxyPass};"
+      }
+      ${optionalString (config.proxyPass != null && cfg.proxyResolveWhileRunning) ''
+        set $nix_proxy_target "${config.proxyPass}";
+        proxy_pass $nix_proxy_target;
+      ''}
+      ${optionalString config.proxyWebsockets ''
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+      ''}
+      ${optionalString (config.index != null) "index ${config.index};"}
+      ${optionalString (config.tryFiles != null) "try_files ${config.tryFiles};"}
+      ${optionalString (config.root != null) "root ${config.root};"}
+      ${optionalString (config.alias != null) "alias ${config.alias};"}
+      ${config.extraConfig}
+      ${optionalString (config.proxyPass != null && cfg.recommendedProxySettings) "include ${recommendedProxyConfig};"}
+    }
+  '') (sortProperties (mapAttrsToList (k: v: v // { location = k; }) locations)));
+  mkBasicAuth = vhostName: authDef: let
+    htpasswdFile = pkgs.writeText "${vhostName}.htpasswd" (
+      concatStringsSep "\n" (mapAttrsToList (user: password: ''
+        ${user}:{PLAIN}${password}
+      '') authDef)
+    );
+  in ''
+    auth_basic secured;
+    auth_basic_user_file ${htpasswdFile};
+  '';
+
+  mkHtpasswd = vhostName: authDef: pkgs.writeText "${vhostName}.htpasswd" (
+    concatStringsSep "\n" (mapAttrsToList (user: password: ''
+      ${user}:{PLAIN}${password}
+    '') authDef)
+  );
+
+  checkConfigCmd = "${cfg.package}/bin/nginx -t -c ${configFile} -p ${cfg.stateDir}";
+in
+
+{
+  options = {
+    services.nginx = {
+      enable = mkEnableOption "Nginx Web Server";
+
+      statusPage = mkOption {
+        default = false;
+        type = types.bool;
+        description = "
+          Enable status page reachable from localhost on http://127.0.0.1/nginx_status.
+        ";
+      };
+
+      recommendedTlsSettings = mkOption {
+        default = false;
+        type = types.bool;
+        description = "
+          Enable recommended TLS settings.
+        ";
+      };
+
+      recommendedOptimisation = mkOption {
+        default = false;
+        type = types.bool;
+        description = "
+          Enable recommended optimisation settings.
+        ";
+      };
+
+      recommendedGzipSettings = mkOption {
+        default = false;
+        type = types.bool;
+        description = "
+          Enable recommended gzip settings.
+        ";
+      };
+
+      recommendedProxySettings = mkOption {
+        default = false;
+        type = types.bool;
+        description = "
+          Enable recommended proxy settings.
+        ";
+      };
+
+      package = mkOption {
+        default = pkgs.nginxStable;
+        defaultText = "pkgs.nginxStable";
+        type = types.package;
+        description = "
+          Nginx package to use. This defaults to the stable version. Note
+          that the nginx team recommends to use the mainline version which
+          available in nixpkgs as <literal>nginxMainline</literal>.
+        ";
+      };
+
+      logError = mkOption {
+        default = "stderr";
+        description = "
+          Configures logging.
+          The first parameter defines a file that will store the log. The
+          special value stderr selects the standard error file. Logging to
+          syslog can be configured by specifying the “syslog:” prefix.
+          The second parameter determines the level of logging, and can be
+          one of the following: debug, info, notice, warn, error, crit,
+          alert, or emerg. Log levels above are listed in the order of
+          increasing severity. Setting a certain log level will cause all
+          messages of the specified and more severe log levels to be logged.
+          If this parameter is omitted then error is used.
+        ";
+      };
+
+      preStart =  mkOption {
+        type = types.lines;
+        default = ''
+          test -d ${cfg.stateDir}/logs || mkdir -m 750 -p ${cfg.stateDir}/logs
+          test `stat -c %a ${cfg.stateDir}` = "750" || chmod 750 ${cfg.stateDir}
+          test `stat -c %a ${cfg.stateDir}/logs` = "750" || chmod 750 ${cfg.stateDir}/logs
+          chown -R ${cfg.user}:${cfg.group} ${cfg.stateDir}
+        '';
+        description = "
+          Shell commands executed before the service's nginx is started.
+        ";
+      };
+
+      config = mkOption {
+        default = "";
+        description = "
+          Verbatim nginx.conf configuration.
+          This is mutually exclusive with the structured configuration
+          via virtualHosts and the recommendedXyzSettings configuration
+          options. See appendConfig for appending to the generated http block.
+        ";
+      };
+
+      appendConfig = mkOption {
+        type = types.lines;
+        default = "";
+        description = ''
+          Configuration lines appended to the generated Nginx
+          configuration file. Commonly used by different modules
+          providing http snippets. <option>appendConfig</option>
+          can be specified more than once and it's value will be
+          concatenated (contrary to <option>config</option> which
+          can be set only once).
+        '';
+      };
+
+      commonHttpConfig = mkOption {
+        type = types.lines;
+        default = "";
+        example = ''
+          resolver 127.0.0.1 valid=5s;
+
+          log_format myformat '$remote_addr - $remote_user [$time_local] '
+                              '"$request" $status $body_bytes_sent '
+                              '"$http_referer" "$http_user_agent"';
+        '';
+        description = ''
+          With nginx you must provide common http context definitions before
+          they are used, e.g. log_format, resolver, etc. inside of server
+          or location contexts. Use this attribute to set these definitions
+          at the appropriate location.
+        '';
+      };
+
+      httpConfig = mkOption {
+        type = types.lines;
+        default = "";
+        description = "
+          Configuration lines to be set inside the http block.
+          This is mutually exclusive with the structured configuration
+          via virtualHosts and the recommendedXyzSettings configuration
+          options. See appendHttpConfig for appending to the generated http block.
+        ";
+      };
+
+      eventsConfig = mkOption {
+        type = types.lines;
+        default = "";
+        description = ''
+          Configuration lines to be set inside the events block.
+        '';
+      };
+
+      appendHttpConfig = mkOption {
+        type = types.lines;
+        default = "";
+        description = "
+          Configuration lines to be appended to the generated http block.
+          This is mutually exclusive with using config and httpConfig for
+          specifying the whole http block verbatim.
+        ";
+      };
+
+      stateDir = mkOption {
+        default = "/var/spool/nginx";
+        description = "
+          Directory holding all state for nginx to run.
+        ";
+      };
+
+      user = mkOption {
+        type = types.str;
+        default = "nginx";
+        description = "User account under which nginx runs.";
+      };
+
+      group = mkOption {
+        type = types.str;
+        default = "nginx";
+        description = "Group account under which nginx runs.";
+      };
+
+      serverTokens = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Show nginx version in headers and error pages.";
+      };
+
+      clientMaxBodySize = mkOption {
+        type = types.string;
+        default = "10m";
+        description = "Set nginx global client_max_body_size.";
+      };
+
+      sslCiphers = mkOption {
+        type = types.str;
+        default = "EECDH+aRSA+AESGCM:EDH+aRSA:EECDH+aRSA:+AES256:+AES128:+SHA1:!CAMELLIA:!SEED:!3DES:!DES:!RC4:!eNULL";
+        description = "Ciphers to choose from when negotiating tls handshakes.";
+      };
+
+      sslProtocols = mkOption {
+        type = types.str;
+        default = "TLSv1.2 TLSv1.3";
+        example = "TLSv1 TLSv1.1 TLSv1.2 TLSv1.3";
+        description = "Allowed TLS protocol versions.";
+      };
+
+      sslDhparam = mkOption {
+        type = types.nullOr types.path;
+        default = null;
+        example = "/path/to/dhparams.pem";
+        description = "Path to DH parameters file.";
+      };
+
+      proxyResolveWhileRunning = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Resolves domains of proxyPass targets at runtime
+          and not only at start, you have to set
+          services.nginx.resolver, too.
+        '';
+      };
+
+      resolver = mkOption {
+        type = types.submodule {
+          options = {
+            addresses = mkOption {
+              type = types.listOf types.str;
+              default = [];
+              example = literalExample ''[ "[::1]" "127.0.0.1:5353" ]'';
+              description = "List of resolvers to use";
+            };
+            valid = mkOption {
+              type = types.str;
+              default = "";
+              example = "30s";
+              description = ''
+                By default, nginx caches answers using the TTL value of a response.
+                An optional valid parameter allows overriding it
+              '';
+            };
+          };
+        };
+        description = ''
+          Configures name servers used to resolve names of upstream servers into addresses
+        '';
+        default = {};
+      };
+
+      upstreams = mkOption {
+        type = types.attrsOf (types.submodule {
+          options = {
+            servers = mkOption {
+              type = types.attrsOf (types.submodule {
+                options = {
+                  backup = mkOption {
+                    type = types.bool;
+                    default = false;
+                    description = ''
+                      Marks the server as a backup server. It will be passed
+                      requests when the primary servers are unavailable.
+                    '';
+                  };
+                };
+              });
+              description = ''
+                Defines the address and other parameters of the upstream servers.
+              '';
+              default = {};
+            };
+            extraConfig = mkOption {
+              type = types.lines;
+              default = "";
+              description = ''
+                These lines go to the end of the upstream verbatim.
+              '';
+            };
+          };
+        });
+        description = ''
+          Defines a group of servers to use as proxy target.
+        '';
+        default = {};
+      };
+
+      virtualHosts = mkOption {
+        type = types.attrsOf (types.submodule (import ./vhost-options.nix {
+          inherit config lib;
+        }));
+        default = {
+          localhost = {};
+        };
+        example = literalExample ''
+          {
+            "hydra.example.com" = {
+              forceSSL = true;
+              enableACME = true;
+              locations."/" = {
+                proxyPass = "http://localhost:3000";
+              };
+            };
+          };
+        '';
+        description = "Declarative vhost config";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    # TODO: test user supplied config file pases syntax test
+
+    warnings =
+    let
+      deprecatedSSL = name: config: optional config.enableSSL
+      ''
+        config.services.nginx.virtualHosts.<name>.enableSSL is deprecated,
+        use config.services.nginx.virtualHosts.<name>.onlySSL instead.
+      '';
+
+    in flatten (mapAttrsToList deprecatedSSL virtualHosts);
+
+    assertions =
+    let
+      hostOrAliasIsNull = l: l.root == null || l.alias == null;
+    in [
+      {
+        assertion = all (host: all hostOrAliasIsNull (attrValues host.locations)) (attrValues virtualHosts);
+        message = "Only one of nginx root or alias can be specified on a location.";
+      }
+
+      {
+        assertion = all (conf: with conf;
+          !(addSSL && (onlySSL || enableSSL)) &&
+          !(forceSSL && (onlySSL || enableSSL)) &&
+          !(addSSL && forceSSL)
+        ) (attrValues virtualHosts);
+        message = ''
+          Options services.nginx.service.virtualHosts.<name>.addSSL,
+          services.nginx.virtualHosts.<name>.onlySSL and services.nginx.virtualHosts.<name>.forceSSL
+          are mutually exclusive.
+        '';
+      }
+
+      {
+        assertion = all (conf: !(conf.enableACME && conf.useACMEHost != null)) (attrValues virtualHosts);
+        message = ''
+          Options services.nginx.service.virtualHosts.<name>.enableACME and
+          services.nginx.virtualHosts.<name>.useACMEHost are mutually exclusive.
+        '';
+      }
+    ];
+
+    systemd.services.nginx = {
+      description = "Nginx Web Server";
+      wantedBy = [ "multi-user.target" ];
+      wants = concatLists (map (vhostConfig: ["acme-${vhostConfig.serverName}.service" "acme-selfsigned-${vhostConfig.serverName}.service"]) acmeEnabledVhosts);
+      after = [ "network.target" ] ++ map (vhostConfig: "acme-selfsigned-${vhostConfig.serverName}.service") acmeEnabledVhosts;
+      before = map (vhostConfig: "acme-${vhostConfig.serverName}.service") acmeEnabledVhosts;
+      stopIfChanged = false;
+      preStart =
+        ''
+        ${cfg.preStart}
+        mkdir -p ${cfg.stateDir}/logs
+        chmod 700 ${cfg.stateDir}
+        chown -R ${cfg.user}:${cfg.group} ${cfg.stateDir}
+        ln -sf ${configFile} /run/nginx/config
+        ln -sf ${cfg.package} /run/nginx/package
+      '';
+      reload = ''
+        echo "Reload triggered, checking config file..."
+        # Check if the new config is valid
+        ${checkConfigCmd} || rc=$?
+
+        if [[ -n $rc ]]; then
+          echo Error: Not restarting / reloading because of config errors.
+          echo New configuration not activated!
+          # We must use 0 as exit code, otherwise systemd would kill the nginx process.
+          # This is a bug in systemd: https://github.com/systemd/systemd/issues/11238
+          exit 0
+        fi
+
+        # Check if the package changed
+
+        if [[ $(readlink /run/nginx/package) != ${cfg.package} ]]; then
+          # If it changed, we need to restart nginx. So we kill nginx
+          # gracefully. We can't send a restart to systemd while in the
+          # reload script. Nginx will be restarted by systemd automatically.
+          echo "Nginx package changed, gracefully quitting so systemd can restart it"
+          ${pkgs.coreutils}/bin/kill -QUIT $MAINPID
+        else
+          # We only need to change the configuration, so update it and reload nginx
+          echo "Reloading Nginx now"
+          ln -sf ${configFile} /run/nginx/config
+          ${pkgs.coreutils}/bin/kill -HUP $MAINPID
+        fi
+      '';
+      reloadIfChanged = true;
+      serviceConfig = {
+        ExecStart = "${cfg.package}/bin/nginx -c /run/nginx/config -p ${cfg.stateDir}";
+        Restart = "always";
+        RuntimeDirectory = "nginx";
+        # X- options are ignored by systemd.
+        # To show the last running config, use:
+        # cat `systemctl cat nginx | grep "X-ConfigFile" | cut -d= -f2`
+        X-ConfigFile = configFile;
+        # To check the current config file:
+        # `systemctl cat nginx | grep "X-CheckConfigCmd" | cut -d= -f2`
+        X-CheckConfigCmd = checkConfigCmd;
+      };
+    };
+
+    system.activationScripts.nginx-reload-check = lib.stringAfter [ "resolvconf" ] ''
+      if ${pkgs.procps}/bin/pgrep nginx &> /dev/null; then
+        nginx_check_msg=$(${checkConfigCmd} 2>&1) || rc=$?
+
+        if [[ -n $rc ]]; then
+          printf "\033[0;31mWarning: \033[0mNginx config is invalid at this point:\n$nginx_check_msg\n"
+          echo Reload may still work if missing Let\'s Encrypt SSL certs are the reason, for example.
+          echo Please check the output of journalctl -eu nginx
+        fi
+      fi
+    '';
+
+    security.acme.certs = filterAttrs (n: v: v != {}) (
+      let
+        acmePairs = map (vhostConfig: { name = vhostConfig.serverName; value = {
+            user = cfg.user;
+            group = lib.mkDefault cfg.group;
+            webroot = vhostConfig.acmeRoot;
+            extraDomains = genAttrs vhostConfig.serverAliases (alias: null);
+            postRun = ''
+              systemctl reload nginx
+            '';
+          }; }) acmeEnabledVhosts;
+      in
+        listToAttrs acmePairs
+    );
+
+    users.users = optionalAttrs (cfg.user == "nginx") (singleton
+      { name = "nginx";
+        group = cfg.group;
+        uid = config.ids.uids.nginx;
+      });
+
+    users.groups = optionalAttrs (cfg.group == "nginx") (singleton
+      { name = "nginx";
+        gid = config.ids.gids.nginx;
+      });
+  };
+}

--- a/nixos/services/nginx/default.nix
+++ b/nixos/services/nginx/default.nix
@@ -46,7 +46,6 @@ let
     fi
   '';
 
-  stateDir = config.services.nginx.stateDir;
   package = config.services.nginx.package;
   localDir = config.flyingcircus.localConfigDirs.nginx.dir;
 
@@ -297,12 +296,7 @@ in
         }
       '';
 
-      # Config check fails on first run if /var/spool/nginx/logs is missing.
-      # Nginx creates it, but we create it here to avoid that useless error.
-      # It's only used on Nginx startup, "real" logging goes to /var/log/nginx.
       systemd.tmpfiles.rules = [
-        "d /var/log/nginx 0755 nginx"
-        "d /var/spool/nginx/logs 0755 nginx nginx 7d"
         "d /etc/local/nginx/modsecurity 2775 nginx service"
       ];
 

--- a/nixos/services/nginx/default.nix
+++ b/nixos/services/nginx/default.nix
@@ -1,3 +1,7 @@
+# Note that Nginx is reloaded when config, unit file or package change.
+# Future changes may require a full Nginx restart to become active.
+# We can use systemd.services.nginx.restartTriggers to force a restart.
+# This may also affect other services that use reloading.
 { lib, config, pkgs, ... }:
 
 with builtins;
@@ -301,6 +305,11 @@ in
         "d /var/spool/nginx/logs 0755 nginx nginx 7d"
         "d /etc/local/nginx/modsecurity 2775 nginx service"
       ];
+
+      systemd.services.nginx.serviceConfig = {
+        Type="forking";
+        PIDFile="/run/nginx/nginx.pid";
+      };
 
       flyingcircus.localConfigDirs.nginx = {
         dir = "/etc/local/nginx";

--- a/nixos/services/nginx/default.nix
+++ b/nixos/services/nginx/default.nix
@@ -131,6 +131,9 @@ let
 
 in
 {
+
+  imports = [ ./base-module.nix ];
+
   options.flyingcircus.services.nginx = with lib; {
     enable = mkEnableOption "FC-customized nginx";
 

--- a/nixos/services/nginx/location-options.nix
+++ b/nixos/services/nginx/location-options.nix
@@ -1,0 +1,87 @@
+# Taken from upstream branch nixos-19.03.
+
+# This file defines the options that can be used both for the Apache
+# main server configuration, and for the virtual hosts.  (The latter
+# has additional options that affect the web server as a whole, like
+# the user/group to run under.)
+
+{ lib }:
+
+with lib;
+
+{
+  options = {
+    proxyPass = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      example = "http://www.example.org/";
+      description = ''
+        Adds proxy_pass directive and sets recommended proxy headers if
+        recommendedProxySettings is enabled.
+      '';
+    };
+
+    proxyWebsockets = mkOption {
+      type = types.bool;
+      default = false;
+      example = true;
+      description = ''
+        Whether to supporty proxying websocket connections with HTTP/1.1.
+      '';
+    };
+
+    index = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      example = "index.php index.html";
+      description = ''
+        Adds index directive.
+      '';
+    };
+
+    tryFiles = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      example = "$uri =404";
+      description = ''
+        Adds try_files directive.
+      '';
+    };
+
+    root = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      example = "/your/root/directory";
+      description = ''
+        Root directory for requests.
+      '';
+    };
+
+    alias = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      example = "/your/alias/directory";
+      description = ''
+        Alias directory for requests.
+      '';
+    };
+
+    extraConfig = mkOption {
+      type = types.lines;
+      default = "";
+      description = ''
+        These lines go to the end of the location verbatim.
+      '';
+    };
+
+    priority = mkOption {
+      type = types.int;
+      default = 1000;
+      description = ''
+        Order of this location block in relation to the others in the vhost.
+        The semantics are the same as with `lib.mkOrder`. Smaller values have
+        a greater priority.
+      '';
+    };
+  };
+}

--- a/nixos/services/nginx/vhost-options.nix
+++ b/nixos/services/nginx/vhost-options.nix
@@ -1,0 +1,250 @@
+# Taken from upstream branch nixos-19.03.
+# Modifications:
+# * listenAddress and listenAddress6 options
+
+# This file defines the options that can be used both for the Apache
+# main server configuration, and for the virtual hosts.  (The latter
+# has additional options that affect the web server as a whole, like
+# the user/group to run under.)
+
+{ lib, ... }:
+
+with lib;
+{
+  options = {
+    serverName = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = ''
+        Name of this virtual host. Defaults to attribute name in virtualHosts.
+      '';
+      example = "example.org";
+    };
+
+    serverAliases = mkOption {
+      type = types.listOf types.str;
+      default = [];
+      example = ["www.example.org" "example.org"];
+      description = ''
+        Additional names of virtual hosts served by this virtual host configuration.
+      '';
+    };
+
+    listen = mkOption {
+      type = with types; listOf (submodule { options = {
+        addr = mkOption { type = str;  description = "IP address.";  };
+        port = mkOption { type = int;  description = "Port number."; default = 80; };
+        ssl  = mkOption { type = bool; description = "Enable SSL.";  default = false; };
+        extraParameters = mkOption { type = listOf str; description = "Extra parameters of this listen directive."; default = []; example = [ "reuseport" "deferred" ]; };
+      }; });
+      default = [];
+      example = [
+        { addr = "195.154.1.1"; port = 443; ssl = true;}
+        { addr = "192.154.1.1"; port = 80; }
+      ];
+      description = ''
+        Listen addresses and ports for this virtual host.
+        IPv6 addresses must be enclosed in square brackets.
+        Note: this option overrides <literal>addSSL</literal>
+        and <literal>onlySSL</literal>.
+      '';
+    };
+
+    listenAddress = mkOption {
+      type = types.str;
+      description = ''
+        IPv4 address to listen to. Defaults to 0.0.0.0.
+        If you need more options, use <option>listen</option>.
+      '';
+      default = "0.0.0.0";
+    };
+
+    listenAddress6 = mkOption {
+      type = types.str;
+      description = ''
+        IPv6 address to listen to. Defaults to [::].
+        If you need more options, use <option>listen</option>.
+      '';
+      default = "[::]";
+    };
+
+    enableACME = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Whether to ask Let's Encrypt to sign a certificate for this vhost.
+        Alternately, you can use an existing certificate through <option>useACMEHost</option>.
+      '';
+    };
+
+    useACMEHost = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = ''
+        A host of an existing Let's Encrypt certificate to use.
+        This is useful if you have many subdomains and want to avoid hitting the
+        <link xlink:href="https://letsencrypt.org/docs/rate-limits/">rate limit</link>.
+        Alternately, you can generate a certificate through <option>enableACME</option>.
+        <emphasis>Note that this option does not create any certificates, nor it does add subdomains to existing ones – you will need to create them manually using  <xref linkend="opt-security.acme.certs"/>.</emphasis>
+      '';
+    };
+
+    acmeRoot = mkOption {
+      type = types.str;
+      default = "/var/lib/acme/acme-challenge";
+      description = "Directory for the acme challenge which is PUBLIC, don't put certs or keys in here";
+    };
+
+    acmeFallbackHost = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = ''
+        Host which to proxy requests to if acme challenge is not found. Useful
+        if you want multiple hosts to be able to verify the same domain name.
+      '';
+    };
+
+    addSSL = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Whether to enable HTTPS in addition to plain HTTP. This will set defaults for
+        <literal>listen</literal> to listen on all interfaces on the respective default
+        ports (80, 443).
+      '';
+    };
+
+    onlySSL = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Whether to enable HTTPS and reject plain HTTP connections. This will set
+        defaults for <literal>listen</literal> to listen on all interfaces on port 443.
+      '';
+    };
+
+    enableSSL = mkOption {
+      type = types.bool;
+      visible = false;
+      default = false;
+    };
+
+    forceSSL = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Whether to add a separate nginx server block that permanently redirects (301)
+        all plain HTTP traffic to HTTPS. This will set defaults for
+        <literal>listen</literal> to listen on all interfaces on the respective default
+        ports (80, 443), where the non-SSL listens are used for the redirect vhosts.
+      '';
+    };
+
+    sslCertificate = mkOption {
+      type = types.path;
+      example = "/var/host.cert";
+      description = "Path to server SSL certificate.";
+    };
+
+    sslCertificateKey = mkOption {
+      type = types.path;
+      example = "/var/host.key";
+      description = "Path to server SSL certificate key.";
+    };
+
+    sslTrustedCertificate = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      example = "/var/root.cert";
+      description = "Path to root SSL certificate for stapling and client certificates.";
+    };
+
+    http2 = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Whether to enable HTTP 2.
+        Note that (as of writing) due to nginx's implementation, to disable
+        HTTP 2 you have to disable it on all vhosts that use a given
+        IP address / port.
+        If there is one server block configured to enable http2,then it is
+        enabled for all server blocks on this IP.
+        See https://stackoverflow.com/a/39466948/263061.
+      '';
+    };
+
+    root = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      example = "/data/webserver/docs";
+      description = ''
+        The path of the web root directory.
+      '';
+    };
+
+    default = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Makes this vhost the default.
+      '';
+    };
+
+    extraConfig = mkOption {
+      type = types.lines;
+      default = "";
+      description = ''
+        These lines go to the end of the vhost verbatim.
+      '';
+    };
+
+    globalRedirect = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      example = "newserver.example.org";
+      description = ''
+        If set, all requests for this host are redirected permanently to
+        the given hostname.
+      '';
+    };
+
+    basicAuth = mkOption {
+      type = types.attrsOf types.str;
+      default = {};
+      example = literalExample ''
+        {
+          user = "password";
+        };
+      '';
+      description = ''
+        Basic Auth protection for a vhost.
+
+        WARNING: This is implemented to store the password in plain text in the
+        nix store.
+      '';
+    };
+
+    basicAuthFile = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      description = ''
+        Basic Auth password file for a vhost.
+      '';
+    };
+
+    locations = mkOption {
+      type = types.attrsOf (types.submodule (import ./location-options.nix {
+        inherit lib;
+      }));
+      default = {};
+      example = literalExample ''
+        {
+          "/" = {
+            proxyPass = "http://localhost:3000";
+          };
+        };
+      '';
+      description = "Declarative location config";
+    };
+  };
+}

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -108,12 +108,24 @@ in {
 
   mysql = super.mariadb;
 
-  nginx = super.nginx.override {
-    modules = [
-      self.nginxModules.dav
-      self.nginxModules.modsecurity
-      self.nginxModules.moreheaders
-      self.nginxModules.rtmp
+  # This is our default version.
+  nginxStable = pkgs-unstable.nginxStable.override {
+    modules = with pkgs-unstable.nginxModules; [
+      dav
+      modsecurity
+      moreheaders
+      rtmp
+    ];
+  };
+
+  nginx = self.nginxStable;
+
+  nginxMainline = pkgs-unstable.nginxMainline.override {
+    modules = with pkgs-unstable.nginxModules; [
+      dav
+      modsecurity
+      moreheaders
+      rtmp
     ];
   };
 

--- a/tests/nginx.nix
+++ b/tests/nginx.nix
@@ -1,39 +1,85 @@
-import ./make-test.nix ({ lib, ... }:
-{
+import ./make-test-python.nix ({ lib, pkgs, testlib, ... }:
+
+let
+  stableMajorVersion = "1.18";
+  mainlineMajorVersion = "1.19";
+
+  rootInitial = pkgs.runCommand "nginx-root-initial" {} ''
+    mkdir $out
+    echo initial content > $out/index.html
+  '';
+
+  rootChanged = pkgs.runCommand "nginx-root-changed" {} ''
+    mkdir $out
+    echo changed content > $out/index.html
+  '';
+in {
   name = "nginx";
   machine =
-    { ... }:
+    { lib, pkgs, ... }:
     {
       imports = [ ../nixos ];
       flyingcircus.services.nginx.enable = true;
-    };
-  testScript = { nodes, ... }: 
-  let 
-    sensuChecks = nodes.machine.config.flyingcircus.services.sensu-client.checks;
-    nginxConfigCheck = sensuChecks.nginx_config.command;
-    nginxWorkerAgeCheck = sensuChecks.nginx_worker_age.command;
-    nginxStatusCheck = sensuChecks.nginx_status.command;
 
+      # Vhost for localhost is predefined by the nginx module and serves the
+      # nginx status page which is expected by the sensu check.
+
+      # Vhost for config reload check.
+      services.nginx.virtualHosts.machine = {
+        root = rootInitial;
+      };
+
+      # Display the nginx version on the 404 page.
+      services.nginx.serverTokens = true;
+    };
+
+  testScript = { nodes, ... }:
+  let
+    sensuCheck = testlib.sensuCheckCmd nodes.machine;
   in ''
-    $machine->waitForUnit('nginx.service');
+    machine.wait_for_unit('nginx.service')
+    machine.wait_for_open_port(80)
 
-    subtest "nginx works", sub {
-      $machine->succeed("curl -v http://localhost/nginx_status | grep 'server accepts handled requests'");
-    };
+    with subtest("nginx should respond with configured content"):
+      machine.succeed("curl machine | grep -q 'initial content'")
 
-    subtest "service user should be able to write to local config dir", sub {
-      $machine->succeed('sudo -u nginx touch /etc/local/nginx/vhosts.json');
-    };
+    with subtest("running nginx should have the expected version"):
+      machine.succeed("curl machine/404 | grep -q ${stableMajorVersion}")
 
-    subtest "all sensu checks should be green", sub {
-      $machine->succeed('${nginxConfigCheck}');
-      $machine->succeed('${nginxWorkerAgeCheck}');
-      $machine->succeed('${nginxStatusCheck}');
-    };
+    with subtest("nginx should use changed config after reload"):
+      # Replace config symlink with a new config file.
+      machine.execute("sed 's#${rootInitial}#${rootChanged}#' /run/nginx/config > /run/nginx/changed_config")
+      machine.execute("mv /run/nginx/changed_config /run/nginx/config")
+      # Trigger reload manually because the reload script would reset the symlink.
+      machine.systemctl("kill -s HUP nginx")
+      machine.wait_until_succeeds("curl machine | grep -q 'changed content'")
+      # Back to initial configuration from Nix store.
+      machine.systemctl("reload nginx")
+      machine.wait_until_succeeds("curl machine | grep -q 'initial content'")
 
-    subtest "status check should be red after shutting down nginx", sub {
-      $machine->succeed('systemctl stop nginx.service');
-      $machine->mustFail('${nginxStatusCheck}');
-    };
+    with subtest("nginx should use changed binary after reload"):
+      # Change to mainline nginx version.
+      machine.execute("ln -sfT ${pkgs.nginxMainline} /run/nginx/package")
+      machine.succeed("nginx-reload-master")
+      machine.wait_until_succeeds("curl machine/404 | grep -q ${mainlineMajorVersion}")
+      # Back to initial binary from nginx stable.
+      machine.systemctl("reload nginx")
+      machine.wait_until_succeeds("curl machine/404 | grep -q ${stableMajorVersion}")
+
+    with subtest("service user should be able to write to local config dir"):
+      machine.succeed('sudo -u nginx touch /etc/local/nginx/vhosts.json')
+
+    with subtest("all sensu checks should be green"):
+      machine.succeed("${sensuCheck "nginx_config"}")
+      machine.succeed("${sensuCheck "nginx_worker_age"}")
+      machine.succeed("${sensuCheck "nginx_status"}")
+
+    with subtest("killing the nginx process should trigger an automatic restart"):
+      machine.succeed("pkill -9 -F /run/nginx/nginx.pid");
+      machine.wait_until_succeeds("${sensuCheck "nginx_status"}")
+
+    with subtest("status check should be red after shutting down nginx"):
+      machine.systemctl('stop nginx')
+      machine.fail("${sensuCheck "nginx_status"}")
   '';
 })

--- a/tests/testlib.nix
+++ b/tests/testlib.nix
@@ -1,9 +1,17 @@
 { lib }:
-{ 
+{
   derivePasswordForHost = prefix:
     builtins.hashString "sha256" (lib.concatStringsSep "/" [
       prefix
       ""
       "machine"
     ]);
+
+    # Returns Sensu check command by name.
+    # Newlines in the command are removed to avoid breaking the test script.
+    sensuCheckCmd = machine: checkName:
+      lib.replaceStrings
+        ["\\" "\n"]
+        ["" " "]
+        machine.config.flyingcircus.services.sensu-client.checks.${checkName}.command;
 }


### PR DESCRIPTION
* update default nginx to 1.18, add 1.19
* reload master process on package changes instead of restarting
* make worker age sensu check less noisy
* add missing modsecurity module
* do not listen on 0.0.0.0 by default
* fix broken NixOS option link

@flyingcircusio/release-managers

## Release process

Impact:

* [NixOS 19.03] Nginx will be restarted.

Changelog:

* Nginx (#127883)

  * Update default package to latest stable version 1.18.0, add mainline version 1.19.0
  * Structured JSON config: use frontend IPs instead of all interfaces when listenAddress is not given.
  * Reload master process when Nginx package changes. This avoids restarts for updates in the future.
  * Add modsecurity module.
  * Don't listen on 0.0.0.0 port 80 by default.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - use recent versions
  - secure defaults: don't listen on all interfaces by default
    - only localhost without config
    - structured config uses frontend IPs by default
  - version updates should not introduce changes that compomise security
- [x] Security requirements tested? (EVIDENCE)
  - 1.18 is the newest stable version, 1.19.0 is not the current version but quite recent
  - checked changelog for security-related changes: http://nginx.org/en/CHANGES-1.18 http://nginx.org/en/CHANGES
  - manual checks on a test VM that Nginx listens only on the expected addresses/interfaces
  - automatic test checks basic functionality and proper reloading
