### PR TITLE
Grafana 7.5.2 -> 7.5.5

### DIFF
--- a/pkgs/grafana.nix
+++ b/pkgs/grafana.nix
@@ -1,8 +1,11 @@
+# Only a version change compared to upstream but overriding doesn't seem to
+# work correctly with Go modules.
+
 { lib, buildGoModule, fetchurl, fetchFromGitHub, nixosTests }:
 
 buildGoModule rec {
   pname = "grafana";
-  version = "7.5.2";
+  version = "7.5.5";
 
   excludedPackages = [ "release_publisher" ];
 
@@ -10,17 +13,24 @@ buildGoModule rec {
     rev = "v${version}";
     owner = "grafana";
     repo = "grafana";
-    sha256 = "sha256-8Qy5YgJZpvaAjeBAi092Jxg4yAD1fYmMteTRm5b0Q+g=";
+    sha256 = "1zqix5r7m8ngpczqd3hfxs46wnylq6nd4x3xk8kicjj1d5qmzrwk";
   };
 
   srcStatic = fetchurl {
     url = "https://dl.grafana.com/oss/release/grafana-${version}.linux-amd64.tar.gz";
-    sha256 = "sha256-yVswMNOLX/AFtv45TXm8WcHEytyYgtjvi7V0dRewDdc=";
+    sha256 = "1drz3kw4vapsrcnx5h6yh64lw4iah13c8mn7544gay8n614rxw7c";
   };
 
-  vendorSha256 = "sha256-oh3GB6Iaqy05IS2MU5LJqTXnlr0vtkACZA6wpmW7W2Q=";
+  vendorSha256 = "01a5v292x59fmayjkqnf4c8k8viasxr2s2khs4yrv6p829lx3hq2";
 
+  # grafana-aws-sdk is specified with two versions which causes a problem later:
+  # go: inconsistent vendoring in /build/source:
+  #  github.com/grafana/grafana-aws-sdk@v0.3.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
+  # Remove the older one here to fix this.
   postPatch = ''
+    substituteInPlace go.mod \
+      --replace 'github.com/grafana/grafana-aws-sdk v0.3.0' ""
+
     substituteInPlace pkg/cmd/grafana-server/main.go \
       --replace 'var version = "5.0.0"'  'var version = "${version}"'
   '';

--- a/pkgs/grafana.nix
+++ b/pkgs/grafana.nix
@@ -1,0 +1,49 @@
+{ lib, buildGoModule, fetchurl, fetchFromGitHub, nixosTests }:
+
+buildGoModule rec {
+  pname = "grafana";
+  version = "7.5.2";
+
+  excludedPackages = [ "release_publisher" ];
+
+  src = fetchFromGitHub {
+    rev = "v${version}";
+    owner = "grafana";
+    repo = "grafana";
+    sha256 = "sha256-8Qy5YgJZpvaAjeBAi092Jxg4yAD1fYmMteTRm5b0Q+g=";
+  };
+
+  srcStatic = fetchurl {
+    url = "https://dl.grafana.com/oss/release/grafana-${version}.linux-amd64.tar.gz";
+    sha256 = "sha256-yVswMNOLX/AFtv45TXm8WcHEytyYgtjvi7V0dRewDdc=";
+  };
+
+  vendorSha256 = "sha256-oh3GB6Iaqy05IS2MU5LJqTXnlr0vtkACZA6wpmW7W2Q=";
+
+  postPatch = ''
+    substituteInPlace pkg/cmd/grafana-server/main.go \
+      --replace 'var version = "5.0.0"'  'var version = "${version}"'
+  '';
+
+  # main module (github.com/grafana/grafana) does not contain package github.com/grafana/grafana/scripts/go
+  # main module (github.com/grafana/grafana) does not contain package github.com/grafana/grafana/dashboard-schemas
+  preBuild = ''
+    rm -r dashboard-schemas scripts/go
+  '';
+
+  postInstall = ''
+    tar -xvf $srcStatic
+    mkdir -p $out/share/grafana
+    mv grafana-*/{public,conf,tools} $out/share/grafana/
+  '';
+
+  passthru.tests = { inherit (nixosTests) grafana; };
+
+  meta = with lib; {
+    description = "Gorgeous metric viz, dashboards & editors for Graphite, InfluxDB & OpenTSDB";
+    license = licenses.asl20;
+    homepage = "https://grafana.com";
+    maintainers = with maintainers; [ offline fpletz willibutz globin ma27 Frostman ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -62,6 +62,8 @@ in {
     };
   });
 
+  grafana = super.callPackage ./grafana.nix { };
+
   grub2_full = super.callPackage ./grub/2.0x.nix { };
 
   innotop = super.callPackage ./percona/innotop.nix { };


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

* [NixOS 20.09] Grafana will be restarted.

Changelog:

* Grafana: 7.5.2 -> 7.5.5. This update fixes a problem with frequent logouts (#PL-129789).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - users should be logged out after a timeout but not randomly 
  - use a recent grafana version
- [x] Security requirements tested? (EVIDENCE)
  - checked changelog 
  - automated test (statshost-global) still runs, checked manually on test RG statshost
