### PR TITLE
Fix influxdb start timeout typo

### DIFF
--- a/nixos/roles/statshost/default.nix
+++ b/nixos/roles/statshost/default.nix
@@ -450,7 +450,7 @@ in
       systemd.services.influxdb = {
         serviceConfig = {
           LimitNOFILE = 65535;
-          TimoutStartSec = "1h";
+          TimeoutStartSec = "1h";
           Restart = "always";
         };
         postStart =


### PR DESCRIPTION
Case 128272

@flyingcircusio/release-managers

## Release process

Impact:

* [NixOS 19.03] InfluxDB will be restarted.

Changelog:

* InfluxDB: fix start timeout (#128272).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - nothing, only affects startup timeout
- [x] Security requirements tested? (EVIDENCE)
  - manually tested on test24
