### PR TITLE
Jitsi: improve startup reliability

### DIFF
--- a/nixos/roles/jitsi/default.nix
+++ b/nixos/roles/jitsi/default.nix
@@ -410,8 +410,11 @@ in {
           };
       };
 
-      systemd.services.jicofo.stopIfChanged = false;
-      systemd.services.jitsi-videobridge2.stopIfChanged = false;
+      systemd.services.jicofo = {
+        after = [ "prosody.service" ];
+        stopIfChanged = false;
+      };
+
     })
 
     (lib.mkIf (cfg.enable && cfg.coturn.enable) {

--- a/nixos/services/jitsi/jitsi-videobridge.nix
+++ b/nixos/services/jitsi/jitsi-videobridge.nix
@@ -213,6 +213,8 @@ in
 
       environment.JAVA_SYS_PROPS = attrsToArgs jvbProps;
 
+      stopIfChanged = false;
+
       script = (concatStrings (mapAttrsToList (name: xmppConfig:
         "export ${toVarName name}=$(cat ${xmppConfig.passwordFile})\n"
       ) cfg.xmppConfigs))
@@ -247,6 +249,28 @@ in
         LimitNPROC = 65000;
         LimitNOFILE = 65000;
       };
+    };
+
+    systemd.services.delay-jitsi-videobridge-start = {
+
+      partOf = [ "jicofo.service" ];
+      after = [ "jicofo.service" ];
+      requiredBy = [ "jitsi-videobridge2.service" ];
+      before = [ "jitsi-videobridge2.service" ];
+
+      restartIfChanged = false;
+
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+      };
+      script = ''
+        echo "Jicofo was just started, waiting 5 seconds..."
+        for x in {1..5}; do
+          sleep 1
+          echo "$x..."
+        done
+      '';
     };
 
     environment.etc."jitsi/videobridge/logging.properties".source =


### PR DESCRIPTION
When jicofo and jitsi-videobridge are starting at the same time,
registration sometimes fails and jicofo cannot see the
videobridge. Starting the videobridge after jicofo with 5 seconds
delay should fix that.

 #PL-129725

@flyingcircusio/release-managers

## Release process

Impact:

* [NixOS 20.09]: Jitsi will be restarted and conferences will not be available for some seconds.

Changelog:

* Jitsi: improve startup reliability. The videobridge sometimes didn't register correctly which required a manual restart (#PL-129725).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - nothing new, we just want reliable startups with a working videobridge 
- [x] Security requirements tested? (EVIDENCE)
  - restarted jitsi many times in various combinations (only jicofo, jicofo and videobridge, only videobridge, reboot) on our Jitsi test VM and checked if conferences work

