### PR TITLE
Add a very generic test for ffmpeg to ensure it's pre-builded

### DIFF
--- a/tests/default.nix
+++ b/tests/default.nix
@@ -26,6 +26,7 @@ in {
   elasticsearch6 = callTest ./elasticsearch.nix { version = "6"; };
   elasticsearch7 = callTest ./elasticsearch.nix { version = "7"; };
   fcagent = callTest ./fcagent.nix {};
+  ffmpeg = callTest ./ffmpeg.nix {};
   garbagecollect = callTest ./garbagecollect.nix {};
   graylog = callTest ./graylog.nix {};
   haproxy = callTest ./haproxy.nix {};

--- a/tests/ffmpeg.nix
+++ b/tests/ffmpeg.nix
@@ -1,0 +1,19 @@
+# This is just a stub to check if ffmpeg builds and to cache the result.
+import ./make-test-python.nix ({ pkgs, lib, ... }:
+{
+  name = "ffmpeg";
+
+  machine = {
+    imports = [ ../nixos ];
+
+    environment.systemPackages = with pkgs; [
+      ffmpeg
+    ];
+
+  };
+
+  testScript = ''
+    start_all()
+    machine.succeed('ffmpeg -version')
+  '';
+})


### PR DESCRIPTION
bugs id: #PL-129478

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Pre-builded package should be available via hydra.flyingcircus.io 
- [x] Security requirements tested? (EVIDENCE)
  - Test runs successfully
  - Did _not_ verify it actually can be accessd via cache in this state 

