### PR TITLE
Grant sudo-srv users sudo access to "vmail"

### DIFF
--- a/nixos/services/mail/default.nix
+++ b/nixos/services/mail/default.nix
@@ -134,6 +134,11 @@ in {
           commands = [ checkMailq ];
           groups = [ "sensuclient" ];
         }
+        {
+          commands = [ "ALL" ];
+          groups = [ "sudo-srv" ];
+          runAs = "vmail";
+        }
       ];
 
       # SNM specific configuration, see


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

Changelog: Mail server: Grant users holding the "sudo-srv" permission sudo access to the "vmail" system user.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

Principle of least privilege not violated: Customers' admins are able to access all mailboxes anyway by setting IMAP passwords. However, this speeds things up e.g. for migrations or deletions.

Availability: Dovecot is able to handle low-level Maildir manipulations transparently.

- [x] Security requirements tested? (EVIDENCE)

Manual testing on test33.