### PR TITLE
First batch of perl tests converted to python

### DIFF
--- a/tests/fcagent.nix
+++ b/tests/fcagent.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ... }:
+import ./make-test-python.nix ({ pkgs, ... }:
 let
   agent_updates_channel_with_maintenance = pkgs.writeScript "agent-updates-channel-with-maintenance" ''
       #!/bin/sh
@@ -34,11 +34,11 @@ in
 
   };
   testScript = ''
-    $nonprod->waitForUnit('multi-user.target');
-    $nonprod->fail('${agent_updates_channel_with_maintenance}');
+    nonprod.wait_for_unit('multi-user.target')
+    nonprod.fail('${agent_updates_channel_with_maintenance}')
 
-    $prod->waitForUnit('multi-user.target');
-    $prod->succeed('${agent_updates_channel_with_maintenance}');
+    prod.wait_for_unit('multi-user.target')
+    prod.succeed('${agent_updates_channel_with_maintenance}')
   '';
 })
 

--- a/tests/memcached.nix
+++ b/tests/memcached.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ ... }:
+import ./make-test-python.nix ({ ... }:
 let 
   ipv4 = "192.168.101.1";
   ipv6 = "2001:db8:f030:1c3::1";
@@ -24,16 +24,16 @@ in {
     };
 
   testScript = ''
-    $machine->waitForUnit('memcached.service');
-    $machine->waitForOpenPort(11211);
+    machine.wait_for_unit('memcached.service')
+    machine.wait_for_open_port(11211)
     # connecting with ipv6 often fails if we don't wait
-    $machine->waitUntilSucceeds("ping -c1 ${ipv6}");
+    machine.wait_until_succeeds("ping -c1 ${ipv6}")
 
-    $machine->succeed("echo -e 'add my_key 0 60 11\\r\\nhello world\\r\\nquit' | nc ::1 11211 | grep STORED");
-    $machine->succeed("echo -e 'get my_key\\r\\nquit' | nc ${ipv4} 11211 | grep 'hello world'");
-    $machine->succeed("echo -e 'get my_key\\r\\nquit' | nc ${ipv6} 11211 | grep 'hello world'");
+    machine.succeed("echo -e 'add my_key 0 60 11\\r\\nhello world\\r\\nquit' | nc ::1 11211 | grep STORED")
+    machine.succeed("echo -e 'get my_key\\r\\nquit' | nc ${ipv4} 11211 | grep 'hello world'")
+    machine.succeed("echo -e 'get my_key\\r\\nquit' | nc ${ipv6} 11211 | grep 'hello world'")
 
     # service user should be able to write to local config dir
-    $machine->succeed('sudo -u memcached touch /etc/local/memcached/memcached.json');
+    machine.succeed('sudo -u memcached touch /etc/local/memcached/memcached.json')
   '';
 })

--- a/tests/nfs.nix
+++ b/tests/nfs.nix
@@ -1,6 +1,6 @@
-import ./make-test.nix ({ ... }:
+import ./make-test-python.nix ({ ... }:
 
-let 
+let
   user = {
     isNormalUser = true;
     uid = 1001;
@@ -23,14 +23,14 @@ let
 in {
   name = "nfs";
   nodes = {
-    client = 
+    client =
       { lib, ... }:
       {
         imports = [ ../nixos ../nixos/roles ];
         config = {
           flyingcircus.roles.nfs_rg_client.enable = true;
           # XXX: same as upstream test, let's see how they fix this
-          networking.firewall.enable = false; 
+          networking.firewall.enable = false;
           flyingcircus.encServices = encServices;
 
           # The test framework overrides the fileSystems setting from the role,
@@ -46,8 +46,8 @@ in {
                 "rsize=8192"
                 "wsize=8192"
                 "noauto"
-                "x-systemd.automount" 
-                "nfsvers=4" 
+                "x-systemd.automount"
+                "nfsvers=4"
               ];
             noCheck = true;
           };
@@ -74,29 +74,31 @@ in {
 
   testScript = ''
 
-    $server->start();
-    $server->waitForUnit("nfs-server");
-    $server->waitForUnit("nfs-idmapd");
-    $server->waitForUnit("nfs-mountd");
-    $client->start();
+    server.start()
+    server.wait_for_unit("nfs-server")
+    server.wait_for_unit("nfs-idmapd")
+    server.wait_for_unit("nfs-mountd")
+    client.start()
 
-    $server->succeed("chown test ${sdir}");
+    server.succeed("chown test ${sdir}")
 
     # user test on server should be able to write to shared dir
-    $server->succeed("sudo -u test echo test_on_server > ${sdir}/test");
-    
+    server.succeed("sudo -u test echo test_on_server > ${sdir}/test")
+
     # share should be mounted upon access
-    $client->succeed("cd ${cdir}");
-    $client->waitForUnit("mnt-nfs-shared.mount");
+    client.succeed("cd ${cdir}")
+    client.wait_for_unit("mnt-nfs-shared.mount")
 
+    # The commented code below was originaly writen in perl and was converted to python.
+    # It ist not tested and the comment below may not apply anymore!
     # XXX: results in permission denied, why?
-    #$client->succeed("grep test_on_server ${cdir}/test");
+    #client.succeed("grep test_on_server ${cdir}/test")
 
-    #$client->succeed("sudo -u test echo test_on_client > $cdir/test");
-    #$server->succeed("grep test_on_client $sdir/test");
+    #client.succeed("sudo -u test echo test_on_client > $cdir/test")
+    #server.succeed("grep test_on_client $sdir/test")
 
-    #$client->fail("echo from_root_user > $cdir/test");
-    #$server->succeed("grep from_test_user $sdir/test");
+    #client.fail("echo from_root_user > $cdir/test")
+    #server.succeed("grep from_test_user $sdir/test")
   '';
 
 })

--- a/tests/systemd-service-cycles.nix
+++ b/tests/systemd-service-cycles.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ ... }:
+import ./make-test-python.nix ({ ... }:
 
 # Checks that systemd does not detect any circular service dependencies on boot.
 {
@@ -10,8 +10,8 @@ import ./make-test.nix ({ ... }:
     };
 
   testScript = ''
-    $machine->waitForUnit('multi-user.target');
-    $machine->waitUntilSucceeds('pgrep -f "agetty.*tty1"');
-    $machine->fail('journalctl -b | egrep "systemd.*cycle"');
+    machine.wait_for_unit('multi-user.target')
+    machine.wait_until_succeeds('pgrep -f "agetty.*tty1"')
+    machine.fail('journalctl -b | egrep "systemd.*cycle"')
   '';
 })


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact: 

None

Changelog:

None

## Security implications

- [X] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

- The developers have much better knowledge of python and more experience with it, in contrast to perl. Problems with the code will be easier to spot and fix now.

- NixOS switched already to only python tests. When all our tests are converted, we won' have to backport the perl test runner anymore.

- [X] Security requirements tested? (EVIDENCE)

- The tests have been executed without any problems.

