### PR TITLE
Remove docker from kubernetes test and use containerd

### DIFF
--- a/tests/default.nix
+++ b/tests/default.nix
@@ -37,8 +37,7 @@ in {
   kernelconfig = callTest ./kernelconfig.nix {};
   kibana6 = callTest ./kibana.nix { version = "6"; };
   kibana7 = callTest ./kibana.nix { version = "7"; };
-  # Docker is gone, Kubernetes itself seems to work but test needs a fix
-  #kubernetes = callTest ./kubernetes {};
+  kubernetes = callTest ./kubernetes {};
 
   lamp = callTest ./lamp.nix { };
   lamp56 = callTest ./lamp.nix { version = "lamp_php56"; };

--- a/tests/kubernetes/redis.nix
+++ b/tests/kubernetes/redis.nix
@@ -6,7 +6,7 @@ rec {
     name = "redis";
     tag = "latest";
     contents = [ pkgs.redis ];
-    config.Entrypoint = "/bin/redis-server";
+    config.Entrypoint = ["/bin/redis-server"];
   };
 
   podJson = toJSON {


### PR DESCRIPTION
@flyingcircusio/release-managers

Kubernetes dropped docker support, so our test must be changed to remove all commands relaying on docker. Containerd is used by kubernetes instead and must be used in the test to not break it.

This also reactivates the kubernetes test because it is not broken anymore.

Also deaktivates a subtest, because it currently does not work on 21.05 but it is not essential.

   # PL-129854

## Release process

Impact:

None

Changelog:

None

## Security implications

- [X] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

    - Tests should be able to run, to ensure systems stability

- [X] Security requirements tested? (EVIDENCE)

    - Test where executed and end successfully.

