### PR TITLE
Nginx: fix/add hash table options

### DIFF
--- a/nixos/services/nginx/base-module.nix
+++ b/nixos/services/nginx/base-module.nix
@@ -136,6 +136,22 @@ let
         include ${recommendedProxyConfig};
       ''}
 
+      ${optionalString (cfg.mapHashBucketSize != null) ''
+        map_hash_bucket_size ${toString cfg.mapHashBucketSize};
+      ''}
+
+      ${optionalString (cfg.mapHashMaxSize != null) ''
+        map_hash_max_size ${toString cfg.mapHashMaxSize};
+      ''}
+
+      ${optionalString (cfg.serverNamesHashBucketSize != null) ''
+        server_names_hash_bucket_size ${toString cfg.serverNamesHashBucketSize};
+      ''}
+
+      ${optionalString (cfg.serverNamesHashMaxSize != null) ''
+        server_names_hash_max_size ${toString cfg.serverNamesHashMaxSize};
+      ''}
+
       # $connection_upgrade is used for websocket proxying
       map $http_upgrade $connection_upgrade {
           default upgrade;
@@ -544,6 +560,40 @@ in
           and not only at start, you have to set
           services.nginx.resolver, too.
         '';
+      };
+
+      mapHashBucketSize = mkOption {
+        type = types.nullOr types.ints.positive;
+        default = null;
+        description = ''
+            Sets the bucket size for the map variables hash tables. Default
+            value depends on the processor’s cache line size.
+          '';
+      };
+
+      mapHashMaxSize = mkOption {
+        type = types.nullOr types.ints.positive;
+        default = null;
+        description = ''
+            Sets the maximum size of the map variables hash tables.
+          '';
+      };
+
+      serverNamesHashBucketSize = mkOption {
+        type = types.nullOr types.ints.positive;
+        default = null;
+        description = ''
+            Sets the bucket size for the server names hash tables. Default
+            value depends on the processor’s cache line size.
+          '';
+      };
+
+      serverNamesHashMaxSize = mkOption {
+        type = types.nullOr types.ints.positive;
+        default = null;
+        description = ''
+            Sets the maximum size of the server names hash tables.
+          '';
       };
 
       resolver = mkOption {

--- a/nixos/services/nginx/default.nix
+++ b/nixos/services/nginx/default.nix
@@ -132,7 +132,6 @@ let
     large_client_header_buffers 4 16k;
     request_pool_size 4k;
     send_timeout 10m;
-    server_names_hash_bucket_size ${toString cfg.mapHashBucketSize};
   '';
 
   plainConfigFiles = filter (p: lib.hasSuffix ".conf" p) (fclib.files localDir);
@@ -152,12 +151,6 @@ in
       description = ''
         Configuration lines to be appended inside of the http {} block.
       '';
-    };
-
-    mapHashBucketSize = mkOption {
-      type = types.int;
-      default = 64;
-      description = "Bucket size for the 'map' variables hash tables.";
     };
 
     workerShutdownTimeout = mkOption {
@@ -287,6 +280,7 @@ in
         recommendedOptimisation = true;
         recommendedProxySettings = true;
         recommendedTlsSettings = true;
+        serverNamesHashBucketSize = fclib.mkPlatform 64;
         statusPage = true;
         inherit virtualHosts;
       };


### PR DESCRIPTION
The option mapHashBucketSize was mapped to the wrong nginx setting.
This adds the fixed option and 3 related ones to the base nginx module
forked from 19.03.

serverNamesHashBucketSize uses 64 as platform default which is used
everywhere at the moment.

Case 128833

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Nginx: remove the `flyingcircus.services.mapHashBucketSize` option which didn't work correctly. It's replaced by `services.nginx.mapHashBucketSize`. This change also adds the related settings `mapHashMaxSize`, `serverNamesHashBucketSize` and `serverNamesHashMaxSize`.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
    - nothing, just some additional options
- [x] Security requirements tested? (EVIDENCE)
  - manually checked on test VM; automated NixOS test still works
