### PR TITLE
create a more flexible PHP (LAMP+CLI) environment

### DIFF
--- a/doc/src/lamp.rst
+++ b/doc/src/lamp.rst
@@ -27,7 +27,7 @@ A complete configuration might looks something like this:
 
 .. code-block:: Nix
 
-	{ ... }:
+	{ pkgs, ... }:
 
 	{
 
@@ -38,6 +38,8 @@ A complete configuration might looks something like this:
 	        docroot = "/srv/s-myserviceuser/application.git/docroot";
 	      }
 	    ];
+
+	    php = pkgs.lamp_php74;
 
 	    apache_conf = ''
 	      MaxRequestWorkers 5
@@ -86,6 +88,34 @@ this to adjust global settings like workers:
 Note that if you distribute your configuration over multiple files then you
 can repeat this option and the values will be concatenated to a single big
 Apache config file. They will also always apply to all vhosts.
+
+
+``flyingcircus.roles.lamp.php`` (optional)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A reference to a PHP package that will be used in Apache and in the
+CLI. 
+
+Supported packages:
+
+* ``pkgs.lamp_php56`` (outdated but provided for legacy applications)
+* ``pkgs.lamp_php73``
+* ``pkgs.lamp_php74``
+
+You can also use any custom PHP package from the NixOS universe (if you
+know what you are doing. ;) )
+
+
+``flyingcircus.roles.lamp.tideways_api_key`` (optional)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you have an account with tideways.com then you can quickly enable the 
+tideways profiler for your application by setting the API key here:
+
+.. code-block:: Nix
+
+	flyingcircus.roles.lamp.tideways_api_key = "my-api-key";
+
 
 ``flyingcircus.roles.lamp.php_ini`` (optional)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/nixos/platform/packages.nix
+++ b/nixos/platform/packages.nix
@@ -53,9 +53,9 @@
         openldap
         openssl
         parted
-        php
         pkgconfig
         protobuf
+        w3m-nographics
         psmisc
         pwgen
         python2Full

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -37,7 +37,14 @@ in {
   kibana6 = callTest ./kibana.nix { version = "6"; };
   kibana7 = callTest ./kibana.nix { version = "7"; };
   kubernetes = callTest ./kubernetes {};
-  lamp = callTest ./lamp.nix {};
+
+  lamp = callTest ./lamp.nix { };
+  lamp56 = callTest ./lamp.nix { version = "lamp_php56"; };
+  lamp73 = callTest ./lamp.nix { version = "lamp_php73"; };
+  lamp73_tideways = callTest ./lamp.nix { version = "lamp_php73"; tideways = "1234"; };
+  lamp74 = callTest ./lamp.nix { version = "lamp_php74"; };
+  lamp74_tideways = callTest ./lamp.nix { version = "lamp_php74"; tideways = "1234"; };
+
   locale = callTest ./locale.nix {};
   login = callTest ./login.nix {};
   logging = callTest ./logging.nix {};

--- a/tests/lamp.nix
+++ b/tests/lamp.nix
@@ -1,15 +1,18 @@
-import ./make-test-python.nix ({ ... }:
+import ./make-test-python.nix ({ version ? "" , tideways ? "", ... }:
 {
   name = "lamp";
   nodes = {
     lamp =
-      { ... }:
+      { pkgs, config, ... }:
       {
         imports = [ ../nixos ../nixos/roles ];
+
         flyingcircus.roles.lamp = {
           enable = true;
 
           vhosts = [ { port = 8000; docroot = "/srv/docroot"; } ];
+
+          php = pkgs.lib.mkIf (version != "") pkgs.${version};
 
           apache_conf = ''
             # XXX test-i-am-the-custom-apache-conf
@@ -18,6 +21,9 @@ import ./make-test-python.nix ({ ... }:
           php_ini = ''
             # XXX test-i-a-m-the-custom-php-ini
           '';
+
+          tideways_api_key = tideways;
+
         };
       };
   };
@@ -32,10 +38,16 @@ import ./make-test-python.nix ({ ... }:
     lamp.wait_for_unit("httpd.service")
     lamp.wait_for_open_port(8000)
 
-    lamp.wait_for_unit("tideways-daemon.service")
-    lamp.wait_for_open_port(9135)
+    php_version = lamp.succeed('php --version').splitlines()[0]
+    php_version = php_version.split()[1]
+    php_version = int(php_version.split('.')[0])
+    print("Detected PHP major version: ", php_version)
 
-    lamp.succeed("journalctl -u tideways.daemon")
+    tideways_api_key = "${tideways}"
+
+    if tideways_api_key:
+      lamp.wait_for_unit("tideways-daemon.service")
+      lamp.wait_for_open_port(9135)
 
     with subtest("apache (httpd) opens expected ports"):
       assert_listen(lamp, "httpd", {"127.0.0.1:7999", "::1:7999", ":::8000"})
@@ -44,30 +56,78 @@ import ./make-test-python.nix ({ ... }:
       lamp.succeed("grep 'custom-apache-conf' ${nodes.lamp.config.services.httpd.configFile}")
       lamp.succeed("grep 'custom-php-ini' ${nodes.lamp.config.systemd.services.httpd.environment.PHPRC}")
 
-    with subtest("check if PHP support is working as expected"):
-      lamp.succeed('mkdir -p /srv/docroot')
-      lamp.succeed('echo "<? phpinfo(); ?>" > /srv/docroot/test.php')
+    lamp.succeed('mkdir -p /srv/docroot')
+    lamp.succeed('echo "<? phpinfo(); ?>" > /srv/docroot/test.php')
 
-      lamp.succeed("curl -f -v http://localhost:8000/test.php -o result")
-      lamp.succeed("grep 'tideways.api_key' result")
-      lamp.succeed("grep 'files user memcached redis rediscluster' result")
-      lamp.succeed("grep module_redis result")
-      lamp.succeed("grep module_imagick result")
-      lamp.succeed("grep module_memcached result")
-      lamp.succeed("grep -e 'short_open_tag.*On' result")
-      lamp.succeed("grep -e 'output_buffering.*>1<' result")
-      lamp.succeed("grep -e 'curl.cainfo.*/etc/ssl/certs/ca-certificates.crt' result")
-      lamp.succeed("grep -e 'Path to sendmail.*sendmail -t -i' result")
+    with subtest("check if PHP support is working as expected in CLI"):
+      lamp.succeed("php /srv/docroot/test.php > result")
+      print(lamp.succeed('cat result'))
+      print(lamp.succeed('set'))
 
-      lamp.succeed("grep -e 'opcache.enable.*On' result")
+      lamp.succeed("egrep 'Registered save handlers.*files' result")
+      lamp.succeed("egrep 'Registered save handlers.*user' result")
+      if php_version > 5:
+        lamp.succeed("egrep 'Registered save handlers.*redis' result")
+        lamp.succeed("egrep 'Registered save handlers.*memcached' result")
 
-      lamp.succeed("grep -e 'error_log.*syslog' result")
-      lamp.succeed("grep -e 'display_errors.*Off' result")
-      lamp.succeed("grep -e 'log_errors.*On' result")
+      lamp.succeed("egrep 'Redis Support => enabled' result")
+      lamp.succeed("egrep 'imagick module => enabled' result")
+      lamp.succeed("egrep 'memcached support => enabled' result")
+      lamp.succeed("egrep 'short_open_tag.*On' result")
+      lamp.succeed("egrep 'output_buffering => 0 => 0' result")
 
-      lamp.succeed("grep -e 'memory_limit.*1024m' result")
-      lamp.succeed("grep -e 'max_execution_time.*800' result")
-      lamp.succeed("grep -e 'session.auto_start.*Off' result")
+      if php_version > 5:
+        lamp.succeed("egrep 'curl.cainfo.*/etc/ssl/certs/ca-certificates.crt' result")
+
+      if tideways_api_key:
+        lamp.succeed("egrep 'tideways' result")  
+        lamp.succeed("grep 'Can connect to tideways-daemon?.*Yes' result")
+
+      lamp.succeed("egrep 'Path to sendmail.*sendmail -t -i' result")
+      lamp.succeed("egrep 'opcache.enable => On => On' result")
+      lamp.succeed("egrep 'opcache.enable_cli => Off => Off' result")
+
+      lamp.succeed("egrep 'error_log.*syslog' result")
+      lamp.succeed("egrep 'display_errors.*Off' result")
+      lamp.succeed("egrep 'log_errors.*On' result")
+
+      lamp.succeed("egrep 'memory_limit.*1024m' result")
+      lamp.succeed("egrep 'max_execution_time => 0 => 0' result")
+      lamp.succeed("egrep 'session.auto_start.*Off' result")
+
+    with subtest("check if PHP support is working as expected in apache"):
+      lamp.succeed("w3m -cols 400 -dump http://localhost:8000/test.php > result")
+      print(lamp.succeed('cat result'))
+
+      lamp.succeed("egrep 'Registered save handlers.*files' result")
+      lamp.succeed("egrep 'Registered save handlers.*user' result")
+      lamp.succeed("egrep 'Registered save handlers.*redis' result")
+      lamp.succeed("egrep 'Registered save handlers.*memcached' result")
+
+      lamp.succeed("egrep 'Redis Support +enabled' result")
+      lamp.succeed("egrep 'imagick module +enabled' result")
+      lamp.succeed("egrep 'memcached support +enabled' result")
+      lamp.succeed("egrep 'short_open_tag.*On' result")
+      lamp.succeed("egrep 'output_buffering +1 +1' result")
+
+      if php_version > 5:
+        lamp.succeed("egrep 'curl.cainfo.*/etc/ssl/certs/ca-certificates.crt' result")
+
+      if tideways_api_key:
+        lamp.succeed("egrep 'tideways' result")
+        lamp.succeed("grep 'Can connect to tideways-daemon?.*Yes' result")
+
+      lamp.succeed("egrep 'Path to sendmail.*sendmail -t -i' result")
+      lamp.succeed("egrep 'opcache.enable.*On' result")
+
+      lamp.succeed("egrep 'error_log.*syslog' result")
+      lamp.succeed("egrep 'display_errors.*Off' result")
+      lamp.succeed("egrep 'log_errors.*On' result")
+
+      lamp.succeed("egrep 'memory_limit.*1024m' result")
+      lamp.succeed("egrep 'max_execution_time.*800' result")
+      lamp.succeed("egrep 'session.auto_start.*Off' result")
+
     '';
 
 })

--- a/versions.json
+++ b/versions.json
@@ -4,5 +4,11 @@
     "repo": "nixpkgs",
     "rev": "fcb7dc1b392549533e00f75d3d7409cf743a5cf0",
     "sha256": "1282rshw33sxl8wpda7yycgx9w1b5kwsinisp5hm8d6bwx5ijr3h"
+  },
+  "nixpkgs_18_03": {
+    "owner": "nixos",
+    "repo": "nixpkgs",
+    "rev": "3e1be2206b4c1eb3299fb633b8ce9f5ac1c32898",
+    "sha256": "11d01fdb4d1avi7564h7w332h3jjjadsqwzfzpyh5z56s6rfksxc"
   }
 }


### PR DESCRIPTION
- support PHP 5.6, 7.3, and 7.4 with appropriate modules
- only enable tideways support if an API key is known
- ensure the proper PHP (incl. php.ini) is used in a CLI environment
- Switch to Apache's mpm_prefork and use adjusted settings.
  mpm_event has shown to be unreliable in some heavy duty scenarios.
- add more tests

@flyingcircusio/release-managers

## Release process

Impact:

* LAMP-based services will be restarted.

Changelog:

* Major improvements of our LAMP role.

  * We now provide PHP 5.6 (legacy), 7.3 (default) and PHP 7.4 (optional)
  * Tideways integration is automatically enabled/disabled if an API key is provided.
  * We are switching from mpm_event to mpm_prefork as we have seen too many issues with threading and rather prefer a stable service.
  * We added more test coverage to ensure future stability.
  
## Security implications

- [X] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

Generally no big changes here, but one important: we are now allowing use of an ooooold PHP version that is required due to customers running legacy applications. However, this requires an additional step to select and install, so it's fine and we document that this is a problem. We did update 5.6 to a the most recent version that exists, though (5.6.40).

- [X] Security requirements tested? (EVIDENCE)

I think I got everything covered with automated tests.