### PR TITLE
Nginx: start master process as root, worker as nginx

### DIFF
--- a/tests/nginx.nix
+++ b/tests/nginx.nix
@@ -96,6 +96,11 @@ in {
     server.wait_for_unit('nginx.service')
     server.wait_for_open_port(80)
 
+    with subtest("proxy cache directory should be accessible only for nginx"):
+      permissions = server.succeed("stat /var/cache/nginx/proxy -c %a:%U:%G").strip()
+      expected = "700:nginx:nginx"
+      assert permissions == expected, f"expected: {expected}, got {permissions}"
+
     with subtest("nginx should forward proxied host and server headers (primary name)"):
       server.execute("cat /etc/proxy.http | nc -l 8008 -N > /tmp/proxy.log &")
       server.succeed("curl http://server/proxy/")


### PR DESCRIPTION
This avoids problems with certificates that are not readable by the
nginx user, for example.
Upstream changed the service to start as nginx but we need
compatibility with older installations.
In the future, SSL certificates should be auto-generated by the
letsencrypt automation NixOS provides.

PL-129520

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Nginx: start as root and allow the master process to read protected files. The workers run as nginx user and drop extended capabilities. This ensures compatibility with our 19.03 platform (PL-129520).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - worker processes should run as unprivileged user nginx
  - cache directories should only be readable by nginx user
- [x] Security requirements tested? (EVIDENCE)
  - manually checked permissions and effective UID of worker processes on VM test45, automated test checks basic functionality, added check for cache dir permissions
