### PR TITLE
Update nixpkgs for Gitlab 13.8.8

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -2,7 +2,7 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "753913a8cb8310f4631860b7f77af13bd00eb031",
-    "sha256": "1d1d06b29856fnml2m6shr28df13gbw83978q9bkq1svsfjpiycf"
+    "rev": "fcb7dc1b392549533e00f75d3d7409cf743a5cf0",
+    "sha256": "1282rshw33sxl8wpda7yycgx9w1b5kwsinisp5hm8d6bwx5ijr3h"
   }
 }


### PR DESCRIPTION
 #PL-129795

@flyingcircusio/release-managers

## Release process

* [NixOS 20.09] Gitlab will be restarted and unavailable for some minutes.

Changelog:

* Gitlab: update to 13.8.8 security release (#PL-129795).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - use a current Gitlab version with the latest security fixes
- [x] Security requirements tested? (EVIDENCE)
  - 13.8.8 is the most recent patch release
  - manually tested on staging Gitlab instance
  - automated test checks basic functionality