### PR TITLE
mongodb: ensure restarts on crashes.

### DIFF
--- a/nixos/roles/mongodb.nix
+++ b/nixos/roles/mongodb.nix
@@ -90,6 +90,7 @@ in {
         serviceConfig.TimeoutStartSec = fclib.mkPlatform 1200;
         serviceConfig.LimitNOFILE = 64000;
         serviceConfig.LimitNPROC = 32000;
+        serviceConfig.Restart = "always";
         serviceConfig.ExecStart = lib.mkForce ''
           ${mcfg.package}/bin/mongod --config ${mongoCnf}
         '';

--- a/tests/mongodb.nix
+++ b/tests/mongodb.nix
@@ -62,6 +62,21 @@ in {
       with subtest("mongodb sensu check should be red after shutting down mongodb"):
         machine.systemctl("stop mongodb")
         machine.fail("${sensuCheck "mongodb"}")
+
+      with subtest("mongodb restarts on crash"):
+        machine.systemctl("start mongodb")
+        machine.wait_for_unit("mongodb.service")
+        _, out = machine.execute('pgrep mongod')
+        print(out)
+        previous_pid = int(out.strip())
+        machine.succeed("killall -11 mongod")
+        import time
+        time.sleep(5)
+        machine.succeed("systemctl show mongodb | grep ActiveState=active")
+        _, out = machine.execute('pgrep mongod')
+        new_pid = int(out.strip())
+        print("new pid:", new_pid, "old pid:", previous_pid)
+        assert new_pid != previous_pid;
     '';
 
 })


### PR DESCRIPTION
Also adds a test for this behaviour.

Fixes PL-108116

@flyingcircusio/release-managers

## Release process

Impact:

* MongoDB servers will be restarted due to changed unit configuration.

Changelog:

* Reconfigure MongoDB server units to ensure restarts are performed on crashes. (PL-108116)
* 
## Security implications

- [X] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

Improving availability is a security goal in itself.

- [x] Security requirements tested? (EVIDENCE)

Added automated test.
