### PR TITLE
128712 gitlab mailin

### DIFF
--- a/nixos/services/gitlab/default.nix
+++ b/nixos/services/gitlab/default.nix
@@ -596,8 +596,8 @@ in {
 
         logPath = mkOption {
           type = types.path;
-          default = "${cfg.statePath}/log/mail_room.log";
-          description = "mail_room.log location. Will be rotated automatically.";
+          default = "/var/log/gitlab/mail_room_json.log";
+          description = "Log file location. Logs will be rotated automatically.";
         };
       };
 
@@ -821,7 +821,7 @@ in {
       "d ${cfg.statePath}/config 0750 ${cfg.user} ${cfg.group} -"
       "d ${cfg.statePath}/config/initializers 0750 ${cfg.user} ${cfg.group} -"
       "d ${cfg.statePath}/db 0750 ${cfg.user} ${cfg.group} -"
-      "d /var/log/gitlab 0750 ${cfg.user} ${cfg.group} -"
+      "d /var/log/gitlab 0755 ${cfg.user} ${cfg.group} -"
       "d ${cfg.statePath}/repositories 2770 ${cfg.user} ${cfg.group} -"
       "d ${cfg.statePath}/shell 0750 ${cfg.user} ${cfg.group} -"
       "d ${cfg.statePath}/tmp 0750 ${cfg.user} ${cfg.group} -"
@@ -1046,14 +1046,7 @@ in {
       requires = [ "gitlab.service" ];
       wantedBy = [ "multi-user.target" ];
       environment = gitlabEnv;
-      path = with pkgs; [
-        postgresqlPackage
-        gitAndTools.git
-        ruby
-        openssh
-        nodejs
-        gnupg
-      ];
+      path = with pkgs; [ ruby ];
       restartTriggers = with builtins; [ (
         # need a different value each time anything changes
         hashString "sha256" (toJSON gitlabConfig.production.incoming_email))
@@ -1069,20 +1062,6 @@ in {
         RestartSec = 30;
         WorkingDirectory = "${cfg.statePath}/home";
       };
-    };
-
-    services.logrotate = mkIf cfg.incomingEmail.enable {
-      enable = mkDefault true;
-      config = ''
-        ${cfg.incomingEmail.logPath} {
-          compress
-          daily
-          dateext
-          delaycompress
-          missingok
-          rotate 7
-        }
-      '';
     };
 
   };

--- a/nixos/services/mail/default.nix
+++ b/nixos/services/mail/default.nix
@@ -11,8 +11,8 @@ with builtins;
 
 let
   snm = fetchTarball {
-    url = "https://github.com/flyingcircusio/nixos-mailserver/archive/e4f8e0c154f3f60487fd9ca8c39f90771c700195.tar.gz";
-    sha256 = "0q535b14h7jln09v1q833ixily6c7vbksbg4bl9pzn86k11fcxff";
+    url = "https://github.com/flyingcircusio/nixos-mailserver/archive/937db90f45e33c7aba1f3a00570d40783a6aed4e.tar.gz";
+    sha256 = "1nhg80dlldm3jgmapg5xxwbhgskqfgzsa265i6s7y1hq3vx7wkan";
   };
 
   role = config.flyingcircus.roles.mailserver;

--- a/tests/mail/test_imap.py
+++ b/tests/mail/test_imap.py
@@ -19,6 +19,7 @@ def verify(user, password, exp_subjects):
             assert f'Subject: {subject}' in msg
 
 
-verify('user1@example.local', 'User1User1', ['testmail1', 'testmail3'])
+verify('user1@example.local', 'User1User1',
+       ['testmail1', 'testmail3', 'testmail6'])
 verify('user2@example.local', 'User2User2',
        ['testmail2', 'testmail4', 'testmail5'])


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact: Gitlab instances will be restarted.

Changelog: Gitlab: add processing of incoming mails via the mail_room component. Settings must be configured via the new `services.gitlab.incomingEmail` attribute set (#128712).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

Security concerns set forth in https://docs.gitlab.com/ee/administration/incoming_email.html#security-concerns apply. Misconfigured mail processing can be a security issue so it should be done with care. Giblab's documentation, however, is quite explicit on this.

- [x] Security requirements tested? (EVIDENCE)

Instance running on cusyce00 does not show problems as outlined above because it uses a dedicated subdomain (ce.cusy.io).