### PR TITLE
Update nixpkgs for gitlab 13.6.4

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -2,7 +2,7 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "60564cf416ba3d6c698209c4f5fc8d531267ba30",
-    "sha256": "03dwjr1bd6dr3da5dfzir5cga4s2cvqgcrz2m6y6qh5j2dvwjj9j"
+    "rev": "7179961331b1e98dd28f07dbcb46ed700ad6a52b",
+    "sha256": "0vg2hb6d4b05vi13wcalk1viqvk3hq8m4nbawqzc9vk0d0lwks59"
   }
 }


### PR DESCRIPTION
 #PL-129575

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Update Gitlab to 13.6.4 (#PL-129575).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - use a version of Gitlab with the latest security patches
- [x] Security requirements tested? (EVIDENCE)
  - checked that release is the current version for the 13.6 series.
  - manually checked basic functionality on fcstag60
