### PR TITLE
HAProxy: fix 19.03 upgrade problems

### DIFF
--- a/nixos/services/haproxy.nix
+++ b/nixos/services/haproxy.nix
@@ -10,7 +10,25 @@ let
 
   configFiles = filter (p: lib.hasSuffix ".cfg" p) (fclib.files /etc/local/haproxy);
 
-  haproxyCfgContent = concatStringsSep "\n" (map readFile configFiles);
+  # This was included in our old example config. Breaks on 20.09 because HAProxy
+  # isn't allowed to write to /run/ anymore and is unneeded because a stats socket
+  # is added by the NixOS module automatically.
+  oldStatsLine = "stats socket /run/haproxy_admin.sock mode 660 group nogroup level operator";
+
+  importedCfgContent = concatStringsSep "\n" (map readFile configFiles);
+  modifiedCfgContent =
+    replaceStrings
+      [ oldStatsLine ]
+      [ ("# XXX: you can remove this after upgrading to 20.09: " + oldStatsLine) ]
+      importedCfgContent;
+
+  haproxyCfgContent =
+    if importedCfgContent != modifiedCfgContent
+    then lib.info
+      ("HAProxy: you can remove the 'stats socket' line from your config."
+      + " It's ignored on NixOS 20.09.")
+      modifiedCfgContent
+    else importedCfgContent;
 
   example = ''
     # haproxy configuration example - copy to haproxy.cfg and adapt.
@@ -65,14 +83,12 @@ in
           in alphabetical order and used as `haproxy.cfg`.
         '';
         "local/haproxy/haproxy.cfg.example".text = example;
-
-        "current-config/haproxy.cfg".source = haproxyCfg;
       };
 
       environment.systemPackages = [
         (pkgs.writeScriptBin
           "haproxy-show-config"
-          "cat /etc/current-config/haproxy.cfg")
+          "cat /etc/haproxy.cfg")
       ];
 
       flyingcircus.services = {
@@ -116,6 +132,22 @@ in
 
       flyingcircus.services.sensu-client.checkEnvPackages = [
         pkgs.fc.check-haproxy
+      ];
+
+      # Upstream reload code hangs for a long time when the socket is missing.
+      systemd.services.haproxy.serviceConfig.ExecReload = lib.mkOverride 90 [
+        (pkgs.writeScript "haproxy-reload" ''
+          #!${pkgs.runtimeShell} -e
+
+          if [[ -S /run/haproxy/haproxy.sock ]]; then
+            ${pkgs.haproxy}/sbin/haproxy -c -f /etc/haproxy.cfg
+            ${pkgs.coreutils}/bin/ln -sf ${pkgs.haproxy}/sbin/haproxy /run/haproxy/haproxy
+            ${pkgs.coreutils}/bin/kill -USR2 $MAINPID
+          else
+            echo Socket not present which is needed for reloading, restarting instead...
+            ${pkgs.coreutils}/bin/kill $MAINPID
+          fi
+        '')
       ];
 
       systemd.services.prometheus-haproxy-exporter = {

--- a/tests/haproxy.nix
+++ b/tests/haproxy.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ... }:
+import ./make-test-python.nix ({ pkgs, ... }:
 {
   name = "haproxy";
   nodes = {
@@ -31,29 +31,36 @@ import ./make-test.nix ({ pkgs, ... }:
       };
   };
   testScript = ''
-    $machine->waitForUnit("haproxy.service");
-    $machine->waitForUnit("syslog.service");
+    machine.wait_for_unit("haproxy.service")
+    machine.wait_for_unit("syslog.service")
 
-    $machine->execute(<<__SETUP__);
-    echo 'Hello World!' > hello.txt
-    ${pkgs.python3.interpreter} -m http.server 7000 &
-    __SETUP__
+    machine.execute("""
+      echo 'Hello World!' > hello.txt
+      ${pkgs.python3.interpreter} -m http.server 7000 &
+    """)
 
-    subtest "request through haproxy should succeed", sub {
-      $machine->succeed("curl -s http://localhost:8888/hello.txt | grep -q 'Hello World!'");
-    };
+    with subtest("request through haproxy should succeed"):
+      machine.succeed("curl -s http://localhost:8888/hello.txt | grep -q 'Hello World!'")
 
-    subtest "log file entry should be present for request", sub {
-      $machine->sleep(0.5);
-      $machine->succeed('grep "haproxy.* http-in server/python .* /hello.txt" /var/log/haproxy.log');
-    };
+    with subtest("log file entry should be present for request"):
+      machine.sleep(1)
+      machine.succeed('grep "haproxy.* http-in server/python .* /hello.txt" /var/log/haproxy.log')
 
-    subtest "service user should be able to write to local config dir", sub {
-      $machine->succeed('sudo -u haproxy touch /etc/local/haproxy/haproxy.cfg');
-    };
+    with subtest("service user should be able to write to local config dir"):
+      machine.succeed('sudo -u haproxy touch /etc/local/haproxy/haproxy.cfg')
 
-    subtest "haproxy check script should be green", sub {
-      $machine->succeed("${pkgs.fc.check-haproxy}/bin/check_haproxy /var/log/haproxy.log");
-    };
+    with subtest("reload should work"):
+      machine.succeed("systemctl reload haproxy")
+      machine.wait_until_succeeds('journalctl -u haproxy -g "Reloaded HAProxy"')
+
+    with subtest("reload should trigger a restart if /run/haproxy is missing"):
+      machine.execute("rm -rf /run/haproxy")
+      machine.succeed("systemctl reload haproxy")
+      machine.wait_until_succeeds("stat /run/haproxy/haproxy.sock 2> /dev/null")
+      machine.wait_until_succeeds('journalctl -u haproxy -g "Socket not present which is needed for reloading, restarting instead"')
+
+    with subtest("haproxy check script should be green"):
+      machine.succeed("${pkgs.fc.check-haproxy}/bin/check_haproxy /var/log/haproxy.log")
   '';
+
 })


### PR DESCRIPTION
Disable the stats socket line from the 19.03 example config
if it's still present in local config. It breaks the service now.

We need to trigger a restart if the haproxy socket at the new
location is missing. This is the case when upgrading from 19.03
or when something accidentally deleted the socket.

Test ported to Python and extended to check reloading.

 #PL-129632

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* HAProxy: fix problems when upgrading from the 19.03 platform that needed manual intervention. The "stats socket" line from the old example config is now obsolete and disabled if it still appears in user config. It can be removed after the upgrade. (#PL-129632).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - we want haproxy to run with the current binary version and config 
  - we need metrics from haproxy to analyze problems  
- [x] Security requirements tested? (EVIDENCE)
  - manually checked if upgrade from 19.03 works without intervention: uses the new binary and config, metrics work
  - automated test checks if reload works
