### PR TITLE
Merge nixpkgs from upstream

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -2,7 +2,7 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "329b208129ca1776bf58339836d232e1782f6d7f",
-    "sha256": "1pjafzy3xrgmrmjwx74csp7js4dqp66kkvnhazj36qzdjni9gf0h"
+    "rev": "753913a8cb8310f4631860b7f77af13bd00eb031",
+    "sha256": "1d1d06b29856fnml2m6shr28df13gbw83978q9bkq1svsfjpiycf"
   }
 }


### PR DESCRIPTION
Notable changes and security updates:

* imagemagick7: 7.0.11-4 -> 7.0.11-6
* linux: 5.4.108 -> 5.4.109
* curl: add patches for CVE-2021-22876, CVE-2021-22890
* grafana: 7.4.5 -> 7.5.2
* python3Packages.pillow: add patches for CVE-2021-25287, CVE-2021-25288,
  CVE-2021-25289, CVE-2021-25290, CVE-2021-25291, CVE-2021-25292,
  CVE-2021-25293, CVE-2021-27921, CVE-2021-27922, CVE-2021-27923
* pythonPackages.lxml: 4.6.2 -> 4.6.3
* python3Packages.pygments: add patch for CVE-2021-27291

 #PL-129787

@flyingcircusio/release-managers

## Release process

 Impact:

* [NixOS 20.09] VMs will schedule a reboot to activate the new kernel version.

Changelog: (include changes from commit msg here)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - pull in upstream security fixes regularly
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still run, works on test VM
  - checked commit log for fixed CVEs and possible problems with updates
