### PR TITLE
Docker role: add docker-compose

### DIFF
--- a/nixos/roles/docker.nix
+++ b/nixos/roles/docker.nix
@@ -1,4 +1,4 @@
-{ config, lib, ... }:
+{ config, lib, pkgs, ... }:
 {
   options = {
     flyingcircus.roles.docker = {
@@ -7,8 +7,9 @@
   };
 
   config = lib.mkIf config.flyingcircus.roles.docker.enable {
-    virtualisation.docker.enable = true;
+    environment.systemPackages = [ pkgs.docker-compose ];
     flyingcircus.users.serviceUsers.extraGroups = [ "docker" ];
+    virtualisation.docker.enable = true;
   };
 
 }


### PR DESCRIPTION
Case 128931

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Docker role: add docker-compose (#128931).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - we just install the docker-compose tool by default which is already installed on various machines using docker.
- [x] Security requirements tested? (EVIDENCE)
  - manually tested if it works on test35

