### PR TITLE
Jitsi: fix some problems when public udp is disabled

### DIFF
--- a/nixos/services/jitsi/jitsi-videobridge.nix
+++ b/nixos/services/jitsi/jitsi-videobridge.nix
@@ -24,10 +24,6 @@ let
   defaultJvbConfig = {
     videobridge = {
       ice = {
-        tcp = {
-          enabled = true;
-          port = 4443;
-        };
         udp.port = 10000;
       };
       stats = {


### PR DESCRIPTION
Some clients seem to have problems with encrypted TURNS. Disabling
public UDP forces them to use it.

Add support for unencrypted TURN. Content is encrypted by DTLS so we
don't need to encrypt it again. We provide TURN on the default port
3478 and 443. Coturn recognized the type of traffic and does the right
thing.

Videobridge should only bind to srv when udp is blocked. This avoids
generating failing ICE candidates that are tried by clients which may
cause errors or startup delays.

Disable videobridge TCP, it cannot be reached from the outside anyways
and is not recommended.

Case 128990

@flyingcircusio/release-managers

## Release process

Impact:

* [NixOS 19.03] Jitsi conferences may be interrupted for a short time period.

Changelog:

* Jitsi: fix some TURN problems when UDP access to videobridge is disabled or blocked (#128990).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - We allow unencrypted TURN traffic now but content is still encrypted by DTLS. Jitsi is built to work with unencrypted TURN without compomising security.
- [x] Security requirements tested? (EVIDENCE)
  - checked functionality on test46, checked open ports

