### PR TITLE
fc-agent: predict kernel change, increase predicted update time to 10min

### DIFF
--- a/pkgs/fc/agent/fc/util/nixos.py
+++ b/pkgs/fc/agent/fc/util/nixos.py
@@ -1,0 +1,24 @@
+"""Helpers for interaction with the NixOS system"""
+
+import logging
+import os
+import os.path as p
+
+
+def kernel_version(kernel):
+    """Guesses kernel version from /run/*-system/kernel.
+
+    Theory of operation: A link like `/run/current-system/kernel` points
+    to a bzImage like `/nix/store/abc...-linux-4.4.27/bzImage`. The
+    directory also contains a `lib/modules` dir which should have the
+    kernel version as sole subdir, e.g.
+    `/nix/store/abc...-linux-4.4.27/lib/modules/4.4.27`. This function
+    returns that version number or bails out if the assumptions laid down here
+    do not hold.
+    """
+    bzImage = os.readlink(kernel)
+    moddir = os.listdir(p.join(p.dirname(bzImage), 'lib', 'modules'))
+    if len(moddir) != 1:
+        raise RuntimeError('modules subdir does not contain exactly '
+                           'one item', moddir)
+    return moddir[0]


### PR DESCRIPTION
Add reboots caused by kernel updates to the channel update message
(delivered via mail and displayed in the directory) and set predicted
time to 10 minutes because 5 may be too short for some services with
long startup time.

 #PL-129798

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

fc-agent: add a notice to the maintenance annoncement when kernel updates will schedule a VM reboot. Estimated time for an update is increased to 10 minutes because some services may take minutes to restart (#PL-129798).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - properly inform customers and staff about what will happen in a scheduled platform update 
- [x] Security requirements tested? (EVIDENCE)
  -  checked manually on a test VM that the kernel update info is added, estimated time is 10min and reboot scheduling works correctly