### PR TITLE
Fix sending local mail via nullmailer

### DIFF
--- a/nixos/services/nullmailer.nix
+++ b/nixos/services/nullmailer.nix
@@ -14,8 +14,6 @@ let
     in
       if services == [] then null else head services;
 
-  mailout = mailoutService + (
-    lib.optionalString (net.domain != null) ".${net.domain}");
   fqdn = net.hostName + (
     lib.optionalString (net.domain != null) ".${net.domain}");
 
@@ -30,8 +28,8 @@ in {
       enable = true;
       config = {
         me = fqdn;
-        adminaddr = "root@${mailout}";
-        remotes = "${mailout} smtp port=25";
+        adminaddr = "root@${mailoutService}";
+        remotes = "${mailoutService} smtp port=25";
       };
     };
   };


### PR DESCRIPTION
The SMTP hostname was wrong because the domain was appended to the
service hostname which already is a FQDN (test44.gocept.net, for
example.)

 #PL-129696

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Fix sending mails via nullmailer which is the default on VMs (#PL-129696).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - sending mails should work 
- [x] Security requirements tested? (EVIDENCE)
  - checked generated config on test VM, automated mail test still works
