### PR TITLE
Port servicecheck role, add test

### DIFF
--- a/nixos/roles/default.nix
+++ b/nixos/roles/default.nix
@@ -32,6 +32,7 @@ in {
     ./rabbitmq.nix
     ./redis.nix
     ./sensuserver.nix
+    ./servicecheck.nix
     ./statshost
     ./webdata_blackbee.nix
     ./webgateway.nix

--- a/nixos/roles/servicecheck.nix
+++ b/nixos/roles/servicecheck.nix
@@ -1,0 +1,42 @@
+# This node runs service checks as defined in directory.
+# Requires ring 0 access.
+{ config, lib, pkgs, ...}:
+
+let
+  cfg = config.flyingcircus.roles.servicecheck;
+in
+{
+
+  options = with lib; {
+    flyingcircus.roles.servicecheck = {
+      enable = mkEnableOption "Enable the Flying Circus Service Check role.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+
+    systemd.services.fc-servicecheck = {
+      description = "Flying Circus global Service Checks";
+      # Run this *before* fc-manage rebuilds the system. This service loads
+      # off the sensu configuration for nixos to pick it up.
+      wantedBy = [ "fc-manage.service" ];
+      before = [ "fc-manage.service" ];
+      wants = [ "network.target" ];
+      after = [ "network.target" ];
+      restartIfChanged = false;
+      unitConfig.X-StopOnRemoval = false;
+      serviceConfig = {
+        ProtectHome = true;
+        ProtectSystem = true;
+        User = "root";
+        Type = "oneshot";
+      };
+
+      script = ''
+        ${pkgs.fc.agent}/bin/fc-monitor --enc ${config.flyingcircus.encPath} configure-checks
+      '';
+    };
+
+  };
+
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -62,6 +62,7 @@ in {
   redis = callTest ./redis.nix {};
   rg-relay = callTest ./statshost/rg-relay.nix {};
   sensu = callTest ./sensu.nix {};
+  servicecheck = callTest ./servicecheck.nix {};
   statshost-global = callTest ./statshost/statshost-global.nix {};
   statshost-master = callTest ./statshost/statshost-master.nix {};
   sudo = callTest ./sudo.nix {};

--- a/tests/servicecheck.nix
+++ b/tests/servicecheck.nix
@@ -1,0 +1,26 @@
+import ./make-test-python.nix ({ pkgs, lib, ... }:
+{
+  name = "servicecheck";
+
+  machine = {
+    imports = [ ../nixos ../nixos/roles ];
+
+    environment.etc."nixos/enc.json".text = ''
+      {"parameters": {"directory_password": "test"}}
+    '';
+
+    flyingcircus.roles.servicecheck.enable = true;
+    networking.extraHosts = ''
+      127.0.0.1 directory.fcio.net
+    '';
+
+  };
+
+  testScript = ''
+    start_all()
+    with subtest("script should try to connect to directory"):
+        machine.execute("nc -l 443 -N > /tmp/out &")
+        machine.systemctl("start fc-servicecheck")
+        machine.succeed("test -s /tmp/out")
+  '';
+})


### PR DESCRIPTION
 #PL-129509

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - script is the same as on 15.09
  - script should connect to directory via HTTPS
- [x] Security requirements tested? (EVIDENCE)
  - manual check on test VM if script is invoked before fc-agent
  - automated test checks that script connects via HTTPS
