### PR TITLE
Update nixpkgs

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "fcb7dc1b392549533e00f75d3d7409cf743a5cf0",
-    "sha256": "1282rshw33sxl8wpda7yycgx9w1b5kwsinisp5hm8d6bwx5ijr3h"
+    "rev": "be3024f017f3c5cbf554516c28c4d0dae97d300d",
+    "sha256": "1dksfs0p9gwcc8sls7s6lkcb4di522fkanirw005xq5r90l3yps3"
   },
   "nixpkgs_18_03": {
     "owner": "nixos",


### PR DESCRIPTION
Notable changes:

* clamav: add patch for CVE-2021-1405
* imagemagick6: 6.9.12-3 -> 6.9.12-8
* imagemagick: 7.0.11-6 -> 7.0.11-8
* linux: 5.4.109 -> 5.4.111
* phpPackages.composer2: 2.0.0 -> 2.0.12
* postfix: 3.5.6 -> 3.5.10

 #PL-129805

@flyingcircusio/release-managers

## Release process

Impact:

* [NixOS 20.09] VMs will schedule a reboot to activate the new kernel version.

Changelog: 

(include changes from commit msg here)


## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - pull in upstream security fixes regularly
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still run, works on test VM and gitlab staging VM
  - checked commit log for fixed CVEs and possible problems with updates