### PR TITLE
Nginx: add legacyTlsSettings option

### DIFF
--- a/nixos/services/nginx/README.txt
+++ b/nixos/services/nginx/README.txt
@@ -100,7 +100,7 @@ TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
 TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
 TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
 
-To use older ciphers based on RSA for legacy clients, a RSA key must be
+To use ciphers based on RSA for legacy clients, an RSA key must be
 used for the certificates. Note that this disables the ciphers listed above
 and reduces performance with current clients.
 
@@ -111,7 +111,7 @@ security.acme.certs."test.fcio.net".keyType = "rsa2048";
 Using two certificates to support both kinds of ciphers is possible with Nginx
 but needs manual configuration.
 
-For ciphers using DHE, a RSA certificate must be used and dhparams must be set:
+For ciphers using DHE, an RSA certificate must be used and dhparams must be set:
 
 services.nginx.sslDhparam = config.security.dhparams.params.nginx.path;
 
@@ -124,6 +124,12 @@ TLS_DHE_RSA_WITH_AES_256_GCM_SHA384
 The services.nginx.sslCiphers option can be used to change the cipher list:
 
 https://search.nixos.org/options?channel=20.09&show=services.nginx.sslCiphers&from=0&size=50&sort=relevance&query=sslCiphers
+
+If you enable weaker ciphers, you should also set services.nginx.legacyTlsSettings to true
+and services.nginx.recommendedTlsSettings to false.
+
+This sets `ssl_prefer_server_ciphers on` so better ciphers at the beginning of
+the cipher list are used if possible.
 
 
 Manual configuration
@@ -152,7 +158,7 @@ without the need to restart Nginx.
 You can check if the config is valid with: `nginx-check-config`.
 The script also warns about potential security issues with your config.
 
-For ciphers using DHE, a RSA certificate must be used and dhparams must be set:
+For ciphers using DHE, an RSA certificate must be used and dhparams must be set:
 
 ssl_dhparam /var/lib/dhparams/nginx.pem;
 

--- a/nixos/services/nginx/base-module.nix
+++ b/nixos/services/nginx/base-module.nix
@@ -131,6 +131,19 @@ let
         ssl_stapling_verify on;
       ''}
 
+      ${optionalString (cfg.legacyTlsSettings) ''
+        # Keep in sync with https://ssl-config.mozilla.org/#server=nginx&config=old
+
+        ssl_session_timeout 1d;
+        ssl_session_cache shared:SSL:10m;
+        ssl_session_tickets off;
+        ssl_prefer_server_ciphers on;
+
+        # OCSP stapling
+        ssl_stapling on;
+        ssl_stapling_verify on;
+      ''}
+
       ${optionalString (cfg.recommendedGzipSettings) ''
         gzip on;
         gzip_proxied any;
@@ -461,7 +474,15 @@ in
         default = false;
         type = types.bool;
         description = "
-          Enable recommended TLS settings.
+          Enable recommended TLS settings (Mozilla intermediate).
+        ";
+      };
+
+      legacyTlsSettings = mkOption {
+        default = false;
+        type = types.bool;
+        description = "
+          Enable legacy TLS settings for very old clients (Mozilla old).
         ";
       };
 
@@ -874,6 +895,14 @@ in
         message = ''
           Options services.nginx.service.virtualHosts.<name>.enableACME and
           services.nginx.virtualHosts.<name>.useACMEHost are mutually exclusive.
+        '';
+      }
+
+      {
+        assertion = !(cfg.legacyTlsSettings && cfg.recommendedTlsSettings);
+        message = ''
+          Options services.nginx.service.legacyTlsSettings and
+          services.nginx.virtualHosts.recommendedTlsSettings are mutually exclusive.
         '';
       }
     ];


### PR DESCRIPTION
Same as recommendedTlsSettings except that server ciphers are preferred
with this option.
Should be used when weaker ciphers are enabled for really old clients.

Mutually exclusive with recommendedTlsSettings.

 #PL-129818

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Nginx: add `services.nginx.legacyTlsSettings` which should be used instead of `recommendedTlsSettings` when weaker ciphers are used for legacy clients (#PL-129818).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  -  make sure that better SSL ciphers are used if weaker ciphers are enabled
- [x] Security requirements tested? (EVIDENCE)
  - checked on test VM that the settings are included in the final nginx config
