### PR TITLE
Add Python3 to sensu-environment

### DIFF
--- a/nixos/services/sensu/client.nix
+++ b/nixos/services/sensu/client.nix
@@ -293,6 +293,7 @@ in {
       nix
       openssl
       procps
+      python3
       sensu
       sysstat
     ];


### PR DESCRIPTION
This PR adds a basic Python3 to environment of sensu client to run easy Python-based checks without adding wrapper scripts.

bugs id: #PL-129656

@flyingcircusio/release-managers

## Release process

Impact:
* Sensu-client will be restarted

Changelog:
* Adding Python3 to sensu environment 

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - /usr/bin/env python3 inside a sensu-check withouta wrapper script should return a Python3

- [x] Security requirements tested? (EVIDENCE)

