### PR TITLE
Update nixpkgs for gitlab 13.6.6

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -2,7 +2,7 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "f0abbebcba43f4806c63385c98a09afb4a3dc64f",
-    "sha256": "1j82k9y00g5kzlc7ad5qcry0m6nml880smgwscbzf7inzgmkdd5k"
+    "rev": "440179063438596f09cabf5d4c78265ab143391a",
+    "sha256": "09pxav8q69rfx53zlfx5dhikh0fh9hxaqlmv0vvz1q2vzq6csjrs"
   }
 }


### PR DESCRIPTION
 #PL-129665

@flyingcircusio/release-managers

## Release process

Impact:

[NixOS 20.09]: Gitlab will be restarted and unavailable for some minutes.

Changelog:

* Gitlab: update to 13.6.6 security release (#PL-129665).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - use a current Gitlab version with the latest security fixes
- [x] Security requirements tested? (EVIDENCE)
  - 13.6.6 is the current patch release
  - manually tested on staging Gitlab instance 