### PR TITLE
Update nixpkgs

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -2,7 +2,7 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "3c5ae423d8afcb608da3bb009b51633a6928e066",
-    "sha256": "0mxnb9p4ymf5f1hp8b52nri9f9d66ampq6xlwvc2mwxaf95l00lk"
+    "rev": "3e2e59332c03371925143b43d4a48cae95ebd699",
+    "sha256": "0630wigw0v33yk7agsl348sdav8slvm7sqlxzq0al7b5kdj5yzgv"
   }
 }


### PR DESCRIPTION
Notable changes:

* gitlab-runner: 13.3.0 -> 13.6.0
* imagemagick7: 7.0.10-46 -> 7.0.10-61 (CVE-2021-20176)
* linux: 5.4.97 -> 5.4.100
* nodejs: 10.23.1 -> 10.24.0, 12.20.1 -> 12.21.0, 14.15.4 -> 14.16.0
  (CVE-2021-22883, CVE-2021-22884, CVE-2021-23840)
* postgresql_10: 10.15 -> 10.16
* postgresql_11: 11.10 -> 11.11 (CVE-2021-3393)
* postgresql_12: 12.5 -> 12.6 (CVE-2021-3393)
* redis: 6.0.10 -> 6.0.11
* screen: apply patch for CVE-2021-26937

@flyingcircusio/release-managers

## Release process

Impact:

* [NixOS 20.09] Many services will be restarted due to a systemd-related change.
* [NixOS 20.09] VM will schedule a reboot to activate the kernel update.

Changelog:

* Merge upstream NixOS changes. Includes security fixes for imagemagick (CVE-2021-20176), nodejs (CVE-2021-22883, CVE-2021-22884, CVE-2021-23840), postgresql (CVE-2021-3393) and screen (CVE-2021-26937).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
   - use a recent nixpkgs version with security fixes from upstream
   - document which CVEs are fixed by a nixpkgs update
- [x] Security requirements tested? (EVIDENCE)
  - ran automated tests, checked on test VM
  -  checked upstream changes for fixed CVEs

