### PR TITLE
Add BCMath to LAMP-PHP-environment

### DIFF
--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -83,8 +83,8 @@ in {
 
   # Those are specialised packages for "direct consumption" use in our LAMP roles.
 
-  lamp_php56 = 
-    let 
+  lamp_php56 =
+    let
       phpIni = super.writeText "php.ini" ''
       ${builtins.readFile "${nixpkgs_18_03.php56}/etc/php.ini"}
       extension = ${nixpkgs_18_03.php56Packages.redis}/lib/php/extensions/redis.so
@@ -103,9 +103,19 @@ in {
     });
 
   lamp_php73 = super.php73.withExtensions ({ enabled, all }:
-              enabled ++ [ all.memcached all.imagick all.redis]);
+              enabled ++ [
+                all.bcmath
+                all.imagick
+                all.memcached
+                all.redis
+              ]);
   lamp_php74 = super.php74.withExtensions ({ enabled, all }:
-              enabled ++ [ all.memcached all.imagick all.redis]);
+              enabled ++ [
+                all.bcmath
+                all.imagick
+                all.memcached
+                all.redis
+              ]);
 
   mc = super.callPackage ./mc.nix { };
 

--- a/tests/lamp.nix
+++ b/tests/lamp.nix
@@ -80,7 +80,7 @@ import ./make-test-python.nix ({ version ? "" , tideways ? "", ... }:
         lamp.succeed("egrep 'curl.cainfo.*/etc/ssl/certs/ca-certificates.crt' result")
 
       if tideways_api_key:
-        lamp.succeed("egrep 'tideways' result")  
+        lamp.succeed("egrep 'tideways' result")
         lamp.succeed("grep 'Can connect to tideways-daemon?.*Yes' result")
 
       lamp.succeed("egrep 'Path to sendmail.*sendmail -t -i' result")
@@ -94,6 +94,7 @@ import ./make-test-python.nix ({ version ? "" , tideways ? "", ... }:
       lamp.succeed("egrep 'memory_limit.*1024m' result")
       lamp.succeed("egrep 'max_execution_time => 0 => 0' result")
       lamp.succeed("egrep 'session.auto_start.*Off' result")
+      lamp.succeed("egrep 'BCMath support.*enabled' result")
 
     with subtest("check if PHP support is working as expected in apache"):
       lamp.succeed("w3m -cols 400 -dump http://localhost:8000/test.php > result")
@@ -109,6 +110,7 @@ import ./make-test-python.nix ({ version ? "" , tideways ? "", ... }:
       lamp.succeed("egrep 'memcached support +enabled' result")
       lamp.succeed("egrep 'short_open_tag.*On' result")
       lamp.succeed("egrep 'output_buffering +1 +1' result")
+      lamp.succeed("egrep 'BCMath support.*enabled' result")
 
       if php_version > 5:
         lamp.succeed("egrep 'curl.cainfo.*/etc/ssl/certs/ca-certificates.crt' result")


### PR DESCRIPTION
This adds BCMath to PHP 7.3 and 7.4 -- on 5.6 it was already present via a compiler flag of PHP itself

@flyingcircusio/release-managers

## Release process

Impact:
* Restarts Apache

Changelog:

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - BCMath is available in PHP scripts
- [x] Security requirements tested? (EVIDENCE)
  - Tested via php -i

