### PR TITLE
LAMP: don't listen on port 80 by default

### DIFF
--- a/nixos/roles/lamp.nix
+++ b/nixos/roles/lamp.nix
@@ -49,8 +49,8 @@ in {
           ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
           ; Tideways
           ;
-          ; This is intended to be production-ready so it doesn't create too 
-          ; much overhead. If you need to increase tracing, then you can 
+          ; This is intended to be production-ready so it doesn't create too
+          ; much overhead. If you need to increase tracing, then you can
           ; adjust this in your local php.ini
 
           extension=${pkgs.tideways_module}/lib/php/extensions/tideways-php-7.3-zts.so
@@ -144,6 +144,9 @@ in {
       services.httpd.extraModules = [ "rewrite" "version" "status" ];
       services.httpd.enablePHP = true;
       services.httpd.phpPackage = pkgs.php73;
+      # The upstream module has a default that makes Apache listen on port 80
+      # which conflicts with our webgateway role.
+      services.httpd.virtualHosts = {};
 
       flyingcircus.services.sensu-client.checks = {
         httpd_status = {

--- a/tests/lamp.nix
+++ b/tests/lamp.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ ... }:
+import ./make-test-python.nix ({ ... }:
 {
   name = "lamp";
   nodes = {
@@ -24,41 +24,50 @@ import ./make-test.nix ({ ... }:
 
   testScript = { nodes, ... }:
     ''
-    $lamp->waitForUnit("httpd.service");
-    $lamp->waitForOpenPort(8000);
+    def assert_listen(machine, process_name, expected_sockets):
+      result = machine.succeed(f"netstat -tlpn | grep {process_name} | awk '{{ print $4 }}'")
+      actual = set(result.splitlines())
+      assert expected_sockets == actual, f"expected sockets: {expected_sockets}, found: {actual}"
 
-    $lamp->waitForUnit("tideways-daemon.service");
-    $lamp->waitForOpenPort(9135);
+    lamp.wait_for_unit("httpd.service")
+    lamp.wait_for_open_port(8000)
 
-    $lamp->succeed("journalctl -u tideways.daemon");
+    lamp.wait_for_unit("tideways-daemon.service")
+    lamp.wait_for_open_port(9135)
 
-    # see that our changes for config files are there
-    $lamp->succeed("grep 'custom-apache-conf' ${nodes.lamp.config.services.httpd.configFile}");
-    $lamp->succeed("grep 'custom-php-ini' ${nodes.lamp.config.systemd.services.httpd.environment.PHPRC}");
+    lamp.succeed("journalctl -u tideways.daemon")
 
-    $lamp->succeed('mkdir -p /srv/docroot');
-    $lamp->succeed('echo "<? phpinfo(); ?>" > /srv/docroot/test.php');
+    with subtest("apache (httpd) opens expected ports"):
+      assert_listen(lamp, "httpd", {"127.0.0.1:7999", "::1:7999", ":::8000"})
 
-    $lamp->succeed("curl -f -v http://localhost:8000/test.php -o result");
-    $lamp->succeed("grep 'tideways.api_key' result");
-    $lamp->succeed("grep 'files user memcached redis rediscluster' result");
-    $lamp->succeed("grep module_redis result");
-    $lamp->succeed("grep module_imagick result");
-    $lamp->succeed("grep module_memcached result");
-    $lamp->succeed("grep -e 'short_open_tag.*On' result");
-    $lamp->succeed("grep -e 'output_buffering.*>1<' result");
-    $lamp->succeed("grep -e 'curl.cainfo.*/etc/ssl/certs/ca-certificates.crt' result");
-    $lamp->succeed("grep -e 'Path to sendmail.*sendmail -t -i' result");
+    with subtest("our changes for config files should be there"):
+      lamp.succeed("grep 'custom-apache-conf' ${nodes.lamp.config.services.httpd.configFile}")
+      lamp.succeed("grep 'custom-php-ini' ${nodes.lamp.config.systemd.services.httpd.environment.PHPRC}")
 
-    $lamp->succeed("grep -e 'opcache.enable.*On' result");
+    with subtest("check if PHP support is working as expected"):
+      lamp.succeed('mkdir -p /srv/docroot')
+      lamp.succeed('echo "<? phpinfo(); ?>" > /srv/docroot/test.php')
 
-    $lamp->succeed("grep -e 'error_log.*syslog' result");
-    $lamp->succeed("grep -e 'display_errors.*Off' result");
-    $lamp->succeed("grep -e 'log_errors.*On' result");
+      lamp.succeed("curl -f -v http://localhost:8000/test.php -o result")
+      lamp.succeed("grep 'tideways.api_key' result")
+      lamp.succeed("grep 'files user memcached redis rediscluster' result")
+      lamp.succeed("grep module_redis result")
+      lamp.succeed("grep module_imagick result")
+      lamp.succeed("grep module_memcached result")
+      lamp.succeed("grep -e 'short_open_tag.*On' result")
+      lamp.succeed("grep -e 'output_buffering.*>1<' result")
+      lamp.succeed("grep -e 'curl.cainfo.*/etc/ssl/certs/ca-certificates.crt' result")
+      lamp.succeed("grep -e 'Path to sendmail.*sendmail -t -i' result")
 
-    $lamp->succeed("grep -e 'memory_limit.*1024m' result");
-    $lamp->succeed("grep -e 'max_execution_time.*800' result");
-    $lamp->succeed("grep -e 'session.auto_start.*Off' result");
+      lamp.succeed("grep -e 'opcache.enable.*On' result")
+
+      lamp.succeed("grep -e 'error_log.*syslog' result")
+      lamp.succeed("grep -e 'display_errors.*Off' result")
+      lamp.succeed("grep -e 'log_errors.*On' result")
+
+      lamp.succeed("grep -e 'memory_limit.*1024m' result")
+      lamp.succeed("grep -e 'max_execution_time.*800' result")
+      lamp.succeed("grep -e 'session.auto_start.*Off' result")
     '';
 
 })


### PR DESCRIPTION
 #PL-129672

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* LAMP: don't listen on port 80 by default because it conflicts with the webgateway role (#PL-129672).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Apache should not bind to port 80
- [x] Security requirements tested? (EVIDENCE)
  - checked open ports and generated config on a test VM, automated test still runs
