### PR TITLE
Fix nix-env -qa by adding a fake libceph

### DIFF
--- a/pkgs/ceph/generic.nix
+++ b/pkgs/ceph/generic.nix
@@ -206,5 +206,9 @@ __EOF__
     platforms = platforms.unix;
   };
 
-  passthru.version = version;
+  passthru = {
+    inherit version;
+    lib = {};
+  };
+
 }

--- a/tests/channel.nix
+++ b/tests/channel.nix
@@ -26,6 +26,8 @@ in {
       isNormalUser = true;
       home = "/home/alice";
     };
+
+    virtualisation.memorySize = 3000;
   };
 
   testScript = ''
@@ -43,6 +45,9 @@ in {
 
     with subtest("Non-root should be able to nix-env install from fc"):
       machine.succeed("su alice -l -c 'nix-env -iA nixos.fc.logcheckhelper'")
+
+    with subtest("Non-root should be able to use nix-env -qa to list packages"):
+      machine.succeed("su alice -l -c 'nix-env -qa'")
 
     with subtest("login/nix-env -i should remove the 19.03 channel hack"):
       # This is the situation after an upgrade from 19.03 to this version.


### PR DESCRIPTION
nix-env -qa evaluates everything and dies if a package is missing.
all-packages.nix defines libceph = ceph.lib but our overridden
ceph didn't have a lib attr.

Adds a check that nix-env -qa is working to the channel test.

 #PL-129750

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Fix nix-env -qa which lists all available packages (#PL-129750).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - not relevant for security, users should be able to list packages 
- [x] Security requirements tested? (EVIDENCE)
  - checked manually on test VM, automated test checks that nix-env -qa works
