### PR TITLE
Update nixpkgs to include upstream changes and Gitlab update

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -2,7 +2,7 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "7179961331b1e98dd28f07dbcb46ed700ad6a52b",
-    "sha256": "0vg2hb6d4b05vi13wcalk1viqvk3hq8m4nbawqzc9vk0d0lwks59"
+    "rev": "984c872d5ca6e521803a4cd9ba72d45c4c3640a6",
+    "sha256": "1zqac91ls48pvf91ar2fkbl9542v56q2y5fszh69fhx14lhlmiyy"
   }
 }


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

* [NixOS 20.09]: Gitlab and associated services will be restarted. Git and frontend access will be unavailable for some minutes. 
* [NixOS 20.09]: VMs will be rebooted for a kernel update.

Changelog:

* Update Gitlab to 13.6.5 (#PL-129597).
* Merge upstream NixOS updates, including: Grafana 7.3.7, Linux 5.4.89

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - use a version of Gitlab with the latest security patches
  - update nixpkgs every two weeks, should not introduce changes that harm security
- [x] Security requirements tested? (EVIDENCE)
  - checked that release is the current version for the 13.6 series.
  - manually checked basic functionality on fcstag60
  - checked commit log for nixpkgs update for relevant changes
