### PR TITLE
Update Jitsi packages, JVB websockets, tuning, optional XMPP websockets

### DIFF
--- a/nixos/roles/jitsi/prosody-plugins/mod_pinger.lua
+++ b/nixos/roles/jitsi/prosody-plugins/mod_pinger.lua
@@ -1,0 +1,52 @@
+local new_watchdog = require "util.watchdog".new;
+local filters = require "util.filters";
+local st = require "util.stanza";
+
+local idle_timeout = module:get_option_number("c2s_idle_timeout", 300);
+local ping_timeout = module:get_option_number("c2s_ping_timeout",  30);
+
+function update_watchdog(data, session)
+	if session.idle_watchdog then
+		session.idle_watchdog:reset();
+		session.idle_pinged = nil;
+	end
+	return data;
+end
+
+function check_session(watchdog)
+	local session = watchdog.session;
+	if session.smacks then
+		unwatch_session(session);
+		return;
+	end
+	if not session.idle_pinged then
+		session.idle_pinged = true;
+		session.send(st.iq({ type = "get", from = module.host, id = "idle-check" })
+				:tag("ping", { xmlns = "urn:xmpp:ping" }));
+		return ping_timeout; -- Call us again after ping_timeout
+	else
+		module:log("info", "Client %q silent for too long, closing...", session.full_jid);
+		session:close("connection-timeout");
+	end
+end
+
+
+function watch_session(session)
+	if not session.idle_watchdog
+	and not session.requests then -- Don't watch BOSH connections (BOSH already has timeouts)
+		session.idle_watchdog = new_watchdog(idle_timeout, check_session);
+		session.idle_watchdog.session = session;
+		filters.add_filter(session, "bytes/in", update_watchdog);
+	end
+end
+
+function unwatch_session(session)
+	if session.idle_watchdog then
+		filters.remove_filter(session, "bytes/in", update_watchdog);
+		session.idle_watchdog:cancel();
+		session.idle_watchdog = nil;
+	end
+end
+
+module:hook("resource-bind", function (event) watch_session(event.session); end);
+module:hook("resource-unbind", function (event) unwatch_session(event.session); end);

--- a/pkgs/jicofo/default.nix
+++ b/pkgs/jicofo/default.nix
@@ -2,10 +2,10 @@
 
 let
   pname = "jicofo";
-  version = "1.0-644";
+  version = "1.0-675";
   src = fetchurl {
-    url = "https://download.jitsi.org/stable/${pname}_${version}-1_all.deb";
-    sha256 = "193p22pavpc92wvr7yy569km7y4fzxsyzcfrl8lvzv2byq2ndciv";
+    url = "https://download.jitsi.org/testing/${pname}_${version}-1_all.deb";
+    sha256 = "0mq244xbj9jkxsqq50x2djs17r1q2jfld6bf6hv6x915ry6byfi7";
   };
 in
 stdenv.mkDerivation {

--- a/pkgs/jitsi-meet/default.nix
+++ b/pkgs/jitsi-meet/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "jitsi-meet";
-  version = "1.0.4466";
+  version = "1.0.4605";
 
   src = fetchurl {
     url = "https://download.jitsi.org/jitsi-meet/src/jitsi-meet-${version}.tar.bz2";
-    sha256 = "0g28gw3cssl9h6cnxx0haa6n5g9lp6q9m8lsdmb13zcx57j289p1";
+    sha256 = "1kg68q281nj022m6kgllz3xh0123m6jz0asfnw1fq5lx2cdxrkbs";
   };
 
   dontBuild = true;

--- a/pkgs/jitsi-videobridge/default.nix
+++ b/pkgs/jitsi-videobridge/default.nix
@@ -2,11 +2,11 @@
 
 let
   pname = "jitsi-videobridge2";
-  version = "2.1-394-g36698039";
+  version = "2.1-406-g812da0a8";
 
   src = fetchurl {
-    url = "https://downloads.fcio.net/packages/${pname}_${version}-1_all.deb";
-    sha256 = "199kv6n7q37k0p61y1k13y13il93dcl239h7srfihm5d2sk6blbk";
+    url = "https://download.jitsi.org/testing/${pname}_${version}-1_all.deb";
+    sha256 = "029gk1rncszk33dqbixwhw1vis1b3iy48xjag5ykdy3r6ypqpazg";
   };
 in
 stdenv.mkDerivation {

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -140,6 +140,17 @@ in {
 
   prometheus-elasticsearch-exporter = super.callPackage ./prometheus-elasticsearch-exporter.nix { };
 
+  prosody = super.prosody.overrideAttrs(_: {
+    version = "0.11.7"; # also update communityModules
+    sha256 = "0iw73ids6lv09pg2fn0cxsm2pvi593md71xk48zbcp28advc1zr8";
+
+    communityModules = super.fetchhg {
+      url = "https://hg.prosody.im/prosody-modules";
+      rev = "7678b4880719";
+      sha256 = "1rpk3jcfhsa9hl7d7y638kprs9in0ljjp1nqxg30w1689v5h85d2";
+    };
+  });
+
   rabbitmq-server_3_6_5 = super.callPackage ./rabbitmq-server/3.6.5.nix {
     erlang = self.erlangR19;
   };


### PR DESCRIPTION
* XMPP websockets are not enabled by default because using them causes
  "ghost users" when clients reload for unknown reasons.
* increase screenshare framerate
* enable REMB (Receiver Estimated Maximum Bitrate) and TCC (Transport-wide
  Congestion Control)
* add XMPP pinger to throw out unresponsive clients
* use layer suspension to save bandwith
* update jicofo, videobridge and webclient which fixes quality issues with
  screenshare caused by simulcast
* Increase default vertical resolution to 720

 #PL-129527

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Jitsi: Update packages, improve video and screenshare quality, save bandwith (#PL-129527).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - websockets should use HTTPS
- [x] Security requirements tested? (EVIDENCE)
  - manually tested on test46
