### PR TITLE
Fix nix-env -iA nixos.*, remove channel hack, test

### DIFF
--- a/nixos/platform/shell.nix
+++ b/nixos/platform/shell.nix
@@ -36,19 +36,17 @@ in
       fi
       unset f
 
-      # Make our overlayed nixpkgs (in fc) available as nixos.* for nix-env for
-      # normal users. This is same the behaviour as on standard NixOS and our
-      # old 15.09 plattform.
-
       if [[ "$USER" != root ]]; then
-        if [[ -e $HOME/.nix-defexpr/channels_root ]]; then
-          rm $HOME/.nix-defexpr/channels_root
+
+        # We don't need that hack anymore because our combined channel works
+        # as expected by Nix tools now.
+        if [[ -e $HOME/.nix-defexpr/nixos ]]; then
+          rm $HOME/.nix-defexpr/nixos
         fi
 
-        if [[ ! -d $HOME/.nix-defexpr ]]; then
-          mkdir -p $HOME/.nix-defexpr
-          ln -sfT /nix/var/nix/profiles/per-user/root/channels/nixos/fc \
-            $HOME/.nix-defexpr/nixos
+        # Delete empty dir, nix-env will recreate it with the correct channel links
+        if [[ ! "$(ls -A $HOME/.nix-defexpr)" ]]; then
+          rmdir $HOME/.nix-defexpr 2> /dev/null || true
         fi
       fi
     '' +

--- a/release/default.nix
+++ b/release/default.nix
@@ -72,6 +72,9 @@ let
         echo -n ${fc.rev} > $out/nixos/.git-revision
         echo -n ${version} > $out/nixos/.version
         echo -n ${versionSuffix} > $out/nixos/.version-suffix
+        # default.nix is needed when the channel is imported directly, for example
+        # from a fetchTarball.
+        echo "{ ... }: import ./fc { nixpkgs = ./nixpkgs; }" > $out/nixos/default.nix
       ''];
       preferLocalBuild = true;
     };
@@ -289,6 +292,9 @@ jobs // {
     src = combinedSources;
     constituents = [ src tested ];
     preferLocalBuild = true;
+
+    passthru.src = combinedSources;
+
     patchPhase = "touch .update-on-nixos-rebuild";
 
     XZ_OPT = "-1";
@@ -301,9 +307,6 @@ jobs // {
     installPhase = ''
       mkdir -p $out/{tarballs,nix-support}
       cd nixos
-      # default.nix is needed when the channel is imported directly, for example
-      # from a fetchTarball.
-      echo "{ ... }: import ./fc { nixpkgs = ./nixpkgs; }" > default.nix
       tar cJhf $out/tarballs/nixexprs.tar.xz ${tarOpts} .
 
       echo "channel - $out/tarballs/nixexprs.tar.xz" > "$out/nix-support/hydra-build-products"

--- a/tests/channel.nix
+++ b/tests/channel.nix
@@ -1,0 +1,59 @@
+# Does our custom combined channel work as expected?
+# Inspired by the installer.nix test from upstream.
+with builtins;
+
+import ./make-test-python.nix ({ pkgs, lib, ... }:
+let
+  release = import ../release {};
+  channel = release.release.src;
+
+in {
+  name = "channel";
+
+  machine = {
+    imports = [ ../nixos ];
+
+    environment.systemPackages = with pkgs; [
+    ];
+
+    environment.etc."nixpkgs-paths-debug".text = toJSON {
+      pkgs = "${pkgs.path}";
+      releaseChannelSrc = "${channel}";
+      nixpkgs = "${<nixpkgs>}";
+    };
+
+    users.users.alice = {
+      isNormalUser = true;
+      home = "/home/alice";
+    };
+  };
+
+  testScript = ''
+    print(machine.succeed("cat /etc/nixpkgs-paths-debug | ${pkgs.jq}/bin/jq"))
+    machine.execute("ln -s ${channel} /nix/var/nix/profiles/per-user/root/channels")
+
+    with subtest("Root should be able to nix-env install from nixpkgs"):
+      machine.succeed("nix-env -iA nixos.procps")
+
+    with subtest("Root should be able to nix-env install from fc"):
+      machine.succeed("nix-env -iA nixos.fc.logcheckhelper")
+
+    with subtest("Non-root should be able to nix-env install from nixpkgs"):
+      machine.succeed("su alice -l -c 'nix-env -iA nixos.procps'")
+
+    with subtest("Non-root should be able to nix-env install from fc"):
+      machine.succeed("su alice -l -c 'nix-env -iA nixos.fc.logcheckhelper'")
+
+    with subtest("login/nix-env -i should remove the 19.03 channel hack"):
+      # This is the situation after an upgrade from 19.03 to this version.
+      machine.execute("rm -f /home/alice/.nix-defexpr/*")
+      machine.execute("ln -s /var/empty /home/alice/.nix-defexpr/nixos")
+      machine.succeed("su alice -l -c 'nix-env -iA nixos.procps'")
+
+    with subtest("login/nix-env -i should fix an empty .nix-defexpr"):
+      # This is the situation after an upgrade from 19.03 to a version with the
+      # bug introduced by commit e118d06114be2d7d6414428db2d3b5608fe64bb5
+      machine.execute("rm -f /home/alice/.nix-defexpr/*")
+      machine.succeed("su alice -l -c 'nix-env -iA nixos.procps'")
+  '';
+})

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -21,6 +21,7 @@ let
 
 in {
   antivirus = callTest ./antivirus.nix {};
+  channel = callTest ./channel.nix {};
   coturn = callTest ./coturn.nix {};
   docker = callTest (nixpkgs + /nixos/tests/docker.nix) {};
   elasticsearch6 = callTest ./elasticsearch.nix { version = "6"; };


### PR DESCRIPTION
Commit e118d06114be2d7d6414428db2d3b5608fe64bb5 introduced a bug
which left an empty .nix-defexpr behind after an platform upgrade
so nix-env couldn't find the nixos channel anymore.

New VMs were not affected.

This also removes the old channel hack which is obsolete since commit
268b9c6fad626cc8db29f5e2984eecd29d457430. Works like on standard NixOS
now.

 #PL-129677

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Fix user package installation (`nix-env -iA nixos.package`) on VMs that were upgraded from an older platform version (#PL-129677).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - no security implications here, we just want a working nix-env in all cases. 
- [x] Security requirements tested? (EVIDENCE)
  - automated test checks known cases for failing nix-env, manually checked on test VM
