### PR TITLE
Fix raid cache bbu monitoring for machines that do not have a BBU.

### DIFF
--- a/pkgs/fc/sensuplugins/fc/sensuplugins/megaraid_cache.py
+++ b/pkgs/fc/sensuplugins/fc/sensuplugins/megaraid_cache.py
@@ -11,10 +11,11 @@ flag. If this flag is set, return CRITICAL unconditionally.
 import argparse
 import collections
 import logging
-import nagiosplugin
 import os
 import re
 import subprocess
+
+import nagiosplugin
 
 _log = logging.getLogger('nagiosplugin')
 
@@ -150,6 +151,9 @@ class BatteryReplace(nagiosplugin.Resource):
                 return [nagiosplugin.Metric('battery_replacement', 'no')]
             raise RuntimeError('failed to query BBU status', e.output,
                                e.returncode)
+        if not 'BBU status for Adapter' in stdout:
+            # There is no adapter (with BBU) here at all. Nothing to report
+            return [nagiosplugin.Metric('battery_replacement', 'none')]
         _log.info('battery status: %s', stdout)
         for line in stdout.splitlines():
             try:


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

none

Changelog:

* Silence RAID controller cache/BBU monitoring for machines that do not have a BBU. (PL-126095)

## Security implications

- [X] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

Monitoring needs to be reliable and avoid confusion.

- [X] Security requirements tested? (EVIDENCE)

Manually executed on bb06.

