### PR TITLE
Stabilise monodb. Now it does not fail anymore just for timing reasons

### DIFF
--- a/tests/mongodb.nix
+++ b/tests/mongodb.nix
@@ -72,6 +72,7 @@ in {
         machine.succeed("killall -11 mongod")
         import time
         time.sleep(5)
+        machine.wait_for_unit("mongodb.service")
         machine.succeed("systemctl show mongodb | grep ActiveState=active")
         _, out = machine.execute('pgrep mongod')
         new_pid = int(out.strip())


### PR DESCRIPTION
Now it does not fail anymore just for timing reasons.
    #PL-129796

@flyingcircusio/release-managers

## Release process

Impact:

NONE

Changelog:

NONE

## Security implications

- [X] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

    - Test results should be consisten with same input. 

- [X] Security requirements tested? (EVIDENCE)

    - Test was run multiple times without failing