### PR TITLE
fix PL-129547 duplicate line for path "/var/log"

### DIFF
--- a/nixos/platform/syslog.nix
+++ b/nixos/platform/syslog.nix
@@ -53,6 +53,17 @@ in
       systemd.tmpfiles.rules = [
         "d /var/log 0755 root root 180d"
       ];
+
+      systemd.tmpfiles.packages = [
+        (lib.mkAfter (pkgs.runCommand "systemd-fc-overwrite-log-tmpfiles" {} ''
+          mkdir -p $out/lib/tmpfiles.d
+          cd $out/lib/tmpfiles.d
+
+          cp -a "${pkgs.systemd}/example/tmpfiles.d/var.conf" .
+          # fixes: Duplicate line for path "/var/log", ignoring.
+          sed -r "s|.+/var/log .+||g" -i var.conf
+        ''))
+      ];
     }
 
     (lib.mkIf config.services.rsyslogd.enable {


### PR DESCRIPTION
This overrides the var.conf file with one that doesn't have the
/var/log statement, so our extra statement doesn't trigger the warning

mkAfter should already ensure this will always overwrite upstream's version

Script is simply stripped down copy and past of upstream's

cc @dpausp 

 # PL-129547


## Release process

Impact:

Changelog:

* Fix warning about duplicate `/var/log` line when rebuilding the system with `fc-manage` (#PL-129854).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - avoid warnings that may distract from real problems (by dpausp)
- [x] Security requirements tested? (EVIDENCE)
  - checked on a test VM that the warning is gone and that the wanted /var/log rule is still there (by dpausp)
