### PR TITLE
Postgresql: role for version 13

### DIFF
--- a/nixos/roles/postgresql.nix
+++ b/nixos/roles/postgresql.nix
@@ -13,6 +13,7 @@ with builtins;
       postgresql10.enable = mkRole "10";
       postgresql11.enable = mkRole "11";
       postgresql12.enable = mkRole "12";
+      postgresql13.enable = mkRole "13";
     };
   };
 
@@ -24,6 +25,7 @@ with builtins;
       "10" = postgresql10.enable;
       "11" = postgresql11.enable;
       "12" = postgresql12.enable;
+      "13" = postgresql13.enable;
     };
     enabledRoles = lib.filterAttrs (n: v: v) pgroles;
     enabledRolesCount = length (lib.attrNames enabledRoles);

--- a/nixos/services/postgresql.nix
+++ b/nixos/services/postgresql.nix
@@ -10,6 +10,7 @@ let
     "10" = pkgs.postgresql_10;
     "11" = pkgs.postgresql_11;
     "12" = pkgs.postgresql_12;
+    "13" = pkgs.postgresql_13;
   };
 
   listenAddresses =
@@ -55,7 +56,7 @@ in {
       majorVersion = mkOption {
           type = types.str;
           description = ''
-            The major version of PostgreSQL to use (9.6, 10, 11, 12).
+            The major version of PostgreSQL to use (9.6, 10, 11, 12, 13).
           '';
         };
     };

--- a/pkgs/postgresql/rum/default.nix
+++ b/pkgs/postgresql/rum/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "rum";
-  version = "1.3.7";
+  version = "1.3.8-g1a4d4b8e";
 
   src = fetchFromGitHub {
-    rev = version;
+    rev = "1a4d4b8e2597483b8545f8111cb3c44e4be0aa73";
     owner = "postgrespro";
     repo = "rum";
-    sha256 = "185bmjd236qis5gqdv2vi52k5bg13cghs95ch5z0vqx59xqs17bm";
+    sha256 = "16jiykarnix9iis2gygn0nmfaxh2gxh794jwf69h7pgm0srz6376";
   };
 
   buildInputs = [ postgresql ];

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -69,6 +69,7 @@ in {
   postgresql10 = callTest ./postgresql.nix { rolename = "postgresql10"; };
   postgresql11 = callTest ./postgresql.nix { rolename = "postgresql11"; };
   postgresql12 = callTest ./postgresql.nix { rolename = "postgresql12"; };
+  postgresql13 = callTest ./postgresql.nix { rolename = "postgresql13"; };
   postgresql96 = callTest ./postgresql.nix { rolename = "postgresql96"; };
   prometheus = callTest ./prometheus.nix {};
   rabbitmq = callTest ./rabbitmq.nix {};

--- a/tests/postgresql.nix
+++ b/tests/postgresql.nix
@@ -1,4 +1,4 @@
-import ./make-test-python.nix ({ rolename ? "postgresql11", lib, pkgs, ... }:
+import ./make-test-python.nix ({ rolename ? "postgresql13", lib, pkgs, ... }:
 let
   ipv4 = "192.168.101.1";
   ipv6 = "2001:db8:f030:1c3::1";
@@ -47,7 +47,7 @@ in {
       psql = "sudo -u postgres -- psql";
 
       createTemporalExtension =
-        if rolename == "postgresql12"
+        if (rolename == "postgresql12" || rolename == "postgresql13")
         then "CREATE EXTENSION periods CASCADE"
         else "CREATE EXTENSION temporal_tables";
     in


### PR DESCRIPTION
Had to update rum to make it work with version 13.

 #PL-129912

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Provide postgresql13 role (#PL-129912).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - same as before for PG12
  - should listen on srv and lo only  
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still run for all postgresql versions
  - checked on a test VM that only the expected ports are open
  - is already running as a database for Discourse staging VM
