### PR TITLE
Update nixpkgs

### DIFF
--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -37,6 +37,18 @@ in {
       boost = super.boost155;
   });
 
+  # Hash is wrong upstream
+  containerd = super.containerd.overrideAttrs(_: rec {
+    version = "1.5.1";
+
+    src = super.fetchFromGitHub {
+      rev = "v${version}";
+      owner = "containerd";
+      repo = "containerd";
+      sha256 = "16q34yiv5q98b9d5vgy1lmmppg8agrmnfd1kzpakkf4czkws0p4d";
+    };
+  });
+
   docsplit = super.callPackage ./docsplit { };
 
   elasticsearch7 = super.elasticsearch7.overrideAttrs(_: rec {

--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "NixOS",
     "repo": "nixpkgs",
-    "rev": "3a2e0c36e79cecaf196cbea23e75e74710140ea4",
-    "sha256": "0gjv2y6vjn3sdpg8ljcw2mk99c1xxdrfv11pc8kf5ms64wby20g5"
+    "rev": "5de44c15758465f8ddf84d541ba300b48e56eda4",
+    "sha256": "05darjv3zc5lfqx9ck7by6p90xgbgs1ni6193pw5zvi7xp2qlg4x"
   },
   "nixpkgs_18_03": {
     "owner": "nixos",


### PR DESCRIPTION
Had to fix the containerd hash, can be removed when upstream moves
to containerd 1.5.2.

Notable changes and security updates:

* gitlab: 13.12.0 -> 13.12.2
* linux: 5.10.37 -> 5.10.40
* lz4: patch CVE-2021-3520 and null pointer dereference
* matrix-synapse: 1.34.0 -> 1.35.1
* nix: 2.3.11 -> 2.3.12
* php74: 7.4.18 -> 7.4.20
* php80: 8.0.5 -> 8.0.7
* phpPackages.composer: 2.1.0 -> 2.1.1
* polkit: Fix authentication bypass vulnerability (CVE-2021-3560)

 #PL-129908

@flyingcircusio/release-managers

## Release process

Impact:

Changelog: (include changes from commit msg here)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - pull in upstream security fixes regularly
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still run, works on test VM
  - checked commit log for fixed CVEs and possible problems with updates
