### PR TITLE
Vagrant: set mode 755 for service user dirs

### DIFF
--- a/nixos/infrastructure/vagrant.nix
+++ b/nixos/infrastructure/vagrant.nix
@@ -89,8 +89,8 @@ in {
       ];
     };
 
-    system.activationScripts.relaxHomePermissions = lib.stringAfter [] ''
-      chmod 755 /home/*
+    system.activationScripts.relaxHomePermissions = lib.stringAfter [ "users" ] ''
+      chmod 755 /home/* /srv/s-*
     '';
   };
 }


### PR DESCRIPTION
Dirs under /home are already set to 755 but we create a s-test user
which has a home dir in /srv with the NixOS default of 700. This is
different from a real VM which sets 755 for all service user dirs.

 #PL-129791

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Vagrant: Set mode for service user dirs (`/srv/s-*`) to 755 like on a regular VM (#PL-129791).

## Security implications

Doesn't affect regular machines, only for development with Vagrant.

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Vagrant dev environment should be close to a real machine 
- [x] Security requirements tested? (EVIDENCE)
  - checked if service user dir permissions are correct in a Vagrant VM
