### PR TITLE
Second batch of perl tests converted to python

### DIFF
--- a/tests/antivirus.nix
+++ b/tests/antivirus.nix
@@ -1,7 +1,7 @@
 # It's hard to test the real functionality because the updater needs internet
 # access and the daemon need large binary files in order to run. We just check
 # the generated config.
-import ./make-test.nix ({ lib, ... }:
+import ./make-test-python.nix ({ lib, ... }:
 let
   ipv4 = "192.168.101.1";
   ipv6 = "2001:db8:f030:1c3::1";
@@ -28,11 +28,11 @@ in {
   testScript =
   let
     check = ipaddr: ''
-      $machine->succeed('grep ${ipaddr} /etc/clamav/clamd.conf');
+      machine.succeed('grep ${ipaddr} /etc/clamav/clamd.conf')
     '';
   in ''
-    $machine->succeed('systemctl cat clamav-daemon.service');
-    $machine->succeed('systemctl cat clamav-freshclam.service');
-    $machine->succeed('systemctl cat clamav-freshclam.timer');
+    machine.succeed('systemctl cat clamav-daemon.service')
+    machine.succeed('systemctl cat clamav-freshclam.service')
+    machine.succeed('systemctl cat clamav-freshclam.timer')
   '' + lib.concatMapStrings check [ "127.0.0.1" "::1" ipv4 ipv6 ];
 })

--- a/tests/journal.nix
+++ b/tests/journal.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ lib, ... }:
+import ./make-test-python.nix ({ lib, ... }:
 
 {
   name = "journal";
@@ -37,28 +37,23 @@ import ./make-test.nix ({ lib, ... }:
     };
 
   testScript = ''
-    $machine->waitForUnit('multi-user.target');
+    machine.wait_for_unit('multi-user.target')
 
-    subtest "user without allowed groups should not see the journal", sub {
-      $machine->mustFail('sudo -iu \#1000 journalctl');
-    };
+    with subtest("user without allowed groups should not see the journal"):
+        machine.fail('sudo -iu \#1000 journalctl')
 
-    subtest "admin user should see the journal", sub {
-      $machine->succeed('sudo -iu \#1001 journalctl');
-    };
+    with subtest("admin user should see the journal"):
+        machine.succeed('sudo -iu \#1001 journalctl')
 
-    subtest "admin user should see the journal", sub {
-      $machine->succeed('sudo -iu \#1002 journalctl');
-    };
+    with subtest("admin user should see the journal"):
+        machine.succeed('sudo -iu \#1002 journalctl')
 
-    subtest "wheel user should see the journal", sub {
-      $machine->succeed('sudo -iu \#1003 journalctl');
-    };
+    with subtest("wheel user should see the journal"):
+        machine.succeed('sudo -iu \#1003 journalctl')
 
-    subtest "service user should see the journal", sub {
-      $machine->succeed('sudo -iu \#1004 journalctl');
-    };
+    with subtest("service user should see the journal"):
+        machine.succeed('sudo -iu \#1004 journalctl')
 
-    print($machine->succeed('getfacl /var/log/journal'));
+    print(machine.succeed('getfacl /var/log/journal'))
   '';
 })

--- a/tests/postgresql.nix
+++ b/tests/postgresql.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ rolename ? "postgresql11", lib, pkgs, ... }:
+import ./make-test-python.nix ({ rolename ? "postgresql11", lib, pkgs, ... }:
 let
   ipv4 = "192.168.101.1";
   ipv6 = "2001:db8:f030:1c3::1";
@@ -52,26 +52,26 @@ in {
         else "CREATE EXTENSION temporal_tables";
     in
     ''
-      $machine->waitForUnit("postgresql.service");
-      $machine->waitForOpenPort(5432);
+      machine.wait_for_unit("postgresql.service")
+      machine.wait_for_open_port(5432)
 
       # simple data round trip
-      $machine->succeed('sudo -u postgres -- sh ${dataTest}');
+      machine.succeed('sudo -u postgres -- sh ${dataTest}')
 
       # connection tests with password
-      $machine->succeed('${psql} -c "CREATE USER test; ALTER USER test WITH PASSWORD \'test\'"');
-      $machine->succeed('${psql} postgresql://test:test@${ipv4}:5432/postgres -c "SELECT \'hello\'" | grep hello');
-      $machine->succeed('${psql} postgresql://test:test@[${ipv6}]:5432/postgres -c "SELECT \'hello\'" | grep hello');
+      machine.succeed('${psql} -c "CREATE USER test; ALTER USER test WITH PASSWORD \'test\'"')
+      machine.succeed('${psql} postgresql://test:test@${ipv4}:5432/postgres -c "SELECT \'hello\'" | grep hello')
+      machine.succeed('${psql} postgresql://test:test@[${ipv6}]:5432/postgres -c "SELECT \'hello\'" | grep hello')
 
       # should not trust connections via TCP
-      $machine->fail('psql --no-password -h localhost -l');
+      machine.fail('psql --no-password -h localhost -l')
 
       # service user should be able to write to local config dir
-      $machine->succeed('sudo -u postgres touch `echo /etc/local/postgresql/*`/test');
+      machine.succeed('sudo -u postgres touch `echo /etc/local/postgresql/*`/test')
 
-      $machine->succeed('${psql} employees -c "CREATE EXTENSION postgis;"');
-      $machine->succeed('${psql} employees -c "CREATE EXTENSION rum;"');
-      $machine->succeed('${psql} employees -c "${createTemporalExtension};"');
+      machine.succeed('${psql} employees -c "CREATE EXTENSION postgis;"')
+      machine.succeed('${psql} employees -c "CREATE EXTENSION rum;"')
+      machine.succeed('${psql} employees -c "${createTemporalExtension};"')
     '';
 
 })

--- a/tests/prometheus.nix
+++ b/tests/prometheus.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ ... }:
+import ./make-test-python.nix ({ ... }:
 {
   name = "prometheus";
   machine =
@@ -8,15 +8,13 @@ import ./make-test.nix ({ ... }:
       config.services.prometheus.enable = true;
     };
   testScript = ''
-    $machine->waitForUnit("prometheus.service");
-    $machine->sleep(5);
+    machine.wait_for_unit("prometheus.service")
+    machine.sleep(5)
 
-    subtest "Prometheus should serve its own metrics", sub {
-      $machine->succeed("curl 'localhost:9090/metrics' | grep go_goroutines");
-    };
+    with subtest("Prometheus should serve its own metrics"):
+        machine.succeed("curl 'localhost:9090/metrics' | grep go_goroutines")
 
-    subtest "Metrics dir should only allow access for prometheus user", sub {
-      $machine->succeed("stat /srv/prometheus/metrics -c %a:%U:%G | grep '700:prometheus:prometheus'");
-    };
+    with subtest("Metrics dir should only allow access for prometheus user"):
+        machine.succeed("stat /srv/prometheus/metrics -c %a:%U:%G | grep '700:prometheus:prometheus'")
   '';
 })


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

None

Changelog:

None

## Security implications

- [X] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

    - All tests in 20.09 are python based. If we don't have perl tests anymore, we don't have to backport the perl test runner.

- [X] Security requirements tested? (EVIDENCE)

    All converted tests where abele to be build.

