### PR TITLE
Update nixpkgs: gitlab update and upstream changes

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -2,7 +2,7 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "440179063438596f09cabf5d4c78265ab143391a",
-    "sha256": "09pxav8q69rfx53zlfx5dhikh0fh9hxaqlmv0vvz1q2vzq6csjrs"
+    "rev": "c2613c908629490eb65e04901006d982781f6f5f",
+    "sha256": "1yji21lfvclkbdzashb5m742a2604gn5npbbb4469g78d6srv975"
   }
 }


### PR DESCRIPTION
Notable changes:

* cifs-utils: security fix (CVE-2020-14342)
* gitlab: 13.6.6 -> 13.6.7
* glibc: 2.31 -> 2.31-74 (CVE-2019-25013)
* grafana: 7.3.7 -> 7.4.1
* graphicsmagick: 1.3.35 -> 1.3.36 (CVE-2020-12672)
* linux: 5.4.93 -> 5.4.97
* nodejs-10_x: 10.22.1 -> 10.23.1
* nodejs-12_x: 12.18.4 -> 12.20.1
* nodejs-14_x: 14.9.0 -> 14.15.4
* openjpeg: 2.3.1 -> 2.4.0 (CVE-2020-15389, CVE-2020-27841, CVE-2020-27842, CVE-2020-27843,
  CVE-2020-27844, and CVE-2020-27845)
* php: 7.3.26 -> 7.3.27 (CVE-2021-21702)
* php: 7.4.14 -> 7.4.15 (CVE-2021-21702)
* varnish: 6.3.1 -> 6.3.2 (CVE-2020-11653)

 #PL-129680

@flyingcircusio/release-managers

## Release process

Impact:

* [NixOS 20.09] Gitlab will be restarted and unavailable for some minutes
* [NixOS 20.09] Most services will be restarted due to a glibc change
* [NixOS 20.09] VMs will schedule a reboot to activate the changed kernel

Changelog:

* Merge upstream NixOS changes. Includes security fixes for PHP 7.3 and 7.4, openjpeg (CVE-2020-15389, CVE-2020-27841, CVE-2020-27842, CVE-2020-27843,
  CVE-2020-27844, and CVE-2020-27845), varnish (CVE-2020-11653), graphicsmagick (CVE-2020-12672), cifs-utils (CVE-2020-14342) and glibc (CVE-2019-25013). (#PL-129680).
* Gitlab: update to 13.6.7 security release (#PL-129680).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - use a recent nixpkgs version with security fixes from upstream  
  - use a recent gitlab version with the latest security patches
  - document which CVEs are fixed by a nixpkgs update
- [x] Security requirements tested? (EVIDENCE)
  - ran automated tests
  - checked gitlab manually on staging VM
  - checked upstream changes for fixed CVEs
