### PR TITLE
Make /etc/local/mail writeable for service user on bootstrapping for mailserver role

### DIFF
--- a/nixos/services/mail/default.nix
+++ b/nixos/services/mail/default.nix
@@ -55,6 +55,12 @@ in {
     })
 
     (lib.mkIf svc.enable {
+
+      flyingcircus.localConfigDirs.mail = {
+        dir = "/etc/local/mail/";
+        user = "root";
+      };
+
       environment.etc = {
         "local/mail/config.json.example".text = (toJSON {
           domains = [ primaryDomain "subdomain.${primaryDomain}" ];


### PR DESCRIPTION
This PR ensures, that /etc/local/mail is created while bootstrapping mailserver role with write permissions for service user so can do its final configurations.


@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  * Folder is created with root:service writing permission for service
- [ ] Security requirements tested? (EVIDENCE)

