### PR TITLE
Sensu: suppress deprecation warnings, 1.7->1.9

### DIFF
--- a/nixos/services/sensu/api.nix
+++ b/nixos/services/sensu/api.nix
@@ -81,6 +81,10 @@ in  {
         "redis.service"
       ];
       after = requires;
+      environment = {
+        # Hide annoying warnings, old Sensu is not developed anymore.
+        RUBYOPT="-W0";
+      };
       path = [ sensu ];
       serviceConfig = {
         User = "sensuapi";

--- a/nixos/services/sensu/client.nix
+++ b/nixos/services/sensu/client.nix
@@ -295,6 +295,10 @@ in {
       procps
       python3
       sensu
+      sensu-plugins-disk-checks
+      sensu-plugins-http
+      sensu-plugins-influxdb
+      sensu-plugins-logs
       sysstat
     ];
 
@@ -327,7 +331,7 @@ in {
       environment = {
         LANG = "en_US.utf8";
         # Hide annoying warnings, old Sensu is not developed anymore.
-        RUBYOPT="-W:no-deprecated -W:no-experimental";
+        RUBYOPT="-W0";
       };
     };
 

--- a/nixos/services/sensu/server.nix
+++ b/nixos/services/sensu/server.nix
@@ -166,7 +166,11 @@ in {
         Restart = "always";
         RestartSec = "5s";
       };
-      environment = { EMBEDDED_RUBY = "false"; };
+      environment = {
+        EMBEDDED_RUBY = "false";
+        # Hide annoying warnings, old Sensu is not developed anymore.
+        RUBYOPT="-W0";
+      };
 
       # rabbitmq needs some time to start up. The wait for pid
       # in the default service config doesn't really seem to help :(

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -266,11 +266,16 @@ in {
   remarshal = super.callPackage ./remarshal.nix { };
   rum = super.callPackage ./postgresql/rum { };
 
+  sensu = super.callPackage ./sensu { };
   sensu-plugins-elasticsearch = super.callPackage ./sensuplugins-rb/sensu-plugins-elasticsearch { };
   sensu-plugins-kubernetes = super.callPackage ./sensuplugins-rb/sensu-plugins-kubernetes { };
   sensu-plugins-memcached = super.callPackage ./sensuplugins-rb/sensu-plugins-memcached { };
   sensu-plugins-mysql = super.callPackage ./sensuplugins-rb/sensu-plugins-mysql { };
+  sensu-plugins-disk-checks = super.callPackage ./sensuplugins-rb/sensu-plugins-disk-checks { };
   sensu-plugins-entropy-checks = super.callPackage ./sensuplugins-rb/sensu-plugins-entropy-checks { };
+  sensu-plugins-http = super.callPackage ./sensuplugins-rb/sensu-plugins-http { };
+  sensu-plugins-influxdb = super.callPackage ./sensuplugins-rb/sensu-plugins-influxdb { };
+  sensu-plugins-logs = super.callPackage ./sensuplugins-rb/sensu-plugins-logs { };
   sensu-plugins-network-checks = super.callPackage ./sensuplugins-rb/sensu-plugins-network-checks { };
   sensu-plugins-postfix = super.callPackage ./sensuplugins-rb/sensu-plugins-postfix { };
   sensu-plugins-postgres = super.callPackage ./sensuplugins-rb/sensu-plugins-postgres { };

--- a/pkgs/sensu/Gemfile
+++ b/pkgs/sensu/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'sensu'

--- a/pkgs/sensu/Gemfile.lock
+++ b/pkgs/sensu/Gemfile.lock
@@ -1,0 +1,100 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
+    amq-protocol (2.0.1)
+    amqp (1.6.0)
+      amq-protocol (>= 2.0.1)
+      eventmachine
+    childprocess (0.5.8)
+      ffi (~> 1.0, >= 1.0.11)
+    cookiejar (0.3.3)
+    em-http-request (1.1.5)
+      addressable (>= 2.3.4)
+      cookiejar (!= 0.3.1)
+      em-socksify (>= 0.3)
+      eventmachine (>= 1.0.3)
+      http_parser.rb (>= 0.6.0)
+    em-http-server (0.1.8)
+      eventmachine
+    em-socksify (0.3.2)
+      eventmachine (>= 1.0.0.beta.4)
+    em-worker (0.0.2)
+      eventmachine
+    eventmachine (1.2.7)
+    ffi (1.9.21)
+    http_parser.rb (0.6.0)
+    oj (2.18.1)
+    parse-cron (0.1.4)
+    public_suffix (4.0.6)
+    sensu (1.9.0)
+      em-http-request (= 1.1.5)
+      em-http-server (= 0.1.8)
+      eventmachine (= 1.2.7)
+      parse-cron (= 0.1.4)
+      sensu-extension (= 1.5.2)
+      sensu-extensions (= 1.11.0)
+      sensu-json (= 2.1.1)
+      sensu-logger (= 1.2.2)
+      sensu-redis (= 2.4.0)
+      sensu-settings (= 10.17.0)
+      sensu-spawn (= 2.5.0)
+      sensu-transport (= 8.3.0)
+    sensu-extension (1.5.2)
+      eventmachine
+    sensu-extensions (1.11.0)
+      sensu-extension
+      sensu-extensions-check-dependencies (= 1.1.0)
+      sensu-extensions-debug (= 1.0.0)
+      sensu-extensions-deregistration (= 1.0.0)
+      sensu-extensions-json (= 1.0.0)
+      sensu-extensions-occurrences (= 1.2.0)
+      sensu-extensions-only-check-output (= 1.0.0)
+      sensu-extensions-ruby-hash (= 1.0.0)
+      sensu-json (>= 1.1.0)
+      sensu-logger
+      sensu-settings
+    sensu-extensions-check-dependencies (1.1.0)
+      sensu-extension
+    sensu-extensions-debug (1.0.0)
+      sensu-extension
+    sensu-extensions-deregistration (1.0.0)
+      sensu-extension
+    sensu-extensions-json (1.0.0)
+      sensu-extension
+    sensu-extensions-occurrences (1.2.0)
+      sensu-extension
+    sensu-extensions-only-check-output (1.0.0)
+      sensu-extension
+    sensu-extensions-ruby-hash (1.0.0)
+      sensu-extension
+    sensu-json (2.1.1)
+      oj (= 2.18.1)
+    sensu-logger (1.2.2)
+      eventmachine
+      sensu-json
+    sensu-redis (2.4.0)
+      eventmachine
+    sensu-settings (10.17.0)
+      parse-cron
+      sensu-json (>= 1.1.0)
+    sensu-spawn (2.5.0)
+      childprocess (= 0.5.8)
+      em-worker (= 0.0.2)
+      eventmachine
+      ffi (= 1.9.21)
+    sensu-transport (8.3.0)
+      amq-protocol (= 2.0.1)
+      amqp (= 1.6.0)
+      eventmachine
+      sensu-redis (>= 1.0.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  sensu
+
+BUNDLED WITH
+   2.1.4

--- a/pkgs/sensu/default.nix
+++ b/pkgs/sensu/default.nix
@@ -1,0 +1,23 @@
+{ lib, ruby, bundlerApp, bundlerUpdateScript }:
+
+bundlerApp {
+  inherit ruby;
+  pname = "sensu";
+  gemdir = ./.;
+  exes = [
+    "sensu-api"
+    "sensu-client"
+    "sensu-install"
+    "sensu-server"
+  ];
+
+  passthru.updateScript = bundlerUpdateScript "sensu";
+
+  meta = with lib; {
+    description = "A monitoring framework that aims to be simple, malleable, and scalable";
+    homepage    = "https://sensuapp.org/";
+    license     = licenses.mit;
+    maintainers = with maintainers; [ theuni peterhoeg manveru nicknovitski ];
+    platforms   = platforms.unix;
+  };
+}

--- a/pkgs/sensu/gemset.nix
+++ b/pkgs/sensu/gemset.nix
@@ -1,0 +1,335 @@
+{
+  addressable = {
+    dependencies = ["public_suffix"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1fvchp2rhp2rmigx7qglf69xvjqvzq7x0g49naliw29r2bz656sy";
+      type = "gem";
+    };
+    version = "2.7.0";
+  };
+  amq-protocol = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1rpn9vgh7y037aqhhp04smihzr73vp5i5g6xlqlha10wy3q0wp7x";
+      type = "gem";
+    };
+    version = "2.0.1";
+  };
+  amqp = {
+    dependencies = ["amq-protocol" "eventmachine"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0kbrqnpjgj9v0722p3n5rw589l4g26ry8mcghwc5yr20ggkpdaz9";
+      type = "gem";
+    };
+    version = "1.6.0";
+  };
+  childprocess = {
+    dependencies = ["ffi"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1lv7axi1fhascm9njxh3lx1rbrnsm8wgvib0g7j26v4h1fcphqg0";
+      type = "gem";
+    };
+    version = "0.5.8";
+  };
+  cookiejar = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0q0kmbks9l3hl0wdq744hzy97ssq9dvlzywyqv9k9y1p3qc9va2a";
+      type = "gem";
+    };
+    version = "0.3.3";
+  };
+  em-http-request = {
+    dependencies = ["addressable" "cookiejar" "em-socksify" "eventmachine" "http_parser.rb"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "13rxmbi0fv91n4sg300v3i9iiwd0jxv0i6xd0sp81dx3jlx7kasx";
+      type = "gem";
+    };
+    version = "1.1.5";
+  };
+  em-http-server = {
+    dependencies = ["eventmachine"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0y8l4gymy9dzjjchjav90ck6has2i2zdjihlhcyrg3jgq6kjzyq5";
+      type = "gem";
+    };
+    version = "0.1.8";
+  };
+  em-socksify = {
+    dependencies = ["eventmachine"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0rk43ywaanfrd8180d98287xv2pxyl7llj291cwy87g1s735d5nk";
+      type = "gem";
+    };
+    version = "0.3.2";
+  };
+  em-worker = {
+    dependencies = ["eventmachine"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0z4jx9z2q5hxvdvik4yp0ahwfk69qsmdnyp72ln22p3qlkq2z5wk";
+      type = "gem";
+    };
+    version = "0.0.2";
+  };
+  eventmachine = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0wh9aqb0skz80fhfn66lbpr4f86ya2z5rx6gm5xlfhd05bj1ch4r";
+      type = "gem";
+    };
+    version = "1.2.7";
+  };
+  ffi = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0c2dl10pi6a30kcvx2s6p2v1wb4kbm48iv38kmz2ff600nirhpb8";
+      type = "gem";
+    };
+    version = "1.9.21";
+  };
+  "http_parser.rb" = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "15nidriy0v5yqfjsgsra51wmknxci2n2grliz78sf9pga3n0l7gi";
+      type = "gem";
+    };
+    version = "0.6.0";
+  };
+  oj = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "147whmq8h2n04chskl3v4a132xhz5i6kk6vhnz83jwng4vihin5f";
+      type = "gem";
+    };
+    version = "2.18.1";
+  };
+  parse-cron = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "02fj9i21brm88nb91ikxwxbwv9y7mb7jsz6yydh82rifwq7357hg";
+      type = "gem";
+    };
+    version = "0.1.4";
+  };
+  public_suffix = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1xqcgkl7bwws1qrlnmxgh8g4g9m10vg60bhlw40fplninb3ng6d9";
+      type = "gem";
+    };
+    version = "4.0.6";
+  };
+  sensu = {
+    dependencies = ["em-http-request" "em-http-server" "eventmachine" "parse-cron" "sensu-extension" "sensu-extensions" "sensu-json" "sensu-logger" "sensu-redis" "sensu-settings" "sensu-spawn" "sensu-transport"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1pks6wij3drk05wwdfccwlndaj9q1bnn30ra2b6magwi34mixbw7";
+      type = "gem";
+    };
+    version = "1.9.0";
+  };
+  sensu-extension = {
+    dependencies = ["eventmachine"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0bpizp4n01rv72cryjjlrbfxxj3csish3mkxjzdy4inpi5j5h1dw";
+      type = "gem";
+    };
+    version = "1.5.2";
+  };
+  sensu-extensions = {
+    dependencies = ["sensu-extension" "sensu-extensions-check-dependencies" "sensu-extensions-debug" "sensu-extensions-deregistration" "sensu-extensions-json" "sensu-extensions-occurrences" "sensu-extensions-only-check-output" "sensu-extensions-ruby-hash" "sensu-json" "sensu-logger" "sensu-settings"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1313g6x3qwldk44p3v46sm3w1hz0pc89nslcwdw3v2j78a99a62y";
+      type = "gem";
+    };
+    version = "1.11.0";
+  };
+  sensu-extensions-check-dependencies = {
+    dependencies = ["sensu-extension"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1hc4kz7k983f6fk27ikg5drvxm4a85qf1k07hqssfyk3k75jyj1r";
+      type = "gem";
+    };
+    version = "1.1.0";
+  };
+  sensu-extensions-debug = {
+    dependencies = ["sensu-extension"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "11abdgn2kkkbvxq4692yg6a27qnxz4349gfiq7d35biy7vrw34lp";
+      type = "gem";
+    };
+    version = "1.0.0";
+  };
+  sensu-extensions-deregistration = {
+    dependencies = ["sensu-extension"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1rarsd7vjflvzgs3hm6z3ypfp3rbzq2723wc0rqxnkpahzdrwr6c";
+      type = "gem";
+    };
+    version = "1.0.0";
+  };
+  sensu-extensions-json = {
+    dependencies = ["sensu-extension"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1wnbn9sycdqdh9m0fhszaqkv0jijs3fkdbvcv8kdspx6irbv3m6g";
+      type = "gem";
+    };
+    version = "1.0.0";
+  };
+  sensu-extensions-occurrences = {
+    dependencies = ["sensu-extension"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0lx5wsbblfs0rvkxfg09bsz0g2mwmckrhga7idnarsnm8m565v1v";
+      type = "gem";
+    };
+    version = "1.2.0";
+  };
+  sensu-extensions-only-check-output = {
+    dependencies = ["sensu-extension"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0ds2i8wd4ji9ifig2zzr4jpxinvk5dm7j10pvaqy4snykxa3rqh3";
+      type = "gem";
+    };
+    version = "1.0.0";
+  };
+  sensu-extensions-ruby-hash = {
+    dependencies = ["sensu-extension"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1xyrj3gbmslbivcd5qcmyclgapn7qf7f5jwfvfpw53bxzib0h7s3";
+      type = "gem";
+    };
+    version = "1.0.0";
+  };
+  sensu-json = {
+    dependencies = ["oj"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "08zlxg5j3bhs72cc7wcllp026jbif0xiw6ib1cgawndlpsfl9fgx";
+      type = "gem";
+    };
+    version = "2.1.1";
+  };
+  sensu-logger = {
+    dependencies = ["eventmachine" "sensu-json"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0jpw4kz36ilaknrzb3rbkhpbgv93w2d668z2cv395dq30d4d3iwm";
+      type = "gem";
+    };
+    version = "1.2.2";
+  };
+  sensu-redis = {
+    dependencies = ["eventmachine"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0widfmmj1h9ca2kk14wy1sqmlkq40linp89a73s3ghngnzri0xyk";
+      type = "gem";
+    };
+    version = "2.4.0";
+  };
+  sensu-settings = {
+    dependencies = ["parse-cron" "sensu-json"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1w3c63di23zqfml4r7f24j307r27digzqdccs8qkja88fbjawvrc";
+      type = "gem";
+    };
+    version = "10.17.0";
+  };
+  sensu-spawn = {
+    dependencies = ["childprocess" "em-worker" "eventmachine" "ffi"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "17yc8ivjpjbvig9r7yl6991d6ma0kcq75fbpz6i856ljvcr3lmd5";
+      type = "gem";
+    };
+    version = "2.5.0";
+  };
+  sensu-transport = {
+    dependencies = ["amq-protocol" "amqp" "eventmachine" "sensu-redis"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0baj3hlc1lr7w9ii65by83z4mn0k7xmjk48pss1y630859z5gzhb";
+      type = "gem";
+    };
+    version = "8.3.0";
+  };
+}

--- a/pkgs/sensuplugins-rb/sensu-plugins-disk-checks/Gemfile
+++ b/pkgs/sensuplugins-rb/sensu-plugins-disk-checks/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'sensu-plugins-disk-checks'

--- a/pkgs/sensuplugins-rb/sensu-plugins-disk-checks/Gemfile.lock
+++ b/pkgs/sensuplugins-rb/sensu-plugins-disk-checks/Gemfile.lock
@@ -1,0 +1,23 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ffi (1.15.1)
+    json (2.5.1)
+    mixlib-cli (1.7.0)
+    sensu-plugin (4.0.0)
+      json (< 3.0.0)
+      mixlib-cli (~> 1.5)
+    sensu-plugins-disk-checks (5.1.4)
+      sensu-plugin (~> 4.0)
+      sys-filesystem (= 1.3.4)
+    sys-filesystem (1.3.4)
+      ffi
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  sensu-plugins-disk-checks
+
+BUNDLED WITH
+   2.1.4

--- a/pkgs/sensuplugins-rb/sensu-plugins-disk-checks/default.nix
+++ b/pkgs/sensuplugins-rb/sensu-plugins-disk-checks/default.nix
@@ -1,0 +1,15 @@
+{ bundlerSensuPlugin }:
+
+bundlerSensuPlugin {
+  pname = "sensu-plugins-disk-checks";
+  exes = [
+    "check-disk-usage.rb"
+    "check-fstab-mounts.rb"
+    "check-smart.rb"
+    "check-smart-status.rb"
+    "check-smart-tests.rb"
+    "metrics-disk-capacity.rb"
+    "metrics-disk.rb"
+    "metrics-disk-usage.rb"
+  ];
+}

--- a/pkgs/sensuplugins-rb/sensu-plugins-disk-checks/gemset.nix
+++ b/pkgs/sensuplugins-rb/sensu-plugins-disk-checks/gemset.nix
@@ -1,0 +1,61 @@
+{
+  ffi = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "15nn2v70rql15vb0pm9cg0f3xsaslwjkv6xgz0k5jh48idmfw9fi";
+      type = "gem";
+    };
+    version = "1.15.1";
+  };
+  json = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0lrirj0gw420kw71bjjlqkqhqbrplla61gbv1jzgsz6bv90qr3ci";
+      type = "gem";
+    };
+    version = "2.5.1";
+  };
+  mixlib-cli = {
+    source = {
+      remotes = ["http://rubygems.org"];
+      sha256 = "0647msh7kp7lzyf6m72g6snpirvhimjm22qb8xgv9pdhbcrmcccp";
+      type = "gem";
+    };
+    version = "1.7.0";
+  };
+  sensu-plugin = {
+    dependencies = ["json" "mixlib-cli"];
+    source = {
+      remotes = ["http://rubygems.org"];
+      sha256 = "1hibm8q4dl5bp949h21zjc3d2ss26mg4sl5svy7gl7bz59k9dg06";
+      type = "gem";
+    };
+    version = "4.0.0";
+  };
+  sensu-plugins-disk-checks = {
+    dependencies = ["sensu-plugin" "sys-filesystem"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1yyw1aa6j8c3whwmvz2w3dhmc1znf90dkhgrnklqizwrkjvp38z9";
+      type = "gem";
+    };
+    version = "5.1.4";
+  };
+  sys-filesystem = {
+    dependencies = ["ffi"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0mizqnsiagagmracadr16s5na2ks2j3ih1w0f3gp4ssrda6szl01";
+      type = "gem";
+    };
+    version = "1.3.4";
+  };
+}

--- a/pkgs/sensuplugins-rb/sensu-plugins-http/Gemfile
+++ b/pkgs/sensuplugins-rb/sensu-plugins-http/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'sensu-plugins-http'

--- a/pkgs/sensuplugins-rb/sensu-plugins-http/Gemfile.lock
+++ b/pkgs/sensuplugins-rb/sensu-plugins-http/Gemfile.lock
@@ -1,0 +1,57 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    aws-eventstream (1.1.1)
+    aws-sdk (2.11.632)
+      aws-sdk-resources (= 2.11.632)
+    aws-sdk-core (2.11.632)
+      aws-sigv4 (~> 1.0)
+      jmespath (~> 1.0)
+    aws-sdk-resources (2.11.632)
+      aws-sdk-core (= 2.11.632)
+    aws-sigv4 (1.2.3)
+      aws-eventstream (~> 1, >= 1.0.2)
+    domain_name (0.5.20190701)
+      unf (>= 0.0.5, < 1.0.0)
+    ethon (0.14.0)
+      ffi (>= 1.15.0)
+    ffi (1.15.1)
+    http-accept (1.7.0)
+    http-cookie (1.0.3)
+      domain_name (~> 0.5)
+    jmespath (1.4.0)
+    json (2.5.1)
+    mime-types (3.3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2021.0225)
+    mixlib-cli (1.7.0)
+    netrc (0.11.0)
+    oj (3.11.5)
+    rest-client (2.1.0)
+      http-accept (>= 1.7.0, < 2.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
+    sensu-plugin (4.0.0)
+      json (< 3.0.0)
+      mixlib-cli (~> 1.5)
+    sensu-plugins-http (6.1.0)
+      aws-sdk (~> 2.3)
+      oj (~> 3.10)
+      rest-client (~> 2.1)
+      sensu-plugin (~> 4.0)
+      typhoeus (~> 1.3.1)
+    typhoeus (1.3.1)
+      ethon (>= 0.9.0)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.7)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  sensu-plugins-http
+
+BUNDLED WITH
+   2.1.4

--- a/pkgs/sensuplugins-rb/sensu-plugins-http/default.nix
+++ b/pkgs/sensuplugins-rb/sensu-plugins-http/default.nix
@@ -1,0 +1,16 @@
+{ bundlerSensuPlugin }:
+
+bundlerSensuPlugin {
+  pname = "sensu-plugins-http";
+  exes = [
+    "check-head-redirect.rb"
+    "check-http-cors.rb"
+    "check-http-json.rb"
+    "check-http.rb"
+    "check-https-cert.rb"
+    "check-last-modified.rb"
+    "metrics-curl.rb"
+    "metrics-http-json-deep.rb"
+    "metrics-http-json.rb"
+  ];
+}

--- a/pkgs/sensuplugins-rb/sensu-plugins-http/gemset.nix
+++ b/pkgs/sensuplugins-rb/sensu-plugins-http/gemset.nix
@@ -1,0 +1,241 @@
+{
+  aws-eventstream = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0jfki5ikfr8ln5cdgv4iv1643kax0bjpp29jh78chzy713274jh3";
+      type = "gem";
+    };
+    version = "1.1.1";
+  };
+  aws-sdk = {
+    dependencies = ["aws-sdk-resources"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1cdw62z2ajxc46h3vsj5wvlw7rywx6h1dzfjy4q3lqqhchcs92j0";
+      type = "gem";
+    };
+    version = "2.11.632";
+  };
+  aws-sdk-core = {
+    dependencies = ["aws-sigv4" "jmespath"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0fvj8z2l7pl62zz78mq4904cr5w6k3pa7ym8v7nfa66i7gmv582p";
+      type = "gem";
+    };
+    version = "2.11.632";
+  };
+  aws-sdk-resources = {
+    dependencies = ["aws-sdk-core"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0vviicpfj3aif3xwglcvxr2zakzp9523b0hrq2m2bbx98kcdrv3l";
+      type = "gem";
+    };
+    version = "2.11.632";
+  };
+  aws-sigv4 = {
+    dependencies = ["aws-eventstream"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1d9zhmi3mpfzkkpg7yw7s9r1dwk157kh9875j3c7gh6cy95lmmaw";
+      type = "gem";
+    };
+    version = "1.2.3";
+  };
+  domain_name = {
+    dependencies = ["unf"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0lcqjsmixjp52bnlgzh4lg9ppsk52x9hpwdjd53k8jnbah2602h0";
+      type = "gem";
+    };
+    version = "0.5.20190701";
+  };
+  ethon = {
+    dependencies = ["ffi"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1bby4hbq96vnzcdbbybcbddin8dxdnj1ns758kcr4akykningqhh";
+      type = "gem";
+    };
+    version = "0.14.0";
+  };
+  ffi = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "15nn2v70rql15vb0pm9cg0f3xsaslwjkv6xgz0k5jh48idmfw9fi";
+      type = "gem";
+    };
+    version = "1.15.1";
+  };
+  http-accept = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "09m1facypsdjynfwrcv19xcb1mqg8z6kk31g8r33pfxzh838c9n6";
+      type = "gem";
+    };
+    version = "1.7.0";
+  };
+  http-cookie = {
+    dependencies = ["domain_name"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "004cgs4xg5n6byjs7qld0xhsjq3n6ydfh897myr2mibvh6fjc49g";
+      type = "gem";
+    };
+    version = "1.0.3";
+  };
+  jmespath = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1d4wac0dcd1jf6kc57891glih9w57552zgqswgy74d1xhgnk0ngf";
+      type = "gem";
+    };
+    version = "1.4.0";
+  };
+  json = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0lrirj0gw420kw71bjjlqkqhqbrplla61gbv1jzgsz6bv90qr3ci";
+      type = "gem";
+    };
+    version = "2.5.1";
+  };
+  mime-types = {
+    dependencies = ["mime-types-data"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1zj12l9qk62anvk9bjvandpa6vy4xslil15wl6wlivyf51z773vh";
+      type = "gem";
+    };
+    version = "3.3.1";
+  };
+  mime-types-data = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1phcq7z0zpipwd7y4fbqmlaqghv07fjjgrx99mwq3z3n0yvy7fmi";
+      type = "gem";
+    };
+    version = "3.2021.0225";
+  };
+  mixlib-cli = {
+    source = {
+      remotes = ["http://rubygems.org"];
+      sha256 = "0647msh7kp7lzyf6m72g6snpirvhimjm22qb8xgv9pdhbcrmcccp";
+      type = "gem";
+    };
+    version = "1.7.0";
+  };
+  netrc = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0gzfmcywp1da8nzfqsql2zqi648mfnx6qwkig3cv36n9m0yy676y";
+      type = "gem";
+    };
+    version = "0.11.0";
+  };
+  oj = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1cnadm83qwnmbpyild9whb9bgf9r7gs046ydxypclb2l756gcnva";
+      type = "gem";
+    };
+    version = "3.11.5";
+  };
+  rest-client = {
+    dependencies = ["http-accept" "http-cookie" "mime-types" "netrc"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1qs74yzl58agzx9dgjhcpgmzfn61fqkk33k1js2y5yhlvc5l19im";
+      type = "gem";
+    };
+    version = "2.1.0";
+  };
+  sensu-plugin = {
+    dependencies = ["json" "mixlib-cli"];
+    source = {
+      remotes = ["http://rubygems.org"];
+      sha256 = "1hibm8q4dl5bp949h21zjc3d2ss26mg4sl5svy7gl7bz59k9dg06";
+      type = "gem";
+    };
+    version = "4.0.0";
+  };
+  sensu-plugins-http = {
+    dependencies = ["aws-sdk" "oj" "rest-client" "sensu-plugin" "typhoeus"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0y7awxs7p0sxg3gvamppzxq180h3xhgpidg9bg6msicma40kmjxh";
+      type = "gem";
+    };
+    version = "6.1.0";
+  };
+  typhoeus = {
+    dependencies = ["ethon"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0cni8b1idcp0dk8kybmxydadhfpaj3lbs99w5kjibv8bsmip2zi5";
+      type = "gem";
+    };
+    version = "1.3.1";
+  };
+  unf = {
+    dependencies = ["unf_ext"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0bh2cf73i2ffh4fcpdn9ir4mhq8zi50ik0zqa1braahzadx536a9";
+      type = "gem";
+    };
+    version = "0.1.4";
+  };
+  unf_ext = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0wc47r23h063l8ysws8sy24gzh74mks81cak3lkzlrw4qkqb3sg4";
+      type = "gem";
+    };
+    version = "0.0.7.7";
+  };
+}

--- a/pkgs/sensuplugins-rb/sensu-plugins-influxdb/Gemfile
+++ b/pkgs/sensuplugins-rb/sensu-plugins-influxdb/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'sensu-plugins-influxdb'

--- a/pkgs/sensuplugins-rb/sensu-plugins-influxdb/Gemfile.lock
+++ b/pkgs/sensuplugins-rb/sensu-plugins-influxdb/Gemfile.lock
@@ -1,0 +1,30 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    cause (0.1)
+    dentaku (2.0.9)
+    influxdb (0.3.13)
+      cause
+      json
+    json (2.5.1)
+    jsonpath (0.5.8)
+      multi_json
+    mixlib-cli (1.7.0)
+    multi_json (1.15.0)
+    sensu-plugin (4.0.0)
+      json (< 3.0.0)
+      mixlib-cli (~> 1.5)
+    sensu-plugins-influxdb (2.0.0)
+      dentaku (= 2.0.9)
+      influxdb (= 0.3.13)
+      jsonpath (= 0.5.8)
+      sensu-plugin (~> 4.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  sensu-plugins-influxdb
+
+BUNDLED WITH
+   2.1.4

--- a/pkgs/sensuplugins-rb/sensu-plugins-influxdb/default.nix
+++ b/pkgs/sensuplugins-rb/sensu-plugins-influxdb/default.nix
@@ -1,0 +1,11 @@
+{ bundlerSensuPlugin }:
+
+bundlerSensuPlugin {
+  pname = "sensu-plugins-influxdb";
+  exes = [
+    "check-influxdb-query.rb"
+    "check-influxdb.rb"
+    "metrics-influxdb.rb"
+    "mutator-influxdb-line-protocol.rb"
+  ];
+}

--- a/pkgs/sensuplugins-rb/sensu-plugins-influxdb/gemset.nix
+++ b/pkgs/sensuplugins-rb/sensu-plugins-influxdb/gemset.nix
@@ -1,0 +1,92 @@
+{
+  cause = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0digirxqlwdg79mkbn70yc7i9i1qnclm2wjbrc47kqv6236bpj00";
+      type = "gem";
+    };
+    version = "0.1";
+  };
+  dentaku = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "11z4cw4lspx3rgmmd2hd4l1iikk6p17icxwn7xym92v1j825zpnr";
+      type = "gem";
+    };
+    version = "2.0.9";
+  };
+  influxdb = {
+    dependencies = ["cause" "json"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0jikl3iylbffsdmb4vr09ysqvpwxk133y6m9ylwcd0931ngsf0ks";
+      type = "gem";
+    };
+    version = "0.3.13";
+  };
+  json = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0lrirj0gw420kw71bjjlqkqhqbrplla61gbv1jzgsz6bv90qr3ci";
+      type = "gem";
+    };
+    version = "2.5.1";
+  };
+  jsonpath = {
+    dependencies = ["multi_json"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1gwhrd7xlysq537yy8ma69jc83lblwiccajl5zvyqpnwyjjc93df";
+      type = "gem";
+    };
+    version = "0.5.8";
+  };
+  mixlib-cli = {
+    source = {
+      remotes = ["http://rubygems.org"];
+      sha256 = "0647msh7kp7lzyf6m72g6snpirvhimjm22qb8xgv9pdhbcrmcccp";
+      type = "gem";
+    };
+    version = "1.7.0";
+  };
+  multi_json = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0pb1g1y3dsiahavspyzkdy39j4q377009f6ix0bh1ag4nqw43l0z";
+      type = "gem";
+    };
+    version = "1.15.0";
+  };
+  sensu-plugin = {
+    dependencies = ["json" "mixlib-cli"];
+    source = {
+      remotes = ["http://rubygems.org"];
+      sha256 = "1hibm8q4dl5bp949h21zjc3d2ss26mg4sl5svy7gl7bz59k9dg06";
+      type = "gem";
+    };
+    version = "4.0.0";
+  };
+  sensu-plugins-influxdb = {
+    dependencies = ["dentaku" "influxdb" "jsonpath" "sensu-plugin"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0q0pz9k69wcvqx3b0syjvbw8jil1rkl2wszpibrk6rgp3l6wc4i4";
+      type = "gem";
+    };
+    version = "2.0.0";
+  };
+}

--- a/pkgs/sensuplugins-rb/sensu-plugins-logs/Gemfile
+++ b/pkgs/sensuplugins-rb/sensu-plugins-logs/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'sensu-plugins-logs'

--- a/pkgs/sensuplugins-rb/sensu-plugins-logs/Gemfile.lock
+++ b/pkgs/sensuplugins-rb/sensu-plugins-logs/Gemfile.lock
@@ -1,0 +1,19 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    json (2.5.1)
+    mixlib-cli (1.7.0)
+    sensu-plugin (4.0.0)
+      json (< 3.0.0)
+      mixlib-cli (~> 1.5)
+    sensu-plugins-logs (4.1.1)
+      sensu-plugin (~> 4.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  sensu-plugins-logs
+
+BUNDLED WITH
+   2.1.4

--- a/pkgs/sensuplugins-rb/sensu-plugins-logs/default.nix
+++ b/pkgs/sensuplugins-rb/sensu-plugins-logs/default.nix
@@ -1,0 +1,11 @@
+{ bundlerSensuPlugin }:
+
+bundlerSensuPlugin {
+  pname = "sensu-plugins-logs";
+  exes = [
+    "check-journal.rb"
+    "check-log.rb"
+    "handler-logevent.rb"
+    "handler-show-event-config.rb"
+  ];
+}

--- a/pkgs/sensuplugins-rb/sensu-plugins-logs/gemset.nix
+++ b/pkgs/sensuplugins-rb/sensu-plugins-logs/gemset.nix
@@ -1,0 +1,40 @@
+{
+  json = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0lrirj0gw420kw71bjjlqkqhqbrplla61gbv1jzgsz6bv90qr3ci";
+      type = "gem";
+    };
+    version = "2.5.1";
+  };
+  mixlib-cli = {
+    source = {
+      remotes = ["http://rubygems.org"];
+      sha256 = "0647msh7kp7lzyf6m72g6snpirvhimjm22qb8xgv9pdhbcrmcccp";
+      type = "gem";
+    };
+    version = "1.7.0";
+  };
+  sensu-plugin = {
+    dependencies = ["json" "mixlib-cli"];
+    source = {
+      remotes = ["http://rubygems.org"];
+      sha256 = "1hibm8q4dl5bp949h21zjc3d2ss26mg4sl5svy7gl7bz59k9dg06";
+      type = "gem";
+    };
+    version = "4.0.0";
+  };
+  sensu-plugins-logs = {
+    dependencies = ["sensu-plugin"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1a5sci9s7a8hqrlh4d1mi350ilywzclh38dhkmwqwps1dc7hlm0v";
+      type = "gem";
+    };
+    version = "4.1.1";
+  };
+}


### PR DESCRIPTION
Move integrated check plugins to separate sensuplugin-rb packages.
The plugin wrapper sets RUBYOPT=-W0 which supresses the annoying
deprecation warnings starting with Ruby 2.7.

Also set RUBYOPT to suppress warnings from Sensu itself.

1.9 is the last version of the old Ruby version of Sensu.

 #PL-129897

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

- Sensu: suppress deprecation warnings in journal, update to 1.9 (#PL-129897).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - use a recent version of Sensu
  - logs should be readable and not be spammed with unhelpful warnings  
- [x] Security requirements tested? (EVIDENCE)
  - Sensu version is the newest for the Ruby branch now but it's deprecated and should be replaced
  - checked changelog for security-relevant changes
  - automated test for sensu-server still runs, checked on test VM if warnings from client are gone 
