### PR TITLE
PL-129909 Replace deprecated StartLimitInterval option

### DIFF
--- a/nixos/roles/elasticsearch.nix
+++ b/nixos/roles/elasticsearch.nix
@@ -165,11 +165,11 @@ in
     };
 
     systemd.services.elasticsearch = {
+      startLimitIntervalSec = 480;
+      startLimitBurst = 3;
       serviceConfig = {
         LimitMEMLOCK = "infinity";
         Restart = "always";
-        StartLimitInterval=480;
-        StartLimitBurst=3;
       };
       preStart = lib.mkAfter ''
         # Install scripts

--- a/nixos/services/nginx/base-module.nix
+++ b/nixos/services/nginx/base-module.nix
@@ -903,6 +903,8 @@ in
         after = [ "network.target" ];
         wantedBy = [ "multi-user.target" ];
         stopIfChanged = false;
+        startLimitIntervalSec = 1 * 60; # 1 minute
+
 
         serviceConfig = {
           Type = "forking";
@@ -914,7 +916,6 @@ in
           ExecReload = "+${nginxReloadConfig}/bin/nginx-reload";
           Restart = "always";
           RestartSec = "10s";
-          StartLimitInterval = "1min";
           # User and group
           # XXX: We start nginx as root and drop later for compatibility reasons, this should change.
           # User = cfg.user;


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:
- reloads/restarts nginx and elasticsearch services

Changelog:
- Changes StartLimitInterval option to StartLimitIntervalSec option in service section. Changed in Systemd v230

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - No security relevant changes
- [x] Security requirements tested? (EVIDENCE)
  - configuration builds and display same behaviour

