### PR TITLE
Update Jitsi components, add Jibri for recordings, WASM

### DIFF
--- a/nixos/roles/jitsi/default.nix
+++ b/nixos/roles/jitsi/default.nix
@@ -14,7 +14,7 @@ let
   turnHostName = if cfg.coturn.enable then cfg.coturn.hostName else cfg.turnHostName;
 
   # Does the same on the backend side but UI buttons can be turned on/off seperately.
-  enableJibriIntegration = cfg.enableRecording || cfg.enableLivestreaming;
+  enableJibri = cfg.enableRecording || cfg.enableLivestreaming;
 
 in {
 
@@ -192,7 +192,7 @@ in {
         lib.optionalAttrs cfg.enableRoomAuthentication {
           "org.jitsi.jicofo.auth.URL" = "XMPP:${cfg.hostName}";
         } //
-        lib.optionalAttrs enableJibriIntegration {
+        lib.optionalAttrs enableJibri {
           "org.jitsi.jicofo.jibri.BREWERY" = "jibribrewery@internal.${cfg.hostName}";
           "org.jitsi.jicofo.jibri.PENDING_TIMEOUT"= "90";
         };
@@ -200,6 +200,7 @@ in {
       services.jitsi-meet = {
         enable = true;
         nginx.enable = true;
+        jibri.enable = enableJibri;
         jicofo.enable = true;
         videobridge.enable = true;
         prosody.enable = true;
@@ -239,7 +240,7 @@ in {
         lib.optionalAttrs cfg.enableRoomAuthentication {
           hosts.anonymousdomain = "guest.${cfg.hostName}";
         } //
-        lib.optionalAttrs enableJibriIntegration {
+        lib.optionalAttrs enableJibri {
           hiddenDomain = "recorder.${cfg.hostName}";
         } //
         lib.optionalAttrs cfg.enableXMPPWebsockets {
@@ -257,6 +258,8 @@ in {
         };
 
       };
+
+      services.jitsi-videobridge.apis = [ "rest" ];
 
       services.nginx.virtualHosts = {
         "${cfg.hostName}" = {
@@ -364,7 +367,7 @@ in {
               '';
             };
           } //
-          lib.optionalAttrs enableJibriIntegration {
+          lib.optionalAttrs enableJibri {
             # Jibri gets special rights and needs its own vhost for that.
             # c2s encryption doesn't work for unknown reasons but both are on the
             # same host, so it's ok.

--- a/nixos/services/default.nix
+++ b/nixos/services/default.nix
@@ -2,9 +2,12 @@
 let
   modulesFromHere = [
     "services/misc/gitlab.nix"
-    "services/monitoring/prometheus/default.nix"
     "services/monitoring/prometheus.nix"
+    "services/monitoring/prometheus/default.nix"
+    "services/networking/jicofo.nix"
     "services/networking/jitsi-videobridge.nix"
+    "services/networking/prosody.nix"
+    "services/web-apps/jitsi-meet.nix"
     "services/web-servers/nginx/default.nix"
   ];
 
@@ -19,7 +22,11 @@ in {
     ./gitlab
     ./graylog
     ./haproxy.nix
+    ./jitsi/jibri.nix
+    ./jitsi/jicofo.nix
+    ./jitsi/jitsi-meet.nix
     ./jitsi/jitsi-videobridge.nix
+    ./jitsi/prosody.nix
     ./logrotate
     ./nginx
     ./nullmailer.nix

--- a/nixos/services/jitsi/jibri.nix
+++ b/nixos/services/jitsi/jibri.nix
@@ -1,0 +1,345 @@
+{ config, lib, pkgs, ... }:
+
+with builtins;
+
+let
+  cfg = config.services.jibri;
+  # HOCON is a JSON superset that videobridge2 uses for configuration.
+  # It can substitute environment variables which we use for passwords here.
+  # https://github.com/lightbend/config/blob/master/README.md
+  #
+  # Substitution for environment variable FOO is represented as attribute set
+  # { __hocon_envvar = "FOO"; }
+  toHOCON = x: if isAttrs x && x ? __hocon_envvar then ("\${" + x.__hocon_envvar + "}")
+    else if isAttrs x then "{${ lib.concatStringsSep "," (lib.mapAttrsToList (k: v: ''"${k}":${toHOCON v}'') x) }}"
+    else if isList x then "[${ lib.concatMapStringsSep "," toHOCON x }]"
+    else toJSON x;
+
+  settings = with cfg; {
+    jibri = {
+      api = {
+        xmpp = {
+          environments = [{
+            name = "prod environment";
+            xmpp-server-hosts = ["${xmppDomain}"];
+            xmpp-domain = "${xmppDomain}";
+
+            control-muc = {
+              domain = "internal.${xmppDomain}";
+              room-name = "JibriBrewery";
+              nickname = "jibri-nickname";
+            };
+
+            control-login = {
+              domain = "${controlDomain}";
+              username = "${controlUser}";
+              password = { __hocon_envvar = "JIBRI_CONTROL_PASSWORD"; };
+            };
+
+            call-login = {
+              domain = "${recorderDomain}";
+              username = "${recorderUser}";
+              password = { __hocon_envvar = "JIBRI_RECORDER_PASSWORD"; };
+            };
+
+            strip-from-room-domain = "conference.";
+            usage-timeout = 0;
+            trust-all-xmpp-certs = true;
+          }];
+        };
+      };
+
+      ffmpeg = {
+        resolution = "${toString cfg.resolution.width}x${toString cfg.resolution.height}";
+      };
+
+      recording = {
+        recordings-directory = "/var/lib/jibri";
+        finalize-script = "${finalizeScript}";
+      };
+    };
+  };
+
+in
+{
+  options.services.jibri = with lib; {
+    enable = mkEnableOption "Enable Jitsi recording and live streaming with Jibri";
+
+    finalizeScript = mkOption {
+      type = types.path;
+      default = pkgs.writeScript "jibri-finalize-recording" ''
+        #!${pkgs.runtimeShell}
+        RECORDINGS_DIR=$1
+
+        echo "This is a dummy finalize script" > /var/lib/jibri/finalize.out
+        echo "The script was invoked with recordings directory $RECORDINGS_DIR." >> /var/lib/jibri/finalize.out
+        echo "You should put any finalize logic (renaming, uploading to a service" >> /var/lib/jibri/finalize.out
+        echo "or storage provider, etc.) in this script" >> /var/lib/jibri/finalize.out
+
+        exit 0
+      '';
+      description = ''
+        Script which is called with the recording's directory after recording has stopped.
+      '';
+    };
+
+    xmppDomain = mkOption {
+      type = with types; nullOr str;
+      example = "meet.example.org";
+      description = ''
+        Domain name of the XMMP server to which to connect as a component.
+      '';
+    };
+
+    controlUser = mkOption {
+      type = types.str;
+      default = "jibri";
+      description = ''
+        User part of the JID for XMPP control connection.
+      '';
+    };
+
+    recorderUser = mkOption {
+      type = types.str;
+      default = "recorder";
+      description = ''
+        User part of the JID for XMPP call (recorder) connection.
+      '';
+    };
+
+    recorderDomain = mkOption {
+      type = types.str;
+      example = "recorder.meet.example.org";
+      description = ''
+        Domain part of the JID for the recorder.
+      '';
+    };
+
+    resolution = mkOption {
+      default = {};
+      type = types.submodule {
+        options = {
+          width = mkOption {
+            type = types.int;
+            default = 1280;
+          };
+          height = mkOption {
+            type = types.int;
+            default = 720;
+          };
+        };
+      };
+    };
+
+    controlDomain = mkOption {
+      type = types.str;
+      example = "auth.meet.example.org";
+      description = ''
+        Domain part of the JID for control connection.
+      '';
+    };
+
+    controlPasswordFile = mkOption {
+      type = types.str;
+      example = "/run/keys/jibri-control";
+      description = ''
+        Path to file containing the password for the control connection.
+      '';
+    };
+
+    recorderPasswordFile = mkOption {
+      type = types.str;
+      example = "/run/keys/jibri-recorder";
+      description = ''
+        Path to file containing the password for the recorder connection.
+      '';
+    };
+
+    loggingConfigFile = mkOption {
+      type = types.path;
+      default = "${pkgs.jibri}/etc/jitsi/jibri/logging.properties-journal";
+    };
+
+    configFile = mkOption {
+      type = types.path;
+      default = "${pkgs.writeText "jibri.conf" (toHOCON cfg.settings)}";
+      description = ''
+        Jibri main config file path.
+        By default, this is set to the auto-generated config which you can override with a custom file path.
+      '';
+    };
+
+    settings = mkOption {
+      type = types.attrs;
+      default = settings;
+      description = "Settings used to generate the default config file";
+    };
+
+  };
+
+  config = lib.mkIf cfg.enable {
+
+    boot.extraModprobeConfig = ''
+      options snd-aloop enable=1,1,1,1,1 index=0,1,2,3,4
+    '';
+    boot.kernelModules = [ "snd-aloop" ];
+
+    sound.enable = true;
+
+    environment.etc."asound.conf".source = "${pkgs.jibri}/etc/jitsi/jibri/asoundrc";
+
+    environment.etc."chromium/policies/managed/managed_policies.json".source =
+      pkgs.writeText "managed_policies.json" (
+        lib.generators.toJSON {} {
+          CommandLineFlagSecurityWarningsEnabled = false;
+        }
+      );
+
+    systemd.services.jibri-icewm = {
+      after = [ "jibri-xorg.service" ];
+      requires = [ "jibri-xorg.service" ];
+      wantedBy = [ "multi-user.target" ];
+      description = "Jibri Window Manager";
+      environment = {
+        DISPLAY = ":0";
+      };
+
+      serviceConfig = {
+        ExecStart = ''
+          ${pkgs.icewm}/bin/icewm-session
+        '';
+        User = "jibri";
+        Group = "jitsi-meet";
+        Restart = "on-failure";
+
+        # Security restrictions, systemd-analyze security score is 3.2
+        CapabilityBoundingSet = "";
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        NoNewPrivileges = true;
+        PrivateTmp = true;
+        PrivateUsers = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectSystem = "strict";
+        RestrictAddressFamilies = [ "AF_INET" "AF_INET6" "AF_UNIX" ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        SystemCallArchitectures = "native";
+      };
+    };
+
+    systemd.services.jibri-xorg = {
+      description = "Jibri Xorg Process";
+
+      wantedBy = [ "multi-user.target" ];
+
+      environment = {
+        DISPLAY = ":0";
+      };
+
+      script =
+      let
+        xorgConf = pkgs.writeText "jitsi-xorg.conf" (pkgs.callPackage
+          ./xorg-video-dummy.conf.nix { inherit (cfg) resolution; });
+      in ''
+        ${pkgs.xorg.xorgserver.out}/bin/Xorg \
+          -nocursor -noreset +extension RANDR +extension RENDER \
+          -config ${xorgConf} \
+          -logfile /var/log/jibri-xorg/xorg.log
+          :0
+      '';
+      serviceConfig = {
+        User = "jibri";
+        LogsDirectory = "jibri-xorg";
+        Group = "jitsi-meet";
+        Restart = "on-failure";
+
+        # Security restrictions, systemd-analyze security score is 3.2
+        CapabilityBoundingSet = "";
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        NoNewPrivileges = true;
+        PrivateTmp = true;
+        PrivateUsers = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectSystem = "strict";
+        RestrictAddressFamilies = [ "AF_INET" "AF_INET6" "AF_UNIX" ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        SystemCallArchitectures = "native";
+      };
+    };
+
+    systemd.services.jibri = {
+      description = "JItsi BRoadcasting Infrastructure";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" "jibri-xorg.service" ];
+      wants = [ "jibri-icewm.service" ];
+
+      environment = {
+        JIBRI_CONFIG_FILE = cfg.configFile;
+        JIBRI_LOGGING_CONFIG_FILE = cfg.loggingConfigFile;
+      };
+
+      script = ''
+        export JIBRI_RECORDER_PASSWORD=$(cat ${cfg.recorderPasswordFile})
+        export JIBRI_CONTROL_PASSWORD=$(cat ${cfg.controlPasswordFile})
+        ${pkgs.jibri}/bin/jibri
+      '';
+
+      serviceConfig = {
+        Type = "exec";
+
+        DynamicUser = true;
+
+        LogsDirectory = "jibri";
+        StateDirectory = "jibri";
+
+        User = "jibri";
+        Group = "jitsi-meet";
+        SupplementaryGroups = [
+          "audio"
+        ];
+
+        # Security restrictions, systemd-analyze security score is 1.6
+        CapabilityBoundingSet = "";
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        NoNewPrivileges = true;
+        PrivateTmp = true;
+        PrivateUsers = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectSystem = "strict";
+        RestrictAddressFamilies = [ "AF_INET" "AF_INET6" ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [
+          "@basic-io"
+          "@network-io"
+        ];
+      };
+    };
+
+  };
+
+  meta.maintainers = lib.teams.jitsi.members;
+}

--- a/nixos/services/jitsi/jicofo.nix
+++ b/nixos/services/jitsi/jicofo.nix
@@ -1,0 +1,156 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.jicofo;
+in
+{
+  options.services.jicofo = with types; {
+    enable = mkEnableOption "Jitsi Conference Focus - component of Jitsi Meet";
+
+    xmppHost = mkOption {
+      type = str;
+      example = "localhost";
+      description = ''
+        Hostname of the XMPP server to connect to.
+      '';
+    };
+
+    xmppDomain = mkOption {
+      type = nullOr str;
+      example = "meet.example.org";
+      description = ''
+        Domain name of the XMMP server to which to connect as a component.
+
+        If null, <option>xmppHost</option> is used.
+      '';
+    };
+
+    userName = mkOption {
+      type = str;
+      default = "focus";
+      description = ''
+        User part of the JID for XMPP user connection.
+      '';
+    };
+
+    userDomain = mkOption {
+      type = str;
+      example = "auth.meet.example.org";
+      description = ''
+        Domain part of the JID for XMPP user connection.
+      '';
+    };
+
+    userPasswordFile = mkOption {
+      type = str;
+      example = "/run/keys/jicofo-user";
+      description = ''
+        Path to file containing password for XMPP user connection.
+      '';
+    };
+
+    bridgeMuc = mkOption {
+      type = str;
+      example = "jvbbrewery@internal.meet.example.org";
+      description = ''
+        JID of the internal MUC used to communicate with Videobridges.
+      '';
+    };
+
+    config = mkOption {
+      type = attrsOf str;
+      default = { };
+      example = literalExample ''
+        {
+          "org.jitsi.jicofo.auth.URL" = "XMPP:jitsi-meet.example.com";
+        }
+      '';
+      description = ''
+        Contents of the <filename>sip-communicator.properties</filename> configuration file for jicofo.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    services.jicofo.config = mapAttrs (_: v: mkDefault v) {
+      "org.jitsi.jicofo.BRIDGE_MUC" = cfg.bridgeMuc;
+    };
+
+    users.groups.jitsi-meet = {};
+
+    systemd.services.jicofo = let
+      jicofoProps = {
+        "-Dnet.java.sip.communicator.SC_HOME_DIR_LOCATION" = "/etc/jitsi";
+        "-Dnet.java.sip.communicator.SC_HOME_DIR_NAME" = "jicofo";
+        "-Djava.util.logging.config.file" = "/etc/jitsi/jicofo/logging.properties";
+        "-Dconfig.file" = "/etc/jitsi/jicofo/jicofo.conf";
+      };
+    in
+    {
+      description = "JItsi COnference FOcus";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+
+      restartTriggers = [
+        config.environment.etc."jitsi/jicofo/sip-communicator.properties".source
+        config.environment.etc."jitsi/jicofo/jicofo.conf".source
+      ];
+      environment.JAVA_SYS_PROPS = concatStringsSep " " (mapAttrsToList (k: v: "${k}=${toString v}") jicofoProps);
+
+      script = ''
+        ${pkgs.jicofo}/bin/jicofo \
+          --host=${cfg.xmppHost} \
+          --domain=${if cfg.xmppDomain == null then cfg.xmppHost else cfg.xmppDomain} \
+          --user_name=${cfg.userName} \
+          --user_domain=${cfg.userDomain} \
+          --user_password=$(cat ${cfg.userPasswordFile})
+      '';
+
+      serviceConfig = {
+        Type = "exec";
+
+        DynamicUser = true;
+        User = "jicofo";
+        Group = "jitsi-meet";
+
+        CapabilityBoundingSet = "";
+        NoNewPrivileges = true;
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        PrivateTmp = true;
+        PrivateDevices = true;
+        ProtectHostname = true;
+        ProtectKernelTunables = true;
+        ProtectKernelModules = true;
+        ProtectControlGroups = true;
+        RestrictAddressFamilies = [ "AF_INET" "AF_INET6" "AF_UNIX" ];
+        RestrictNamespaces = true;
+        LockPersonality = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+      };
+    };
+
+    environment.etc."jitsi/jicofo/jicofo.conf".source =
+      pkgs.writeText "jicofo.conf" ''
+      jicofo {
+        xmpp {
+          client {
+            client-proxy: focus.${cfg.xmppDomain}
+          }
+        }
+      }
+      '';
+
+    environment.etc."jitsi/jicofo/sip-communicator.properties".source =
+      pkgs.writeText "sip-communicator.properties" (
+        generators.toKeyValue {} cfg.config
+      );
+    environment.etc."jitsi/jicofo/logging.properties".source =
+      mkDefault "${pkgs.jicofo}/etc/jitsi/jicofo/logging.properties-journal";
+  };
+
+  meta.maintainers = lib.teams.jitsi.members;
+}

--- a/nixos/services/jitsi/jitsi-meet.nix
+++ b/nixos/services/jitsi/jitsi-meet.nix
@@ -1,0 +1,358 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.jitsi-meet;
+
+  # The configuration files are JS of format "var <<string>> = <<JSON>>;". In order to
+  # override only some settings, we need to extract the JSON, use jq to merge it with
+  # the config provided by user, and then reconstruct the file.
+  overrideJs =
+    source: varName: userCfg: appendExtra:
+    let
+      extractor = pkgs.writeText "extractor.js" ''
+        var fs = require("fs");
+        eval(fs.readFileSync(process.argv[2], 'utf8'));
+        process.stdout.write(JSON.stringify(eval(process.argv[3])));
+      '';
+      userJson = pkgs.writeText "user.json" (builtins.toJSON userCfg);
+    in (pkgs.runCommand "${varName}.js" { } ''
+      ${pkgs.nodejs}/bin/node ${extractor} ${source} ${varName} > default.json
+      (
+        echo "var ${varName} = "
+        ${pkgs.jq}/bin/jq -s '.[0] * .[1]' default.json ${userJson}
+        echo ";"
+        echo ${escapeShellArg appendExtra}
+      ) > $out
+    '');
+
+  # Essential config - it's probably not good to have these as option default because
+  # types.attrs doesn't do merging. Let's merge explicitly, can still be overriden if
+  # user desires.
+  defaultCfg = {
+    hosts = {
+      domain = cfg.hostName;
+      muc = "conference.${cfg.hostName}";
+      focus = "focus.${cfg.hostName}";
+    };
+    bosh = "//${cfg.hostName}/http-bind";
+  };
+in
+{
+  options.services.jitsi-meet = with types; {
+    enable = mkEnableOption "Jitsi Meet - Secure, Simple and Scalable Video Conferences";
+
+    hostName = mkOption {
+      type = str;
+      example = "meet.example.org";
+      description = ''
+        Hostname of the Jitsi Meet instance.
+      '';
+    };
+
+    config = mkOption {
+      type = attrs;
+      default = { };
+      example = literalExample ''
+        {
+          enableWelcomePage = false;
+          defaultLang = "fi";
+        }
+      '';
+      description = ''
+        Client-side web application settings that override the defaults in <filename>config.js</filename>.
+
+        See <link xlink:href="https://github.com/jitsi/jitsi-meet/blob/master/config.js" /> for default
+        configuration with comments.
+      '';
+    };
+
+    extraConfig = mkOption {
+      type = lines;
+      default = "";
+      description = ''
+        Text to append to <filename>config.js</filename> web application config file.
+
+        Can be used to insert JavaScript logic to determine user's region in cascading bridges setup.
+      '';
+    };
+
+    interfaceConfig = mkOption {
+      type = attrs;
+      default = { };
+      example = literalExample ''
+        {
+          SHOW_JITSI_WATERMARK = false;
+          SHOW_WATERMARK_FOR_GUESTS = false;
+        }
+      '';
+      description = ''
+        Client-side web-app interface settings that override the defaults in <filename>interface_config.js</filename>.
+
+        See <link xlink:href="https://github.com/jitsi/jitsi-meet/blob/master/interface_config.js" /> for
+        default configuration with comments.
+      '';
+    };
+
+    videobridge = {
+      enable = mkOption {
+        type = bool;
+        default = true;
+        description = ''
+          Whether to enable Jitsi Videobridge instance and configure it to connect to Prosody.
+
+          Additional configuration is possible with <option>services.jitsi-videobridge</option>.
+        '';
+      };
+
+      passwordFile = mkOption {
+        type = nullOr str;
+        default = null;
+        example = "/run/keys/videobridge";
+        description = ''
+          File containing password to the Prosody account for videobridge.
+
+          If <literal>null</literal>, a file with password will be generated automatically. Setting
+          this option is useful if you plan to connect additional videobridges to the XMPP server.
+        '';
+      };
+    };
+
+    jibri.enable = mkOption {
+      type = bool;
+      default = true;
+      description = ''
+        Whether to enable Jibri instance and configure it to connect to Prosody.
+
+        Additional configuration is possible with <option>services.jibri</option>.
+      '';
+    };
+
+    jicofo.enable = mkOption {
+      type = bool;
+      default = true;
+      description = ''
+        Whether to enable JiCoFo instance and configure it to connect to Prosody.
+
+        Additional configuration is possible with <option>services.jicofo</option>.
+      '';
+    };
+
+    nginx.enable = mkOption {
+      type = bool;
+      default = true;
+      description = ''
+        Whether to enable nginx virtual host that will serve the javascript application and act as
+        a proxy for the XMPP server. Further nginx configuration can be done by adapting
+        <option>services.nginx.virtualHosts.&lt;hostName&gt;</option>.
+        When this is enabled, ACME will be used to retrieve a TLS certificate by default. To disable
+        this, set the <option>services.nginx.virtualHosts.&lt;hostName&gt;.enableACME</option> to
+        <literal>false</literal> and if appropriate do the same for
+        <option>services.nginx.virtualHosts.&lt;hostName&gt;.forceSSL</option>.
+      '';
+    };
+
+    prosody.enable = mkOption {
+      type = bool;
+      default = true;
+      description = ''
+        Whether to configure Prosody to relay XMPP messages between Jitsi Meet components. Turn this
+        off if you want to configure it manually.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    services.prosody = mkIf cfg.prosody.enable {
+      enable = mkDefault true;
+      package = pkgs.prosody.override {
+        withOnlyInstalledCommunityModules = [ "roster_command" "client_proxy" ];
+      };
+      xmppComplianceSuite = mkDefault false;
+      modules = {
+        admin_adhoc = mkDefault false;
+        bosh = mkDefault true;
+        ping = mkDefault true;
+        roster = mkDefault true;
+        saslauth = mkDefault true;
+        tls = mkDefault true;
+      };
+      muc = [
+        {
+          domain = "conference.${cfg.hostName}";
+          name = "Jitsi Meet MUC";
+          roomLocking = false;
+          roomDefaultPublicJids = true;
+          extraConfig = ''
+            storage = "memory"
+          '';
+        }
+        {
+          domain = "internal.${cfg.hostName}";
+          name = "Jitsi Meet Videobridge MUC";
+          extraConfig = ''
+            storage = "memory"
+            admins = { "focus@auth.${cfg.hostName}", "jvb@auth.${cfg.hostName}" }
+          '';
+          #-- muc_room_cache_size = 1000
+        }
+      ];
+      extraModules = [ "pubsub" ];
+      extraConfig = mkAfter ''
+        Component "focus.${cfg.hostName}" "client_proxy"
+          target_address = "focus@auth.${cfg.hostName}"
+      '';
+      virtualHosts.${cfg.hostName} = {
+        enabled = true;
+        domain = cfg.hostName;
+        extraConfig = ''
+          authentication = "anonymous"
+          c2s_require_encryption = false
+          admins = { "focus@auth.${cfg.hostName}" }
+        '';
+        ssl = {
+          cert = "/var/lib/jitsi-meet/jitsi-meet.crt";
+          key = "/var/lib/jitsi-meet/jitsi-meet.key";
+        };
+      };
+      virtualHosts."auth.${cfg.hostName}" = {
+        enabled = true;
+        domain = "auth.${cfg.hostName}";
+        extraConfig = ''
+          authentication = "internal_plain"
+        '';
+        ssl = {
+          cert = "/var/lib/jitsi-meet/jitsi-meet.crt";
+          key = "/var/lib/jitsi-meet/jitsi-meet.key";
+        };
+      };
+    };
+    systemd.services.prosody.serviceConfig = mkIf cfg.prosody.enable {
+      SupplementaryGroups = [ "jitsi-meet" ];
+    };
+
+    users.groups.jitsi-meet = {};
+    systemd.tmpfiles.rules = [
+      "d '/var/lib/jitsi-meet' 0750 root jitsi-meet - -"
+    ];
+
+    systemd.services.jitsi-meet-init-secrets = {
+      wantedBy = [ "multi-user.target" ];
+      before = [ "jicofo.service" "jitsi-videobridge2.service" ] ++ (optional cfg.prosody.enable "prosody.service");
+      serviceConfig = {
+        Type = "oneshot";
+      };
+
+      path = [ config.services.prosody.package ];
+
+      script = let
+        secrets = [ "jicofo-user-secret" ]
+          ++ (optional (cfg.videobridge.passwordFile == null) "videobridge-secret")
+          ++ (optionals (cfg.jibri.enable) [ "jibri-user-secret" "jibri-recorder-secret" ]);
+        videobridgeSecret = if cfg.videobridge.passwordFile != null then cfg.videobridge.passwordFile else "/var/lib/jitsi-meet/videobridge-secret";
+      in
+      ''
+        cd /var/lib/jitsi-meet
+        ${concatMapStringsSep "\n" (s: ''
+          if [ ! -f ${s} ]; then
+            tr -dc a-zA-Z0-9 </dev/urandom | head -c 64 > ${s}
+            chown root:jitsi-meet ${s}
+            chmod 640 ${s}
+          fi
+        '') secrets}
+      ''
+      + optionalString (cfg.prosody.enable && cfg.jibri.enable) ''
+        prosodyctl register jibri auth.${cfg.hostName} "$(cat /var/lib/jitsi-meet/jibri-control-secret)"
+        prosodyctl register recorder recorder.${cfg.hostName} "$(cat /var/lib/jitsi-meet/jibri-recorder-secret)"
+      ''
+      + optionalString cfg.prosody.enable ''
+        prosodyctl register jvb auth.${cfg.hostName} "$(cat ${videobridgeSecret})"
+        prosodyctl register focus auth.${cfg.hostName} "$(cat /var/lib/jitsi-meet/jicofo-user-secret)"
+        prosodyctl mod_roster_command subscribe focus.${cfg.hostName} focus@auth.${cfg.hostName}
+
+        # generate self-signed certificates
+        if [ ! -f /var/lib/jitsi-meet.crt ]; then
+          ${getBin pkgs.openssl}/bin/openssl req \
+            -x509 \
+            -newkey rsa:4096 \
+            -keyout /var/lib/jitsi-meet/jitsi-meet.key \
+            -out /var/lib/jitsi-meet/jitsi-meet.crt \
+            -days 36500 \
+            -nodes \
+            -subj '/CN=${cfg.hostName}/CN=auth.${cfg.hostName}'
+          chmod 640 /var/lib/jitsi-meet/jitsi-meet.{crt,key}
+          chown root:jitsi-meet /var/lib/jitsi-meet/jitsi-meet.{crt,key}
+        fi
+      '';
+    };
+
+    services.nginx = mkIf cfg.nginx.enable {
+      enable = mkDefault true;
+      virtualHosts.${cfg.hostName} = {
+        enableACME = mkDefault true;
+        forceSSL = mkDefault true;
+        root = pkgs.jitsi-meet;
+        extraConfig = ''
+          ssi on;
+        '';
+        locations."@root_path".extraConfig = ''
+          rewrite ^/(.*)$ / break;
+        '';
+        locations."~ ^/([^/\\?&:'\"]+)$".tryFiles = "$uri @root_path";
+        locations."=/http-bind" = {
+          proxyPass = "http://localhost:5280/http-bind";
+          extraConfig = ''
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header Host $host;
+          '';
+        };
+        locations."=/external_api.js" = mkDefault {
+          alias = "${pkgs.jitsi-meet}/libs/external_api.min.js";
+        };
+        locations."=/config.js" = mkDefault {
+          alias = overrideJs "${pkgs.jitsi-meet}/config.js" "config" (recursiveUpdate defaultCfg cfg.config) cfg.extraConfig;
+        };
+        locations."=/interface_config.js" = mkDefault {
+          alias = overrideJs "${pkgs.jitsi-meet}/interface_config.js" "interfaceConfig" cfg.interfaceConfig "";
+        };
+      };
+    };
+
+    services.jitsi-videobridge = mkIf cfg.videobridge.enable {
+      enable = true;
+      xmppConfigs."localhost" = {
+        userName = "jvb";
+        domain = "auth.${cfg.hostName}";
+        passwordFile = "/var/lib/jitsi-meet/videobridge-secret";
+        mucJids = "jvbbrewery@internal.${cfg.hostName}";
+        disableCertificateVerification = true;
+      };
+    };
+
+    services.jibri = mkIf cfg.jibri.enable {
+      enable = true;
+      xmppDomain = cfg.hostName;
+      recorderDomain = "recorder.${cfg.hostName}";
+      controlDomain = "auth.${cfg.hostName}";
+      controlPasswordFile = "/var/lib/jitsi-meet/jibri-control-secret";
+      recorderPasswordFile = "/var/lib/jitsi-meet/jibri-recorder-secret";
+    };
+
+    services.jicofo = mkIf cfg.jicofo.enable {
+      enable = true;
+      xmppHost = "localhost";
+      xmppDomain = cfg.hostName;
+      userDomain = "auth.${cfg.hostName}";
+      userName = "focus";
+      userPasswordFile = "/var/lib/jitsi-meet/jicofo-user-secret";
+      bridgeMuc = "jvbbrewery@internal.${cfg.hostName}";
+      config = {
+        "org.jitsi.jicofo.ALWAYS_TRUST_MODE_ENABLED" = "true";
+      };
+    };
+  };
+
+  meta.doc = ./jitsi-meet.xml;
+  meta.maintainers = lib.teams.jitsi.members;
+}

--- a/nixos/services/jitsi/jitsi-videobridge.nix
+++ b/nixos/services/jitsi/jitsi-videobridge.nix
@@ -187,6 +187,16 @@ in
         Whether to open ports in the firewall for the videobridge.
       '';
     };
+
+    apis = mkOption {
+      type = with types; listOf str;
+      description = ''
+        What is passed as --apis= parameter. If this is empty, "none" is passed.
+        Needed for monitoring jitsi.
+      '';
+      default = [];
+      example = literalExample "[ \"colibri\" \"rest\" ]";
+    };
   };
 
   config = mkIf cfg.enable {
@@ -219,7 +229,7 @@ in
         "export ${toVarName name}=$(cat ${xmppConfig.passwordFile})\n"
       ) cfg.xmppConfigs))
       + ''
-        ${pkgs.jitsi-videobridge}/bin/jitsi-videobridge --apis=rest
+        ${pkgs.jitsi-videobridge}/bin/jitsi-videobridge --apis=${if (cfg.apis == []) then "none" else concatStringsSep "," cfg.apis}
       '';
 
       serviceConfig = {

--- a/nixos/services/jitsi/prosody.nix
+++ b/nixos/services/jitsi/prosody.nix
@@ -1,0 +1,884 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  cfg = config.services.prosody;
+
+  sslOpts = { ... }: {
+
+    options = {
+
+      key = mkOption {
+        type = types.path;
+        description = "Path to the key file.";
+      };
+
+      # TODO: rename to certificate to match the prosody config
+      cert = mkOption {
+        type = types.path;
+        description = "Path to the certificate file.";
+      };
+
+      extraOptions = mkOption {
+        type = types.attrs;
+        default = {};
+        description = "Extra SSL configuration options.";
+      };
+
+    };
+  };
+
+  discoOpts = {
+    options = {
+      url = mkOption {
+        type = types.str;
+        description = "URL of the endpoint you want to make discoverable";
+      };
+      description = mkOption {
+        type = types.str;
+        description = "A short description of the endpoint you want to advertise";
+      };
+    };
+  };
+
+  moduleOpts = {
+    # Required for compliance with https://compliance.conversations.im/about/
+    roster = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Allow users to have a roster";
+    };
+
+    saslauth = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Authentication for clients and servers. Recommended if you want to log in.";
+    };
+
+    tls = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Add support for secure TLS on c2s/s2s connections";
+    };
+
+    dialback = mkOption {
+      type = types.bool;
+      default = true;
+      description = "s2s dialback support";
+    };
+
+    disco = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Service discovery";
+    };
+
+    # Not essential, but recommended
+    carbons = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Keep multiple clients in sync";
+    };
+
+    csi = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Implements the CSI protocol that allows clients to report their active/inactive state to the server";
+    };
+
+    cloud_notify = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Push notifications to inform users of new messages or other pertinent information even when they have no XMPP clients online";
+    };
+
+    pep = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Enables users to publish their mood, activity, playing music and more";
+    };
+
+    private = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Private XML storage (for room bookmarks, etc.)";
+    };
+
+    blocklist = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Allow users to block communications with other users";
+    };
+
+    vcard = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Allow users to set vCards";
+    };
+
+    vcard_legacy = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Converts users profiles and Avatars between old and new formats";
+    };
+
+    bookmarks = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Allows interop between older clients that use XEP-0048: Bookmarks in its 1.0 version and recent clients which use it in PEP";
+    };
+
+    # Nice to have
+    version = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Replies to server version requests";
+    };
+
+    uptime = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Report how long server has been running";
+    };
+
+    time = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Let others know the time here on this server";
+    };
+
+    ping = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Replies to XMPP pings with pongs";
+    };
+
+    register = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Allow users to register on this server using a client and change passwords";
+    };
+
+    mam = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Store messages in an archive and allow users to access it";
+    };
+
+    smacks = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Allow a client to resume a disconnected session, and prevent message loss";
+    };
+
+    # Admin interfaces
+    admin_adhoc = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Allows administration via an XMPP client that supports ad-hoc commands";
+    };
+
+    http_files = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Serve static files from a directory over HTTP";
+    };
+
+    proxy65 = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Enables a file transfer proxy service which clients behind NAT can use";
+    };
+
+    admin_telnet = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Opens telnet console interface on localhost port 5582";
+    };
+
+    # HTTP modules
+    bosh = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Enable BOSH clients, aka 'Jabber over HTTP'";
+    };
+
+    websocket = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Enable WebSocket support";
+    };
+
+    # Other specific functionality
+    limits = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Enable bandwidth limiting for XMPP connections";
+    };
+
+    groups = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Shared roster support";
+    };
+
+    server_contact_info = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Publish contact information for this service";
+    };
+
+    announce = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Send announcement to all online users";
+    };
+
+    welcome = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Welcome users who register accounts";
+    };
+
+    watchregistrations = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Alert admins of registrations";
+    };
+
+    motd = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Send a message to users when they log in";
+    };
+
+    legacyauth = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Legacy authentication. Only used by some old clients and bots";
+    };
+  };
+
+  toLua = x:
+    if builtins.isString x then ''"${x}"''
+    else if builtins.isBool x then (if x == true then "true" else "false")
+    else if builtins.isInt x then toString x
+    else if builtins.isList x then ''{ ${lib.concatStringsSep ", " (map (n: toLua n) x) } }''
+    else throw "Invalid Lua value";
+
+  createSSLOptsStr = o: ''
+    ssl = {
+      cafile = "/etc/ssl/certs/ca-bundle.crt";
+      key = "${o.key}";
+      certificate = "${o.cert}";
+      ${concatStringsSep "\n" (mapAttrsToList (name: value: "${name} = ${toLua value};") o.extraOptions)}
+    };
+  '';
+
+  mucOpts = { ... }: {
+    options = {
+      domain = mkOption {
+        type = types.str;
+        description = "Domain name of the MUC";
+      };
+      name = mkOption {
+        type = types.str;
+        description = "The name to return in service discovery responses for the MUC service itself";
+        default = "Prosody Chatrooms";
+      };
+      restrictRoomCreation = mkOption {
+        type = types.enum [ true false "admin" "local" ];
+        default = false;
+        description = "Restrict room creation to server admins";
+      };
+      maxHistoryMessages = mkOption {
+        type = types.int;
+        default = 20;
+        description = "Specifies a limit on what each room can be configured to keep";
+      };
+      roomLocking = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          Enables room locking, which means that a room must be
+          configured before it can be used. Locked rooms are invisible
+          and cannot be entered by anyone but the creator
+        '';
+      };
+      roomLockTimeout = mkOption {
+        type = types.int;
+        default = 300;
+        description = ''
+          Timout after which the room is destroyed or unlocked if not
+          configured, in seconds
+       '';
+      };
+      tombstones = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          When a room is destroyed, it leaves behind a tombstone which
+          prevents the room being entered or recreated. It also allows
+          anyone who was not in the room at the time it was destroyed
+          to learn about it, and to update their bookmarks. Tombstones
+          prevents the case where someone could recreate a previously
+          semi-anonymous room in order to learn the real JIDs of those
+          who often join there.
+        '';
+      };
+      tombstoneExpiry = mkOption {
+        type = types.int;
+        default = 2678400;
+        description = ''
+          This settings controls how long a tombstone is considered
+          valid. It defaults to 31 days. After this time, the room in
+          question can be created again.
+        '';
+      };
+
+      vcard_muc = mkOption {
+        type = types.bool;
+        default = true;
+      description = "Adds the ability to set vCard for Multi User Chat rooms";
+      };
+
+      # Extra parameters. Defaulting to prosody default values.
+      # Adding them explicitly to make them visible from the options
+      # documentation.
+      #
+      # See https://prosody.im/doc/modules/mod_muc for more details.
+      roomDefaultPublic = mkOption {
+        type = types.bool;
+        default = true;
+        description = "If set, the MUC rooms will be public by default.";
+      };
+      roomDefaultMembersOnly = mkOption {
+        type = types.bool;
+        default = false;
+        description = "If set, the MUC rooms will only be accessible to the members by default.";
+      };
+      roomDefaultModerated = mkOption {
+        type = types.bool;
+        default = false;
+        description = "If set, the MUC rooms will be moderated by default.";
+      };
+      roomDefaultPublicJids = mkOption {
+        type = types.bool;
+        default = false;
+        description = "If set, the MUC rooms will display the public JIDs by default.";
+      };
+      roomDefaultChangeSubject = mkOption {
+        type = types.bool;
+        default = false;
+        description = "If set, the rooms will display the public JIDs by default.";
+      };
+      roomDefaultHistoryLength = mkOption {
+        type = types.int;
+        default = 20;
+        description = "Number of history message sent to participants by default.";
+      };
+      roomDefaultLanguage = mkOption {
+        type = types.str;
+        default = "en";
+        description = "Default room language.";
+      };
+      extraConfig = mkOption {
+        type = types.lines;
+        default = "";
+        description = "Additional MUC specific configuration";
+      };
+    };
+  };
+
+  uploadHttpOpts = { ... }: {
+    options = {
+      domain = mkOption {
+        type = types.nullOr types.str;
+        description = "Domain name for the http-upload service";
+      };
+      uploadFileSizeLimit = mkOption {
+        type = types.str;
+        default = "50 * 1024 * 1024";
+        description = "Maximum file size, in bytes. Defaults to 50MB.";
+      };
+      uploadExpireAfter = mkOption {
+        type = types.str;
+        default = "60 * 60 * 24 * 7";
+        description = "Max age of a file before it gets deleted, in seconds.";
+      };
+      userQuota = mkOption {
+        type = types.nullOr types.int;
+        default = null;
+        example = 1234;
+        description = ''
+          Maximum size of all uploaded files per user, in bytes. There
+          will be no quota if this option is set to null.
+        '';
+      };
+      httpUploadPath = mkOption {
+        type = types.str;
+        description = ''
+          Directory where the uploaded files will be stored. By
+          default, uploaded files are put in a sub-directory of the
+          default Prosody storage path (usually /var/lib/prosody).
+        '';
+        default = "/var/lib/prosody";
+      };
+    };
+  };
+
+  vHostOpts = { ... }: {
+
+    options = {
+
+      # TODO: require attribute
+      domain = mkOption {
+        type = types.str;
+        description = "Domain name";
+      };
+
+      enabled = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Whether to enable the virtual host";
+      };
+
+      ssl = mkOption {
+        type = types.nullOr (types.submodule sslOpts);
+        default = null;
+        description = "Paths to SSL files";
+      };
+
+      extraConfig = mkOption {
+        type = types.lines;
+        default = "";
+        description = "Additional virtual host specific configuration";
+      };
+
+    };
+
+  };
+
+in
+
+{
+
+  ###### interface
+
+  options = {
+
+    services.prosody = {
+
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Whether to enable the prosody server";
+      };
+
+      xmppComplianceSuite = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          The XEP-0423 defines a set of recommended XEPs to implement
+          for a server. It's generally a good idea to implement this
+          set of extensions if you want to provide your users with a
+          good XMPP experience.
+
+          This NixOS module aims to provide a "advanced server"
+          experience as per defined in the XEP-0423[1] specification.
+
+          Setting this option to true will prevent you from building a
+          NixOS configuration which won't comply with this standard.
+          You can explicitely decide to ignore this standard if you
+          know what you are doing by setting this option to false.
+
+          [1] https://xmpp.org/extensions/xep-0423.html
+        '';
+      };
+
+      package = mkOption {
+        type = types.package;
+        description = "Prosody package to use";
+        default = pkgs.prosody;
+        defaultText = "pkgs.prosody";
+        example = literalExample ''
+          pkgs.prosody.override {
+            withExtraLibs = [ pkgs.luaPackages.lpty ];
+            withCommunityModules = [ "auth_external" ];
+          };
+        '';
+      };
+
+      dataDir = mkOption {
+        type = types.path;
+        description = "Directory where Prosody stores its data";
+        default = "/var/lib/prosody";
+      };
+
+      disco_items = mkOption {
+        type = types.listOf (types.submodule discoOpts);
+        default = [];
+        description = "List of discoverable items you want to advertise.";
+      };
+
+      user = mkOption {
+        type = types.str;
+        default = "prosody";
+        description = "User account under which prosody runs.";
+      };
+
+      group = mkOption {
+        type = types.str;
+        default = "prosody";
+        description = "Group account under which prosody runs.";
+      };
+
+      allowRegistration = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Allow account creation";
+      };
+
+      # HTTP server-related options
+      httpPorts = mkOption {
+        type = types.listOf types.int;
+        description = "Listening HTTP ports list for this service.";
+        default = [ 5280 ];
+      };
+
+      httpInterfaces = mkOption {
+        type = types.listOf types.str;
+        default = [ "*" "::" ];
+        description = "Interfaces on which the HTTP server will listen on.";
+      };
+
+      httpsPorts = mkOption {
+        type = types.listOf types.int;
+        description = "Listening HTTPS ports list for this service.";
+        default = [ 5281 ];
+      };
+
+      httpsInterfaces = mkOption {
+        type = types.listOf types.str;
+        default = [ "*" "::" ];
+        description = "Interfaces on which the HTTPS server will listen on.";
+      };
+
+      c2sRequireEncryption = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          Force clients to use encrypted connections? This option will
+          prevent clients from authenticating unless they are using encryption.
+        '';
+      };
+
+      s2sRequireEncryption = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          Force servers to use encrypted connections? This option will
+          prevent servers from authenticating unless they are using encryption.
+          Note that this is different from authentication.
+        '';
+      };
+
+      s2sSecureAuth = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Force certificate authentication for server-to-server connections?
+          This provides ideal security, but requires servers you communicate
+          with to support encryption AND present valid, trusted certificates.
+          For more information see https://prosody.im/doc/s2s#security
+        '';
+      };
+
+      s2sInsecureDomains = mkOption {
+        type = types.listOf types.str;
+        default = [];
+        example = [ "insecure.example.com" ];
+        description = ''
+          Some servers have invalid or self-signed certificates. You can list
+          remote domains here that will not be required to authenticate using
+          certificates. They will be authenticated using DNS instead, even
+          when s2s_secure_auth is enabled.
+        '';
+      };
+
+      s2sSecureDomains = mkOption {
+        type = types.listOf types.str;
+        default = [];
+        example = [ "jabber.org" ];
+        description = ''
+          Even if you leave s2s_secure_auth disabled, you can still require valid
+          certificates for some domains by specifying a list here.
+        '';
+      };
+
+
+      modules = moduleOpts;
+
+      extraModules = mkOption {
+        type = types.listOf types.str;
+        default = [];
+        description = "Enable custom modules";
+      };
+
+      extraPluginPaths = mkOption {
+        type = types.listOf types.path;
+        default = [];
+        description = "Addtional path in which to look find plugins/modules";
+      };
+
+      uploadHttp = mkOption {
+        description = ''
+          Configures the Prosody builtin HTTP server to handle user uploads.
+        '';
+        type = types.nullOr (types.submodule uploadHttpOpts);
+        default = null;
+        example = {
+          domain = "uploads.my-xmpp-example-host.org";
+        };
+      };
+
+      muc = mkOption {
+        type = types.listOf (types.submodule mucOpts);
+        default = [ ];
+        example = [ {
+          domain = "conference.my-xmpp-example-host.org";
+        } ];
+        description = "Multi User Chat (MUC) configuration";
+      };
+
+      virtualHosts = mkOption {
+
+        description = "Define the virtual hosts";
+
+        type = with types; attrsOf (submodule vHostOpts);
+
+        example = {
+          myhost = {
+            domain = "my-xmpp-example-host.org";
+            enabled = true;
+          };
+        };
+
+        default = {
+          localhost = {
+            domain = "localhost";
+            enabled = true;
+          };
+        };
+
+      };
+
+      ssl = mkOption {
+        type = types.nullOr (types.submodule sslOpts);
+        default = null;
+        description = "Paths to SSL files";
+      };
+
+      admins = mkOption {
+        type = types.listOf types.str;
+        default = [];
+        example = [ "admin1@example.com" "admin2@example.com" ];
+        description = "List of administrators of the current host";
+      };
+
+      authentication = mkOption {
+        type = types.enum [ "internal_plain" "internal_hashed" "cyrus" "anonymous" ];
+        default = "internal_hashed";
+        example = "internal_plain";
+        description = "Authentication mechanism used for logins.";
+      };
+
+      extraConfig = mkOption {
+        type = types.lines;
+        default = "";
+        description = "Additional prosody configuration";
+      };
+
+    };
+  };
+
+
+  ###### implementation
+
+  config = mkIf cfg.enable {
+
+    assertions = let
+      genericErrMsg = ''
+
+          Having a server not XEP-0423-compliant might make your XMPP
+          experience terrible. See the NixOS manual for further
+          informations.
+
+          If you know what you're doing, you can disable this warning by
+          setting config.services.prosody.xmppComplianceSuite to false.
+      '';
+      errors = [
+        { assertion = (builtins.length cfg.muc > 0) || !cfg.xmppComplianceSuite;
+          message = ''
+            You need to setup at least a MUC domain to comply with
+            XEP-0423.
+          '' + genericErrMsg;}
+        { assertion = cfg.uploadHttp != null || !cfg.xmppComplianceSuite;
+          message = ''
+            You need to setup the uploadHttp module through
+            config.services.prosody.uploadHttp to comply with
+            XEP-0423.
+          '' + genericErrMsg;}
+      ];
+    in errors;
+
+    environment.systemPackages = [ cfg.package ];
+
+    environment.etc."prosody/prosody.cfg.lua".text =
+      let
+        httpDiscoItems = if (cfg.uploadHttp != null)
+            then [{ url = cfg.uploadHttp.domain; description = "HTTP upload endpoint";}]
+            else [];
+        mucDiscoItems = builtins.foldl'
+            (acc: muc: [{ url = muc.domain; description = "${muc.domain} MUC endpoint";}] ++ acc)
+            []
+            cfg.muc;
+        discoItems = cfg.disco_items ++ httpDiscoItems ++ mucDiscoItems;
+      in ''
+
+      pidfile = "/run/prosody/prosody.pid"
+
+      log = {
+        debug = "*syslog";
+      }
+
+      data_path = "${cfg.dataDir}"
+      plugin_paths = {
+        ${lib.concatStringsSep ", " (map (n: "\"${n}\"") cfg.extraPluginPaths) }
+      }
+
+      ${ optionalString  (cfg.ssl != null) (createSSLOptsStr cfg.ssl) }
+
+      admins = ${toLua cfg.admins}
+
+      -- we already build with libevent, so we can just enable it for a more performant server
+      use_libevent = true
+
+      modules_enabled = {
+
+        ${ lib.concatStringsSep "\n  " (lib.mapAttrsToList
+          (name: val: optionalString val "${toLua name};")
+        cfg.modules) }
+        ${ lib.concatStringsSep "\n" (map (x: "${toLua x};") cfg.package.communityModules)}
+        ${ lib.concatStringsSep "\n" (map (x: "${toLua x};") cfg.extraModules)}
+      };
+
+      disco_items = {
+      ${ lib.concatStringsSep "\n" (builtins.map (x: ''{ "${x.url}", "${x.description}"};'') discoItems)}
+      };
+
+      allow_registration = ${toLua cfg.allowRegistration}
+
+      c2s_require_encryption = ${toLua cfg.c2sRequireEncryption}
+
+      s2s_require_encryption = ${toLua cfg.s2sRequireEncryption}
+
+      s2s_secure_auth = ${toLua cfg.s2sSecureAuth}
+
+      s2s_insecure_domains = ${toLua cfg.s2sInsecureDomains}
+
+      s2s_secure_domains = ${toLua cfg.s2sSecureDomains}
+
+      authentication = ${toLua cfg.authentication}
+
+      http_interfaces = ${toLua cfg.httpInterfaces}
+
+      https_interfaces = ${toLua cfg.httpsInterfaces}
+
+      http_ports = ${toLua cfg.httpPorts}
+
+      https_ports = ${toLua cfg.httpsPorts}
+
+      ${ cfg.extraConfig }
+
+      ${lib.concatMapStrings (muc: ''
+        Component ${toLua muc.domain} "muc"
+            modules_enabled = { "muc_mam"; ${optionalString muc.vcard_muc ''"vcard_muc";'' } }
+            name = ${toLua muc.name}
+            restrict_room_creation = ${toLua muc.restrictRoomCreation}
+            max_history_messages = ${toLua muc.maxHistoryMessages}
+            muc_room_locking = ${toLua muc.roomLocking}
+            muc_room_lock_timeout = ${toLua muc.roomLockTimeout}
+            muc_tombstones = ${toLua muc.tombstones}
+            muc_tombstone_expiry = ${toLua muc.tombstoneExpiry}
+            muc_room_default_public = ${toLua muc.roomDefaultPublic}
+            muc_room_default_members_only = ${toLua muc.roomDefaultMembersOnly}
+            muc_room_default_moderated = ${toLua muc.roomDefaultModerated}
+            muc_room_default_public_jids = ${toLua muc.roomDefaultPublicJids}
+            muc_room_default_change_subject = ${toLua muc.roomDefaultChangeSubject}
+            muc_room_default_history_length = ${toLua muc.roomDefaultHistoryLength}
+            muc_room_default_language = ${toLua muc.roomDefaultLanguage}
+            ${ muc.extraConfig }
+        '') cfg.muc}
+
+      ${ lib.optionalString (cfg.uploadHttp != null) ''
+        Component ${toLua cfg.uploadHttp.domain} "http_upload"
+            http_upload_file_size_limit = ${cfg.uploadHttp.uploadFileSizeLimit}
+            http_upload_expire_after = ${cfg.uploadHttp.uploadExpireAfter}
+            ${lib.optionalString (cfg.uploadHttp.userQuota != null) "http_upload_quota = ${toLua cfg.uploadHttp.userQuota}"}
+            http_upload_path = ${toLua cfg.uploadHttp.httpUploadPath}
+      ''}
+
+      ${ lib.concatStringsSep "\n" (lib.mapAttrsToList (n: v: ''
+        VirtualHost "${v.domain}"
+          enabled = ${boolToString v.enabled};
+          ${ optionalString (v.ssl != null) (createSSLOptsStr v.ssl) }
+          ${ v.extraConfig }
+        '') cfg.virtualHosts) }
+    '';
+
+    users.users.prosody = mkIf (cfg.user == "prosody") {
+      uid = config.ids.uids.prosody;
+      description = "Prosody user";
+      createHome = true;
+      inherit (cfg) group;
+      home = "${cfg.dataDir}";
+    };
+
+    users.groups.prosody = mkIf (cfg.group == "prosody") {
+      gid = config.ids.gids.prosody;
+    };
+
+    systemd.services.prosody = {
+      description = "Prosody XMPP server";
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
+      wantedBy = [ "multi-user.target" ];
+      restartTriggers = [ config.environment.etc."prosody/prosody.cfg.lua".source ];
+      serviceConfig = {
+        User = cfg.user;
+        Group = cfg.group;
+        Type = "forking";
+        RuntimeDirectory = [ "prosody" ];
+        PIDFile = "/run/prosody/prosody.pid";
+        ExecStart = "${cfg.package}/bin/prosodyctl start";
+        ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
+
+        MemoryDenyWriteExecute = true;
+        PrivateDevices = true;
+        PrivateMounts = true;
+        PrivateTmp = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+      };
+    };
+
+  };
+  meta.doc = ./prosody.xml;
+}

--- a/nixos/services/jitsi/xorg-video-dummy.conf.nix
+++ b/nixos/services/jitsi/xorg-video-dummy.conf.nix
@@ -1,0 +1,146 @@
+# Taken from the Jibri Debian package.
+
+with builtins;
+
+{ xorg, xkeyboard_config, resolution }: ''
+Section "ServerFlags"
+  Option "DontVTSwitch" "true"
+  Option "AllowMouseOpenFail" "true"
+  Option "PciForceNone" "true"
+  Option "AutoEnableDevices" "false"
+  Option "AutoAddDevices" "false"
+EndSection
+
+Section "Files"
+  ModulePath "${xorg.xorgserver.out}/lib/xorg/modules"
+  ModulePath "${xorg.xf86videodummy}/lib/xorg/modules"
+  ModulePath "${xorg.xf86inputvoid}/lib/xorg/modules"
+  XkbDir "${xkeyboard_config}/share/X11/xkb"
+  FontPath "${xorg.fontadobe75dpi}/lib/X11/fonts/75dpi"
+  FontPath "${xorg.fontadobe100dpi}/lib/X11/fonts/100dpi"
+  FontPath "${xorg.fontmiscmisc}/lib/X11/fonts/misc"
+  FontPath "${xorg.fontcursormisc}/lib/X11/fonts/misc"
+EndSection
+
+Section "InputDevice"
+  Identifier "dummy_mouse"
+  Option "CorePointer" "true"
+  Driver "void"
+EndSection
+
+Section "InputDevice"
+  Identifier "dummy_keyboard"
+  Option "CoreKeyboard" "true"
+  Driver "void"
+EndSection
+
+Section "Device"
+  Identifier "dummy_videocard"
+  Driver "dummy"
+  Option "ConstantDPI" "true"
+  #VideoRam 4096000
+  #VideoRam 256000
+  VideoRam 192000
+EndSection
+
+Section "Monitor"
+  Identifier "dummy_monitor"
+  HorizSync   5.0 - 1000.0
+  VertRefresh 5.0 - 200.0
+  #This can be used to get a specific DPI, but only for the default resolution:
+  #DisplaySize 508 317
+  #NOTE: the highest modes will not work without increasing the VideoRam
+  # for the dummy video card.
+  Modeline "32768x32768" 15226.50 32768 35800 39488 46208 32768 32771 32781 32953
+  Modeline "32768x16384" 7516.25 32768 35544 39192 45616 16384 16387 16397 16478
+  Modeline "16384x8192" 2101.93 16384 16416 24400 24432 8192 8390 8403 8602
+  Modeline "8192x4096" 424.46 8192 8224 9832 9864 4096 4195 4202 4301
+  Modeline "5496x1200" 199.13 5496 5528 6280 6312 1200 1228 1233 1261
+  Modeline "5280x1080" 169.96 5280 5312 5952 5984 1080 1105 1110 1135
+  Modeline "5280x1200" 191.40 5280 5312 6032 6064 1200 1228 1233 1261
+  Modeline "5120x3200" 199.75 5120 5152 5904 5936 3200 3277 3283 3361
+  Modeline "4800x1200" 64.42 4800 4832 5072 5104 1200 1229 1231 1261
+  Modeline "3840x2880" 133.43 3840 3872 4376 4408 2880 2950 2955 3025
+  Modeline "3840x2560" 116.93 3840 3872 4312 4344 2560 2622 2627 2689
+  Modeline "3840x2048" 91.45 3840 3872 4216 4248 2048 2097 2101 2151
+  Modeline "3840x1080" 100.38 3840 3848 4216 4592 1080 1081 1084 1093
+  Modeline "3600x1200" 106.06 3600 3632 3984 4368 1200 1201 1204 1214
+  Modeline "3288x1080" 39.76 3288 3320 3464 3496 1080 1106 1108 1135
+  Modeline "2048x2048" 49.47 2048 2080 2264 2296 2048 2097 2101 2151
+  Modeline "2048x1536" 80.06 2048 2104 2312 2576 1536 1537 1540 1554
+  Modeline "2560x1600" 47.12 2560 2592 2768 2800 1600 1639 1642 1681
+  Modeline "2560x1440" 42.12 2560 2592 2752 2784 1440 1475 1478 1513
+  Modeline "1920x1440" 69.47 1920 1960 2152 2384 1440 1441 1444 1457
+  Modeline "1920x1200" 26.28 1920 1952 2048 2080 1200 1229 1231 1261
+  Modeline "1920x1080" 23.53 1920 1952 2040 2072 1080 1106 1108 1135
+  Modeline "1680x1050" 20.08 1680 1712 1784 1816 1050 1075 1077 1103
+  Modeline "1600x1200" 22.04 1600 1632 1712 1744 1200 1229 1231 1261
+  Modeline "1600x900" 33.92 1600 1632 1760 1792 900 921 924 946
+  Modeline "1440x900" 30.66 1440 1472 1584 1616 900 921 924 946
+  ModeLine "1366x768" 72.00 1366 1414 1446 1494  768 771 777 803
+  Modeline "1280x1024" 31.50 1280 1312 1424 1456 1024 1048 1052 1076
+  Modeline "1280x800" 24.15 1280 1312 1400 1432 800 819 822 841
+  Modeline "1280x768" 23.11 1280 1312 1392 1424 768 786 789 807
+  Modeline "1360x768" 24.49 1360 1392 1480 1512 768 786 789 807
+  Modeline "1024x768" 18.71 1024 1056 1120 1152 768 786 789 807
+  Modeline "768x1024" 19.50 768 800 872 904 1024 1048 1052 1076
+
+
+  #common resolutions for android devices (both orientations):
+  Modeline "800x1280" 25.89 800 832 928 960 1280 1310 1315 1345
+  Modeline "1280x800" 24.15 1280 1312 1400 1432 800 819 822 841
+  Modeline "720x1280" 30.22 720 752 864 896 1280 1309 1315 1345
+  Modeline "1280x720" 27.41 1280 1312 1416 1448 720 737 740 757
+  Modeline "768x1024" 24.93 768 800 888 920 1024 1047 1052 1076
+  Modeline "1024x768" 23.77 1024 1056 1144 1176 768 785 789 807
+  Modeline "600x1024" 19.90 600 632 704 736 1024 1047 1052 1076
+  Modeline "1024x600" 18.26 1024 1056 1120 1152 600 614 617 631
+  Modeline "536x960" 16.74 536 568 624 656 960 982 986 1009
+  Modeline "960x536" 15.23 960 992 1048 1080 536 548 551 563
+  Modeline "600x800" 15.17 600 632 688 720 800 818 822 841
+  Modeline "800x600" 14.50 800 832 880 912 600 614 617 631
+  Modeline "480x854" 13.34 480 512 560 592 854 873 877 897
+  Modeline "848x480" 12.09 848 880 920 952 480 491 493 505
+  Modeline "480x800" 12.43 480 512 552 584 800 818 822 841
+  Modeline "800x480" 11.46 800 832 872 904 480 491 493 505
+  #resolutions for android devices (both orientations)
+  #minus the status bar
+  #38px status bar (and width rounded up)
+  Modeline "800x1242" 25.03 800 832 920 952 1242 1271 1275 1305
+  Modeline "1280x762" 22.93 1280 1312 1392 1424 762 780 783 801
+  Modeline "720x1242" 29.20 720 752 856 888 1242 1271 1276 1305
+  Modeline "1280x682" 25.85 1280 1312 1408 1440 682 698 701 717
+  Modeline "768x986" 23.90 768 800 888 920 986 1009 1013 1036
+  Modeline "1024x730" 22.50 1024 1056 1136 1168 730 747 750 767
+  Modeline "600x986" 19.07 600 632 704 736 986 1009 1013 1036
+  Modeline "1024x562" 17.03 1024 1056 1120 1152 562 575 578 591
+  Modeline "536x922" 16.01 536 568 624 656 922 943 947 969
+  Modeline "960x498" 14.09 960 992 1040 1072 498 509 511 523
+  Modeline "600x762" 14.39 600 632 680 712 762 779 783 801
+  Modeline "800x562" 13.52 800 832 880 912 562 575 578 591
+  Modeline "480x810" 12.59 480 512 552 584 810 828 832 851
+  Modeline "848x442" 11.09 848 880 920 952 442 452 454 465
+  Modeline "480x762" 11.79 480 512 552 584 762 779 783 801
+EndSection
+
+Section "Screen"
+  Identifier "dummy_screen"
+  Device "dummy_videocard"
+  Monitor "dummy_monitor"
+  DefaultDepth 24
+  SubSection "Display"
+    Viewport 0 0
+    Depth 24
+    #Modes "32768x32768" "32768x16384" "16384x8192" "8192x4096" "5120x3200" "3840x2880" "3840x2560" "3840x2048" "2048x2048" "2560x1600" "1920x1440" "1920x1200" "1920x1080" "1600x1200" "1680x1050" "1600x900" "1400x1050" "1440x900" "1280x1024" "1366x768" "1280x800" "1024x768" "1024x600" "800x600" "320x200"
+    Modes "5120x3200" "3840x2880" "3840x2560" "3840x2048" "2048x2048" "2560x1600" "1920x1440" "1920x1200" "1920x1080" "1600x1200" "1680x1050" "1600x900" "1400x1050" "1440x900" "1280x1024" "1366x768" "1280x800" "1024x768" "1024x600" "800x600" "320x200"
+    Virtual ${toString resolution.width} ${toString resolution.height}
+  EndSubSection
+EndSection
+
+Section "ServerLayout"
+  Identifier   "dummy_layout"
+  Screen       "dummy_screen"
+  InputDevice  "dummy_mouse"
+  InputDevice  "dummy_keyboard"
+EndSection
+''

--- a/nixos/services/nginx/base-module.nix
+++ b/nixos/services/nginx/base-module.nix
@@ -59,9 +59,13 @@ let
       # The mime type definitions included with nginx are very incomplete, so
       # we use a list of mime types from the mailcap package, which is also
       # used by most other Linux distributions by default.
+      types {
+        application/wasm          wasm;
+      }
       include ${pkgs.mailcap}/etc/nginx/mime.types;
       include ${cfg.package}/conf/fastcgi.conf;
       include ${cfg.package}/conf/uwsgi_params;
+
   '';
 
   writeNginxConfig = name: text: pkgs.runCommandLocal name {

--- a/pkgs/jibri/default.nix
+++ b/pkgs/jibri/default.nix
@@ -1,0 +1,44 @@
+{ pkgs, lib, stdenv, fetchurl, dpkg, jre_headless, chromium, chromedriver, ffmpeg, curl }:
+
+let
+  jibriPkgs = with pkgs; [
+    chromium
+    chromedriver
+    ffmpeg
+    curl
+    procps
+  ];
+in
+stdenv.mkDerivation rec {
+  pname = "jibri";
+  version = "8.0-83-g204354d";
+  src = fetchurl {
+    url = "https://download.jitsi.org/stable/${pname}_${version}-1_all.deb";
+    sha256 = "0407zfd14y9l1021l3fqs3qnlvq2j7prsf8dzfhj9gnkrshb7cnn";
+  };
+  dontBuild = true;
+  buildInputs = [ pkgs.makeWrapper ];
+  unpackCmd = "${dpkg}/bin/dpkg-deb -x $src debcontents";
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mv opt $out/
+    mv etc $out/
+    cp ${./logging.properties-journal} $out/etc/jitsi/jibri/logging.properties-journal
+
+    cat > $out/bin/jibri << __EOF__
+    export PATH='${lib.makeBinPath jibriPkgs}:$PATH'
+    exec ${jre_headless}/bin/java -Djava.util.logging.config.file=\$JIBRI_LOGGING_CONFIG_FILE -Dconfig.file=\$JIBRI_CONFIG_FILE -jar $out/opt/jitsi/jibri/jibri.jar "\$@"
+    __EOF__
+
+    chmod +x $out/bin/jibri
+  '';
+
+  meta = with lib; {
+    description = "JItsi BRoadcasting Infrastructure";
+    homepage = "https://github.com/jitsi/jibri";
+    license = licenses.asl20;
+    maintainers = lib.teams.jitsi.members;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/jibri/logging.properties-journal
+++ b/pkgs/jibri/logging.properties-journal
@@ -1,0 +1,28 @@
+handlers = java.util.logging.ConsoleHandler
+java.util.logging.ConsoleHandler.level = ALL
+java.util.logging.ConsoleHandler.formatter = net.java.sip.communicator.util.ScLogFormatter
+.level = INFO
+net.sf.level = SEVERE
+net.java.sip.communicator.plugin.reconnectplugin.level = FINE
+org.ice4j.level = SEVERE
+org.jitsi.impl.neomedia.level = SEVERE
+net.java.sip.communicator.service.resources.AbstractResourcesService.level = SEVERE
+net.java.sip.communicator.util.ScLogFormatter.disableTimestamp = true
+
+org.jitsi.jibri.capture.ffmpeg.util.FfmpegFileHandler.level = FINE
+org.jitsi.jibri.capture.ffmpeg.util.FfmpegFileHandler.pattern   = /var/log/jibri/ffmpeg.%g.txt
+org.jitsi.jibri.capture.ffmpeg.util.FfmpegFileHandler.formatter = net.java.sip.communicator.util.ScLogFormatter
+org.jitsi.jibri.capture.ffmpeg.util.FfmpegFileHandler.count = 10
+org.jitsi.jibri.capture.ffmpeg.util.FfmpegFileHandler.limit = 10000000
+
+org.jitsi.jibri.sipgateway.pjsua.util.PjsuaFileHandler.level = FINE
+org.jitsi.jibri.sipgateway.pjsua.util.PjsuaFileHandler.pattern   = /var/log/jibri/pjsua.%g.txt
+org.jitsi.jibri.sipgateway.pjsua.util.PjsuaFileHandler.formatter = net.java.sip.communicator.util.ScLogFormatter
+org.jitsi.jibri.sipgateway.pjsua.util.PjsuaFileHandler.count = 10
+org.jitsi.jibri.sipgateway.pjsua.util.PjsuaFileHandler.limit = 10000000
+
+org.jitsi.jibri.selenium.util.BrowserFileHandler.level = FINE
+org.jitsi.jibri.selenium.util.BrowserFileHandler.pattern   = /var/log/jibri/browser.%g.txt
+org.jitsi.jibri.selenium.util.BrowserFileHandler.formatter = net.java.sip.communicator.util.ScLogFormatter
+org.jitsi.jibri.selenium.util.BrowserFileHandler.count = 10
+org.jitsi.jibri.selenium.util.BrowserFileHandler.limit = 10000000

--- a/pkgs/jicofo/default.nix
+++ b/pkgs/jicofo/default.nix
@@ -1,11 +1,11 @@
-{ pkgs, stdenv, fetchurl, dpkg, jre_headless, nixosTests }:
+{ pkgs, stdenv, lib, fetchurl, dpkg, jre_headless, nixosTests }:
 
 let
   pname = "jicofo";
-  version = "1.0-690";
+  version = "1.0-740";
   src = fetchurl {
-    url = "https://download.jitsi.org/testing/${pname}_${version}-1_all.deb";
-    sha256 = "1w5nz2p6scd7w0ac93vhxlk5i8in5160c0icwl27m4x4km9xf6al";
+    url = "https://download.jitsi.org/stable/${pname}_${version}-1_all.deb";
+    sha256 = "1p590n0l7xn27zkbmlp5pzdxp51dmwc0my2zwaj9cpnxqq7cdj23";
   };
 in
 stdenv.mkDerivation {
@@ -30,7 +30,7 @@ stdenv.mkDerivation {
     single-node-smoke-test = nixosTests.jitsi-meet;
   };
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "A server side focus component used in Jitsi Meet conferences";
     longDescription = ''
       JItsi COnference FOcus is a server side focus component used in Jitsi Meet conferences.

--- a/pkgs/jitsi-meet/default.nix
+++ b/pkgs/jitsi-meet/default.nix
@@ -1,12 +1,12 @@
-{ pkgs, stdenv, fetchurl, nixosTests }:
+{ pkgs, stdenv, lib, fetchurl, nixosTests }:
 
 stdenv.mkDerivation rec {
   pname = "jitsi-meet";
-  version = "1.0.4628";
+  version = "1.0.4900";
 
   src = fetchurl {
     url = "https://download.jitsi.org/jitsi-meet/src/jitsi-meet-${version}.tar.bz2";
-    sha256 = "1kw4byy6mvqk3qd5nk5raka1bl9jp0kniszq6j5kc8nz3jql4qdz";
+    sha256 = "1z3bb8ln38jk6jkgis31c39pn6jqcb6jfhgy6kgdvhasx8r9bh9d";
   };
 
   dontBuild = true;
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     single-host-smoke-test = nixosTests.jitsi-meet;
   };
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Secure, Simple and Scalable Video Conferences";
     longDescription = ''
       Jitsi Meet is an open-source (Apache) WebRTC JavaScript application that uses Jitsi Videobridge

--- a/pkgs/jitsi-videobridge/default.nix
+++ b/pkgs/jitsi-videobridge/default.nix
@@ -1,11 +1,11 @@
-{ stdenv, fetchurl, dpkg, jre_headless, nixosTests }:
+{ stdenv, lib, fetchurl, dpkg, jre_headless, nixosTests }:
 
 let
   pname = "jitsi-videobridge2";
-  version = "2.1-416-g2f43d1b4";
+  version = "2.1-478-gc6da57bd";
   src = fetchurl {
     url = "https://download.jitsi.org/testing/${pname}_${version}-1_all.deb";
-    sha256 = "0s9wmbba1nlpxaawzmaqg92882y5sfs2ws64w5sqvpi7n77hy54m";
+    sha256 = "1z439nmjl42gigl1xraw5s9f58fj1nmv4nqalqd5li4sgym368n8";
   };
 in
 stdenv.mkDerivation {
@@ -30,7 +30,7 @@ stdenv.mkDerivation {
     single-host-smoke-test = nixosTests.jitsi-meet;
   };
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "A WebRTC compatible video router";
     longDescription = ''
       Jitsi Videobridge is an XMPP server component that allows for multiuser video communication.

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -66,6 +66,7 @@ in {
 
   innotop = super.callPackage ./percona/innotop.nix { };
 
+  jibri = super.callPackage ./jibri { };
   jicofo = super.callPackage ./jicofo { };
   jitsi-meet = super.callPackage ./jitsi-meet { };
   jitsi-videobridge = super.callPackage ./jitsi-videobridge { };
@@ -253,17 +254,6 @@ in {
   });
 
   prometheus-elasticsearch-exporter = super.callPackage ./prometheus-elasticsearch-exporter.nix { };
-
-  prosody = super.prosody.overrideAttrs(_: {
-    version = "0.11.7"; # also update communityModules
-    sha256 = "0iw73ids6lv09pg2fn0cxsm2pvi593md71xk48zbcp28advc1zr8";
-
-    communityModules = super.fetchhg {
-      url = "https://hg.prosody.im/prosody-modules";
-      rev = "7678b4880719";
-      sha256 = "1rpk3jcfhsa9hl7d7y638kprs9in0ljjp1nqxg30w1689v5h85d2";
-    };
-  });
 
   rabbitmq-server_3_6_5 = super.callPackage ./rabbitmq-server/3.6.5.nix {
     erlang = self.erlangR19;


### PR DESCRIPTION
* Update videobridge, jicofo and jitsi-meet to the stable version
  from April. The newest version has an issue with screen sharing so we
  skip that.
* Jibri is now provided as NixOS module instead of using Jibri from the
  old docker deployment. Configuration is similar to the videobridge,
  using HOCON with env var substitution for secrets.
* update prosody
* Replace deprecated stdenv.lib with lib
* Nginx now knows the media type WASM which speeds up the Jitsi clients
  significantly. Until now, WebAssembly optimizations were disabled
  because Nginx used the wrong media type.

 #PL-129794

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Jitsi: update components including a new UI, enable WebAssembly optimizations which reduce client load significantly, add recording and live streaming support via Jibri (#PL-129794).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - use up-to-date version of the Jitsi components 
  - access from Jibri to the XMPP server must be protected by passwords
  - Jibri API ports must not reachable from the outside
- [x] Security requirements tested? (EVIDENCE)
  - checked on the Jitsi test VM that recording and live streaming works, Jibri API ports are protected by firewall
  - checked changelogs for Jitsi components for security-relevant changes

