### PR TITLE
modsecurity: remove old module, update current module, test owasp core

### DIFF
--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -93,14 +93,37 @@ in {
     };
   });
 
+
+  libmodsecurity = super.libmodsecurity.overrideAttrs(_: rec {
+      version = "3.0.4";
+
+      src = super.fetchFromGitHub {
+        owner = "SpiderLabs";
+        repo = "ModSecurity";
+        fetchSubmodules = true;
+        rev = "v3.0.4";
+        sha256 = "07vry10cdll94sp652hwapn0ppjv3mb7n2s781yhy7hssap6f2vp";
+      };
+
+    });
+
   mysql = super.mariadb;
 
   # This is our default version.
   nginxStable = (super.nginxStable.override {
     modules = with super.nginxModules; [
       dav
-      modsecurity
-      modsecurity-nginx
+
+     ( {
+        src = super.fetchFromGitHub {
+          owner = "SpiderLabs";
+          repo = "ModSecurity-nginx";
+          rev = "v1.0.1";
+          sha256 = "0cbb3g3g4v6q5zc6an212ia5kjjad62bidnkm8b70i4qv1615pzf";
+        };
+        inputs = [ super.curl super.geoip self.libmodsecurity super.libxml2 super.lmdb super.yajl ];
+        })
+
       moreheaders
       rtmp
     ];
@@ -120,8 +143,17 @@ in {
   nginxMainline = super.nginxMainline.override {
     modules = with super.nginxModules; [
       dav
-      modsecurity
-      modsecurity-nginx
+
+      ( {
+        src = super.fetchFromGitHub {
+          owner = "SpiderLabs";
+          repo = "ModSecurity-nginx";
+          rev = "v1.0.1";
+          sha256 = "0cbb3g3g4v6q5zc6an212ia5kjjad62bidnkm8b70i4qv1615pzf";
+        };
+        inputs = [ super.curl super.geoip super.libmodsecurity super.libxml2 super.lmdb super.yajl ];
+        })
+
       moreheaders
       rtmp
     ];

--- a/tests/nginx.nix
+++ b/tests/nginx.nix
@@ -34,6 +34,12 @@ let
     mkdir $out
     echo changed content > $out/index.html
   '';
+
+  owaspCoreRules = pkgs.fetchgit {
+    url = "https://github.com/coreruleset/coreruleset.git";
+    rev = "v3.3.0";
+    sha256 = "0n8q5pa913cjbxhgmdi8jaivqnrc8y4pyqcv0y3si1i5dzn15lgw";
+  };
 in {
   name = "nginx";
   nodes = {
@@ -78,6 +84,8 @@ in {
         "local/nginx/modsecurity/modsecurity_includes.conf".text =
           ''
           include modsecurity.conf
+          include ${owaspCoreRules}/crs-setup.conf.example
+          include ${owaspCoreRules}/rules/*.conf
           SecRule ARGS:testparam "@contains test" "id:1234,deny,status:999"
           '';
       };


### PR DESCRIPTION
Fixes PL-129610

@flyingcircusio/release-managers

## Release process

Impact:

* nginx will be restarted.

Changelog:

* Provide further upgrades to modsecurity to ensure stability when using the OWASP core rules. (PL-129610)
* 
## Security implications

- [X] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

touching only qualified, explicit sources, only micro version upgrades for bugfixes.

- [X] Security requirements tested? (EVIDENCE)

extended tests to check for edge case with owasp core rules that broke before
