### PR TITLE
Servicecheck: use a timer to start the unit, monitor updates

### DIFF
--- a/pkgs/fc/agent/fc/manage/monitor.py
+++ b/pkgs/fc/agent/fc/manage/monitor.py
@@ -3,6 +3,7 @@
 import argparse
 import datetime
 import json
+import pathlib
 import shlex
 import socket
 import sys
@@ -68,6 +69,8 @@ def write_checks(directory=None, config_file=None, **kw):
     if old_check_configuration != sensu_checks:
         with open(config_file, 'w') as f:
             json.dump(sensu_checks, f, indent=2, sort_keys=True)
+    else:
+        pathlib.Path(config_file).touch()
 
 
 def handle_result(directory=None, enc=None, **kw):


### PR DESCRIPTION
Wasn't started at all because it depended on fc-manage.service which is
called fc-agent since 19.03. Using a timer is better because we will
switch to an event-based agent run model later.

A sensu check now checks the update time of the servicecheck file
which is expected to be updated (or at least touched) every ten minutes.

 #PL-129738

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - service checks must be updated regularly to reflect changes in the directory or we may miss outages if expected checks are not in place 
- [x] Security requirements tested? (EVIDENCE)
  - tested timer and sensu check on services VM which has the servicecheck role
