### PR TITLE
Kernel: update to newest LTS (5.4) from nixpkgs upstream.

### DIFF
--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -65,17 +65,9 @@ in {
   inherit (pkgs-unstable) kubernetes;
 
   libpcap_1_8 = super.callPackage ./libpcap-1.8.nix { };
-
-  linux_4_19 = super.linux_4_19.override {
-    argsOverride = rec {
-      src = super.fetchurl {
-            url = "mirror://kernel/linux/kernel/v4.x/linux-${version}.tar.xz";
-            sha256 = "0rvlz94mjl7ygpmhz0yn2whx9dq9fmy0w1472bj16hkwbaki0an6";
-      };
-      version = "4.19.94";
-      modDirVersion = "4.19.94";
-      };
-  };
+  
+  linuxPackages_5_4 = pkgs-unstable.linuxPackages_5_4;
+  linuxPackages = pkgs-unstable.linuxPackages_5_4;
 
   mailx = super.callPackage ./mailx.nix { };
   mc = super.callPackage ./mc.nix { };


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

* Will schedule reboots for all NixOS 19.03 machines.

Changelog:

* Update Linux-Kernel to newest LTS (5.4) branch. We have seen a number of VFS caching bugs with suspected memory leaks on a number of machines for which no direct bugfix seems available. Tests showed better behaviour on the newest LTS branch, though.

## Security implications

- [X] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

* Relying on NixOS upstream defaults and our own known additional kernel options as well as Linux default settings.

- [X] Security requirements tested? (EVIDENCE)

Verified proper boot and operations on various machines. Dependent builds will also be verified on Hydra upon merge.

