### PR TITLE
Update Jitsi packages

### DIFF
--- a/nixos/roles/jitsi/default.nix
+++ b/nixos/roles/jitsi/default.nix
@@ -208,7 +208,6 @@ in {
           defaultLanguage = cfg.defaultLanguage;
           enableLipSync = false;
           enableAutomaticUrlCopy = true;
-          useStunTurn = true;
           p2p.enabled = false;
           inherit (cfg) resolution;
           startVideoMuted = 8;

--- a/pkgs/jicofo/default.nix
+++ b/pkgs/jicofo/default.nix
@@ -2,10 +2,10 @@
 
 let
   pname = "jicofo";
-  version = "1.0-636";
+  version = "1.0-644";
   src = fetchurl {
     url = "https://download.jitsi.org/stable/${pname}_${version}-1_all.deb";
-    sha256 = "1b8lkfcidl5psq4j09lccyr0czy9dsaib9cswc8qja9q3snvnszk";
+    sha256 = "193p22pavpc92wvr7yy569km7y4fzxsyzcfrl8lvzv2byq2ndciv";
   };
 in
 stdenv.mkDerivation {

--- a/pkgs/jitsi-meet/default.nix
+++ b/pkgs/jitsi-meet/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "jitsi-meet";
-  version = "1.0.4428";
+  version = "1.0.4466";
 
   src = fetchurl {
     url = "https://download.jitsi.org/jitsi-meet/src/jitsi-meet-${version}.tar.bz2";
-    sha256 = "15v686vdw6kvsrmykkk82zhif65v2nr478zp84kzsx3rqlfm9gwh";
+    sha256 = "0g28gw3cssl9h6cnxx0haa6n5g9lp6q9m8lsdmb13zcx57j289p1";
   };
 
   dontBuild = true;

--- a/pkgs/jitsi-videobridge/default.nix
+++ b/pkgs/jitsi-videobridge/default.nix
@@ -2,11 +2,11 @@
 
 let
   pname = "jitsi-videobridge2";
-  version = "2.1-351-g0bfaac1c";
+  version = "2.1-394-g36698039";
 
   src = fetchurl {
-    url = "https://download.jitsi.org/stable/${pname}_${version}-1_all.deb";
-    sha256 = "06f9vz6n8wdaabzdzwqm2sqbdmxd0prlifz99bn4anzn1b6i69ip";
+    url = "https://downloads.fcio.net/packages/${pname}_${version}-1_all.deb";
+    sha256 = "199kv6n7q37k0p61y1k13y13il93dcl239h7srfihm5d2sk6blbk";
   };
 in
 stdenv.mkDerivation {


### PR DESCRIPTION
Should fix a memory leak in the videobridge with some newer Chrome
versions. Also removes an obsolete option.

Case 129464

@flyingcircusio/release-managers

## Release process

Impact:

* [NixOS 19.03] Jitsi conferences will be interrupted for a short time

Changelog:

* Jitsi: update packages, should fix a memory leak in the videobridge with some newer Chrome
versions (#129464).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - nothing new
- [x] Security requirements tested? (EVIDENCE)
  - checked commit logs of videobridge, jitsi-meet and jicofo
  - tested functionality on test VM
