### PR TITLE
Update Jitsi versions

### DIFF
--- a/pkgs/jicofo/default.nix
+++ b/pkgs/jicofo/default.nix
@@ -2,10 +2,10 @@
 
 let
   pname = "jicofo";
-  version = "1.0-626";
+  version = "1.0-636";
   src = fetchurl {
     url = "https://download.jitsi.org/stable/${pname}_${version}-1_all.deb";
-    sha256 = "12r68f41x39pcdfc477zwlkki8ga75iv9i4r9d8fd3nbk45scx0l";
+    sha256 = "1b8lkfcidl5psq4j09lccyr0czy9dsaib9cswc8qja9q3snvnszk";
   };
 in
 stdenv.mkDerivation {

--- a/pkgs/jitsi-meet/default.nix
+++ b/pkgs/jitsi-meet/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "jitsi-meet";
-  version = "1.0.4383";
+  version = "1.0.4428";
 
   src = fetchurl {
     url = "https://download.jitsi.org/jitsi-meet/src/jitsi-meet-${version}.tar.bz2";
-    sha256 = "1jfxfz6qqn98pdgyhn90pizzwx3nqzjrm6dgx8bxwqnjmad1c4cj";
+    sha256 = "15v686vdw6kvsrmykkk82zhif65v2nr478zp84kzsx3rqlfm9gwh";
   };
 
   dontBuild = true;

--- a/pkgs/jitsi-videobridge/default.nix
+++ b/pkgs/jitsi-videobridge/default.nix
@@ -2,11 +2,11 @@
 
 let
   pname = "jitsi-videobridge2";
-  version = "2.1-315-g40ba83c6";
+  version = "2.1-351-g0bfaac1c";
 
   src = fetchurl {
-    url = "https://downloads.fcio.net/packages/${pname}_${version}-1_all.deb";
-    sha256 = "0knwjx48aj1zhqkkfm2ra8cc44mavnfc2lbczv4zna8j4m7nzb1j";
+    url = "https://download.jitsi.org/stable/${pname}_${version}-1_all.deb";
+    sha256 = "06f9vz6n8wdaabzdzwqm2sqbdmxd0prlifz99bn4anzn1b6i69ip";
   };
 in
 stdenv.mkDerivation {


### PR DESCRIPTION
Updates jicofo, jitsi-videobridge and jitsi-meet-web to newest stable releases

Case 128836

@flyingcircusio/release-managers

## Release process

Impact:

* [NixOS]: Jitsi will be restarted, interrupts running conferences for a short time

Changelog:

* Jitsi: update all components to the newest stable release (#128836).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - just an update, no additional security requirements
- [x] Security requirements tested? (EVIDENCE)
  - check basic functionality on test46, checked commit logs of affected components

