### PR TITLE
Kubernetes: run dashboard and coredns as systemd services on the master

### DIFF
--- a/nixos/roles/kubernetes/frontend.nix
+++ b/nixos/roles/kubernetes/frontend.nix
@@ -19,6 +19,8 @@ let
     then null
     else head (head nodeServices).ips;
 
+  master = fclib.findOneService "kubernetes-master-master";
+
   clusterNet = config.services.kubernetes.apiserver.serviceClusterIpRange;
   ipCmd = action: ''
     ip route ${action} ${clusterNet} via ${routerIP} dev ethsrv
@@ -27,21 +29,33 @@ in
 {
   config = lib.mkIf (routerIP != null) {
 
-      systemd.services.kubernetes-frontend-routing = rec {
-        description = "IP routing from frontend VMs to the Kubernetes cluster network";
-        after = [ "network-addresses-ethsrv.service" ];
-        before = [ "network-local-commands.service" ];
-        wantedBy = [ "multi-user.target" ];
-        bindsTo = [ "sys-subsystem-net-devices-ethsrv.device" ] ++ after;
-        path = [ fclib.relaxedIp ];
-        script = ipCmd "add";
-        preStop = ipCmd "del";
-        serviceConfig = {
-          Type = "oneshot";
-          RemainAfterExit = true;
-        };
-      };
+    assertions = [
+      {
+        assertion = master != null;
+        message = "Invalid cluster configuration: Kubernetes node found but no master!";
+      }
+    ];
 
+    networking.nameservers = lib.mkOverride 90 master.ips;
+
+    # Interferes with cluster networking, disable it.
+    flyingcircus.network.policyRouting.enable = false;
+
+    systemd.services.kubernetes-frontend-routing = rec {
+      description = "IP routing from frontend VMs to the Kubernetes cluster network";
+      after = [ "network-addresses-ethsrv.service" ];
+      before = [ "network-local-commands.service" ];
+      wantedBy = [ "multi-user.target" ];
+      bindsTo = [ "sys-subsystem-net-devices-ethsrv.device" ] ++ after;
+      path = [ fclib.relaxedIp ];
+      script = ipCmd "add";
+      preStop = ipCmd "del";
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+      };
     };
+
+  };
 
 }

--- a/nixos/roles/kubernetes/node.nix
+++ b/nixos/roles/kubernetes/node.nix
@@ -20,13 +20,23 @@ in
 
     (lib.mkIf cfg.enable {
 
+      assertions = [
+        {
+          assertion = master != null;
+          message = "Invalid Cluster configuration: Kubernetes node found but no master!";
+        }
+      ];
+
       environment.systemPackages = with pkgs; [
         bridge-utils
       ];
 
       services.kubernetes = {
         # Kubelet doesn't start with swap by default but we want to use swap.
-        kubelet.extraOpts = "--fail-swap-on=false";
+        kubelet = {
+          extraOpts = lib.mkForce "--fail-swap-on=false";
+          clusterDns = head master.ips;
+        };
         proxy = {
           # Works without proper hostname but avoids the error in kube-proxy log
           extraOpts = "--hostname-override=${config.networking.hostName}.fcio.net";
@@ -68,6 +78,8 @@ in
         umask 077
         echo ${master.password} | md5sum | head -c32 > /var/lib/kubernetes/secrets/apitoken.secret
       '';
+
+      networking.nameservers = lib.mkOverride 90 master.ips;
 
       services.kubernetes = {
         # The certificates only support fcio.net but the directory still uses gocept.net

--- a/nixos/services/default.nix
+++ b/nixos/services/default.nix
@@ -12,6 +12,7 @@ let
     "services/continuous-integration/gitlab-runner.nix"
     "services/misc/docker-registry.nix"
     "services/monitoring/grafana.nix"
+    "services/networking/coredns.nix"
     "services/networking/prosody.nix"
     "services/search/elasticsearch.nix"
     "services/search/kibana.nix"

--- a/pkgs/kubernetes-dashboard.nix
+++ b/pkgs/kubernetes-dashboard.nix
@@ -1,0 +1,18 @@
+{ stdenv, fetchurl, tree }:
+
+stdenv.mkDerivation rec {
+  version = "2.0.4";
+  pname = "kubernetes-dashboard";
+
+  src = fetchurl {
+    url = "http://downloads.fcio.net/packages/${pname}-${version}.tar.gz";
+    sha256 = "0z3fpqh6p9mwj44k213qp5whsa42hz1whaqjfwd2rrdc1yfyz9p5";
+  };
+
+  buildPhase = ":";
+
+  installPhase = ''
+    mkdir $out
+    cp -r * $out/
+  '';
+}

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -35,6 +35,7 @@ in {
   certmgr = super.callPackage ./certmgr.nix { inherit (pkgs-unstable) buildGoPackage; };
   cfssl = super.callPackage ./cfssl.nix { inherit (pkgs-unstable) buildGoPackage; };
 
+  inherit (pkgs-unstable) coredns;
   inherit (pkgs-unstable) coturn;
 
   inherit (pkgs-unstable) docker-distribution;
@@ -62,6 +63,8 @@ in {
     };
     meta.license = null;
   });
+
+  kubernetes-dashboard = super.callPackage ./kubernetes-dashboard.nix { };
 
   inherit (pkgs-unstable) gitlab gitlab-shell gitaly gitlab-workhorse gitlab-runner;
 


### PR DESCRIPTION
Kubernetes: run dashboard and coredns as systemd services on the master

On NixOS, dashboard and coredns run in the Kubernetes cluster while all
other Kubernetes core services run directly on the master as systemd
services. We had various problems with coredns and dashboard that were
hard to debug, mostly related to secrets management.
The new setup is less complex and should be more reliable.

The master node runs coredns which acts as nameserver for pods in the
cluster and other VMs in the Kubernetes RG.

This also adds some assertions that a master is present in the
RG.

Dashboard now does HTTP Basic auth using the generated
htpasswd_fcio_users file.

Case 128939
 

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Kubernetes: run CoreDNS and Dashboard as SystemD services on the master; Dashboard now uses HTTP Basic Auth instead of kubeconfig files for authentication (#128939).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - dashboard: only system users with login permission should be able to use the dashboard (htpasswd_fcio_users)
- [x] Security requirements tested? (EVIDENCE)
  - automated NixOS test checks basic functionality; manually tested functionality and dashboard auth on kubtest00
