### PR TITLE
Update backy to enable hot reload instead of restarts.

### DIFF
--- a/nixos/roles/backyserver.nix
+++ b/nixos/roles/backyserver.nix
@@ -76,6 +76,10 @@ in
           CEPH_ARGS = "--id ${enc.name}";
         };
 
+        serviceConfig = {
+          ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
+        };
+
         # Theory of operation: raising write_expire timeouts means that
         # requests are much more unlikely to get into 'expired' state which effectively
         # means FIFO which means thrashing under high load.

--- a/pkgs/backy.nix
+++ b/pkgs/backy.nix
@@ -62,8 +62,8 @@ py.buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "flyingcircusio";
     repo = "backy";
-    rev = "f70db74126d1408ef2da6be09101efe80af6e388";
-    sha256 = "1scsqr03543rbgkk4ifj067lmfsf3q0fr6d5cwb2b1wqg43kxi2m";
+    rev = "4419a55aa2c1c1bfb88d81549102f5f63b58bd1b";
+    sha256 = "1fqfa7zgyp3ik1gqg05r8bjz2yi3gb9iydx7plckx0xybkpbgyii";
   };
 
   buildInputs = [
@@ -78,6 +78,8 @@ py.buildPythonPackage rec {
     py.pytz
     py.setuptools
     py.prettytable
+    py.humanize
+    py.tzlocal
     consulate
     murmurhash3
     telnetlib3

--- a/pkgs/backy.nix
+++ b/pkgs/backy.nix
@@ -62,8 +62,8 @@ py.buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "flyingcircusio";
     repo = "backy";
-    rev = "4419a55aa2c1c1bfb88d81549102f5f63b58bd1b";
-    sha256 = "1fqfa7zgyp3ik1gqg05r8bjz2yi3gb9iydx7plckx0xybkpbgyii";
+    rev = "80222fafe47ad4a9c3032857059c41e1b1185e03";
+    sha256 = "0n0a32v657g9n03dab8zh8q47jqf66qn73f4kmapmph87ycw8j08";
   };
 
   buildInputs = [

--- a/pkgs/fc/agent/fc/manage/backy.py
+++ b/pkgs/fc/agent/fc/manage/backy.py
@@ -38,7 +38,7 @@ class BackyConfig(object):
         self.purge()
         if self.changed and restart:
             _log.info('config changed, restarting backy')
-            subprocess.check_call(['systemctl', 'restart', 'backy'])
+            subprocess.check_call(['systemctl', 'reload', 'backy'])
 
     @property
     def deletions(self):


### PR DESCRIPTION
Fixes PL-129718

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Upgrade our backup software (backy) with a variety of improvements. Most notably we implemented a hot reload feature so that backup schedules will be more consistent when many config changes are processed, which previously led to frequent restarts and aborted backups that had to be retried later on.

## Security implications

- [X] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

* 2 new dependencies
* more consistent SLAs contribute to overall system safety by ensuring backup availability

- [X] Security requirements tested? (EVIDENCE)

* Author communities of dependencies are known and dependencies appear to be trustworthy.
* Tests work
* Improved test coverage analysis
* Manual testing on patty