### PR TITLE
Nginx: disable gixy security check when building config

### DIFF
--- a/nixos/services/nginx/default.nix
+++ b/nixos/services/nginx/default.nix
@@ -231,7 +231,7 @@ in
 
         nginx_config = {
           notification = "Nginx configuration check problems";
-          command = "/run/wrappers/bin/sudo /run/current-system/sw/bin/nginx-check-config || exit 2";
+          command = "/run/wrappers/bin/sudo /run/current-system/sw/bin/nginx-check-config";
           interval = 300;
         };
 


### PR DESCRIPTION
Add it to `nginx-check-config` instead.

Upstream added gixy as security checker for Nginx configs. The build
fails when gixy reports an potential security issue, even low-impact
ones and the builder cuts off the output which makes finding the problem annoying.
This would break too many working configs right now, so we have to make it
optional. The `nginx-check-config` script for interactive use now runs both
the built-in nginx check and gixy.

PL-129528

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Nginx: Add gixy config security checker to the `nginx-check-config` command instead of running it automatically when building the config. This would break too many running configs when upgrading from earlier platform versions so we don't make it mandatory right now (PL-129528).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - nginx-check-config should show nginx security issues
- [x] Security requirements tested? (EVIDENCE)
  - manually checked nginx-check-config output on test45: security issue in config was found; sensu check displays warning for gixy issue
