### PR TITLE
Loghost/graylog: upgrade mongodb 3.4 -> 3.6

### DIFF
--- a/nixos/roles/graylog.nix
+++ b/nixos/roles/graylog.nix
@@ -141,7 +141,7 @@ in
 
       };
 
-      flyingcircus.roles.mongodb34.enable = true;
+      flyingcircus.roles.mongodb36.enable = true;
       services.mongodb.replSetName = replSetName;
       services.mongodb.extraConfig = ''
         storage.wiredTiger.engineConfig.cacheSizeGB: 1


### PR DESCRIPTION
We want to upgrade to 4.0 but we must do that in steps.

We have to make sure that the feature compat version is set to 3.4
before the release.

Case 129344

@flyingcircusio/release-managers

## Release process

Impact:

* [NixOS 19.03] MongoDB will be restarted on loghost/graylog VMs.

Changelog:

* Loghost/graylog: upgrade MongoDB to 3.6 (#129344).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - nothing new, just activating a different role that we already use in different contexts
- [x] Security requirements tested? (EVIDENCE)
  - basic functionality tested on services17

