### PR TITLE
Update tideways for php80

### DIFF
--- a/pkgs/tideways/daemon.nix
+++ b/pkgs/tideways/daemon.nix
@@ -2,7 +2,7 @@
 
 assert stdenv.hostPlatform.system == "x86_64-linux";
 
-let version = "1.6.16"; in
+let version = "1.6.32"; in
 
 stdenv.mkDerivation {
   name = "tideways-daemon-${version}";
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "https://s3-eu-west-1.amazonaws.com/tideways/daemon/${version}/tideways-daemon_linux_amd64-${version}.tar.gz";
-    sha256 = "0b1i9n7916vis26d75f119hxr0q89vps9hw7cqbx8473f31l6my3";
+    sha256 = "0ksnq6z89n9y8qyd46slia5ykqiwz7qvw53c9f9cyjbfbkqkzzzc";
   };
 
   meta = {

--- a/pkgs/tideways/module.nix
+++ b/pkgs/tideways/module.nix
@@ -2,7 +2,7 @@
 
 assert stdenv.hostPlatform.system == "x86_64-linux";
 
-let version = "5.1.18"; in
+let version = "5.3.20"; in
 
 stdenv.mkDerivation {
   name = "tideways-php-module-${version}";
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "https://s3-eu-west-1.amazonaws.com/tideways/extension/${version}/tideways-php-${version}-x86_64.tar.gz";
-    sha256 = "0nrpdkwb87xj6ampxslgvz320ihd94bh342bxbvmi9022w3ibv83";
+    sha256 = "00l8vn37kn8qp742rhcs7pq6cwkqijllg5m68ajxx9gh9j5h08nk";
   };
 
   meta = {


### PR DESCRIPTION
@flyingcircusio/release-managers

This PR updates tideways-daemon and php modules for some upstream bugfixes and support of PHP 8

## Release process

Impact:
* Restart of Apache with tideways active 

Changelog:
* Update tideways daemon and PHP modules 

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [x] Security requirements tested? (EVIDENCE)
  - All tests are green
  - Tested on VM
