### PR TITLE
Nginx: ensure correct logfile permissions, logrotate fixes

### DIFF
--- a/nixos/services/logrotate/default.nix
+++ b/nixos/services/logrotate/default.nix
@@ -64,6 +64,13 @@ in
         "logrotate.options".text = globalOptions;
       };
 
+      environment.systemPackages = with pkgs; [
+        logrotate
+        (pkgs.writeScriptBin "logrotate-config-file" ''
+          grep exec $(systemctl cat logrotate | grep ExecStart= | cut -f 2 -d=) | cut -f 3 -d" "
+        '')
+      ];
+
       services.logrotate = {
         enable = true;
         extraConfig = mkOrder 50 globalOptions;


### PR DESCRIPTION
We always want the logfiles to be writable by root or restarts
will fail. The master process runs as root but due to restrictions
enforced by SystemD it can only open its own files for writing.
Nginx creates and/or chowns logfiles when:

* reopening log files after logrotate (SIGUSR1)
* checking the config
* startup
* reload

The results vary. Some variations don't break things
but we force root:nginx everywhere now for consistency.

The automated test covers multiple situations I could think of.
Let's hope that this is enough for now...
Not running Nginx as root should make things easier but that
would need some more work.

Logrotate now uses the correct permissions and uses reload instead of
restart if log file reopening failed to avoid restarts that may fail and
leave us without a running Nginx.

The maximum age for log files now uses the rotateLogs setting so
tmpfiles doesn't delete log files that should still be kept around.
The fixed value of 10 meant that rotateLogs > 10 (days) had no
effect.

Also adds logrotate to the system packages and adds a command
logrotate-config-file to show the location of the config file which
makes debugging logrotate config easier and is needed for the test.

 #PL-129618

@flyingcircusio/release-managers

## Release process

Impact:

* [NixOS 20.09]: Nginx will be restarted.

Changelog:

* Nginx: ensure correct permissions for log files. We encountered some situations where startup failed because Nginx couldn't open the log files (#PL-129618).
* Nginx: fix log retention time (for non-standard cases). Log files were always deleted after 10 days even if the rotateLogs setting (default 7 days) was set to a higher value (#PL-129618).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - logfiles should be writable by root (nginx master runs as root) 
- [x] Security requirements tested? (EVIDENCE)
  - automated test checks logfile permissions
