### PR TITLE
Compile dynamicMaps on Postfix reload

### DIFF
--- a/nixos/services/mail/default.nix
+++ b/nixos/services/mail/default.nix
@@ -284,6 +284,15 @@ in {
         startAt = "04:39:47";
       };
 
+      systemd.services.postfix.serviceConfig.ExecReload = lib.mkOverride 50 (
+        pkgs.writeScript "postfix-reload" ''
+          #! ${pkgs.stdenv.shell} -e
+          # Include pre-start script here to have maps regenerated:
+          ${config.systemd.services.postfix.preStart}
+
+          ${pkgs.postfix}/bin/postfix reload
+        '');
+
       systemd.tmpfiles.rules = [
         "f ${role.passwdFile} 0660 vmail service"
         "d /etc/local/mail 02775 postfix service"


### PR DESCRIPTION
Include preStart script also into the reload action. This way, dynamicMaps are updated also on reload. Until now, the Postfix service had to be restarted to pick up map updates.

Case 127993

@flyingcircusio/release-managers

## Release process

Impact:

Changelog: Pick up changed Postfix map files (like transport etc.) on `systemctl reload postfix`.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

  * Availability: Reduce number of required restarts which would terminate running sessions.
  * Reduce likeliness of misconfiguration (forgotten updates) by non conforming with expected behaviour.

- [x] Security requirements tested? (EVIDENCE)

Manual testing on test33