### PR TITLE
Use hashedPassword for user vagrant on vagrant box

### DIFF
--- a/nixos/infrastructure/vagrant.nix
+++ b/nixos/infrastructure/vagrant.nix
@@ -39,8 +39,8 @@ in {
     # These groups are created through the ENC normally which
     # doesn't exist in vagrant or at least here, yet.
     users.groups = {
-      login = {};
-      service = {};
+      login = { members = ["vagrant"]; };
+      service = { members = ["vagrant"]; };
       sudo-srv = {};
       admins = {};
     };
@@ -48,8 +48,9 @@ in {
     users.users.vagrant = {
       description = "Vagrant user";
       group = "users";
-      extraGroups = [ "login" "service" "docker" ];
-      password = "vagrant";
+      extraGroups = [ "docker" ];
+      # password: vagrant
+      hashedPassword = "$5$xS9kX8R5VNC0g$ZS7QkUYTk/61dUyUgq9r0jLAX1NbiScBT5v1PODz4UC";
       home = "/home/vagrant";
       isNormalUser = true;
       openssh.authorizedKeys.keys = [


### PR DESCRIPTION
This PR uses hashedPassword instead of password for creation of the user vagrant as well as adds the user vagrant to group login. Both is used for generating /etc/local/nginx/htpasswd_fcio_users

bugs id: #129041


@flyingcircusio/release-managers

## Release process

Impact:

Changelog:
* /etc/local/nginx/htpasswd_fcio_users can now be used on Vagrant with the vagrant user

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
* Password still working for the user vagrant
* /etc/local/nginx/htpasswd_fcio_users with a entry for user vagrant

- [ ] Security requirements tested? (EVIDENCE)

