### PR TITLE
Mailserver: allow service users to run postsuper

### DIFF
--- a/nixos/roles/mailserver.nix
+++ b/nixos/roles/mailserver.nix
@@ -141,6 +141,13 @@ in
       flyingcircus.services.nginx.enable = true;
       flyingcircus.services.redis.enable = true;
 
+      flyingcircus.passwordlessSudoRules = [
+        {
+          commands = [ "${pkgs.postfix}/bin/postsuper" ];
+          groups = [ "sudo-srv" "service" ];
+        }
+      ];
+
       flyingcircus.roles.mailserver =
         fclib.jsonFromFile "/etc/local/mail/config.json" "{}";
     })

--- a/tests/mail/default.nix
+++ b/tests/mail/default.nix
@@ -118,6 +118,13 @@ in
   };
   testScript = ''
     start_all()
+
+    with subtest("postsuper sudo rule should be present for service group"):
+      mail.succeed('grep %service /etc/sudoers | grep -q postsuper')
+
+    with subtest("postsuper sudo rule should be present for sudo-srv group"):
+      mail.succeed('grep %sudo-srv /etc/sudoers | grep -q postsuper')
+
     mail.execute('rm -rf /srv/mail/example.local')
     mail.wait_for_file('/run/rspamd/rspamd-milter.sock')
     mail.wait_for_open_port(25)


### PR DESCRIPTION
Users may want to clean the postfix queue or do other maintenance tasks.

 #PL-129874

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Mailserver: allow service/sudo-srv users to run sudo postsuper without password (#PL-129874).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - allow passwordless access to postsuper to service/sudo-srv users (and only to to them)
  - use flyingcircus.passwordlessSudoRules (limited to the wanted groups) which is safer than writing sudo rules by hand. 
- [x] Security requirements tested? (EVIDENCE)
  - automated test checks if sudo rules are present
