### PR TITLE
Roundcube: fix sending mails

### DIFF
--- a/nixos/services/mail/roundcube.nix
+++ b/nixos/services/mail/roundcube.nix
@@ -25,6 +25,10 @@ in lib.mkMerge [
         $config['password_confirm_current'] = true;
         $config['password_driver'] = 'chpasswd';
         $config['password_minimum_length'] = 10;
+        $config['smtp_server'] = 'tls://${role.mailHost}';
+        $config['smtp_user'] = '%u';
+        $config['smtp_pass'] = '%p';
+
       '';
       database = {
         username = "roundcube";


### PR DESCRIPTION
SMTP auth config was missing.

 #PL-129588

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Mailserver: fix sending mails from Roundcube web interface (#PL-129588).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - SMTP connection from roundcube to postfix should be secured by STARTTLS
- [x] Security requirements tested? (EVIDENCE)
  - checked manually on test mail server if sending works as expected