### PR TITLE
Varnish: fix reload error

### DIFF
--- a/nixos/roles/webproxy.nix
+++ b/nixos/roles/webproxy.nix
@@ -118,7 +118,7 @@ in
               varnishadm vcl.list | grep -q $name && echo "Config unchanged." && exit
               varnishadm vcl.load $name $config && varnishadm vcl.use $name
 
-              for vcl in $(varnishadm vcl.list | grep ^available | awk {'print $4'});
+              for vcl in $(varnishadm vcl.list | grep ^available | awk {'print $5'});
               do
                 varnishadm vcl.discard $vcl
               done

--- a/tests/webproxy.nix
+++ b/tests/webproxy.nix
@@ -40,7 +40,7 @@ import ./make-test.nix ({ pkgs, ... }:
 
     subtest "changing config and reloading should activate new config", sub {
       $webproxy->execute('ln -sf /etc/local/varnish/newconfig.vcl /etc/current-config/varnish.vcl');
-      $webproxy->execute('systemctl reload varnish');
+      $webproxy->succeed('systemctl reload varnish');
       $webproxy->succeed('varnishadm vcl.list | grep active | grep -q newconfig');
     };
   '';


### PR DESCRIPTION
Output of vcl.list changed, name column moved to the right

PL-129524

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Varnish: fix error on reload when deleting the old config (PL-129524).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - nothing changed
- [x] Security requirements tested? (EVIDENCE)
  - automated test checks reload
