### PR TITLE
Jitsi: update all packages to latest stable versions

### DIFF
--- a/nixos/roles/jitsi/default.nix
+++ b/nixos/roles/jitsi/default.nix
@@ -33,21 +33,21 @@ in {
             '';
 
             listenAddress = mkOption {
-              type = with types; string;
+              type = types.str;
               description = ''
                 Specify here which IPv4 address to use for coturn.";
               '';
             };
 
             listenAddress6 = mkOption {
-              type = with types; string;
+              type = types.str;
               description = ''
                 Specify here which IPv6 address to use for coturn.";
               '';
             };
 
             hostName = mkOption {
-              type = types.string;
+              type = types.str;
             };
           };
         };
@@ -92,25 +92,25 @@ in {
       };
 
       listenAddress = mkOption {
-        type = with types; string;
+        type = types.str;
         description = ''
           IPv4 address to use for Jitsi.
         '';
       };
 
       listenAddress6 = mkOption {
-        type = with types; string;
+        type = types.str;
         description = ''
           IPv6 address to use for Jitsi.
         '';
       };
 
       hostName = mkOption {
-        type = types.string;
+        type = types.str;
       };
 
       turnHostName = mkOption {
-        type = with types; nullOr string;
+        type = with types; nullOr str;
         default = null;
         description = ''
           Only needed for an external TURN server.
@@ -123,7 +123,7 @@ in {
       };
 
       defaultLanguage = mkOption {
-        type = types.string;
+        type = types.str;
         default = "de";
       };
 

--- a/pkgs/jicofo/default.nix
+++ b/pkgs/jicofo/default.nix
@@ -2,10 +2,10 @@
 
 let
   pname = "jicofo";
-  version = "1.0-675";
+  version = "1.0-690";
   src = fetchurl {
     url = "https://download.jitsi.org/testing/${pname}_${version}-1_all.deb";
-    sha256 = "0mq244xbj9jkxsqq50x2djs17r1q2jfld6bf6hv6x915ry6byfi7";
+    sha256 = "1w5nz2p6scd7w0ac93vhxlk5i8in5160c0icwl27m4x4km9xf6al";
   };
 in
 stdenv.mkDerivation {

--- a/pkgs/jitsi-meet/default.nix
+++ b/pkgs/jitsi-meet/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "jitsi-meet";
-  version = "1.0.4605";
+  version = "1.0.4628";
 
   src = fetchurl {
     url = "https://download.jitsi.org/jitsi-meet/src/jitsi-meet-${version}.tar.bz2";
-    sha256 = "1kg68q281nj022m6kgllz3xh0123m6jz0asfnw1fq5lx2cdxrkbs";
+    sha256 = "1kw4byy6mvqk3qd5nk5raka1bl9jp0kniszq6j5kc8nz3jql4qdz";
   };
 
   dontBuild = true;

--- a/pkgs/jitsi-videobridge/default.nix
+++ b/pkgs/jitsi-videobridge/default.nix
@@ -2,11 +2,10 @@
 
 let
   pname = "jitsi-videobridge2";
-  version = "2.1-406-g812da0a8";
-
+  version = "2.1-416-g2f43d1b4";
   src = fetchurl {
     url = "https://download.jitsi.org/testing/${pname}_${version}-1_all.deb";
-    sha256 = "029gk1rncszk33dqbixwhw1vis1b3iy48xjag5ykdy3r6ypqpazg";
+    sha256 = "0s9wmbba1nlpxaawzmaqg92882y5sfs2ws64w5sqvpi7n77hy54m";
   };
 in
 stdenv.mkDerivation {


### PR DESCRIPTION
Also fixes deprecated usages of the string type in options.

 #PL-129607

@flyingcircusio/release-managers

## Release process

Impact:

* [NixOS 20.09] Jitsi Videobridge will be restarted which will interrupt conferences for a short time.

Changelog:

* Jitsi: update components to the latest stable versions (#PL-129607).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - nothing new 
- [x] Security requirements tested? (EVIDENCE)
  - checked commit logs of videobridge, jitsi-meet and jicofo
  - checked functionality on test VM
