### PR TITLE
fc-userscan: fix effective user id in subprocess

### DIFF
--- a/nixos/platform/garbagecollect/default.nix
+++ b/nixos/platform/garbagecollect/default.nix
@@ -29,7 +29,7 @@ let
                     user.pw_dir + "/.cache/fc-userscan.cache", "-L10000000",
                     "--unzip=*.egg", "-E", EXCLUDE, user.pw_dir],
                 stdin=subprocess.DEVNULL,
-                preexec_fn=lambda: os.setuid(user.pw_uid))
+                preexec_fn=lambda: os.setresuid(user.pw_uid, 0, 0))
             rc.append(p.wait())
 
         status = max(rc)


### PR DESCRIPTION
Using plain os.setuid() in Python resets the euid. This removes the
possibility for fc-userscan to regain root privileges. We now use
setresuid to set all user ids at once.

@flyingcircusio/release-managers

## Release process

Impact:

Changelog: fc-userscan: fix permission bug

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
Failing fc-userscan jobs cause availability problems due to overfull disks.

- [x] Security requirements tested? (EVIDENCE)

Verified that the systemd service is working now even after deleting everything under /nix/var/nix/gcroots/per-user/*.
Verified that the user ids are all correct now with a debugger.
