### PR TITLE
Statshost: use TLS for connections to location proxies

### DIFF
--- a/nixos/roles/statshost/default.nix
+++ b/nixos/roles/statshost/default.nix
@@ -53,7 +53,8 @@ let
 
   relayLocationNodes = map
     (proxy: { job_name = proxy.location;
-              proxy_url = "http://${proxy.address}:9090"; })
+              proxy_url = "https://${proxy.address}:9443";
+            } // cfgStats.prometheusLocationProxyExtraSettings)
     relayLocationProxies;
 
   relayLocationProxies =
@@ -158,6 +159,18 @@ in
         type = types.listOf types.attrs;
         default = [];
         description = "Prometheus metric relabel configuration.";
+      };
+
+      prometheusLocationProxyExtraSettings = mkOption {
+        type = types.attrs;
+        description = "Additional settings for jobs fetching from location proxies.";
+        example = ''
+        {
+          tls_config = {
+            ca_file = "/srv/prometheus/proxy_cert.pem";
+          };
+        }
+        '';
       };
 
       dashboardsRepository = mkOption {


### PR DESCRIPTION
 #PL-129612

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Statshost: use TLS for fetching metrics via location proxies (#PL-129612).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - transport security: use HTTPS for communication between locations  
- [x] Security requirements tested? (EVIDENCE)
  - automated test checks fetching metrics via HTTPS
