### PR TITLE
Update nixpkgs

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "be3024f017f3c5cbf554516c28c4d0dae97d300d",
-    "sha256": "1dksfs0p9gwcc8sls7s6lkcb4di522fkanirw005xq5r90l3yps3"
+    "rev": "e9de7f2ce45c58127fe27db9617d4de96e7d49b5",
+    "sha256": "0h0lvvdwnjgdqwd0lzfkg8if46vs2wcml4z5r969054f36mprkx8"
   },
   "nixpkgs_18_03": {
     "owner": "nixos",


### PR DESCRIPTION
Notable security fixes and updates:

* cifs-utils: fix CVE-2021-20208
* imagemagick: 7.0.11-8 -> 7.0.11-9
* perlPackages.ImageExifTool: apply fix for CVE-2021-22204
* linux: 5.4.111 -> 5.4.114
* phpPackages.composer: 1.10.8 -> 1.10.22 (CVE-2021-29472)
* phpPackages.composer2: 2.0.12 -> 2.0.13 (CVE-2021-29472)
* dnsmasq: 2.84 -> 2.85

 #PL-129839

@flyingcircusio/release-managers

## Release process

Impact: 

* VMs will schedule a reboot to activate the new kernel version.

Changelog: (include changes from commit msg here)

## Security implications
 
- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - pull in upstream security fixes regularly
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still run, works on test VM
  - checked commit log for fixed CVEs and possible problems with updates
