### PR TITLE
Update nixpkgs version to include systemd script name patch

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -8,7 +8,7 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "a8c81cafb6fa77d25ab628f540ca23522042b94b",
-    "sha256": "0fsi4hvbcl3a97wlpisqpwpab9wfjfk0gi5a3yx9yi5pnchmyj89"
+    "rev": "193f1ee8c5d86acba280fb310dbc131d2720795b",
+    "sha256": "13fl2kywjaz59wpqf5mxgzpngl0w5gnl9qaplj9pmcyy80jn99hr"
   }
 }


### PR DESCRIPTION
91qm06djb47knx1pzrrm66h2isgzid8p-unit-script-postgresql-start
becomes postgresql-start for example.

This affects the default journalctl output and the application_name
sent to Graylog (loghost).

Case 126523

Nixpkgs changes:

https://github.com/flyingcircusio/nixpkgs/commit/193f1ee8c5d86acba280fb310dbc131d2720795b

@flyingcircusio/release-managers

## Release process

Impact: 

* [NixOS 19.03] Multiple services will be restarted, including elasticsearch, mongodb, mysql, postgresql, redis, rabbitmq and sshd.

Changelog:

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - no security implications, just better usability for journalctl output and centralized logging
- [x] Security requirements tested? (EVIDENCE)
  - manually tested on test35, executed all NixOS tests