### PR TITLE
Switch modsecurity to use newer, more stable version.

### DIFF
--- a/nixos/services/nginx/default.nix
+++ b/nixos/services/nginx/default.nix
@@ -235,7 +235,7 @@ in
           ./modsecurity_includes.conf;
 
         "local/nginx/modsecurity/unicode.mapping".source =
-          "${pkgs.modsecurity_standalone.nginx}/unicode.mapping";
+          "${pkgs.libmodsecurity.src}/unicode.mapping";
       };
 
       flyingcircus.services.telegraf.inputs = {

--- a/nixos/services/nginx/example-config.nix
+++ b/nixos/services/nginx/example-config.nix
@@ -63,8 +63,8 @@ in
           #proxy_pass http://@varnish;
 
           # enable mod_security
-          #ModSecurityEnabled on;
-          #ModSecurityConfig /etc/local/nginx/modsecurity/modsecurity_includes.conf;
+          #modsecurity on;
+          #modsecurity_rules_file /etc/local/nginx/modsecurity/modsecurity_includes.conf;
       }
   }
 ''

--- a/nixos/services/nginx/modsecurity.conf
+++ b/nixos/services/nginx/modsecurity.conf
@@ -38,12 +38,6 @@ SecRule REQUEST_HEADERS:Content-Type "application/json" \
 SecRequestBodyLimit 13107200
 SecRequestBodyNoFilesLimit 131072
 
-# Store up to 128 KB of request body data in memory. When the multipart
-# parser reaches this limit, it will start using your hard disk for
-# storage. That is slow, but unavoidable.
-#
-SecRequestBodyInMemoryLimit 131072
-
 # What do do if the request body size is above our configured limit.
 # Keep in mind that this setting will automatically be set to ProcessPartial
 # when SecRuleEngine is set to DetectionOnly mode in order to minimize

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -100,6 +100,7 @@ in {
     modules = with super.nginxModules; [
       dav
       modsecurity
+      modsecurity-nginx
       moreheaders
       rtmp
     ];
@@ -120,6 +121,7 @@ in {
     modules = with super.nginxModules; [
       dav
       modsecurity
+      modsecurity-nginx
       moreheaders
       rtmp
     ];

--- a/tests/nginx.nix
+++ b/tests/nginx.nix
@@ -96,8 +96,8 @@ in {
         locations."/proxy".proxyPass = "http://127.0.0.1:8008";
 
         extraConfig = ''
-          ModSecurityEnabled on;
-          ModSecurityConfig /etc/local/nginx/modsecurity/modsecurity_includes.conf;
+          modsecurity on;
+          modsecurity_rules_file /etc/local/nginx/modsecurity/modsecurity_includes.conf;
         '';
       };
 


### PR DESCRIPTION
Fixes PL-129571

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Switch mod_security to newest stable branch using a new nginx module that should also be more stable.

## Security implications

- [X] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
mod_security is part of the front line of defenses. when introducing it we missed that there was a big restructuring and picked up the old module. this change picks up the most current module.

- [X] Security requirements tested? (EVIDENCE)

covered by existing automatic tests