### PR TITLE
Nginx: do not remove Accept-Encoding in recommended proxy settings, fix SSL cert name for statshost location-proxy

### DIFF
--- a/nixos/roles/statshost/location-proxy.nix
+++ b/nixos/roles/statshost/location-proxy.nix
@@ -5,6 +5,8 @@ with lib;
 let
   fclib = config.fclib;
   statshostServiceIPs = fclib.listServiceIPs "statshost-collector";
+  domain = config.networking.domain;
+  location = lib.attrByPath [ "parameters" "location" ] "standalone" config.flyingcircus.enc;
   feFQDN = "${config.networking.hostName}.fe.${location}.${domain}";
   httpPort = 9090;
   httpsPort = 9443;
@@ -28,7 +30,8 @@ in
       recommendedOptimisation = true;
       recommendedProxySettings = true;
       recommendedTlsSettings = true;
-      virtualHosts."${config.networking.hostName}.${config.networking.domain}" = {
+      virtualHosts."${feFQDN}" = {
+        serverAliases = [ "${config.networking.hostName}.${config.networking.domain}" ];
         enableACME = true;
         addSSL = true;
         listen =

--- a/nixos/services/nginx/base-module.nix
+++ b/nixos/services/nginx/base-module.nix
@@ -42,7 +42,6 @@ let
     proxy_set_header        X-Forwarded-Proto $scheme;
     proxy_set_header        X-Forwarded-Host $host;
     proxy_set_header        X-Forwarded-Server $server_name;
-    proxy_set_header        Accept-Encoding "";
   '';
 
   upstreamConfig = toString (flip mapAttrsToList cfg.upstreams (name: upstream: ''


### PR DESCRIPTION
Backends should be able to serve compressed content through Nginx.
The setting, which is removed here, prevented that.
We noticed the problem for the statshost location proxy
which sent metrics uncompressed since the upgrade.
On 15.09, compression was done by telegraf.

This is also fixed in NixOS unstable:

https://github.com/NixOS/nixpkgs/pull/100708

Also adds the fe FQDN to the certificate of the statshost location proxy
which was discovered while debugging the compression problem.

 #PL-129611

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Webgateway/Nginx: do not remove Accept-Encoding header in recommended proxy settings which are enabled by default. This allows backends to send already compressed content, for example (#PL-129611). 

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  -  Don't have surprising defaults... Removing/changig the header can still be done in config, if needed.
  - location-proxy should have a valid SSL cert
- [x] Security requirements tested? (EVIDENCE)
  - automated nginx and statshost-global tests still work
  - manually checked on test VM and dev location proxy
