### PR TITLE
Update nixpkgs

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -2,7 +2,7 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "7a2e6154d76f68f8f3a8add4af6aa43aa1b67dd7",
-    "sha256": "1yl4dvcp66x5117dryicbzqgb4xy9kv7bihf402lbk947yy7hawc"
+    "rev": "bf5803c2f45babf24d339ba643f8d46d5c46c925",
+    "sha256": "1fk3gwrxn2r8i82xibnhf6dg7hf76cdill89m5w6z8x6vmg8fdsp"
   }
 }


### PR DESCRIPTION
Notable version changes and security fixes:

* go_1_15: 1.15.8 -> 1.15.10 (CVE-2021-27918, CVE-2021-27919)
* grafana: 7.4.3 -> 7.4.5 (CVE-2021-27962, CVE-2021-28146, CVE-2021-28147, CVE-2021-28148)
* imagemagick6: 6.9.11-60 -> 6.9.12-3
* imagemagick: 7.0.10-61 -> 7.0.11-4
* libtiff: CVE-2020-35523, CVE-2020-35524
* linux: 5.4.104 -> 5.4.108
* openssh: 8.4p1 -> 8.5p1
* openssl: 1.1.1j -> 1.1.1k
* php74: 7.4.15 -> 7.4.16
* python3Packages.aiohttp: patch CVE-2021-21330

 #PL-129756

@flyingcircusio/release-managers

## Release process

Impact:

* [NixOS 20.09] Many services will be restarted due to a openssl update. VMs will schedule a reboot to activate the new kernel version.

Changelog: (include changes from commit msg here)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - pull in upstream security fixes regularly
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still run, works on test VM and gitlab staging VM
  - checked commit log for fixed CVEs and possible problems with updates