### PR TITLE
nginx: shorten log retention

### DIFF
--- a/nixos/roles/statshost/location-proxy.nix
+++ b/nixos/roles/statshost/location-proxy.nix
@@ -52,9 +52,5 @@ in
       };
     };
 
-    systemd.tmpfiles.rules = [
-      "d /var/log/nginx 0755 nginx"
-    ];
-
   };
 }

--- a/nixos/roles/statshost/rg-relay.nix
+++ b/nixos/roles/statshost/rg-relay.nix
@@ -8,9 +8,6 @@ with lib;
   config = mkIf config.flyingcircus.roles.statshost-relay.enable {
 
     services.nginx.enable = true;
-    systemd.tmpfiles.rules = [
-      "d /var/log/nginx 0755 nginx"
-    ];
     services.nginx.appendHttpConfig = ''
       server {
         listen ${config.services.prometheus.listenAddress};

--- a/nixos/services/nginx/default.nix
+++ b/nixos/services/nginx/default.nix
@@ -308,7 +308,7 @@ in
       services.logrotate.config = ''
         /var/log/nginx/*.log
         {
-            rotate 92
+            rotate 7
             create 0644 nginx service
             postrotate
                 systemctl kill nginx -s USR1 --kill-who=main || systemctl restart nginx
@@ -318,6 +318,8 @@ in
 
       systemd.tmpfiles.rules = [
         "d /etc/local/nginx/modsecurity 2775 nginx service"
+        # clean up whatever logrotate may have missed after 10 days
+        "d /var/log/nginx 0755 nginx service 10d"
       ];
 
       systemd.services.nginx.serviceConfig = {


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

Changelog: Lower default retention period for nginx logs to 7 days.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

GRDP: Use as few data as possible. We choose to keep 7 days worth of logs to have a complete log record in weekly backups.

- [x] Security requirements tested? (EVIDENCE)

Ran changed setup over night to see that last week's log file has been deleted. Noticed that logrotate tends to forget older logs in case of changed retention periods. Add tmpfiles rule to clean up whatever logrotate may have missed.