### PR TITLE
Servicecheck: re-add --sni flag for SSL checks

### DIFF
--- a/pkgs/fc/agent/fc/manage/monitor.py
+++ b/pkgs/fc/agent/fc/manage/monitor.py
@@ -42,6 +42,7 @@ def get_sensucheck_configuration(servicechecks):
             command.extend(['-u', shlex.quote(path)])
         if url.scheme == 'https':
             command.append('-S')
+            command.append('--sni')
         if url.username:
             auth_pair = ':'.join([url.username, url.password or ''])
             command.extend(['-a', auth_pair])


### PR DESCRIPTION
We already used that on 15.09, got lost on newer versions.

 #PL-129931

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - SSL service checks should work and check the correct hostname 
- [x] Security requirements tested? (EVIDENCE)
  - we already use this on our servicecheck machine
