### PR TITLE
Postgres: use postgis 2.5.5 for versions before 12

### DIFF
--- a/nixos/services/postgresql.nix
+++ b/nixos/services/postgresql.nix
@@ -68,7 +68,7 @@ in {
     postgresqlPkg = getAttr cfg.majorVersion packages;
 
     extensions = lib.optionals (lib.versionOlder cfg.majorVersion "12") [
-      (pkgs.postgis.override { postgresql = postgresqlPkg; })
+      (pkgs.postgis_2_5.override { postgresql = postgresqlPkg; })
       (pkgs.temporal_tables.override { postgresql = postgresqlPkg; })
       (pkgs.rum.override { postgresql = postgresqlPkg; })
     ] ++ lib.optionals (lib.versionAtLeast cfg.majorVersion "12") [

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -138,6 +138,14 @@ in {
   percona57 = super.callPackage ./percona/5.7.nix { boost = self.boost159; };
   percona80 = super.callPackage ./percona/8.0.nix { boost = self.boost172; };
 
+  postgis_2_5 = super.postgis.overrideAttrs(_: rec {
+    version = "2.5.5";
+    src = super.fetchurl {
+      url = "https://download.osgeo.org/postgis/source/postgis-${version}.tar.gz";
+      sha256 = "0547xjk6jcwx44s6dsfp4f4j93qrbf2d2j8qhd23w55a58hs05qj";
+    };
+  });
+
   prometheus-elasticsearch-exporter = super.callPackage ./prometheus-elasticsearch-exporter.nix { };
 
   prosody = super.prosody.overrideAttrs(_: {


### PR DESCRIPTION
Switching the major version of postgis on a platform upgrade doesn't
work. Use the same major version as on the 19.03 platform.

PG 12 already uses postgis 3.0.

 #PL-129602

@flyingcircusio/release-managers

## Release process

Impact:

* [NixOS 20.09]: PostgreSQL will be restarted.

Changelog:

* PostgreSQL: Use Postgis 2.5 for versions before 12 to make upgrades from 19.03 easier. 12 is unaffected because it already used Postgis 3.0 on 19.03. (PL-129602). 

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - just a downgrade to the major version used on the old platform 
- [x] Security requirements tested? (EVIDENCE)
  - manually tested platform upgrade + postgis update on a test VM 

