### PR TITLE
PL-129831 telegraf nix store config

### DIFF
--- a/nixos/platform/default.nix
+++ b/nixos/platform/default.nix
@@ -16,9 +16,6 @@ let
           (fn: lib.hasSuffix ".nix" fn)
           (lib.attrNames (builtins.readDir "/etc/local/nixos")))
     else [];
-  telegrafShowConfig = pkgs.writeScriptBin "telegraf-show-config" ''
-    cat $(systemctl cat telegraf | grep "ExecStart=" | cut -d" " -f3 | tr -d '"')
-  '';
 
 in {
   imports = [
@@ -177,7 +174,6 @@ in {
 
     environment.systemPackages = with pkgs; [
       fc.userscan
-      telegrafShowConfig
       dmidecode
     ];
 


### PR DESCRIPTION
@flyingcircusio/release-managers

(#PL-129831)

- Pull config from /etc/local/telegraf into the nix store for telegraf to be read 
- Makes telegraf restart when config files in that directory have changed
- Add config files from folder to `telegraf-show-config`

## Release process

Impact:

Changelog:

- Pull config from /etc/local/telegraf into the nix store for telegraf to be read instead of simply reading from the folder making the service restart on rebuild if the config changed (#PL-129831)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Telegraf Config files can now be read by all users from the nix store - check for sensitive data?
- [x] Security requirements tested? (EVIDENCE)
  -  rebuild the system with changes, test telegraf-show-config

