### PR TITLE
Try to fix hydra build product listing for IPXE script.

### DIFF
--- a/release/default.nix
+++ b/release/default.nix
@@ -169,7 +169,7 @@ let
       build = evaled.config.system.build;
       kernelTarget = evaled.pkgs.stdenv.hostPlatform.platform.kernelTarget;
 
-      customIPXEScript = pkgs.writeText "netboot.ipxe" ''
+      customIPXEScript = pkgs.writeTextDir "netboot.ipxe" ''
         #!ipxe
 
         set console ttyS2,115200
@@ -235,13 +235,13 @@ let
         paths = [
           build.netbootRamdisk
           build.kernel
+          customIPXEScript
         ];
         postBuild = ''
           mkdir -p $out/nix-support
-          ln -s ${customIPXEScript} $out/netboot.ipxe
           echo "file ${kernelTarget} ${build.kernel}/${kernelTarget}" >> $out/nix-support/hydra-build-products
           echo "file initrd ${build.netbootRamdisk}/initrd" >> $out/nix-support/hydra-build-products
-          echo "file ipxe $out/netboot.ipxe " >> $out/nix-support/hydra-build-products
+          echo "file ipxe ${customIPXEScript}/netboot.ipxe" >> $out/nix-support/hydra-build-products
         '';
         preferLocalBuild = true;
       };


### PR DESCRIPTION
Apparently hydra might be picky with trailing whitespace for filenames
in the build products support file... :(

@flyingcircusio/release-managers

## Release process

Impact:

-

Changelog:

* Fix network boot image creation for physical machine bootstraps. 

## Security implications

- [X] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined?  (WHERE)

No. Fixing a typo bug of something that already worked this way before.

- [X] Security requirements tested? (EVIDENCE)

n/a