### PR TITLE
Bring back docsplit package

### DIFF
--- a/pkgs/docsplit/Gemfile
+++ b/pkgs/docsplit/Gemfile
@@ -1,0 +1,2 @@
+source 'http://rubygems.org'
+gem 'docsplit', "0.7.6"

--- a/pkgs/docsplit/Gemfile.lock
+++ b/pkgs/docsplit/Gemfile.lock
@@ -1,0 +1,13 @@
+GEM
+  remote: http://rubygems.org/
+  specs:
+    docsplit (0.7.6)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  docsplit (= 0.7.6)
+
+BUNDLED WITH
+   1.10.6

--- a/pkgs/docsplit/default.nix
+++ b/pkgs/docsplit/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, bundlerApp
+, ruby
+, libreoffice
+, file
+, graphicsmagick
+, poppler_utils
+, pdftk
+, jre
+, makeWrapper
+, ... }:
+
+bundlerApp {
+  pname = "docsplit";
+  ruby = ruby;
+  gemdir = ./.;
+  exes = [ "docsplit" ];
+  postBuild = ''
+    # this is somewhat of a hack as bundlerApp defines its own set of wrappers
+    source ${makeWrapper}/nix-support/setup-hook
+
+    wrapProgram $out/bin/docsplit \
+      --set OFFICE_PATH ${libreoffice}/bin \
+      --prefix PATH : ${lib.makeBinPath
+        [ file graphicsmagick poppler_utils pdftk jre ] }
+  '';
+
+  meta = with lib; {
+    description = ''
+      A command-line utility and Ruby library for splitting apart documents
+      into their component parts
+    '';
+    homepage    = https://documentcloud.github.io/docsplit/;
+    license     = licenses.lgpl2;
+    maintainers = with maintainers; [ zagy ];
+    platforms   = platforms.unix;
+  };
+}

--- a/pkgs/docsplit/gemset.nix
+++ b/pkgs/docsplit/gemset.nix
@@ -1,0 +1,9 @@
+{
+  "docsplit" = {
+    version = "0.7.6";
+    source = {
+      type = "gem";
+      sha256 = "0qx8sr7klp272zylsnf7bdq77vizxd2bc9ym2vb4mky93nb68k55";
+    };
+  };
+}

--- a/pkgs/docsplit/update.sh
+++ b/pkgs/docsplit/update.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -x
+export NIX_PATH="nixpkgs=$(dirname $0)/../../../../../"
+rm -rf .bundle
+rm -f Gemfile.lock
+rm -rf /tmp/bundix
+nix-shell -p git -p stdenv -p stdenv -p cacert -p bundler -p openssl \
+    -p nix-prefetch-scripts \
+    --command "bundler package --all --no-install --path /tmp/bundix/bundle"
+nix-shell -p bundix -p nix-prefetch-scripts --command bundix

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -37,6 +37,8 @@ in {
       boost = super.boost155;
   });
 
+  docsplit = super.callPackage ./docsplit { };
+
   elasticsearch7 = super.elasticsearch7.overrideAttrs(_: rec {
     version = elk7Version;
     name = "elasticsearch-${version}";


### PR DESCRIPTION
The old code still works and the reason for removing it is gone.
Libreoffice is now fetched from the upstream cache.

 #PL-129829

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Add docsplit package (#PL-129829).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - same as before, we already used that piece of code in earlier versions
  - not installed by default, only used for customer deployments
- [x] Security requirements tested? (EVIDENCE)
  - ran the executable to see if it works
