### PR TITLE
[21.05] Update nixpkgs

### DIFF
--- a/pkgs/ceph/generic.nix
+++ b/pkgs/ceph/generic.nix
@@ -81,8 +81,6 @@ let
   };
 
   ceph-python-env = python2Packages.python.withPackages (ps: [
-    ps.sphinx
-    ps.flask
     ps.cython
     ps.setuptools
     ps.pip

--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "NixOS",
     "repo": "nixpkgs",
-    "rev": "5de44c15758465f8ddf84d541ba300b48e56eda4",
-    "sha256": "05darjv3zc5lfqx9ck7by6p90xgbgs1ni6193pw5zvi7xp2qlg4x"
+    "rev": "6613a30c5e3ee59753181512b4bedd4121569925",
+    "sha256": "18v74cwjcl7qkdhgc8xic9fvp3330dsc82ah4xs3qzl5ks2h9d5h"
   },
   "nixpkgs_18_03": {
     "owner": "nixos",


### PR DESCRIPTION
Notable security updates and version changes:

* apacheHttpd: 2.4.47 -> 2.4.48
* curl: add patches for CVE-2021-22897, CVE-2021-22898 & CVE-2021-22901
* discourse: 2.7.0 -> 2.7.4
* gitlab: 13.12.2 -> 13.12.4
* imagemagick6: 6.9.12-12 -> 6.9.12-15
* linux: 5.10.40 -> 5.10.44
* matrix-synapse: 1.35.1 -> 1.36.0
* phpPackages.composer: 2.1.1 -> 2.1.3
* postgresql_10: 10.16 -> 10.17 (CVE-2021-32027, CVE-2021-32028)
* postgresql_11: 11.11 -> 11.12 (CVE-2021-32027, CVE-2021-32028, CVE-2021-32029)
* postgresql_12: 12.6 -> 12.7 (CVE-2021-32027, CVE-2021-32028, CVE-2021-32029)
* postgresql_13: 13.2 -> 13.3 (CVE-2021-32027, CVE-2021-32028, CVE-2021-32029)
* postgresql_9_6: 9.6.21 -> 9.6.22 (CVE-2021-32027, CVE-2021-32028)

 #PL-129930

@flyingcircusio/release-managers

## Release process

Impact:

Changelog: (include changes from commit msg here)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - pull in upstream security fixes regularly
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still run, works on test VM
  - checked commit log for fixed CVEs and possible problems with updates