### PR TITLE
userscan: update to 0.4.8

### DIFF
--- a/pkgs/fc/userscan.nix
+++ b/pkgs/fc/userscan.nix
@@ -7,17 +7,17 @@
 
 rustPlatform.buildRustPackage rec {
   name = "fc-userscan-${version}";
-  version = "0.4.7";
+  version = "0.4.8";
 
   src = fetchFromGitHub {
     name = "fc-userscan-src-${version}";
     owner = "flyingcircusio";
     repo = "userscan";
     rev = version;
-    sha256 = "19jk0x03i0glsn96a26inbf7mznxzcadxvcsp5g9bilp28c4ibj3";
+    sha256 = "095m0f05m5kfpnnvz2bllvfbb8kfabhcxanva4cl9b1i0z8ckvnn";
   };
 
-  cargoSha256 = "0qvccpxgmk3pp35d9ivr4wwvfh4j6gi3ql04qb2icw19m93hna17";
+  cargoSha256 = "1kgmzdbhiwdd2v6nr72azpr1k863f24lzpmd20h9iaxr3i5vhfbr";
   nativeBuildInputs = [ docutils ];
   propagatedBuildInputs = [ lzo ];
 


### PR DESCRIPTION
This release fixes bugs w.r.t. gcroots/per-user permissions and unknown file types.

PL-129504
PL-129537

@flyingcircusio/release-managers

## Release process

Impact:

Changelog: Update fc-userscan to 0.4.8 bugfix release.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

Availability: fc-collect-garbage stopped working and thus, disks filled up.

- [x] Security requirements tested? (EVIDENCE)

Reproduced test case mentioned in the original ticket and verified manually that the problem is resolved.