### PR TITLE
Update nixpkgs for gitlab 13.8.7

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -2,7 +2,7 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "bf5803c2f45babf24d339ba643f8d46d5c46c925",
-    "sha256": "1fk3gwrxn2r8i82xibnhf6dg7hf76cdill89m5w6z8x6vmg8fdsp"
+    "rev": "329b208129ca1776bf58339836d232e1782f6d7f",
+    "sha256": "1pjafzy3xrgmrmjwx74csp7js4dqp66kkvnhazj36qzdjni9gf0h"
   }
 }


### PR DESCRIPTION
 #PL-129770

@flyingcircusio/release-managers

## Release process

Impact:

* [NixOS 20.09] Gitlab will be restarted and unavailable for some minutes.

Changelog:

* Gitlab: update to 13.8.7 security release (#PL-129770).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - use a current Gitlab version with the latest security fixes
- [x] Security requirements tested? (EVIDENCE)
  - 13.8.7 is the most recent patch release
  - manually tested on staging Gitlab instance
  - automated test checks basic functionality

