### PR TITLE
Make release channel usable for direct imports

### DIFF
--- a/release/default.nix
+++ b/release/default.nix
@@ -301,6 +301,9 @@ jobs // {
     installPhase = ''
       mkdir -p $out/{tarballs,nix-support}
       cd nixos
+      # default.nix is needed when the channel is imported directly, for example
+      # from a fetchTarball.
+      echo "{ ... }: import ./fc { nixpkgs = ./nixpkgs; }" > default.nix
       tar cJhf $out/tarballs/nixexprs.tar.xz ${tarOpts} .
 
       echo "channel - $out/tarballs/nixexprs.tar.xz" > "$out/nix-support/hydra-build-products"


### PR DESCRIPTION
We want a channel that adds packages from our overlay and can be used with
import fetchTarball from a pinned version.
That is recommended in our docs for user package management with
buildEnv but it only worked with upstream channels.

 #PL-129619

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Make our release channel usable for importing from a pinned version. This is recommended in our docs but only worked for upstream NixOS channels before. Now, packages from our overlay can be installed in custom user environments in combination with channel pinning (#PL-129619).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Users should be able to use a pinned NixOS channel that is under our control and tested by us. Our overlay may contain package overrides that are relevant for security that are not present in upstream NixOS.
- [x] Security requirements tested? (EVIDENCE)
  - checked manually if import fetchTarball works and packages from our overlay are present

