### PR TITLE
Allow symlinks in local config dirs for nginx, haproxy and systemd

### DIFF
--- a/nixos/lib/files.nix
+++ b/nixos/lib/files.nix
@@ -8,16 +8,16 @@ with lib;
 
 rec {
 
-  # Get all regular files with their name relative to path
+  # Get all regular files and symlinks with their name relative to path
   filesRel = path:
     optionals
       (pathExists path)
       (attrNames
         (filterAttrs
-          (filename: type: (type == "regular"))
+          (filename: type: (type == "regular" || type == "symlink"))
           (builtins.readDir path)));
 
-  # Get all regular files with their absolute name
+  # Get all regular files and symlinks with their absolute name
   files = path:
     (map
       (filename: path + ("/" + filename))


### PR DESCRIPTION
fclib.filesRel filtered out symlinks before. It should be safe to allow
it.

 #PL-129628

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Include symlinked files in local config directories for Nginx, HAproy and SystemD units. They were silently ignored before (#PL-129628).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - We want to avoid situations were config files are ignored silently which the user expects to be used.
- [x] Security requirements tested? (EVIDENCE)
  - Manually checked on test VM that symlinked config is included now for nginx, haproxy and systemd.
