### PR TITLE
Bring back mysql56 role (percona)

### DIFF
--- a/nixos/roles/mysql.nix
+++ b/nixos/roles/mysql.nix
@@ -28,6 +28,7 @@ with builtins;
         };
       };
 
+      mysql56.enable = mkRole "5.6";
       mysql57.enable = mkRole "5.7";
       percona80.enable = mkRole "8.0";
     };
@@ -37,11 +38,13 @@ with builtins;
   config =
   let
     mysqlRoles = with config.flyingcircus.roles; {
+      "5.6" = mysql56.enable;
       "5.7" = mysql57.enable;
       "8.0" = percona80.enable;
     };
 
     mysqlPackages = with pkgs; {
+      "5.6" = percona56;
       "5.7" = percona57;
       "8.0" = percona80;
     };

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -196,6 +196,7 @@ in {
     '';
   });
 
+  percona56 = super.callPackage ./percona/5.6.nix { boost = self.boost159; };
   percona57 = super.callPackage ./percona/5.7.nix { boost = self.boost159; };
   percona80 = super.callPackage ./percona/8.0.nix { boost = self.boost172; };
 

--- a/pkgs/percona/5.6.nix
+++ b/pkgs/percona/5.6.nix
@@ -1,0 +1,65 @@
+{ stdenv, fetchurl, cmake, boost, bison, ncurses, openssl, readline, zlib, perl }:
+
+# Note: zlib is not required; MySQL can use an internal zlib.
+
+stdenv.mkDerivation rec {
+  name = "percona-${version}";
+  version = "5.6.51-91.0";
+
+  src = fetchurl {
+    url = "https://www.percona.com/downloads/Percona-Server-5.6/Percona-Server-${version}/source/tarball/percona-server-${version}.tar.gz";
+    sha256 = "0byxjzpksqpngm1dd95slic5yddb2x4bb36gchf5dfgb4k8w30j4";
+  };
+
+  preConfigure = stdenv.lib.optional stdenv.isDarwin ''
+    ln -s /bin/ps $TMPDIR/ps
+    export PATH=$PATH:$TMPDIR
+  '';
+
+  buildInputs = [
+      cmake bison ncurses openssl readline zlib boost.out boost.dev
+    ] ++ stdenv.lib.optional stdenv.isDarwin perl;
+
+  enableParallelBuilding = true;
+
+  cmakeFlags = [
+    "-DWITH_SSL=yes"
+    "-DWITH_EMBEDDED_SERVER=no"
+    "-DWITH_ZLIB=yes"
+    "-DWITH_EDITLINE=bundled"
+    "-DHAVE_IPV6=yes"
+    "-DMYSQL_UNIX_ADDR=/run/mysqld/mysqld.sock"
+    "-DMYSQL_DATADIR=/var/lib/mysql"
+    "-DINSTALL_SYSCONFDIR=etc/mysql"
+    "-DINSTALL_INFODIR=share/mysql/docs"
+    "-DINSTALL_MANDIR=share/man"
+    "-DINSTALL_PLUGINDIR=lib/mysql/plugin"
+    "-DINSTALL_SCRIPTDIR=bin"
+    "-DINSTALL_INCLUDEDIR=include/mysql"
+    "-DINSTALL_DOCREADMEDIR=share/mysql"
+    "-DINSTALL_SUPPORTFILESDIR=share/mysql"
+    "-DINSTALL_MYSQLSHAREDIR=share/mysql"
+    "-DINSTALL_DOCDIR=share/mysql/docs"
+    "-DINSTALL_SHAREDIR=share/mysql"
+  ];
+
+  NIX_LDFLAGS = stdenv.lib.optionalString stdenv.isLinux "-lgcc_s";
+
+  prePatch = ''
+    sed -i -e "s|/usr/bin/libtool|libtool|" cmake/libutils.cmake
+  '';
+  postInstall = ''
+    sed -i -e "s|basedir=\"\"|basedir=\"$out\"|" $out/bin/mysql_install_db
+    rm -r $out/mysql-test $out/sql-bench $out/data "$out"/lib/*.a
+  '';
+
+  passthru.mysqlVersion = "5.6";
+
+  meta = {
+    homepage = http://www.percona.com/;
+    description = ''
+      Is a free, fully compatible, enhanced, open source drop-in replacement for
+      MySQL® that provides superior performance, scalability and instrumentation.
+    '';
+  };
+}


### PR DESCRIPTION
Same code as on 19.03 but with an updated percona 5.6 version.

We need it to be able to upgrade systems to 20.09 faster.
It's EOL and will be removed as soon as possible.

Also increases waiting time on startup as initializing may
take a long time.

 #PL-129731

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

## Security implications

This version is EOL and doesn't receive security updates anymore but we want to upgrade our systems to 20.09 which is better from a security perspective. It will be removed asap.

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - use the latest version of the 5.6 branch
- [x] Security requirements tested? (EVIDENCE)
  - automated test checks basic functionality, checked if it works on a test VM
