### PR TITLE
Letsencrypt: don't start renewal service on fc-manage run, retry

### DIFF
--- a/nixos/platform/acme.nix
+++ b/nixos/platform/acme.nix
@@ -1,0 +1,30 @@
+{ config, pkgs, lib, ... }:
+{
+  systemd.services =
+  let
+    # Retry certificate renewal 30s after a failure.
+    serviceConfig = {
+      Restart = "on-failure";
+      RestartSec = 30;
+    };
+
+    # Allow 5 retries/starts per day.
+    unitConfig = {
+      StartLimitIntervalSec = "24h";
+      StartLimitBurst = 5;
+    };
+  in
+    lib.listToAttrs
+      (map (n: lib.nameValuePair "acme-${n}" {
+        inherit serviceConfig unitConfig;
+        # Upstream added the renewal service to multi-user.target which means that
+        # every fc-manage run triggers a renewal. We want that the renewal is
+        # only triggered by the timer.
+        wantedBy = lib.mkForce [];
+      })
+      (lib.attrNames config.security.acme.certs));
+
+    # fallback ACME settings
+    security.acme.acceptTerms = true;
+    security.acme.email = "admin@flyingcircus.io";
+}

--- a/nixos/platform/default.nix
+++ b/nixos/platform/default.nix
@@ -19,6 +19,7 @@ let
 
 in {
   imports = [
+    ./acme.nix
     ./agent.nix
     ./enc.nix
     ./firewall.nix
@@ -192,10 +193,6 @@ in {
 
     flyingcircus.enc_services = enc_services;
 
-
-    # fallback ACME settings
-    security.acme.acceptTerms = true;
-    security.acme.email = "admin@flyingcircus.io";
 
     # implementation for flyingcircus.passwordlessSudoRules
     security.sudo.extraRules = let


### PR DESCRIPTION
acme-*.service units are started only by the timer now (once a day).
SystemD now tries to restart the services when they fail (up to 5
times per day).

PL-129535

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Letsencrypt SSL certificates: automatic certificate renewal now only runs once a day and is retried if it fails (#PL-129535).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - nothing new, certificate renewal should happen once a day
- [x] Security requirements tested? (EVIDENCE)
  - checked manually on test45 if cert service + timer have the correct unit settings

