### PR TITLE
Nginx: generate dhparams

### DIFF
--- a/nixos/services/nginx/default.nix
+++ b/nixos/services/nginx/default.nix
@@ -278,6 +278,12 @@ in
 
       security.acme.certs = acmeSettings;
 
+      # DH param file is located at /var/lib/dhparams/nginx.pem.
+      # The path can also be referenced from Nix code by `security.dhparams.params.nginx.path`;
+      security.dhparams.params = {
+        nginx = {};
+      };
+
       flyingcircus.passwordlessSudoRules = [
         {
           commands = [ "/run/current-system/sw/bin/nginx-check-config" ];

--- a/tests/nginx.nix
+++ b/tests/nginx.nix
@@ -236,5 +236,9 @@ in {
     with subtest("status check should be red after shutting down nginx"):
       server.systemctl('stop nginx')
       server.fail("${sensuCheck "nginx_status"}")
+
+    with subtest("dhparams file should contain something"):
+      server.wait_for_unit("dhparams-init.service")
+      server.succeed("test -s /var/lib/dhparams/nginx.pem")
   '';
 })


### PR DESCRIPTION
Generate dhparams at /var/lib/dhparams/nginx.pem. Note they are not used
by default and must be added to the config manually or by setting
services.nginx.sslDhparam = config.security.dhparams.params.nginx.path;

 #PL-129859

@flyingcircusio/release-managers

## Release process

Impact: 

Changelog:

* Nginx: generate dhparams at /var/lib/dhparams/nginx.pem. Note they are not used by default and must be added to the config manually or by setting `services.nginx.sslDhparam = config.security.dhparams.params.nginx.path;`

## Security implications

The change only affects security if the dhparams are used in the Nginx config which is not the case by default.

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - use strong SSL ciphers but allow the use of weaker ciphers if needed
- [x] Security requirements tested? (EVIDENCE)
  - checked that dhparams are generated on a test VM
  - automated test checks that dhparams file is generated
