### PR TITLE
PL-129792 persist scheduler=none for database vms

### DIFF
--- a/nixos/infrastructure/default.nix
+++ b/nixos/infrastructure/default.nix
@@ -17,6 +17,11 @@
       example = "flyingcircus";
       description = "Load config module for specific infrastructure.";
     };
+    flyingcircus.infrastructure.preferNoneSchedulerOnSsd = mkOption {
+      type = types.bool;
+      default = false;
+      description = "If running on SSD set I/O scheduler to none";
+    };
   };
 
 }

--- a/nixos/infrastructure/flyingcircus-virtual.nix
+++ b/nixos/infrastructure/flyingcircus-virtual.nix
@@ -4,6 +4,9 @@ with lib;
 
 let
   cfg = config.flyingcircus;
+  ioScheduler =  if (cfg.infrastructure.preferNoneSchedulerOnSsd && (cfg.enc.parameters.rbd_pool == "rbd.ssd"))
+                 then "none"
+                 else "bfq";
 in
 mkIf (cfg.infrastructureModule == "flyingcircus") {
  
@@ -55,8 +58,7 @@ mkIf (cfg.infrastructureModule == "flyingcircus") {
     udev.extraRules = ''
       # GRUB boot device should be device-by-alias/root
       SUBSYSTEM=="block", KERNEL=="vda", SYMLINK+="disk/device-by-alias/root"
-      # Use BFQ for better fairness
-      SUBSYSTEM=="block", ACTION=="add|change", KERNEL=="vd[a-z]", ATTR{queue/scheduler}="bfq", ATTR{queue/rotational}="0"
+      SUBSYSTEM=="block", ACTION=="add|change", KERNEL=="vd[a-z]", ATTR{queue/scheduler}="${ioScheduler}", ATTR{queue/rotational}="0"
     '';
   };
 

--- a/nixos/roles/mongodb.nix
+++ b/nixos/roles/mongodb.nix
@@ -106,6 +106,8 @@ in {
         home = "/srv/mongodb";
       };
 
+      flyingcircus.infrastructure.preferNoneSchedulerOnSsd = true;
+
       flyingcircus.activationScripts = {
 
         mongodb-dirs = lib.stringAfter [ "users" "groups" ] ''

--- a/nixos/services/percona.nix
+++ b/nixos/services/percona.nix
@@ -219,6 +219,8 @@ in
 
     environment.systemPackages = [ mysql ];
 
+    flyingcircus.infrastructure.preferNoneSchedulerOnSsd = true;
+
     systemd.services.mysql = {
       description = "MySQL Server";
       wantedBy = [ "multi-user.target" ];

--- a/nixos/services/postgresql.nix
+++ b/nixos/services/postgresql.nix
@@ -109,6 +109,8 @@ in {
         is being included with include_dir.
         '';
 
+    flyingcircus.infrastructure.preferNoneSchedulerOnSsd = true;
+
     flyingcircus.activationScripts = {
       postgresql-srv = lib.stringAfter [ "users" "groups" ] ''
         install -d -o postgres /srv/postgresql


### PR DESCRIPTION
@flyingcircusio/release-managers

Add option to disable I/O scheduler on SSDs and sets this option in database roles.

## Release process

Impact:

NONE

Changelog:

Machines with database roles (percona, mongodb, mysql and postgresql) now disable I/O scheduling when running on SSDs for better performance.

## Security implications

- [X] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

Codes has no implications for security but changes settings for optimisation.

- [X] Security requirements tested? (EVIDENCE)