### PR TITLE
Nginx: anonymize IP addresses in access logs by default

### DIFF
--- a/nixos/services/nginx/default.nix
+++ b/nixos/services/nginx/default.nix
@@ -97,20 +97,6 @@ let
     charset UTF-8;
 
     # === Logging ===
-    map $remote_addr $remote_addr_anon_head {
-      default 0.0.0;
-      "~(?P<ip>\d+\.\d+\.\d+)\.\d+" $ip;
-      "~(?P<ip>[^:]+:[^:]+:[^:]+):" $ip;
-    }
-    map $remote_addr $remote_addr_anon_tail {
-      default .0;
-      "~(?P<ip>\d+\.\d+\.\d+)\.\d+" .0;
-      "~(?P<ip>[^:]+:[^:]+:[^:]+):" ::;
-    }
-    map $remote_addr_anon_head$remote_addr_anon_tail $remote_addr_anon {
-        default 0.0.0.0;
-        "~(?P<ip>.*)" $ip;
-    }
 
     # same as 'anonymized'
     log_format main

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -117,14 +117,23 @@ in {
   mysql = super.mariadb;
 
   # This is our default version.
-  nginxStable = pkgs-unstable.nginxStable.override {
+  nginxStable = (pkgs-unstable.nginxStable.override {
     modules = with pkgs-unstable.nginxModules; [
       dav
       modsecurity
       moreheaders
       rtmp
     ];
-  };
+  }).overrideAttrs(_: rec {
+    src = super.fetchFromGitHub {
+      owner = "flyingcircusio";
+      repo = "nginx";
+      rev = "2ad7b63de0391df4c49c887f2929a72658bce329";
+      sha256 = "02rnpy1w8ia2yxlbcfvx5d4swdrs8a58grffch9pgr1x11kakvl6";
+    };
+
+    configureScript = "./auto/configure";
+  });
 
   nginx = self.nginxStable;
 


### PR DESCRIPTION
Uses our patched version which modifies the default combined log format
to anonymise IP addresses.

Case 127632

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Nginx: anonymize IP addresses (IPv4 and IPv6) in access logs by default. We use a patched Nginx which provides $remote_addr_anon as a variable for log formats. This variable is used in the default combined log format (#127632).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - data protection (GDPR): IP addresses in log files must be anonymized.
- [x] Security requirements tested? (EVIDENCE)
  - checked proper anonymization of IPv4 and IPv6 on a test VM
