### PR TITLE
Nginx: reuseport for structured vhost config, also recommended for plain config

### DIFF
--- a/doc/src/webgateway.rst
+++ b/doc/src/webgateway.rst
@@ -55,7 +55,7 @@ HAProxy
 ~~~~~~~
 
 For HAProxy, you will already find a configuration file which you can change to
-fit your needs. For reference, please refer to the 
+fit your needs. For reference, please refer to the
 `official documentation <http://cbonte.github.io/haproxy-dconv/1.9/configuration.html>`_.
 
 
@@ -74,7 +74,7 @@ following is sufficient:
 .. code-block:: console
 
    server {
-       listen 127.0.0.1:8080;
+       listen 127.0.0.1:8080 reuseport;
        # The rest of server configuration
    }
 

--- a/nixos/services/nginx/README.txt
+++ b/nixos/services/nginx/README.txt
@@ -7,8 +7,8 @@ the next fc-manage run if the config is valid. It will display a warning if
 invalid settings are found in the nginx config.
 
 Note that changes to listen directives that are incompatible with the running config
-require a manual Ngnix restart that drops connections. This happens when changing
-`listenAddress` from 0.0.0.0 to a single IP address 123.123.123.123, for example.
+may require a manual Nginx restart that drops connections.
+Using `reuseport` can avoid such situations (see below).
 
 The combined nginx config file can be shown with: `nginx-show-config`
 
@@ -61,6 +61,11 @@ If none of the `listenAddress*` options is given, all frontend IPs are used.
 The `listen` option overrides our defaults: the `listenAddress*` options have
 no effect and no IP is used automatically in this case.
 
+We also support a custom `reuseport` option for `listen` which is true by default.
+The effect is that Nginx will start a separate socket listener for each worker.
+This helps performance and also allows changing listen IPs on config reload
+without the need to restart Nginx.
+
 
 ### HTTPS and Let's Encrypt
 
@@ -87,7 +92,13 @@ use the following snippet, and *USE SSL*:
 auth_basic "FCIO user";
 auth_basic_user_file "/etc/local/htpasswd_fcio_users";
 
-There is also an `example-configuration` here. Copy to some file ending with
-*.conf and adapt.
+There is also an `example-configuration` here. Copy to some file with the extension
+.conf and adapt.
 
-You can check if the config is valid with: `nginx-check-config`
+We recommend to use `listen ... reuseport` like in the example configuration.
+The effect is that Nginx will start a separate socket listener for each worker.
+This helps performance and also allows changing listen IPs on config reload
+without the need to restart Nginx.
+
+You can check if the config is valid with: `nginx-check-config`.
+The script also warns about potential security issues with your config.

--- a/nixos/services/nginx/base-module.nix
+++ b/nixos/services/nginx/base-module.nix
@@ -235,11 +235,12 @@ let
             then filter (x: x.ssl) defaultListen
             else defaultListen;
 
-        listenString = { addr, port, ssl, extraParameters ? [], ... }:
+        listenString = { addr, port, ssl, reuseport ? true, extraParameters ? [], ... }:
           "listen ${addr}:${toString port} "
           + optionalString ssl "ssl "
           + optionalString (ssl && vhost.http2) "http2 "
           + optionalString vhost.default "default_server "
+          + optionalString reuseport "reuseport "
           + optionalString (extraParameters != []) (concatStringsSep " " extraParameters)
           + ";";
 

--- a/nixos/services/nginx/example-config.nix
+++ b/nixos/services/nginx/example-config.nix
@@ -7,8 +7,8 @@ let
     builtins.concatStringsSep "\n    "
       (lib.concatMap
         (formatted_addr: [
-          "listen ${formatted_addr}:80;"
-          "listen ${formatted_addr}:443 ssl;"])
+          "listen ${formatted_addr}:80 reuseport;"
+          "listen ${formatted_addr}:443 ssl reuseport;"])
         (map
           (addr:
             if fclib.isIp4 addr then addr else "[${addr}]")

--- a/nixos/services/nginx/vhost-options.nix
+++ b/nixos/services/nginx/vhost-options.nix
@@ -35,6 +35,7 @@ with lib;
         addr = mkOption { type = str;  description = "IP address.";  };
         port = mkOption { type = int;  description = "Port number."; default = 80; };
         ssl  = mkOption { type = bool; description = "Enable SSL.";  default = false; };
+        reuseport = mkOption { type = bool; description = "Each worker gets its own socket listener.";  default = true; };
         extraParameters = mkOption { type = listOf str; description = "Extra parameters of this listen directive."; default = []; example = [ "reuseport" "deferred" ]; };
       }; });
       default = [];


### PR DESCRIPTION
listen ... reuseport ... starts a separate socket listener for each
Nginx worker process instead of having only one in the master process.
This is meant for higher performance but also allows worker reloading
when the listen IP changes from 127.0.0.1 to 0.0.0.0, for example.

Add an `reuseport` option for `listen` which is on by default.
This affects structured JSON and Nix config.

For plain config files, the option is recommended in the documentation and
example config.

 #PL-129589

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

*  Nginx: set reuseport by default in structured vhost config and recommend to use it in plain config files. Avoids failures on config reload when listen statements are incompatible with the previous config. This caused situations where Nginx had to be fully restarted to activate new config which means that connections are dropped. (#PL-129589).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - nothing new, should have no security implications
- [x] Security requirements tested? (EVIDENCE)
  - tested on dev VM, automated test still works
