### PR TITLE
Coturn: fix ACME cert renewal

### DIFF
--- a/nixos/roles/coturn.nix
+++ b/nixos/roles/coturn.nix
@@ -91,8 +91,10 @@ in
     };
 
     security.acme.certs."${hostname}" = {
-      group = "turnserver";
-      postRun = "systemctl kill -s USR2 coturn.service";
+      postRun = ''
+        ${pkgs.acl}/bin/setfacl -Rm u:turnserver:rX .
+        systemctl kill -s USR2 coturn.service
+      '';
     };
 
     flyingcircus.services = {


### PR DESCRIPTION
Using the group option of the ACME certificate doesn't work as expected on
20.09 anymore. Previously, setting it to turnserver enabled coturn to see
the cert. Now, the group is used as the group for the ACME challenge file
which must be readable by Nginx. Changing it made the file inacessible
for Nginx. This is fixed by using ACL instead to allow the turnserver user
to see the certificates.

 #PL-129729

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Coturn: fix ACME certificate renewal (#PL-129729).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - ACME cert for coturn should be renewed if needed and coturn should be able to use it 
- [x] Security requirements tested? (EVIDENCE)
  - checked on a test VM if permissions are set properly and coturn picks up the certificate after renewal.
  - (cannot be checked by automated test because we don't have a way to run ACME inside a test yet)
