### PR TITLE
Switch Grafana and Graylog to proper new LDAPS connection settings.

### DIFF
--- a/nixos/roles/statshost/default.nix
+++ b/nixos/roles/statshost/default.nix
@@ -103,9 +103,10 @@ let
     verbose_logging = true
 
     [[servers]]
-    host = "ldap.rzob.gocept.net"
-    port = 389
-    start_tls = true
+    host = "ldap.fcio.net"
+    port = 636
+    start_tls = false
+    use_ssl = true
     bind_dn = "uid=%s,ou=People,dc=gocept,dc=com"
     search_base_dns = ["ou=People,dc=gocept,dc=com"]
     search_filter = "(&(&(objectClass=inetOrgPerson)(uid=%s))(memberOf=cn=${config.flyingcircus.enc.parameters.resource_group},ou=GroupOfNames,dc=gocept,dc=com))"

--- a/nixos/services/graylog/default.nix
+++ b/nixos/services/graylog/default.nix
@@ -364,7 +364,7 @@ in {
             enabled = true;
             system_username = fclib.getLdapNodeDN;
             system_password = fclib.getLdapNodePassword;
-            ldap_uri = "ldaps://ldap.rzob.gocept.net:636/";
+            ldap_uri = "ldaps://ldap.fcio.net:636/";
             trust_all_certificates = true;
             use_start_tls = false;
             active_directory = false;


### PR DESCRIPTION
REQUIRES BACKPORT TO 20.09!

Re PL-24593 ldap.fcio.net publicly reachable via unencrypted channel
(port 389)

@flyingcircusio/release-managers

## Release process

REQUIRES BACKPORT TO 20.09!

Impact:

Changelog:

* Switch LDAP connection settings for all Grafana and Graylog instances to properly use LDAPS and use the new canonical address `ldap.fcio.net`.

## Security implications

- [X] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

LDAP needs to properly implement network security and we did not reliably ensure a cryptographically secure connection.

- [X] Security requirements tested? (EVIDENCE)

Generally those settings are good now and have been manually tested in various applications. Due to the deployment structure we need to roll those out in dev/staging/prod and I will follow up on any connections that do not use the proper connections in the original ticket PL-24593.

REQUIRES BACKPORT TO 20.09!
