### PR TITLE
PostgreSQL: install matching package, socket in /tmp

### DIFF
--- a/nixos/platform/packages.nix
+++ b/nixos/platform/packages.nix
@@ -44,7 +44,6 @@
         nano
         ncdu
         netcat
-        netcat
         ngrep
         nmap
         nodejs
@@ -72,8 +71,7 @@
         wget
         xfsprogs
         zip
-    ] ++
-    lib.optional (!config.services.postgresql.enable) pkgs.postgresql;
+    ];
 
     flyingcircus.passwordlessSudoRules = [
       {

--- a/nixos/roles/postgresql.nix
+++ b/nixos/roles/postgresql.nix
@@ -38,6 +38,7 @@ with builtins;
           }
         ];
 
+      environment.systemPackages = [ config.services.postgresql.package ];
       flyingcircus.services.postgresql.enable = true;
       flyingcircus.services.postgresql.majorVersion =
         head (lib.attrNames enabledRoles);

--- a/nixos/services/postgresql.nix
+++ b/nixos/services/postgresql.nix
@@ -214,6 +214,12 @@ in {
 
     };
 
+    # PostgreSQL used /tmp as socket location in earlier NixOS versions.
+    # That has been changed to /run/postgresql but users may still expect the old location.
+    systemd.tmpfiles.rules = [
+      "L /tmp/.s.PGSQL.5432 - - - - /run/postgresql/.s.PGSQL.5432"
+    ];
+
     flyingcircus.services = {
 
       sensu-client.checks =


### PR DESCRIPTION
* install package that matches the active postgresql role, not the NixOS default
* link socket now in /run/postgresql to old location in /tmp

PL-129526

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* PostgreSQL: install globally available commands (like psql) with the same version as the active role; link socket which is now in /run/postgresql for all versions to old location in /tmp (PL-129526).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - nothing new
- [x] Security requirements tested? (EVIDENCE)
  - not applicable
