### PR TITLE
Remove `/result` symlink automatically after 3d

### DIFF
--- a/nixos/platform/agent.nix
+++ b/nixos/platform/agent.nix
@@ -57,6 +57,13 @@ in {
     (mkIf cfg.agent.install {
       environment.systemPackages = [ pkgs.fc.agent ];
 
+      flyingcircus.passwordlessSudoRules = [
+        {
+          commands = [ "${pkgs.fc.agent}/bin/fc-manage" ];
+          groups = [ "sudo-srv" "service" ];
+        }
+      ];
+
       systemd.services.fc-agent = rec {
         description = "Flying Circus Management Task";
         enable = cfg.agent.enable;
@@ -110,12 +117,12 @@ in {
         "d /var/spool/maintenance/archive - - - 180d"
       ];
 
-      flyingcircus.passwordlessSudoRules = [
-        {
-          commands = [ "${pkgs.fc.agent}/bin/fc-manage" ];
-          groups = [ "sudo-srv" "service" ];
-        }
-      ];
+      # Remove obsolete `/result` symlink
+      system.activationScripts.result-symlink = stringAfter [] ''
+        ${pkgs.fc.check-age}/bin/check_age -m -w 3d /result >/dev/null || \
+          rm /result
+      '';
+
     })
 
     (mkIf (cfg.agent.install && cfg.agent.enable) {

--- a/nixos/services/sensu.nix
+++ b/nixos/services/sensu.nix
@@ -460,7 +460,8 @@ in {
         notification = ''
           Obsolete 'result' symlinks possibly causing Nix store bloat
         '';
-        command = "${fc.check-age}/bin/check_age -m -w 1d /result /root/result";
+        # see also activationScript in nixos/platform/agent.nix
+        command = "${fc.check-age}/bin/check_age -m -w 3h /result /root/result";
         interval = 300;
       };
     };


### PR DESCRIPTION
After discussion we came to the conclusion that / is never a good place
for a result symlink and such links should be automatically removed
after a grace period. `result` links in /root or any other home
directory are not touched.

We use check_age to dermine if the link can be deleted. tmpfiles.d and
other mechanisms are not able to measure the age of the link (and not
its target).

Case 128533

@flyingcircusio/release-managers

## Release process

Impact:

Changelog: Automatically remove left over `/result` symlinks to free disk space (#128533).

## Security implications

Same as in case 128343.
