### PR TITLE
Remove wkhtmltopdf 0.12.4

### DIFF
--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -282,7 +282,6 @@ in {
   tideways_daemon = super.callPackage ./tideways/daemon.nix {};
   tideways_module = super.callPackage ./tideways/module.nix {};
 
-  wkhtmltopdf_0_12_4 = super.callPackage ./wkhtmltopdf/0_12_4.nix { };
   wkhtmltopdf_0_12_5 = super.callPackage ./wkhtmltopdf/0_12_5.nix { };
   wkhtmltopdf_0_12_6 = super.callPackage ./wkhtmltopdf/0_12_6.nix { };
   wkhtmltopdf = self.wkhtmltopdf_0_12_6;

--- a/release/default.nix
+++ b/release/default.nix
@@ -114,7 +114,6 @@ let
     "python38Packages"
     # XXX: fails on 21.05, must be fixed
     "backy"
-    "wkhtmltopdf_0_12_4"
   ];
 
   includedPkgNames = [


### PR DESCRIPTION
Doesn't build on 21.05 anymore and it's likely that nobody uses it.
20.09 channels can be used in user env to get the package, if needed.

 #PL-129900

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Remove wkhtmltopdf version 0.12.4. We still support versions 0.12.5 and 0.12.6. 20.09 can be used in user environments to get the package, if needed (#PL-129900).

## Security implications

Just removing a package which likely nobody uses at the moment.

- [ n/a] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [ n/a] Security requirements tested? (EVIDENCE)

