### PR TITLE
Add Jitsi role

### DIFF
--- a/nixos/roles/default.nix
+++ b/nixos/roles/default.nix
@@ -16,6 +16,7 @@ in {
     ./elasticsearch.nix
     ./gitlab.nix
     ./graylog.nix
+    ./jitsi
     ./kibana.nix
     ./kubernetes
     ./lamp.nix

--- a/nixos/roles/jitsi/default.nix
+++ b/nixos/roles/jitsi/default.nix
@@ -1,0 +1,330 @@
+{ config, pkgs, lib, ... }:
+
+with builtins;
+
+let
+
+  fclib = config.fclib;
+  cfg = config.flyingcircus.roles.jitsi;
+
+  generatedTurnSecret = readFile
+      (pkgs.runCommand "jitsi-turn-secret" {}
+      "${pkgs.apg}/bin/apg -a 1 -M lnc -n 1 -m 32 > $out");
+  turnSecret = lib.removeSuffix "\n" (fclib.configFromFile /etc/local/jitsi/turn-secret generatedTurnSecret);
+  turnHostName = if cfg.coturn.enable then cfg.coturn.hostName else cfg.turnHostName;
+
+  # Does the same on the backend side but UI buttons can be turned on/off seperately.
+  enableJibriIntegration = cfg.enableRecording || cfg.enableLivestreaming;
+
+in {
+
+  options = with lib; {
+    flyingcircus.roles.jitsi = {
+
+      enable = mkEnableOption "Enable a Jitsi Meet server with all needed services.";
+
+      coturn = mkOption {
+        default = {};
+        type = types.submodule {
+          options = {
+            enable = mkEnableOption ''
+              Enable a local coturn preconfigured for Jitsi
+              Machines with Jitsi and a local coturn need two public IP addresses.
+            '';
+
+            listenAddress = mkOption {
+              type = with types; string;
+              description = ''
+                Specify here which IPv4 address to use for coturn.";
+              '';
+            };
+
+            listenAddress6 = mkOption {
+              type = with types; string;
+              description = ''
+                Specify here which IPv6 address to use for coturn.";
+              '';
+            };
+
+            hostName = mkOption {
+              type = types.string;
+            };
+          };
+        };
+      };
+
+      enablePublicUDP = mkOption {
+        description =  "Allow public access to the videobridge via UDP 10000";
+        type = types.bool;
+        default = true;
+      };
+
+      enableRecording = mkOption {
+        description =  ''
+          Enable integration for recording and show the recording button in the UI.
+          Needs a separate Jibri installation which is not part of this role.
+        '';
+        type = types.bool;
+        default = false;
+      };
+
+      enableLivestreaming = mkOption {
+        description =  ''
+          Enable integration for recording and show the livestream button in the UI.
+          Needs a separate Jibri installation which is not part of this role.
+        '';
+        type = types.bool;
+        default = false;
+      };
+
+      enableRoomAuthentication = mkOption {
+        description =  ''
+          Require a username and password to create new rooms.
+          Guests can join after the room is created
+        '';
+        type = types.bool;
+        default = false;
+      };
+
+      listenAddress = mkOption {
+        type = with types; string;
+        description = ''
+          IPv4 address to use for Jitsi.
+        '';
+      };
+
+      listenAddress6 = mkOption {
+        type = with types; string;
+        description = ''
+          IPv6 address to use for Jitsi.
+        '';
+      };
+
+      hostName = mkOption {
+        type = types.string;
+      };
+
+      turnHostName = mkOption {
+        type = with types; nullOr string;
+        default = null;
+        description = ''
+          Only needed for an external TURN server.
+        '';
+      };
+
+      resolution = mkOption {
+        type = types.int;
+        default = 480;
+      };
+
+      defaultLanguage = mkOption {
+        type = types.string;
+        default = "de";
+      };
+
+    };
+
+  };
+
+  config = lib.mkMerge [
+
+    (lib.mkIf cfg.enable {
+
+      environment.etc."local/jitsi/README.txt".text = ''
+        To customize the content on the welcome page, add a file called welcomePageAdditionalContent.html here.
+
+        You can set a static auth secret for TURN in a file called turn-secret.
+        If the file is missing, a random secret is generated on rebuild.
+      '';
+
+      environment.systemPackages = with pkgs; [
+        (writeScriptBin "jitsi-jvb-show-config" ''
+          cat $(systemctl cat jitsi-videobridge | grep JAVA_SYS_PROPS | cut -d= -f4 | cut -d" " -f1)
+        '')
+
+        (writeScriptBin "jitsi-jicofo-show-config" ''
+          cat /etc/jitsi/jicofo/sip-communicator.properties
+        '')
+
+        (writeScriptBin "jitsi-prosody-show-config" ''
+          cat /etc/prosody/prosody.cfg.lua
+        '')
+      ];
+
+      flyingcircus.localConfigDirs.jitsi = {
+        dir = "/etc/local/jitsi";
+      };
+
+      flyingcircus.roles.nginx.enable = true;
+
+      flyingcircus.services.telegraf.inputs.http = [{
+          urls = [ "http://127.0.0.1:8080/colibri/stats" ];
+          tagexclude = [ "url" ];
+          name_override = "jitsi_jvb";
+          data_format = "json";
+          fielddrop = [ "p2p_conferences" "version" ];
+          json_time_key = "current_timestamp";
+          json_time_format = "2006-01-02 15:04:05.000";
+          json_timezone = "UTC";
+        }];
+
+      flyingcircus.services.sensu-client.checks = {
+        jitsi-videobridge-alive = {
+          notification = "Jitsi videobridge alive";
+          command = "check_http -v -j HEAD -H localhost -p 8080 -u /about/health";
+        };
+      };
+
+      networking.firewall.allowedUDPPorts = lib.optional cfg.enablePublicUDP 10000;
+
+      services.jicofo.config =
+        lib.optionalAttrs cfg.enableRoomAuthentication {
+          "org.jitsi.jicofo.auth.URL" = "XMPP:${cfg.hostName}";
+        } //
+        lib.optionalAttrs enableJibriIntegration {
+          "org.jitsi.jicofo.jibri.BREWERY" = "jibribrewery@internal.${cfg.hostName}";
+          "org.jitsi.jicofo.jibri.PENDING_TIMEOUT"= "90";
+        };
+
+      services.jitsi-meet = {
+        enable = true;
+        nginx.enable = true;
+        jicofo.enable = true;
+        videobridge.enable = true;
+        prosody.enable = true;
+
+        config = {
+          channelLastN = 8;
+          constraints = {
+            video = {
+              height = {
+                ideal = cfg.resolution;
+                max = cfg.resolution;
+                min = cfg.resolution;
+              };
+            };
+          };
+          defaultLanguage = cfg.defaultLanguage;
+          enableLipSync = false;
+          enableAutomaticUrlCopy = true;
+          useStunTurn = true;
+          p2p.enabled = false;
+          inherit (cfg) resolution;
+          startVideoMuted = 8;
+          stunServers = [];
+          fileRecordingsEnabled = cfg.enableRecording;
+          liveStreamingEnabled = cfg.enableLivestreaming;
+        } //
+        lib.optionalAttrs cfg.enableRoomAuthentication {
+          hosts.anonymousdomain = "guest.${cfg.hostName}";
+        } //
+        lib.optionalAttrs enableJibriIntegration {
+          hiddenDomain = "recorder.${cfg.hostName}";
+        };
+
+        hostName = cfg.hostName;
+
+        interfaceConfig = {
+          DISABLE_VIDEO_BACKGROUND = true;
+          MOBILE_APP_PROMO = false;
+          SHOW_JITSI_WATERMARK = false;
+          SHOW_WATERMARK_FOR_GUESTS = false;
+        };
+
+      };
+
+      services.nginx.virtualHosts = {
+        "${cfg.hostName}" = {
+          listenAddress = cfg.listenAddress;
+          listenAddress6 = fclib.quoteIPv6Address cfg.listenAddress6;
+        } //
+        lib.optionalAttrs (pathExists /etc/local/jitsi/welcomePageAdditionalContent.html) {
+          locations."=/static/welcomePageAdditionalContent.html" = {
+            alias = "${/etc/local/jitsi/welcomePageAdditionalContent.html}";
+          };
+        };
+      };
+
+      services.prosody = {
+
+        extraModules = [
+          "ping"
+          "turncredentials"
+        ];
+
+        extraConfig = ''
+          turncredentials_secret = "${turnSecret}";
+          turncredentials = {
+            { type = "turns",
+              host = "${turnHostName}",
+              port = "443",
+              transport = "tcp"
+            }
+          }
+        '';
+
+        extraPluginPaths = [
+          ./prosody-plugins
+        ];
+
+        virtualHosts =
+          lib.optionalAttrs cfg.enableRoomAuthentication {
+
+            # Force authentication on default vhost which is used for room creation.
+            "${cfg.hostName}" = {
+              extraConfig = lib.mkForce ''
+                authentication = "internal_hashed"
+                c2s_require_encryption = false
+                admins = { "focus@auth.${cfg.hostName}" }
+              '';
+            };
+
+            # Define new vhost for anonymous guests in rooms.
+            "guest.${cfg.hostName}" = {
+              domain = "guest.${cfg.hostName}";
+              enabled = true;
+              extraConfig = ''
+                authentication = "anonymous"
+                c2s_require_encryption = false
+              '';
+            };
+          } //
+          lib.optionalAttrs enableJibriIntegration {
+            # Jibri gets special rights and needs its own vhost for that.
+            # c2s encryption doesn't work for unknown reasons but both are on the
+            # same host, so it's ok.
+            "recorder.${cfg.hostName}" = {
+              domain = "recorder.${cfg.hostName}";
+              enabled = true;
+              extraConfig = ''
+                authentication = "internal_plain"
+                c2s_require_encryption = false
+              '';
+            };
+          };
+
+      };
+
+    })
+
+    (lib.mkIf (cfg.enable && cfg.coturn.enable) {
+
+      flyingcircus.roles.coturn = {
+        enable = true;
+        hostName = cfg.coturn.hostName;
+      };
+
+      services.coturn = {
+        listening-ips = [ cfg.coturn.listenAddress cfg.coturn.listenAddress6 ];
+        no-tcp = true;
+        static-auth-secret = turnSecret;
+        tls-listening-port = 443;
+        extraConfig = ''
+          no-stun
+        '';
+      };
+
+    })
+
+  ];
+}

--- a/nixos/roles/jitsi/prosody-plugins/mod_turncredentials.lua
+++ b/nixos/roles/jitsi/prosody-plugins/mod_turncredentials.lua
@@ -1,0 +1,83 @@
+-- XEP-0215 implementation for time-limited turn credentials
+-- Copyright (C) 2012-2014 Philipp Hancke
+-- This file is MIT/X11 licensed.
+
+--turncredentials_secret = "keepthissecret";
+--turncredentials = {
+--    { type = "stun", host = "8.8.8.8" },
+--    { type = "turn", host = "8.8.8.8", port = "3478" },
+--    { type = "turn", host = "8.8.8.8", port = "80", transport = "tcp" }
+--}
+-- for stun servers, host is required, port defaults to 3478
+-- for turn servers, host is required, port defaults to tcp,
+--          transport defaults to udp
+--          hosts can be a list of server names / ips for random
+--          choice loadbalancing
+
+
+module:log("info", "mod_turncredentials here")
+local st = require "util.stanza";
+local hmac_sha1 = require "util.hashes".hmac_sha1;
+local base64 = require "util.encodings".base64;
+local os_time = os.time;
+local secret = module:get_option_string("turncredentials_secret");
+local ttl = module:get_option_number("turncredentials_ttl", 86400);
+local hosts = module:get_option("turncredentials") or {};
+if not (secret) then
+    module:log("error", "turncredentials not configured");
+    return;
+end
+
+module:add_feature("urn:xmpp:extdisco:1");
+
+function random(arr)
+    local index = math.random(1, #arr);
+    return arr[index];
+end
+
+
+module:hook_global("config-reloaded", function()
+    module:log("debug", "config-reloaded")
+    secret = module:get_option_string("turncredentials_secret");
+    ttl = module:get_option_number("turncredentials_ttl", 86400);
+    hosts = module:get_option("turncredentials") or {};
+end);
+
+module:hook("iq-get/host/urn:xmpp:extdisco:1:services", function(event)
+    module:log("info", "turncredentials extdisco hook here")
+    local origin, stanza = event.origin, event.stanza;
+    if origin.type ~= "c2s" then
+        return;
+    end
+    local now = os_time() + ttl;
+    local userpart = tostring(now);
+    local nonce = base64.encode(hmac_sha1(secret, tostring(userpart), false));
+    local reply = st.reply(stanza):tag("services", {xmlns = "urn:xmpp:extdisco:1"})
+    for idx, item in pairs(hosts) do
+        if item.type == "stun" or item.type == "stuns" then
+            -- stun items need host and port (defaults to 3478)
+            reply:tag("service",
+                { type = item.type, host = item.host, port = tostring(item.port) or "3478" }
+            ):up();
+        elseif item.type == "turn" or item.type == "turns" then
+            local turn = {}
+            -- turn items need host, port (defaults to 3478),
+	          -- transport (defaults to udp)
+	          -- username, password, ttl
+            turn.type = item.type;
+            turn.port = tostring(item.port);
+            turn.transport = item.transport;
+            turn.username = userpart;
+            turn.password = nonce;
+            turn.ttl = tostring(ttl);
+            if item.hosts then
+                turn.host = random(item.hosts)
+            else
+                turn.host = item.host
+            end
+            reply:tag("service", turn):up();
+        end
+    end
+    origin.send(reply);
+    return true;
+end);

--- a/nixos/services/default.nix
+++ b/nixos/services/default.nix
@@ -12,8 +12,10 @@ let
     "services/continuous-integration/gitlab-runner.nix"
     "services/misc/docker-registry.nix"
     "services/monitoring/grafana.nix"
+    "services/networking/prosody.nix"
     "services/search/elasticsearch.nix"
     "services/search/kibana.nix"
+    "services/web-apps/jitsi-meet.nix"
   ];
 
   nixpkgs-unstable-src = (import ../../versions.nix {}).nixos-unstable;
@@ -27,6 +29,8 @@ in {
     ./gitlab
     ./graylog.nix
     ./haproxy.nix
+    ./jitsi/jicofo.nix
+    ./jitsi/jitsi-videobridge.nix
     ./logrotate
     ./nginx
     ./percona.nix

--- a/nixos/services/jitsi/jicofo.nix
+++ b/nixos/services/jitsi/jicofo.nix
@@ -1,0 +1,152 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.jicofo;
+in
+{
+  options.services.jicofo = with types; {
+    enable = mkEnableOption "Jitsi Conference Focus - component of Jitsi Meet";
+
+    xmppHost = mkOption {
+      type = str;
+      example = "localhost";
+      description = ''
+        Hostname of the XMPP server to connect to.
+      '';
+    };
+
+    xmppDomain = mkOption {
+      type = nullOr str;
+      example = "meet.example.org";
+      description = ''
+        Domain name of the XMMP server to which to connect as a component.
+
+        If null, <option>xmppHost</option> is used.
+      '';
+    };
+
+    componentPasswordFile = mkOption {
+      type = str;
+      example = "/run/keys/jicofo-component";
+      description = ''
+        Path to file containing component secret.
+      '';
+    };
+
+    userName = mkOption {
+      type = str;
+      default = "focus";
+      description = ''
+        User part of the JID for XMPP user connection.
+      '';
+    };
+
+    userDomain = mkOption {
+      type = str;
+      example = "auth.meet.example.org";
+      description = ''
+        Domain part of the JID for XMPP user connection.
+      '';
+    };
+
+    userPasswordFile = mkOption {
+      type = str;
+      example = "/run/keys/jicofo-user";
+      description = ''
+        Path to file containing password for XMPP user connection.
+      '';
+    };
+
+    bridgeMuc = mkOption {
+      type = str;
+      example = "jvbbrewery@internal.meet.example.org";
+      description = ''
+        JID of the internal MUC used to communicate with Videobridges.
+      '';
+    };
+
+    config = mkOption {
+      type = attrsOf str;
+      default = { };
+      example = literalExample ''
+        {
+          "org.jitsi.jicofo.auth.URL" = "XMPP:jitsi-meet.example.com";
+        }
+      '';
+      description = ''
+        Contents of the <filename>sip-communicator.properties</filename> configuration file for jicofo.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    services.jicofo.config = mapAttrs (_: v: mkDefault v) {
+      "org.jitsi.jicofo.BRIDGE_MUC" = cfg.bridgeMuc;
+    };
+
+    users.groups.jitsi-meet = {};
+
+    systemd.services.jicofo = let
+      jicofoProps = {
+        "-Dnet.java.sip.communicator.SC_HOME_DIR_LOCATION" = "/etc/jitsi";
+        "-Dnet.java.sip.communicator.SC_HOME_DIR_NAME" = "jicofo";
+        "-Djava.util.logging.config.file" = "/etc/jitsi/jicofo/logging.properties";
+      };
+    in
+    {
+      description = "JItsi COnference FOcus";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+
+      restartTriggers = [
+        config.environment.etc."jitsi/jicofo/sip-communicator.properties".source
+      ];
+      environment.JAVA_SYS_PROPS = concatStringsSep " " (mapAttrsToList (k: v: "${k}=${toString v}") jicofoProps);
+
+      script = ''
+        ${pkgs.jicofo}/bin/jicofo \
+          --host=${cfg.xmppHost} \
+          --domain=${if cfg.xmppDomain == null then cfg.xmppHost else cfg.xmppDomain} \
+          --secret=$(cat ${cfg.componentPasswordFile}) \
+          --user_name=${cfg.userName} \
+          --user_domain=${cfg.userDomain} \
+          --user_password=$(cat ${cfg.userPasswordFile})
+      '';
+
+      serviceConfig = {
+        Type = "simple";
+
+        DynamicUser = true;
+        User = "jicofo";
+        Group = "jitsi-meet";
+
+        CapabilityBoundingSet = "";
+        NoNewPrivileges = true;
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        PrivateTmp = true;
+        PrivateDevices = true;
+        ProtectHostname = true;
+        ProtectKernelTunables = true;
+        ProtectKernelModules = true;
+        ProtectControlGroups = true;
+        RestrictAddressFamilies = [ "AF_INET" "AF_INET6" "AF_UNIX" ];
+        RestrictNamespaces = true;
+        LockPersonality = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+      };
+    };
+
+    environment.etc."jitsi/jicofo/sip-communicator.properties".source =
+      pkgs.writeText "sip-communicator.properties" (
+        generators.toKeyValue {} cfg.config
+      );
+    environment.etc."jitsi/jicofo/logging.properties".source =
+      mkDefault "${pkgs.jicofo}/etc/jitsi/jicofo/logging.properties-journal";
+  };
+
+  meta.maintainers = with lib.maintainers; [ ];
+}

--- a/nixos/services/jitsi/jitsi-videobridge.nix
+++ b/nixos/services/jitsi/jitsi-videobridge.nix
@@ -1,0 +1,276 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.jitsi-videobridge;
+  attrsToArgs = a: concatStringsSep " " (mapAttrsToList (k: v: "${k}=${toString v}") a);
+
+  # HOCON is a JSON superset that videobridge2 uses for configuration.
+  # It can substitute environment variables which we use for passwords here.
+  # https://github.com/lightbend/config/blob/master/README.md
+  #
+  # Substitution for environment variable FOO is represented as attribute set
+  # { __hocon_envvar = "FOO"; }
+  toHOCON = x: if isAttrs x && x ? __hocon_envvar then ("\${" + x.__hocon_envvar + "}")
+    else if isAttrs x then "{${ concatStringsSep "," (mapAttrsToList (k: v: ''"${k}":${toHOCON v}'') x) }}"
+    else if isList x then "[${ concatMapStringsSep "," toHOCON x }]"
+    else builtins.toJSON x;
+
+  # We're passing passwords in environment variables that have names generated
+  # from an attribute name, which may not be a valid bash identifier.
+  toVarName = s: "XMPP_PASSWORD_" + stringAsChars (c: if builtins.match "[A-Za-z0-9]" c != null then c else "_") s;
+
+  defaultJvbConfig = {
+    videobridge = {
+      ice = {
+        tcp = {
+          enabled = true;
+          port = 4443;
+        };
+        udp.port = 10000;
+      };
+      stats = {
+        enabled = true;
+        transports = [ { type = "muc"; } ];
+      };
+      apis.xmpp-client.configs = flip mapAttrs cfg.xmppConfigs (name: xmppConfig: {
+        hostname = xmppConfig.hostName;
+        domain = xmppConfig.domain;
+        username = xmppConfig.userName;
+        password = { __hocon_envvar = toVarName name; };
+        muc_jids = xmppConfig.mucJids;
+        muc_nickname = xmppConfig.mucNickname;
+        disable_certificate_verification = xmppConfig.disableCertificateVerification;
+      });
+    };
+  };
+
+  # Allow overriding leaves of the default config despite types.attrs not doing any merging.
+  jvbConfig = recursiveUpdate defaultJvbConfig cfg.config;
+in
+{
+  options.services.jitsi-videobridge = with types; {
+    enable = mkEnableOption "Jitsi Videobridge, a WebRTC compatible video router";
+
+    config = mkOption {
+      type = attrs;
+      default = { };
+      example = literalExample ''
+        {
+          videobridge = {
+            ice.udp.port = 5000;
+            websockets = {
+              enabled = true;
+              server-id = "jvb1";
+            };
+          };
+        }
+      '';
+      description = ''
+        Videobridge configuration.
+
+        See <link xlink:href="https://github.com/jitsi/jitsi-videobridge/blob/master/src/main/resources/reference.conf" />
+        for default configuration with comments.
+      '';
+    };
+
+    xmppConfigs = mkOption {
+      description = ''
+        XMPP servers to connect to.
+
+        See <link xlink:href="https://github.com/jitsi/jitsi-videobridge/blob/master/doc/muc.md" /> for more information.
+      '';
+      default = { };
+      example = literalExample ''
+        {
+          "localhost" = {
+            hostName = "localhost";
+            userName = "jvb";
+            domain = "auth.xmpp.example.org";
+            passwordFile = "/var/lib/jitsi-meet/videobridge-secret";
+            mucJids = "jvbbrewery@internal.xmpp.example.org";
+          };
+        }
+      '';
+      type = attrsOf (submodule ({ name, ... }: {
+        options = {
+          hostName = mkOption {
+            type = str;
+            example = "xmpp.example.org";
+            description = ''
+              Hostname of the XMPP server to connect to. Name of the attribute set is used by default.
+            '';
+          };
+          domain = mkOption {
+            type = nullOr str;
+            default = null;
+            example = "auth.xmpp.example.org";
+            description = ''
+              Domain part of JID of the XMPP user, if it is different from hostName.
+            '';
+          };
+          userName = mkOption {
+            type = str;
+            default = "jvb";
+            description = ''
+              User part of the JID.
+            '';
+          };
+          passwordFile = mkOption {
+            type = str;
+            example = "/run/keys/jitsi-videobridge-xmpp1";
+            description = ''
+              File containing the password for the user.
+            '';
+          };
+          mucJids = mkOption {
+            type = str;
+            example = "jvbbrewery@internal.xmpp.example.org";
+            description = ''
+              JID of the MUC to join. JiCoFo needs to be configured to join the same MUC.
+            '';
+          };
+          mucNickname = mkOption {
+            # Upstream DEBs use UUID, let's use hostname instead.
+            type = str;
+            description = ''
+              Videobridges use the same XMPP account and need to be distinguished by the
+              nickname (aka resource part of the JID). By default, system hostname is used.
+            '';
+          };
+          disableCertificateVerification = mkOption {
+            type = bool;
+            default = false;
+            description = ''
+              Whether to skip validation of the server's certificate.
+            '';
+          };
+        };
+        config = {
+          hostName = mkDefault name;
+          mucNickname = mkDefault (builtins.replaceStrings [ "." ] [ "-" ] (
+            config.networking.hostName + optionalString (config.networking.domain != null) ".${config.networking.domain}"
+          ));
+        };
+      }));
+    };
+
+    nat = {
+      localAddress = mkOption {
+        type = nullOr str;
+        default = null;
+        example = "192.168.1.42";
+        description = ''
+          Local address when running behind NAT.
+        '';
+      };
+
+      publicAddress = mkOption {
+        type = nullOr str;
+        default = null;
+        example = "1.2.3.4";
+        description = ''
+          Public address when running behind NAT.
+        '';
+      };
+    };
+
+    extraProperties = mkOption {
+      type = attrsOf str;
+      default = { };
+      description = ''
+        Additional Java properties passed to jitsi-videobridge.
+      '';
+    };
+
+    openFirewall = mkOption {
+      type = bool;
+      default = false;
+      description = ''
+        Whether to open ports in the firewall for the videobridge.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    users.groups.jitsi-meet = {};
+
+    services.jitsi-videobridge.extraProperties = optionalAttrs (cfg.nat.localAddress != null) {
+      "org.ice4j.ice.harvest.NAT_HARVESTER_LOCAL_ADDRESS" = cfg.nat.localAddress;
+      "org.ice4j.ice.harvest.NAT_HARVESTER_PUBLIC_ADDRESS" = cfg.nat.publicAddress;
+    };
+
+    systemd.services.jitsi-videobridge2 = let
+      jvbProps = {
+        "-Dnet.java.sip.communicator.SC_HOME_DIR_LOCATION" = "/etc/jitsi";
+        "-Dnet.java.sip.communicator.SC_HOME_DIR_NAME" = "videobridge";
+        "-Djava.util.logging.config.file" = "/etc/jitsi/videobridge/logging.properties";
+        "-Dconfig.file" = pkgs.writeText "jvb.conf" (toHOCON jvbConfig);
+      } // (mapAttrs' (k: v: nameValuePair "-D${k}" v) cfg.extraProperties);
+    in
+    {
+      aliases = [ "jitsi-videobridge.service" ];
+      description = "Jitsi Videobridge";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      environment.JAVA_SYS_PROPS = attrsToArgs jvbProps;
+
+      script = (concatStrings (mapAttrsToList (name: xmppConfig:
+        "export ${toVarName name}=$(cat ${xmppConfig.passwordFile})\n"
+      ) cfg.xmppConfigs))
+      + ''
+        ${pkgs.jitsi-videobridge}/bin/jitsi-videobridge --apis=rest
+      '';
+
+      serviceConfig = {
+        Type = "simple";
+
+        DynamicUser = true;
+        User = "jitsi-videobridge";
+        Group = "jitsi-meet";
+
+        CapabilityBoundingSet = "";
+        NoNewPrivileges = true;
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        PrivateTmp = true;
+        PrivateDevices = true;
+        ProtectHostname = true;
+        ProtectKernelTunables = true;
+        ProtectKernelModules = true;
+        ProtectControlGroups = true;
+        RestrictAddressFamilies = [ "AF_INET" "AF_INET6" "AF_UNIX" ];
+        RestrictNamespaces = true;
+        LockPersonality = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+
+        TasksMax = 65000;
+        LimitNPROC = 65000;
+        LimitNOFILE = 65000;
+      };
+    };
+
+    environment.etc."jitsi/videobridge/logging.properties".source =
+      mkDefault "${pkgs.jitsi-videobridge}/etc/jitsi/videobridge/logging.properties-journal";
+
+    # (from videobridge2 .deb)
+    # this sets the max, so that we can bump the JVB UDP single port buffer size.
+    boot.kernel.sysctl."net.core.rmem_max" = mkDefault 10485760;
+    boot.kernel.sysctl."net.core.netdev_max_backlog" = mkDefault 100000;
+
+    networking.firewall.allowedTCPPorts = mkIf cfg.openFirewall
+      [ jvbConfig.videobridge.ice.tcp.port ];
+    networking.firewall.allowedUDPPorts = mkIf cfg.openFirewall
+      [ jvbConfig.videobridge.ice.udp.port ];
+
+    assertions = [{
+      message = "publicAddress must be set if and only if localAddress is set";
+      assertion = (cfg.nat.publicAddress == null) == (cfg.nat.localAddress == null);
+    }];
+  };
+
+  meta.maintainers = with lib.maintainers; [ ];
+}

--- a/pkgs/jicofo/default.nix
+++ b/pkgs/jicofo/default.nix
@@ -1,0 +1,43 @@
+{ pkgs, stdenv, fetchurl, dpkg, jre_headless, nixosTests }:
+
+let
+  pname = "jicofo";
+  version = "1.0-626";
+  src = fetchurl {
+    url = "https://download.jitsi.org/stable/${pname}_${version}-1_all.deb";
+    sha256 = "12r68f41x39pcdfc477zwlkki8ga75iv9i4r9d8fd3nbk45scx0l";
+  };
+in
+stdenv.mkDerivation {
+  inherit pname version src;
+
+  dontBuild = true;
+
+  unpackCmd = "${dpkg}/bin/dpkg-deb -x $src debcontents";
+
+  installPhase = ''
+    substituteInPlace usr/share/jicofo/jicofo.sh \
+      --replace "exec java" "exec ${jre_headless}/bin/java"
+
+    mkdir -p $out/{share,bin}
+    mv usr/share/jicofo $out/share/
+    mv etc $out/
+    cp ${./logging.properties-journal} $out/etc/jitsi/jicofo/logging.properties-journal
+    ln -s $out/share/jicofo/jicofo.sh $out/bin/jicofo
+  '';
+
+  passthru.tests = {
+    single-node-smoke-test = nixosTests.jitsi-meet;
+  };
+
+  meta = with stdenv.lib; {
+    description = "A server side focus component used in Jitsi Meet conferences";
+    longDescription = ''
+      JItsi COnference FOcus is a server side focus component used in Jitsi Meet conferences.
+    '';
+    homepage = "https://github.com/jitsi/jicofo";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/jicofo/logging.properties-journal
+++ b/pkgs/jicofo/logging.properties-journal
@@ -1,0 +1,10 @@
+handlers = java.util.logging.ConsoleHandler
+java.util.logging.ConsoleHandler.level = ALL
+java.util.logging.ConsoleHandler.formatter = net.java.sip.communicator.util.ScLogFormatter
+.level = INFO
+net.sf.level = SEVERE
+net.java.sip.communicator.plugin.reconnectplugin.level = FINE
+org.ice4j.level = SEVERE
+org.jitsi.impl.neomedia.level = SEVERE
+net.java.sip.communicator.service.resources.AbstractResourcesService.level = SEVERE
+net.java.sip.communicator.util.ScLogFormatter.disableTimestamp = true

--- a/pkgs/jitsi-meet/default.nix
+++ b/pkgs/jitsi-meet/default.nix
@@ -1,0 +1,34 @@
+{ pkgs, stdenv, fetchurl, nixosTests }:
+
+stdenv.mkDerivation rec {
+  pname = "jitsi-meet";
+  version = "1.0.4383";
+
+  src = fetchurl {
+    url = "https://download.jitsi.org/jitsi-meet/src/jitsi-meet-${version}.tar.bz2";
+    sha256 = "1jfxfz6qqn98pdgyhn90pizzwx3nqzjrm6dgx8bxwqnjmad1c4cj";
+  };
+
+  dontBuild = true;
+
+  installPhase = ''
+    mkdir $out
+    mv * $out/
+  '';
+
+  passthru.tests = {
+    single-host-smoke-test = nixosTests.jitsi-meet;
+  };
+
+  meta = with stdenv.lib; {
+    description = "Secure, Simple and Scalable Video Conferences";
+    longDescription = ''
+      Jitsi Meet is an open-source (Apache) WebRTC JavaScript application that uses Jitsi Videobridge
+      to provide high quality, secure and scalable video conferences.
+    '';
+    homepage = "https://github.com/jitsi/jitsi-meet";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/jitsi-videobridge/default.nix
+++ b/pkgs/jitsi-videobridge/default.nix
@@ -1,0 +1,48 @@
+{ stdenv, fetchurl, dpkg, jre_headless, nixosTests }:
+
+let
+  pname = "jitsi-videobridge2";
+  version = "2.1-304-g8488f77d";
+
+  src = fetchurl {
+    url = "https://download.jitsi.org/stable/${pname}_${version}-1_all.deb";
+    sha256 = "13gi2pdx4kavhmis9c29yyn5wbig6icy6gwkpg7ql70whv69iw40";
+  };
+in
+stdenv.mkDerivation {
+  inherit pname version src;
+
+  dontBuild = true;
+
+  unpackCmd = "${dpkg}/bin/dpkg-deb -x $src debcontents";
+
+  installPhase = ''
+    substituteInPlace usr/share/jitsi-videobridge/jvb.sh \
+      --replace "exec java" "exec ${jre_headless}/bin/java"
+
+    mkdir -p $out/{bin,share/jitsi-videobridge,etc/jitsi/videobridge}
+    mv etc/jitsi/videobridge/logging.properties $out/etc/jitsi/videobridge/
+    cp ${./logging.properties-journal} $out/etc/jitsi/videobridge/logging.properties-journal
+    mv usr/share/jitsi-videobridge/* $out/share/jitsi-videobridge/
+    ln -s $out/share/jitsi-videobridge/jvb.sh $out/bin/jitsi-videobridge
+  '';
+
+  passthru.tests = {
+    single-host-smoke-test = nixosTests.jitsi-meet;
+  };
+
+  meta = with stdenv.lib; {
+    description = "A WebRTC compatible video router";
+    longDescription = ''
+      Jitsi Videobridge is an XMPP server component that allows for multiuser video communication.
+      Unlike the expensive dedicated hardware videobridges, Jitsi Videobridge does not mix the video
+      channels into a composite video stream, but only relays the received video channels to all call
+      participants. Therefore, while it does need to run on a server with good network bandwidth,
+      CPU horsepower is not that critical for performance.
+    '';
+    homepage = "https://github.com/jitsi/jitsi-videobridge";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/jitsi-videobridge/logging.properties-journal
+++ b/pkgs/jitsi-videobridge/logging.properties-journal
@@ -1,0 +1,7 @@
+handlers = java.util.logging.ConsoleHandler
+java.util.logging.ConsoleHandler.level = ALL
+java.util.logging.ConsoleHandler.formatter = org.jitsi.utils.logging2.JitsiLogFormatter
+.level = INFO
+org.jitsi.videobridge.xmpp.ComponentImpl.level = FINE
+org.jitsi.impl.neomedia.MediaStreamImpl.level = WARNING
+org.jitsi.utils.logging2.JitsiLogFormatter.disableTimestamp = true

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -73,6 +73,10 @@ in {
 
   innotop = super.callPackage ./percona/innotop.nix { };
 
+  jicofo = super.callPackage ./jicofo { };
+  jitsi-meet = super.callPackage ./jitsi-meet { };
+  jitsi-videobridge = super.callPackage ./jitsi-videobridge { };
+
   inherit (pkgs-unstable) kubernetes;
 
   libpcap_1_8 = super.callPackage ./libpcap-1.8.nix { };
@@ -150,6 +154,8 @@ in {
   inherit (pkgs-unstable) postgresql_12;
 
   inherit (pkgs-unstable) prometheus;
+
+  inherit (pkgs-unstable) prosody;
 
   prometheus-elasticsearch-exporter = super.callPackage ./prometheus-elasticsearch-exporter.nix { };
 


### PR DESCRIPTION
* supports fallback to TURN if UDP doesn't work
* Jibri integration for recording and livestreaming
  * Jibri itself must be provided separately
* optional authentication for room creation

Auth support and Jibri integration should be integrated upstream.

Case 127649

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Add Jitsi Meet role (#127649).

## Security implications

Jitsi is essentially a public service and anyone who knows a room link can join. Authentication is only relevant when someone wants to create a new room. Most of the implementation is from NixOS upstream which was reviewed there.

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - use recent versions
  - transmit data securely:  coturn and nginx only use TLS, video and audio traffic is encrypted by jitsi videobridge
  - only open required ports: firewall additional coturn ports, videobridge UDP port can be firewalled optionally to route everything via TLS-encrypted coturn, internal Jitsi components shouldn't be exposed to public internet
- [x] Security requirements tested? (EVIDENCE)
  - we use the current stable versions of Jitsi components except Jitsi Meet (just the frontend) which uses a recent dev version
  - manually tested on VM test46, checked open ports
