### PR TITLE
Update nixpkgs

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "d31f3c6c5154f5574979e3e1d6230ebd50733761",
-    "sha256": "1vzfdwmhzm19zd5wqnfdc3q8cdi16dykxcyp67ay4zk4nwljpfak"
+    "rev": "d95ebbf43015df5cb9acfd8ac484a4447ab29bfd",
+    "sha256": "0ig351lnxbfn7ilf5sn1dsk588w9q4waa4nx94cwhpwgwbsxi3m1"
   },
   "nixpkgs_18_03": {
     "owner": "nixos",


### PR DESCRIPTION
Notable updates and security fixes:

* cacert: 3.57 -> 3.66
* imagemagick: 7.0.11-12 -> 7.0.11.13
* lz4: patch CVE-2021-3520 and null pointer dereference
* nginx: Fix off-by-one in DNS resolver heap write (CVE-2021-23017)
* nss_latest: 3.63 -> 3.64
* openvpn: 2.4.9 -> 2.4.11 (CVE-2020-15078)
* php74.extensions.iconv: fix error signalling
* polkit: Fix local privilege escalation vulnerability (CVE-2021-3560)
* python3Packages.websockets: add patch for CVE-2018-1000518-redux
* redis: 6.0.11 -> 6.0.13 (CVE-2021-29477, CVE-2021-29478)
* samba: 4.12.14 -> 4.12.15 (CVE-2021-20254)

 #PL-129901

@flyingcircusio/release-managers

## Release process

Impact:

* [NixOS 20.09] Redis and OpenVPN server will be restarted.


Changelog: (include changes from commit msg here)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - pull in upstream security fixes regularly
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still run, works on test VM
  - checked commit log for fixed CVEs and possible problems with updates
