### PR TITLE
Fix SNI in ACME cert sensu check

### DIFF
--- a/nixos/platform/acme.nix
+++ b/nixos/platform/acme.nix
@@ -6,7 +6,7 @@
     lib.listToAttrs
       (map (n: lib.nameValuePair "ssl_cert_acme_${n}" {
         notification = "ACME (Letsencrypt) certificate for ${n} is invalid or will expire soon";
-        command = "check_http -p 443 -S -–sni -C 25,14 -H ${n}";
+        command = "check_http -p 443 -S --sni -C 25,14 -H ${n}";
         interval = 600;
       })
       (lib.attrNames config.security.acme.certs));


### PR DESCRIPTION
The --sni parameter didn't work because the second dash was actually not
a dash but a different unicode character. The check still worked but SNI
was not used. That means that always the certificate for the default vhost
was checked instead of the one for the specified hostname.

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Fix ACME certificate validity check for multiple virtual hosts. SNI was not used so only the certificate for the default vhost was monitored (#PL-129749). 

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - check for all certificates managed by ACME that they are still valid 
- [x] Security requirements tested? (EVIDENCE)
  - verified on a test VM that the two generated checks do actually check different certificates
