### PR TITLE
Pl 129855 fix openvpn on 21.05

### DIFF
--- a/nixos/roles/external_net/generate-pki.nix
+++ b/nixos/roles/external_net/generate-pki.nix
@@ -6,11 +6,12 @@
 , resource_group ? "unknown-rg"
 , location ? "standalone"
 , caDir ? "/var/lib/openvpn-pki"
+, gnused
 }:
 
 {
   generate = runCommand "generate-pki.sh" {
-    inherit easyrsa openvpn gawk resource_group location caDir;
+    inherit easyrsa openvpn gawk resource_group location gnused caDir;
     inherit (stdenv) shell;
     preferLocalBuild = true;
     allowSubstitutes = false;

--- a/nixos/roles/external_net/generate-pki.sh
+++ b/nixos/roles/external_net/generate-pki.sh
@@ -10,7 +10,7 @@ LOCATION="@location@"
 EASYRSA="@easyrsa@"
 OPENVPN="@openvpn@"
 
-export PATH="@gawk@/bin:$PATH"
+export PATH="@gnused@/bin:@gawk@/bin:$PATH"
 
 ersa="$EASYRSA/bin/easyrsa --batch --days=999999"
 stamp="${DIR}/.stamp-generate-pki"

--- a/nixos/roles/external_net/openvpn.nix
+++ b/nixos/roles/external_net/openvpn.nix
@@ -180,6 +180,10 @@ let
     management localhost ${mgmPort} ${pkgs.writeText "openvpn-mgm-psk" mgmPsk}
 
     comp-lzo
+
+    # Since 21.05 cipher must be set. Previously it defaulted to BF-CBC as fallback
+    cipher AES-256-GCM
+
     user nobody
     group nogroup
 

--- a/nixos/roles/external_net/openvpn.nix
+++ b/nixos/roles/external_net/openvpn.nix
@@ -173,7 +173,7 @@ let
     tls-cipher ${lib.concatStringsSep ":" allowedTlsCiphers}
 
     # data channel ciphers that can be negotiated
-    ncp-ciphers ${lib.concatStringsSep ":" allowedCiphers}
+    data-ciphers ${lib.concatStringsSep ":" allowedCiphers}
 
     keepalive 10 120
     plugin ${openvpn}/lib/openvpn/plugins/openvpn-plugin-auth-pam.so openvpn

--- a/nixos/roles/external_net/openvpn.nix
+++ b/nixos/roles/external_net/openvpn.nix
@@ -179,8 +179,6 @@ let
     plugin ${openvpn}/lib/openvpn/plugins/openvpn-plugin-auth-pam.so openvpn
     management localhost ${mgmPort} ${pkgs.writeText "openvpn-mgm-psk" mgmPsk}
 
-    comp-lzo
-
     # Since 21.05 cipher must be set. Previously it defaulted to BF-CBC as fallback
     cipher AES-256-GCM
 

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -62,8 +62,7 @@ in {
   network = callSubTests ./network {};
   nfs = callTest ./nfs.nix {};
   nginx = callTest ./nginx.nix {};
-  # test fails
-  # openvpn = callTest ./openvpn.nix {};
+  openvpn = callTest ./openvpn.nix {};
   percona80 = callTest ./mysql.nix { rolename = "percona80"; };
   postgresql10 = callTest ./postgresql.nix { rolename = "postgresql10"; };
   postgresql11 = callTest ./postgresql.nix { rolename = "postgresql11"; };


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process
Fixes multiple deprecation warnings and a broken key generation script to get openvpn working again. Also disable compression as it is deemed unsafe by [openvpn](https://community.openvpn.net/openvpn/wiki/VORACLE).

Impact:

   - Restart Openvpn

Changelog:

   - Port openvpn to 21.05
   - Disable compression

## Security implications

- [X] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

    - Features should work and deprecation warnings should be dealt with before the actual deprecation.
    - When possible, block known attacks.

- [X] Security requirements tested? (EVIDENCE)

    - Openvpn test executed without errors

