### PR TITLE
php: fix locales for PHP 5.6

### DIFF
--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -95,11 +95,16 @@ in {
     in (nixpkgs_18_03.php56).overrideAttrs (oldAttrs: rec {
       version = "5.6.40";
       name = "php-5.6.40";
+      buildInputs = oldAttrs.buildInputs ++ [ super.makeWrapper ];
       src = super.fetchurl {
         url = "http://www.php.net/distributions/php-${version}.tar.bz2";
         sha256 = "005s7w167dypl41wlrf51niryvwy1hfv53zxyyr3lm938v9jbl7z";
       };
       passthru = { phpIni = "${phpIni}"; };
+      postInstall = oldAttrs.postInstall or "" + ''
+        wrapProgram $out/bin/php \
+          --set LOCALE_ARCHIVE ${nixpkgs_18_03.glibcLocales}/lib/locale/locale-archive
+      '';
     });
 
   lamp_php73 = super.php73.withExtensions ({ enabled, all }:

--- a/tests/lamp.nix
+++ b/tests/lamp.nix
@@ -96,6 +96,9 @@ import ./make-test-python.nix ({ version ? "" , tideways ? "", ... }:
       lamp.succeed("egrep 'session.auto_start.*Off' result")
       lamp.succeed("egrep 'BCMath support.*enabled' result")
 
+      # PL-129824 PHP (5.6) locales
+      lamp.succeed("php -r 'var_dump(setlocale(LC_TIME, \"de_DE.UTF8\"));' | grep de_DE")
+
     with subtest("check if PHP support is working as expected in apache"):
       lamp.succeed("w3m -cols 400 -dump http://localhost:8000/test.php > result")
       print(lamp.succeed('cat result'))


### PR DESCRIPTION
Fixes PL-129824

@flyingcircusio/release-managers

## Release process

Impact:

* LAMP servers using PHP 5.6 will be restarted.

Changelog:

* Fix usage of `locale-archive` for ported PHP 5.6 binaries by using the correct glibc-compatible archive. (PL-129824)

## Security implications

- [X] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

not relevant IMHO

- [X] Security requirements tested? (EVIDENCE)

added test for edge case