### PR TITLE
Fix sensu-api: back to Ruby 2.6

### DIFF
--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -279,7 +279,7 @@ in {
   remarshal = super.callPackage ./remarshal.nix { };
   rum = super.callPackage ./postgresql/rum { };
 
-  sensu = super.callPackage ./sensu { };
+  sensu = super.callPackage ./sensu { ruby = super.ruby_2_6; };
   sensu-plugins-elasticsearch = super.callPackage ./sensuplugins-rb/sensu-plugins-elasticsearch { };
   sensu-plugins-kubernetes = super.callPackage ./sensuplugins-rb/sensu-plugins-kubernetes { };
   sensu-plugins-memcached = super.callPackage ./sensuplugins-rb/sensu-plugins-memcached { };


### PR DESCRIPTION
sensu-json uses a method that is deprecated on 2.6 and removed on 2.7.
Default ruby on 21.05 is 2.7, so sensu-api doesn't work anymore.
The deprecation warning is already suppressed and sensu
should be quiet now.

 #PL-129743

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

## Security implications

Ruby Sensu is outdated and we need to replace it in the near future.

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - sensu monitoring should work 
- [x] Security requirements tested? (EVIDENCE)
  - tested on staging sensu server, automated test still runs
