### PR TITLE
Own FQDN should resolve to SRV address, not 127.0.0.1

### DIFF
--- a/nixos/platform/network.nix
+++ b/nixos/platform/network.nix
@@ -121,6 +121,13 @@ in
     '';
 
     networking = {
+
+      # FQDN and host name should resolve to the SRV address
+      # (set by hostsFromEncAddresses) and not 127.0.0.1.
+      # Restores old behaviour that we know from 15.09.
+      # -> #PL-129549
+      hosts = lib.mkOverride 90 {};
+
       nameservers =
         if (hasAttr location cfg.static.nameservers)
         then cfg.static.nameservers.${location}


### PR DESCRIPTION
This was changed upstream in NixOS 20.09 which causes too much trouble
for us when upgrading. Fix is from the NixOS manual. Maybe we can go back
to the upstream default in the future when everything is on 20.09.

 #PL-129549

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Own FQDN (like test99.fcio.net) should resolve to SRV address, not 127.0.0.1. This change restores the behaviour of our older platform versions (#PL-129549).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - own FQDN should resolve to SRV address
- [x] Security requirements tested? (EVIDENCE)
  - manually checked entries in /etc/hosts on test45
