### PR TITLE
Add feFQDN to our lib and use it as default for statshost

### DIFF
--- a/nixos/lib/network.nix
+++ b/nixos/lib/network.nix
@@ -25,6 +25,17 @@ rec {
   # choose correct "ip" invocation depending on the address
   ip' = a: "ip " + (if isIp4 a then "-4" else if isIp6 a then "-6" else "");
 
+  feFQDN =
+    let
+      inherit (config.networking) domain hostName;
+      location =
+        lib.attrByPath
+          [ "parameters" "location" ]
+          "standalone"
+          config.flyingcircus.enc;
+    in
+      "${hostName}.fe.${location}.${domain}";
+
   # list IP addresses for service configuration (e.g. nginx)
   listenAddresses = iface:
     if iface == "lo"

--- a/nixos/roles/coturn.nix
+++ b/nixos/roles/coturn.nix
@@ -16,8 +16,6 @@ let
     cat $(systemctl cat coturn.service | grep "ExecStart" | cut -d" " -f3)
   '';
 
-  domain = config.networking.domain;
-  location = lib.attrByPath [ "parameters" "location" ] "standalone" config.flyingcircus.enc;
   cfg = config.flyingcircus.roles.coturn;
 
   ourSettings = [
@@ -53,7 +51,12 @@ in
 
       hostName = mkOption {
         type = types.str;
-        default = "${config.networking.hostName}.fe.${location}.${domain}";
+        default = fclib.feFQDN;
+        description = ''
+          Public host name for the TURN server.
+          A Letsencrypt certificate is generated for it.
+          Defaults to the FE FQDN.
+        '';
       };
 
     };

--- a/nixos/roles/external_net/default.nix
+++ b/nixos/roles/external_net/default.nix
@@ -18,14 +18,10 @@ let
 
   # pick a suitable DNS name for client config
   domain = config.networking.domain;
-  location = lib.attrByPath [ "parameters" "location" ] "standalone" cfg.enc;
   defaultFrontendName =
     if feReverses != {}
     then fclib.normalizeDomain domain (head (attrValues feReverses))
-    else
-      if location != null
-      then "${config.networking.hostName}.fe.${location}.${domain}"
-      else "localhost";
+    else fclib.feFQDN;
 
 in
 {

--- a/nixos/roles/gitlab.nix
+++ b/nixos/roles/gitlab.nix
@@ -5,9 +5,6 @@ with builtins;
 let
   cfg = config.flyingcircus.roles.gitlab;
   fclib = config.fclib;
-  domain = config.networking.domain;
-  location = lib.attrByPath [ "parameters" "location" ] "standalone" config.flyingcircus.enc;
-  feFQDN = "${config.networking.hostName}.fe.${location}.${domain}";
 in
 
 {
@@ -27,8 +24,12 @@ in
 
       hostName = mkOption {
         type = types.str;
-        description = "HTTP virtual host for the Gitlab frontend.";
-        default = feFQDN;
+        description = ''
+          Public host name for the Gitlab frontend.
+          A Letsencrypt certificate is generated for it.
+          Defaults to the FE FQDN.
+        '';
+        default = fclib.feFQDN;
         example = "gitlab.test.fcio.net";
       };
 

--- a/nixos/roles/kubernetes/master.nix
+++ b/nixos/roles/kubernetes/master.nix
@@ -14,9 +14,7 @@ let
   kublib = config.services.kubernetes.lib;
   master = fclib.findOneService "kubernetes-master-master";
 
-  domain = config.networking.domain;
   location = lib.attrByPath [ "parameters" "location" ] "standalone" config.flyingcircus.enc;
-  feFQDN = "${config.networking.hostName}.fe.${location}.${domain}";
   srvFQDN = "${config.networking.hostName}.fcio.net";
 
 
@@ -27,7 +25,7 @@ let
   # dashboards and kubectl. Names can be used for both dashboard and API server.
   addresses = [
     "kubernetes.${fclib.currentRG}.fcio.net"
-    feFQDN
+    fclib.feFQDN
     srvFQDN
   ];
 

--- a/nixos/roles/statshost/default.nix
+++ b/nixos/roles/statshost/default.nix
@@ -144,8 +144,14 @@ in
     flyingcircus.roles.statshost = {
 
       hostName = mkOption {
+        default = fclib.feFQDN;
         type = types.str;
-        description = "HTTP virtual host for the frontend. Must be set.";
+        description = ''
+          Host name for the Grafana frontend.
+          A Letsencrypt certificate is generated for it.
+          Defaults to the FE FQDN.
+          Also used by collectdproxy if it's the global FCIO statshost.
+        '';
         example = "stats.example.com";
       };
 

--- a/nixos/roles/statshost/location-proxy.nix
+++ b/nixos/roles/statshost/location-proxy.nix
@@ -5,9 +5,6 @@ with lib;
 let
   fclib = config.fclib;
   statshostServiceIPs = fclib.listServiceIPs "statshost-collector";
-  domain = config.networking.domain;
-  location = lib.attrByPath [ "parameters" "location" ] "standalone" config.flyingcircus.enc;
-  feFQDN = "${config.networking.hostName}.fe.${location}.${domain}";
   httpPort = 9090;
   httpsPort = 9443;
 in
@@ -30,7 +27,7 @@ in
       recommendedOptimisation = true;
       recommendedProxySettings = true;
       recommendedTlsSettings = true;
-      virtualHosts."${feFQDN}" = {
+      virtualHosts."${fclib.feFQDN}" = {
         serverAliases = [ "${config.networking.hostName}.${config.networking.domain}" ];
         enableACME = true;
         addSSL = true;


### PR DESCRIPTION
Various roles use the same code to determine the frontend FQDN.
Moved it to our lib.

For statshost, there was no default so the role failed to build when
activating it without custom config. Roles shouldn't break without
custom config in general.

 #PL-129540

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Statshost roles now use the frontend FQDN as default host name and can now be enabled without local config. Roles shouldn't break without custom config in general (#PL-129540).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - no security implications here, we just want to provide sane defaults
- [x] Security requirements tested? (EVIDENCE)
  - checked on a test VM, automated tests still run. They don't explicitly check the default values but ensure that nothing is horribly broken.
