### PR TITLE
Update nixpkgs

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -2,7 +2,7 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "3e2e59332c03371925143b43d4a48cae95ebd699",
-    "sha256": "0630wigw0v33yk7agsl348sdav8slvm7sqlxzq0al7b5kdj5yzgv"
+    "rev": "2f191170b675f5f0d11b104ed7fa150720c2666f",
+    "sha256": "1nv3vp7701ncy7gk9zgbalk8rvjz6d65rjr2nnp8cn2ydgxrgi94"
   }
 }


### PR DESCRIPTION
binutils: fix CVE-2018-20623, CVE-2018-20651, CVE-2018-20671, CVE-2020-35493, CVE-2020-35494, CVE-2020-35495, CVE-2020-35496, CVE-2020-35497
ffmpeg: 4.3.1 -> 4.3.2 (CVE-2020-35964, CVE-2020-35965)
git: 2.29.2 -> 2.29.3 (CVE-2021-21300)
grafana: 7.4.1 -> 7.4.3
linux: 5.4.100 -> 5.4.104
openssl: 1.1.1i -> 1.1.1j (CVE-2021-23839, CVE-2021-23840,
CVE-2021-23841)
python27: fix CVE-2021-3177
python36: 3.6.12 -> 3.6.13
python37: 3.7.9 -> 3.7.10
python38: 3.8.5 -> 3.8.6
python39: 3.9.1 -> 3.9.2
pythonPackages.pyyaml: fix CVE-2020-1434
re2c: fix CVE-2018-21232

 #PL-129728

@flyingcircusio/release-managers

## Release process

Impact:

* [NixOS 20.09] Many services will be restarted.
* [NixOS 20.09] VM will schedule a reboot to activate the kernel update.


Changelog:

* Merge upstream NixOS changes (#PL-129728) [include changes from commit msg here]. 

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
   - use a recent nixpkgs version with security fixes from upstream
   - document which CVEs are fixed by a nixpkgs update
- [x] Security requirements tested? (EVIDENCE)
  - ran automated tests, checked on test VM
  -  checked upstream changes for fixed CVEs