### PR TITLE
webgateway: fix X-Forwarded-Server to use $server_name instead of $host

### DIFF
--- a/nixos/services/nginx/base-module.nix
+++ b/nixos/services/nginx/base-module.nix
@@ -37,7 +37,7 @@ let
     proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header        X-Forwarded-Proto $scheme;
     proxy_set_header        X-Forwarded-Host $host;
-    proxy_set_header        X-Forwarded-Server $host;
+    proxy_set_header        X-Forwarded-Server $server_name;
     proxy_set_header        Accept-Encoding "";
   '';
 


### PR DESCRIPTION
Fixes #3-129399

@flyingcircusio/release-managers

## Release process

Impact:

-

Changelog:

* webgateway: fix X-Forwarded-Server to use $server_name instead of $host (#3-129399)

## Security implications

- [X] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

nothing changed, maybe even improves security a little

- [X] Security requirements tested? (EVIDENCE)

added unit tests