### PR TITLE
ClamAV: Check whether daily.cld was updated instead of mirrors.dat

### DIFF
--- a/nixos/roles/antivirus.nix
+++ b/nixos/roles/antivirus.nix
@@ -52,7 +52,7 @@ in
         clamav-updater = {
           notification = "ClamAV virus database up-to-date";
           command = ''
-            check_file_age -w 86400 -c 172800 /var/lib/clamav/mirrors.dat
+            check_file_age -w 86400 -c 172800 /var/lib/clamav/daily.cld
           '';
           interval = 300;
           };


### PR DESCRIPTION
bugs id: #PL-129234

mirrors.dat is not updated anymore (and even on some VM not even present anymore). When the freshclam-update is running daily.cld is updated with latest information. 

@flyingcircusio/release-managers

## Release process

Impact: Restarts sensu-client

Changelog:

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
    * Check should get red if signature files are not recent.
- [x] Security requirements tested? (EVIDENCE)
    *  Tested on test25 by activating role and seeing check becoming green. Manipulated modification time of file 5 days back and check becomes red. After deleting and re-running the freshclam-timer file was generated again and check back to green.

