### PR TITLE
Install zip by default on VM

### DIFF
--- a/nixos/platform/packages.nix
+++ b/nixos/platform/packages.nix
@@ -71,11 +71,12 @@
         wdiff
         wget
         xfsprogs
+        zip
     ] ++
     lib.optional (!config.services.postgresql.enable) pkgs.postgresql;
 
     flyingcircus.passwordlessSudoRules = [
-      { 
+      {
         commands = [ "${pkgs.iotop}/bin/iotop" ];
         groups = [ "sudo-srv" "service" ];
       }


### PR DESCRIPTION
bugs id: PL-129517

This PR adds the tool zip to our default environment. 

@flyingcircusio/release-managers

## Release process

Impact:
* -- 
Changelog:
* Provide zip on our default installation

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
    * Users often needs to the tool 'zip' to zip/unzip files on VM. 
- [x] Security requirements tested? (EVIDENCE)
    * Tested via an simple before-after-test on test-VM: Without the change zip was not inside $PATH of a normal user; after applying the change zip could be found in $PATH. 

