### PR TITLE
Extend list of by-default ignored patterns for fc-userscan

### DIFF
--- a/nixos/platform/garbagecollect/userscan.exclude
+++ b/nixos/platform/garbagecollect/userscan.exclude
@@ -18,6 +18,7 @@ fc-userscan.cache
 GeoLite2-City.mmdb
 *.gif
 .git/objects/
+.gnupg/
 graylog/data/
 *.gz
 *.hg/store/
@@ -87,4 +88,6 @@ solr/data/
 *.xlsx
 *.xml
 *.xz
+*.zdsock
 zeoclient_*.zec
+*.zopectlsock


### PR DESCRIPTION
@flyingcircusio/release-managers

This PR extends the list of by-default ignored patterns for fc-usercan.
The .gnupg folder has very often restricted permissions which might causes the userscan process from to fail. Also adding some more versions of (zope) related sockets. 

## Release process

Impact:

Changelog:

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [x] Security requirements tested? (EVIDENCE)
   * Used the patterns in customer .fc-userscan configuration file on some VM 

