### PR TITLE
Jitsi-videobridge: 2.1-304 -> 2.1-315

### DIFF
--- a/pkgs/jitsi-videobridge/default.nix
+++ b/pkgs/jitsi-videobridge/default.nix
@@ -2,11 +2,11 @@
 
 let
   pname = "jitsi-videobridge2";
-  version = "2.1-304-g8488f77d";
+  version = "2.1-315-g40ba83c6";
 
   src = fetchurl {
-    url = "https://download.jitsi.org/stable/${pname}_${version}-1_all.deb";
-    sha256 = "13gi2pdx4kavhmis9c29yyn5wbig6icy6gwkpg7ql70whv69iw40";
+    url = "https://download.jitsi.org/unstable/${pname}_${version}-1_all.deb";
+    sha256 = "0knwjx48aj1zhqkkfm2ra8cc44mavnfc2lbczv4zna8j4m7nzb1j";
   };
 in
 stdenv.mkDerivation {


### PR DESCRIPTION
Fixes a NullPointerException that forces jvb to drop all connections.

https://github.com/jitsi/jitsi-videobridge/issues/1434

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Update Jitsi videobridge to fix an error that closed all client connections (#128579).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - nothing new, only small changes compared to previous version
- [x] Security requirements tested? (EVIDENCE)
  - manually tested on VM test46 if clients can connect
  - checked commit log

