### PR TITLE
129939 cleanup wkhtmltopdf

### DIFF
--- a/pkgs/wkhtmltopdf/0_12_4.nix
+++ b/pkgs/wkhtmltopdf/0_12_4.nix
@@ -33,75 +33,47 @@ stdenv.mkDerivation rec {
       + # This is taken from the wkhtml build script that we don't run
       ''
         -confirm-license
-        -exceptions
+        -opensource
         -fast
+        -release
+        -static
         -graphicssystem raster
-        -iconv
-        -largefile
-        -no-3dnow
-        -no-accessibility
-        -no-audio-backend
-        -no-avx
-        -no-cups
-        -no-dbus
-        -no-declarative
-        -no-glib
-        -no-gstreamer
-        -no-gtkstyle
-        -no-icu
-        -no-javascript-jit
+        -webkit
+        -exceptions
+        -xmlpatterns
+        -system-libjpeg
+        -system-libpng
+        -system-zlib
         -no-libmng
         -no-libtiff
+        -no-accessibility
+        -no-stl
+        -no-qt3support
+        -no-phonon
+        -no-phonon-backend
+        -no-opengl
+        -no-declarative
+        -no-scripttools
+        -no-sql-db2
+        -no-sql-ibase
+        -no-sql-mysql
+        -no-sql-oci
+        -no-sql-odbc
+        -no-sql-psql
+        -no-sql-sqlite
+        -no-sql-sqlite2
+        -no-sql-tds
+        -no-mmx
+        -no-3dnow
+        -no-sse
+        -no-sse2
+        -no-multimedia
         -nomake demos
         -nomake docs
         -nomake examples
         -nomake tests
         -nomake tools
         -nomake translations
-        -no-mitshm
-        -no-mmx
-        -no-multimedia
-        -no-nas-sound
-        -no-neon
-        -no-nis
-        -no-opengl
-        -no-openvg
-        -no-pch
-        -no-phonon
-        -no-phonon-backend
-        -no-qt3support
-        -no-rpath
-        -no-scripttools
-        -no-sm
-        -no-sql-ibase
-        -no-sql-mysql
-        -no-sql-odbc
-        -no-sql-psql
-        -no-sql-sqlite
-        -no-sql-sqlite2
-        -no-sse
-        -no-sse2
-        -no-sse3
-        -no-sse4.1
-        -no-sse4.2
-        -no-ssse3
-        -no-stl
-        -no-xcursor
-        -no-xfixes
-        -no-xinerama
-        -no-xinput
-        -no-xkb
-        -no-xrandr
-        -no-xshape
-        -no-xsync
-        -opensource
-        -release
-        -static
-        -system-libjpeg
-        -system-libpng
-        -system-zlib
-        -webkit
-        -xmlpatterns
       '';
   });
 

--- a/pkgs/wkhtmltopdf/0_12_5.nix
+++ b/pkgs/wkhtmltopdf/0_12_5.nix
@@ -63,75 +63,47 @@ let
       + # This is taken from the wkhtml build script that we don't run
       ''
         -confirm-license
-        -exceptions
+        -opensource
         -fast
+        -release
+        -static
         -graphicssystem raster
-        -iconv
-        -largefile
-        -no-3dnow
-        -no-accessibility
-        -no-audio-backend
-        -no-avx
-        -no-cups
-        -no-dbus
-        -no-declarative
-        -no-glib
-        -no-gstreamer
-        -no-gtkstyle
-        -no-icu
-        -no-javascript-jit
+        -webkit
+        -exceptions
+        -xmlpatterns
+        -system-libjpeg
+        -system-libpng
+        -system-zlib
         -no-libmng
         -no-libtiff
+        -no-accessibility
+        -no-stl
+        -no-qt3support
+        -no-phonon
+        -no-phonon-backend
+        -no-opengl
+        -no-declarative
+        -no-scripttools
+        -no-sql-db2
+        -no-sql-ibase
+        -no-sql-mysql
+        -no-sql-oci
+        -no-sql-odbc
+        -no-sql-psql
+        -no-sql-sqlite
+        -no-sql-sqlite2
+        -no-sql-tds
+        -no-mmx
+        -no-3dnow
+        -no-sse
+        -no-sse2
+        -no-multimedia
         -nomake demos
         -nomake docs
         -nomake examples
         -nomake tests
         -nomake tools
         -nomake translations
-        -no-mitshm
-        -no-mmx
-        -no-multimedia
-        -no-nas-sound
-        -no-neon
-        -no-nis
-        -no-opengl
-        -no-openvg
-        -no-pch
-        -no-phonon
-        -no-phonon-backend
-        -no-qt3support
-        -no-rpath
-        -no-scripttools
-        -no-sm
-        -no-sql-ibase
-        -no-sql-mysql
-        -no-sql-odbc
-        -no-sql-psql
-        -no-sql-sqlite
-        -no-sql-sqlite2
-        -no-sse
-        -no-sse2
-        -no-sse3
-        -no-sse4.1
-        -no-sse4.2
-        -no-ssse3
-        -no-stl
-        -no-xcursor
-        -no-xfixes
-        -no-xinerama
-        -no-xinput
-        -no-xkb
-        -no-xrandr
-        -no-xshape
-        -no-xsync
-        -opensource
-        -release
-        -static
-        -system-libjpeg
-        -system-libpng
-        -system-zlib
-        -webkit
-        -xmlpatterns
       '';
   });
 in

--- a/pkgs/wkhtmltopdf/0_12_6.nix
+++ b/pkgs/wkhtmltopdf/0_12_6.nix
@@ -63,75 +63,47 @@ let
       + # This is taken from the wkhtml build script that we don't run
       ''
         -confirm-license
-        -exceptions
+        -opensource
         -fast
+        -release
+        -static
         -graphicssystem raster
-        -iconv
-        -largefile
-        -no-3dnow
-        -no-accessibility
-        -no-audio-backend
-        -no-avx
-        -no-cups
-        -no-dbus
-        -no-declarative
-        -no-glib
-        -no-gstreamer
-        -no-gtkstyle
-        -no-icu
-        -no-javascript-jit
+        -webkit
+        -exceptions
+        -xmlpatterns
+        -system-libjpeg
+        -system-libpng
+        -system-zlib
         -no-libmng
         -no-libtiff
+        -no-accessibility
+        -no-stl
+        -no-qt3support
+        -no-phonon
+        -no-phonon-backend
+        -no-opengl
+        -no-declarative
+        -no-scripttools
+        -no-sql-db2
+        -no-sql-ibase
+        -no-sql-mysql
+        -no-sql-oci
+        -no-sql-odbc
+        -no-sql-psql
+        -no-sql-sqlite
+        -no-sql-sqlite2
+        -no-sql-tds
+        -no-mmx
+        -no-3dnow
+        -no-sse
+        -no-sse2
+        -no-multimedia
         -nomake demos
         -nomake docs
         -nomake examples
         -nomake tests
         -nomake tools
         -nomake translations
-        -no-mitshm
-        -no-mmx
-        -no-multimedia
-        -no-nas-sound
-        -no-neon
-        -no-nis
-        -no-opengl
-        -no-openvg
-        -no-pch
-        -no-phonon
-        -no-phonon-backend
-        -no-qt3support
-        -no-rpath
-        -no-scripttools
-        -no-sm
-        -no-sql-ibase
-        -no-sql-mysql
-        -no-sql-odbc
-        -no-sql-psql
-        -no-sql-sqlite
-        -no-sql-sqlite2
-        -no-sse
-        -no-sse2
-        -no-sse3
-        -no-sse4.1
-        -no-sse4.2
-        -no-ssse3
-        -no-stl
-        -no-xcursor
-        -no-xfixes
-        -no-xinerama
-        -no-xinput
-        -no-xkb
-        -no-xrandr
-        -no-xshape
-        -no-xsync
-        -opensource
-        -release
-        -static
-        -system-libjpeg
-        -system-libpng
-        -system-zlib
-        -webkit
-        -xmlpatterns
       '';
   });
 in

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -67,4 +67,5 @@ in {
   systemd-service-cycles = callTest ./systemd-service-cycles.nix {};
   vxlan = callTest ./vxlan.nix {};
   webproxy = callTest ./webproxy.nix {};
+  wkhtmltopdf = callTest ./wkhtmltopdf.nix {};
 }

--- a/tests/wkhtmltopdf.nix
+++ b/tests/wkhtmltopdf.nix
@@ -1,0 +1,147 @@
+import ./make-test-python.nix ({ lib, pkgs, testlib, ... }:
+let
+  sample = pkgs.writeText "sample.html"
+      ''
+      <!DOCTYPE html>
+      <html>
+      <head>
+        <title>Infos</title>
+        <meta charset="UTF-8" />
+        <style type="text/css">
+          * {
+            font-family: Arial,sans-serif;
+            font-size: 13px;
+          }
+          sup {
+            vertical-align: super;
+            font-size: 9px;
+          }
+          table {
+            border-collapse: collapse;
+          }
+          tr {
+            page-break-inside: avoid;
+          }
+          .striped td,
+          .striped th {
+            background: #eeeeee;
+          }
+          td {
+            border: 1px solid #fff;
+            vertical-align: top;
+            padding: 0px 4px;
+          }
+          th {
+            border: 1px solid #fff;
+            vertical-align: top;
+            padding: 0px 4px;
+            font-weight: bold;
+            text-align: left;
+            background: #fff;
+          }
+          thead {
+            display: table-header-group;
+          }
+          .reseller-heading {
+            background: #e0e0e0;
+          }
+          thead th {
+            border-bottom-color: #000000;
+          }
+        </style>
+      </head>
+      <body>
+      <table style="width: 100%;">
+        <thead>
+        <tr>
+          <th>Header 1</th>
+          <th colspan="2">Header 2</th>
+          <th>Header 3-<br>subheader</th>
+          <th>Header 4<br>subheader</th>
+          <th>Header5-<br>subheader</th>
+          <th colspan="2">Foo&nbsp;/&nbsp;foo</th>
+        </tr>
+        </thead>
+        <tbody>
+            <tr>
+            <th class="reseller-heading" colspan="8">
+              Test
+            </th>
+          </tr>
+                        <tr >
+                <!-- 1 -->
+                <td>Test Produkt<sup>1</sup></td>           <!-- 2 -->
+                <td style="text-align: right;">1.000</td>
+                <td style="text-align: right;">50.000</td>
+                <!-- 3 -->
+                <td style="text-align: right;">50,00 €</td>
+                <!-- 4 -->
+                <td style="text-align: right;"></td>
+                <!-- 5 -->
+                          <!-- 6 -->
+                <td style="text-align: right;"></td>
+                <!-- 7 -->
+                <td style="text-align: right;">50 %</td>
+                <td style="text-align: right;">50 %</td>
+              </tr>
+                    <tr >
+                <!-- 1 -->
+                <td></td>           <!-- 2 -->
+                <td style="text-align: right;">50.001</td>
+                <td style="text-align: right;">100.000</td>
+                <!-- 3 -->
+                <td style="text-align: right;">100,00 €</td>
+                <!-- 4 -->
+                <td style="text-align: right;"></td>
+                <!-- 5 -->
+                          <!-- 6 -->
+                <td style="text-align: right;">50,00 €</td>
+                <!-- 7 -->
+                <td style="text-align: right;">50 %</td>
+                <td style="text-align: right;">50 %</td>
+              </tr>
+                    </tbody>
+      </table>
+      <p>
+        <b>ERLÄUTERUNG</b>
+      </p>
+      <ul>
+        <li>Lorem di lorem la lorem</li>
+        <li>Lorem di lorem la lorem</li>
+        <li>Lorem di lorem la lorem</li>
+        <li>Lorem di lorem la lorem</li>
+        <li>Lorem di lorem la lorem</li>
+        <li>Lorem di lorem la lorem</li>
+        </ul>
+        <p><b>Anbieter Zusatzinformationen</b></p>
+            <p><b>Test Anbieter</b></p>
+          <ol>
+                    <li value="1">Test</li>
+                </ol>
+        
+      </body>
+      </html>
+      '';
+in 
+{
+  machine =
+    { pkgs, lib, config, ... }:
+    {
+      imports = [
+        ../nixos
+      ];
+    };
+      
+  testScript = ''
+    print("${pkgs.wkhtmltopdf_0_12_6}")
+    machine.succeed('${pkgs.wkhtmltopdf_0_12_6}/bin/wkhtmltopdf --orientation Landscape --footer-spacing 0 --header-spacing 5 ${sample} /tmp/sample1.pdf')
+    machine.succeed('${pkgs.poppler_utils}/bin/pdftohtml -s -fontfullname /tmp/sample1.pdf')
+    _, output = machine.execute('cat /etc/font')
+    _, output = machine.execute('cat sample1-html.html')
+    print(output)
+    # This is kind of insane, but the PDF appears to create a *bold* header
+    # (and poppler detecting this) by providing the character twice 
+    # with a shift of 1 px.
+    assert output.count('Header&#160;3') == 2
+  '';
+})

--- a/tests/wkhtmltopdf.nix
+++ b/tests/wkhtmltopdf.nix
@@ -136,7 +136,6 @@ in
     print("${pkgs.wkhtmltopdf_0_12_6}")
     machine.succeed('${pkgs.wkhtmltopdf_0_12_6}/bin/wkhtmltopdf --orientation Landscape --footer-spacing 0 --header-spacing 5 ${sample} /tmp/sample1.pdf')
     machine.succeed('${pkgs.poppler_utils}/bin/pdftohtml -s -fontfullname /tmp/sample1.pdf')
-    _, output = machine.execute('cat /etc/font')
     _, output = machine.execute('cat sample1-html.html')
     print(output)
     # This is kind of insane, but the PDF appears to create a *bold* header


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

none

Changelog:

* Review and streamline our wkhtmltopdf builds (0.12.4, 0.12.5, 0.12.6) to reflect build options as used by upstream. Added test coverage to validate proper usage of fonts in CSS. (#129939)

## Security implications

- [X] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

Reviewed changes, but did not see anything security-related AFAICT: libraries and versions still the same, build options are changed to the upstream builds, so I tend to trust them.

- [X] Security requirements tested? (EVIDENCE)

nothing to test