### PR TITLE
fc-agent: fix pre-building for maintenance, improve update info

### DIFF
--- a/pkgs/fc/agent/default.nix
+++ b/pkgs/fc/agent/default.nix
@@ -35,7 +35,7 @@ py.buildPythonPackage rec {
   version = "1.0";
   namePrefix = "";
   src = ./.;
-  buildInputs = [
+  checkInputs = [
     py.freezegun
     py.pytest
     py.pytestcov

--- a/pkgs/fc/agent/fc/manage/tests/test_manage.py
+++ b/pkgs/fc/agent/fc/manage/tests/test_manage.py
@@ -22,6 +22,18 @@ def test_channel_eq():
     assert ch1 != ch2
 
 
+def test_channel_str_local_checkout():
+    channel = Channel('file://1', name='name', environment='env')
+    assert str(channel) == '<Channel name=name, version=local-checkout, from=1>'
+
+
+def test_channel_str(mocked_responses):
+    url = 'https://hydra.flyingcircus.io/build/54522/download/1/nixexprs.tar.xz'
+    mocked_responses.add(responses.HEAD, url)
+    channel = Channel(url, name='name', environment='env')
+    assert str(channel) == f'<Channel name=name, version=unknown, from={url}>'
+
+
 def test_channel_from_expr_url(mocked_responses):
     url = 'https://hydra.flyingcircus.io/build/54522/download/1/nixexprs.tar.xz'
     mocked_responses.add(responses.HEAD, url)

--- a/pkgs/fc/agent/shell.nix
+++ b/pkgs/fc/agent/shell.nix
@@ -1,0 +1,4 @@
+let
+  pkgs = import <nixpkgs> {};
+
+in pkgs.callPackage ./. {}


### PR DESCRIPTION
nixos-rebuild dry-build actually built the current system, not the next
channel as expected so the building happened later in the maintenance activity.
Also, the list of changing services was missing from the
maintenance activity message because of that.

The error exists since 19.03. Back then, the error message that
default.nix is missing in the combined channel
(release channel at /root/.nix-defexpr/channels/next) was discarded. It
"worked" without an error on 20.09 because there's a default.nix in the
combined channel but it still isn't used by nixos-rebuild because the
directory structure is wrong. It's just ignored and nixos-rebuild goes
to the next NIX_PATH entry
/nix/var/nix/profiles/per-user/root/channels/nixos which is the current
channel.

The combined channel is a directory that contains nixpkgs but isn't
nixpkgs so -I nixpkgs=(...)/next should be -I (...)/next. Nixos-rebuild
now correctly finds the new nixpkgs inside the dir and builds it.

The message now also includes the new environment name and the Hydra
URL.

The string representation of Channel is now more helpful
and consistent even with local checkouts.

 #PL-120275

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* fc-agent: pre-build updates which are scheduled to run in a maintenance window. Stopped/started/restarted/reloaded services are now reported correctly in maintenance mails and the UI. This also helps to find build errors earlier (#PL-120275).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  -  properly inform customers and staff about what will happen in a scheduled platform update
- [x] Security requirements tested? (EVIDENCE)
  - checked manually on a test VM that maintenances are scheduled correctly with the expected information
