### PR TITLE
Update nixpkgs for gitlab update

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -2,7 +2,7 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "2f191170b675f5f0d11b104ed7fa150720c2666f",
-    "sha256": "1nv3vp7701ncy7gk9zgbalk8rvjz6d65rjr2nnp8cn2ydgxrgi94"
+    "rev": "f28899aafa98474be57f550906a1f8e7a4d2029c",
+    "sha256": "0yah9hbw79xa57hicjgs99hhqr07s1d77hk7b4jnnd6g5kr2gngm"
   }
 }


### PR DESCRIPTION
Important security release, already rolled out on our Gitlab.

 #PL-129734

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Gitlab: update to 13.8.6 security release (#PL-129734).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - use a current Gitlab version with the latest security fixes
- [x] Security requirements tested? (EVIDENCE)
  - 13.8.6 is the most recent patch release
  - manually tested on staging Gitlab instance
  - automated test checks basic functionality
