### PR TITLE
Kubernetes: add FC nameservers to resolv.conf as fallback

### DIFF
--- a/nixos/roles/kubernetes/frontend.nix
+++ b/nixos/roles/kubernetes/frontend.nix
@@ -15,6 +15,8 @@ let
 
   masterRoleEnabled = config.flyingcircus.roles.kubernetes-master.enable;
   nodeRoleEnabled = config.flyingcircus.roles.kubernetes-node.enable;
+  location = lib.attrByPath [ "parameters" "location" ] "standalone" config.flyingcircus.enc;
+  fcNameservers = config.flyingcircus.static.nameservers.${location} or [];
 
   haproxyCfg = ''
     global
@@ -96,7 +98,7 @@ in
         echo ${master.password} | md5sum | head -c32 > /var/lib/kubernetes/secrets/apitoken.secret
       '';
 
-      networking.nameservers = lib.mkOverride 90 master.ips;
+      networking.nameservers = lib.mkOverride 90 (master.ips ++ fcNameservers);
 
       services.kubernetes = {
         easyCerts = true;

--- a/nixos/roles/kubernetes/master.nix
+++ b/nixos/roles/kubernetes/master.nix
@@ -327,7 +327,12 @@ in
 
     };
 
-    networking.nameservers = [ "127.0.0.1" ];
+    networking.nameservers = lib.mkOverride 90 ([ "127.0.0.1" ] ++ fcNameservers);
+    networking.resolvconf.extraConfig = ''
+      # resolvconf only adds the local resolver to resolv.conf by default,
+      # but we want all of the servers as fallback.
+      resolv_conf_local_only=NO
+    '';
 
     networking.firewall = {
       allowedTCPPorts = [ apiserverPort ];

--- a/nixos/roles/kubernetes/node.nix
+++ b/nixos/roles/kubernetes/node.nix
@@ -8,6 +8,8 @@ let
   fclib = config.fclib;
   kublib = config.services.kubernetes.lib;
   master = fclib.findOneService "kubernetes-master-master";
+  location = lib.attrByPath [ "parameters" "location" ] "standalone" config.flyingcircus.enc;
+  fcNameservers = config.flyingcircus.static.nameservers.${location} or [];
 in
 {
   options = {
@@ -72,7 +74,7 @@ in
         echo ${master.password} | md5sum | head -c32 > /var/lib/kubernetes/secrets/apitoken.secret
       '';
 
-      networking.nameservers = lib.mkOverride 90 master.ips;
+      networking.nameservers = lib.mkOverride 90 (master.ips ++ fcNameservers);
 
       services.kubernetes = {
         # The certificates only support fcio.net but the directory still uses gocept.net


### PR DESCRIPTION
resolv.conf on Kubernetes VMs only used the CoreDNS on the master as
nameserver. CoreDNS forwards requests to FC nameservers.

Also adding the FC nameservers to resolv.conf avoids annoying failures,
for example when the acme client wants to contact
the letsencrypt servers on a fc-manage run when CoreDNS is restarted at
the same time.

 #PL-129590

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Kubernetes: add FC nameservers to resolv.conf on VMs with a Kubernetes role as fallback when CoreDNS is down (#PL-129590).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - nothing new, uses the same nameservers as before but also works now when CoreDNS is down.
- [x] Security requirements tested? (EVIDENCE)
  - checked if resolv.conf is correct for all Kubernetes roles on our kubtest cluster. 

