### PR TITLE
Graylog: create separate telegraf users to avoid conflict

### DIFF
--- a/nixos/services/graylog/default.nix
+++ b/nixos/services/graylog/default.nix
@@ -104,6 +104,7 @@ let
 
   graylogConfPath = "/run/graylog/graylog.conf";
 
+  telegrafUsername = "telegraf-${config.networking.hostName}";
   telegrafPassword = fclib.derivePasswordForHost "graylog-telegraf";
 
 in {
@@ -409,7 +410,7 @@ in {
 
         ${callApi "ensure-role Metrics '${toJSON metricsRole}'"}
 
-        ${callApi "ensure-user telegraf '${toJSON telegrafUser}'"}
+        ${callApi "ensure-user ${telegrafUsername} '${toJSON telegrafUser}'"}
       '';
     };
 
@@ -423,7 +424,7 @@ in {
         RestartSec = "10";
         ExecStart = ''
           ${pkgs.fc.agent}/bin/fc-graylog \
-            -u telegraf \
+            -u ${telegrafUsername} \
             -p '${telegrafPassword}' \
             collect-journal-age-metric --socket-path /run/telegraf/influx.sock
 
@@ -491,7 +492,7 @@ in {
                     "org.graylog2.journal.size-limit"
                     "org.graylog2.throughput.input"
                     "org.graylog2.throughput.output" ];
-        username = "telegraf";
+        username = telegrafUsername;
         password = telegrafPassword;
       }
     ];

--- a/tests/graylog.nix
+++ b/tests/graylog.nix
@@ -81,7 +81,7 @@ in {
 
     with subtest("config script must create telegraf user"):
       machine.wait_for_unit("fc-graylog-config.service")
-      machine.succeed("${graylogApi} /users | grep -q telegraf")
+      machine.succeed("${graylogApi} /users | grep -q telegraf-machine")
 
     with subtest("public HTTPS should serve graylog dashboard"):
       machine.wait_until_succeeds("curl -k https://${host} | grep -q 'Graylog Web Interface'")


### PR DESCRIPTION
Add an hostname suffix to the telegraf user name to make it unique in
the cluster so each node can have its own telegraf password.
Before, each node overwrote user "telegraf" with a different password
which meant that only one node had the correct password and could gather
metrics.

In a graylog cluster, we want metrics from each graylog node.

 #PL-129455

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Graylog: make telegraf metrics collection work for all nodes in a cluster (#PL-129455).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  -  metrics collection should work on all nodes without sharing passwords between nodes
- [x] Security requirements tested? (EVIDENCE)
  - automated test checks if telegraf user is created
  - manual check if metrics collection works on a test VM
