### PR TITLE
Nginx reload: fix dependencies on acme cert services

### DIFF
--- a/nixos/services/nginx/base-module.nix
+++ b/nixos/services/nginx/base-module.nix
@@ -12,8 +12,8 @@ let
   vhostsConfigs = mapAttrsToList (vhostName: vhostConfig: vhostConfig) virtualHosts;
   acmeEnabledVhosts = filter (vhostConfig: vhostConfig.enableACME || vhostConfig.useACMEHost != null) vhostsConfigs;
   dependentCertNames = unique (map (hostOpts: hostOpts.certName) acmeEnabledVhosts);
-  sslServices = map (certName: "acme-${certName}") dependentCertNames;
-  sslSelfSignedServices = map (certName: "acme-selfsigned-${certName}") dependentCertNames;
+  sslServices = map (certName: "acme-${certName}.service") dependentCertNames;
+  sslSelfSignedServices = map (certName: "acme-selfsigned-${certName}.service") dependentCertNames;
   sslTargetNames = map (certName: "acme-finished-${certName}") dependentCertNames;
   sslTargets = map (targetName: "${targetName}.target") sslTargetNames;
   virtualHosts = mapAttrs (vhostName: vhostConfig:


### PR DESCRIPTION
SystemD was complaining about an "Invalid argument" which
means that the ".service" extension was missing.

 #PL-129544

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Nginx: fix dependencies between services to ensure that Nginx reloads correctly after Letsencrypt certs have been changed automatically (#PL-129544).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - nothing new, restores expected reload behaviour 
- [x] Security requirements tested? (EVIDENCE)
  - automated test checks basic functionality and that services dependencies are correct, also checked manually on test45

