### PR TITLE
Convert last tests to python (pt.6) and fixed missing test in default.nix

### DIFF
--- a/tests/default.nix
+++ b/tests/default.nix
@@ -38,6 +38,7 @@ in {
   kibana7 = callTest ./kibana.nix { version = "7"; };
   kubernetes = callTest ./kubernetes {};
   lamp = callTest ./lamp.nix {};
+  locale = callTest ./locale.nix {};
   login = callTest ./login.nix {};
   logging = callTest ./logging.nix {};
   logrotate = callTest ./logrotate.nix {};

--- a/tests/locale.nix
+++ b/tests/locale.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ ... }:
+import ./make-test-python.nix ({ ... }:
 {
   name = "locale";
   machine =
@@ -8,8 +8,8 @@ import ./make-test.nix ({ ... }:
     };
 
   testScript = ''
-    $machine->succeed("locale -a | grep -q de_DE.utf8");
-    $machine->succeed("locale -a | grep -q en_US.utf8");
-    $machine->succeed('(($(locale -a | wc -l) > 100))');
+    machine.succeed("locale -a | grep -q de_DE.utf8")
+    machine.succeed("locale -a | grep -q en_US.utf8")
+    machine.succeed('(($(locale -a | wc -l) > 100))')
   '';
 })


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

NONE

Changelog:

NONE

## Security implications

- [X] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

  - All tests in 20.09 are python based. If we don't have perl tests anymore, we don't have to backport the perl test runner.
  - Tests should automaticly be used.

- [X] Security requirements tested? (EVIDENCE)

   - All converted tests where able to be build.