### PR TITLE
Update nixpkgs

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -2,7 +2,7 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "984c872d5ca6e521803a4cd9ba72d45c4c3640a6",
-    "sha256": "1zqac91ls48pvf91ar2fkbl9542v56q2y5fszh69fhx14lhlmiyy"
+    "rev": "f0abbebcba43f4806c63385c98a09afb4a3dc64f",
+    "sha256": "1j82k9y00g5kzlc7ad5qcry0m6nml880smgwscbzf7inzgmkdd5k"
   }
 }


### PR DESCRIPTION
Notable changes:

* Linux 5.4.93
* sudo 1.9.5p2 (fixes CVE-2021-3156)
* imagemagick7 7.0.10-4 (fixes CVE-2020-29599, CVE-2020-27560)

 #PL-129624

@flyingcircusio/release-managers

## Release process

Impact:

* [NixOS 20.09] VMs will be rebooted for a kernel update.

Changelog:

* Merge upstream NixOS changes. Includes security fixes for sudo and imagemagick.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - merge nixpkgs changes every two weeks
- [x] Security requirements tested? (EVIDENCE)
  - ran tested job on hydra, manually tested on test VM
  - checked upstream commit log
