### PR TITLE
Make number of Nginx' logfile rotations configurable

### DIFF
--- a/nixos/services/nginx/default.nix
+++ b/nixos/services/nginx/default.nix
@@ -164,6 +164,16 @@ in
       '';
     };
 
+    rotateLogs = mkOption {
+      type = types.int;
+      default = 7;
+      description = ''
+       Configures how often log files are rotated before being removed.
+       If count is 0, old versions are removed rather than rotated.
+      '';
+    };
+
+
   };
 
   config = lib.mkMerge [
@@ -288,7 +298,7 @@ in
       services.logrotate.config = ''
         /var/log/nginx/*.log
         {
-            rotate 7
+            rotate ${toString config.flyingcircus.services.nginx.rotateLogs}
             create 0644 nginx service
             postrotate
                 systemctl kill nginx -s USR1 --kill-who=main || systemctl restart nginx


### PR DESCRIPTION
bugs id: #PL-129495

@flyingcircusio/release-managers

This MR allows to set the number of rotations. Default stays at 7.

## Release process

Impact:

Changelog:

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - none
- [x] Security requirements tested? (EVIDENCE)
  - not applicable
