### PR TITLE
Docker role: disable policy routing

### DIFF
--- a/nixos/roles/docker.nix
+++ b/nixos/roles/docker.nix
@@ -8,6 +8,8 @@
 
   config = lib.mkIf config.flyingcircus.roles.docker.enable {
     environment.systemPackages = [ pkgs.docker-compose ];
+    # Policy routing interferes with host-container networking, disable it.
+    flyingcircus.network.policyRouting.enable = false;
     flyingcircus.users.serviceUsers.extraGroups = [ "docker" ];
     virtualisation.docker.enable = true;
   };


### PR DESCRIPTION
We already do it for Kubernetes nodes and various docker VMs,
doesn't play well with container networking.

Case 128979

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Docker: fix problems with container networking by disabling policy routing (#128979).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - nothing
- [x] Security requirements tested? (EVIDENCE)
  - manually tested on test35, already in use on multiple docker VMs including Kubernetes
