### PR TITLE
LAMP: don't load PHP extensions twice in PHP CLI & add php56 from fossar/nix-phps

### DIFF
--- a/nixos/roles/lamp.nix
+++ b/nixos/roles/lamp.nix
@@ -120,10 +120,10 @@ in {
 
           services.httpd.enable = true;
           services.httpd.adminAddr = "admin@flyingcircus.io";
-          environment.shellInit = ''
-            export PHPRC='${config.systemd.services.httpd.environment.PHPRC}'
-          '';
-
+          # Provide a similar PHP config for the PHP CLI as for Apache (httpd).
+          # The file referenced by PHPRC is loaded together with the php.ini
+          # from the global PHP package which only specifies the extensions.
+          environment.variables.PHPRC = "${pkgs.writeText "php.ini" config.services.httpd.phpOptions}";
           services.httpd.logPerVirtualHost = true;
           services.httpd.group = "service";
           services.httpd.user = "nobody";

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -4,7 +4,12 @@ let
   versions = import ../versions.nix { pkgs = super; };
   elk7Version = "7.10.2";
 
-  nixpkgs_18_03 = import versions.nixpkgs_18_03 {};
+  # import fossar/nix-phps overlay with nixpkgs-unstable from versions.json
+  # so it can get latest generic.nix but use current release package set to build
+  phps = (import "${versions.nix-phps}/pkgs/phps.nix")
+    ({ outPath = versions.nix-phps-unstable; })
+      {} super;
+
   inherit (super) lib;
 
 in {
@@ -99,31 +104,19 @@ in {
 
   kubernetes-dashboard = super.callPackage ./kubernetes-dashboard.nix { };
 
+  # Import old php versions from nix-phps
+  # NOTE: php7.3 is already removed on unstable
+  inherit (phps) php56;
+
   # Those are specialised packages for "direct consumption" use in our LAMP roles.
 
-  lamp_php56 =
-    let
-      phpIni = super.writeText "php.ini" ''
-      ${builtins.readFile "${nixpkgs_18_03.php56}/etc/php.ini"}
-      extension = ${nixpkgs_18_03.php56Packages.redis}/lib/php/extensions/redis.so
-      extension = ${nixpkgs_18_03.php56Packages.memcached}/lib/php/extensions/memcached.so
-      extension = ${nixpkgs_18_03.php56Packages.imagick}/lib/php/extensions/imagick.so
-      zend_extension = opcache.so
-    '';
-    in (nixpkgs_18_03.php56).overrideAttrs (oldAttrs: rec {
-      version = "5.6.40";
-      name = "php-5.6.40";
-      buildInputs = oldAttrs.buildInputs ++ [ super.makeWrapper ];
-      src = super.fetchurl {
-        url = "http://www.php.net/distributions/php-${version}.tar.bz2";
-        sha256 = "005s7w167dypl41wlrf51niryvwy1hfv53zxyyr3lm938v9jbl7z";
-      };
-      passthru = { phpIni = "${phpIni}"; };
-      postInstall = oldAttrs.postInstall or "" + ''
-        wrapProgram $out/bin/php \
-          --set LOCALE_ARCHIVE ${nixpkgs_18_03.glibcLocales}/lib/locale/locale-archive
-      '';
-    });
+  lamp_php56 = self.php56.withExtensions ({ enabled, all }:
+              enabled ++ [
+                all.bcmath
+                all.imagick
+                all.memcached
+                all.redis
+              ]);
 
   lamp_php73 = super.php73.withExtensions ({ enabled, all }:
               enabled ++ [
@@ -132,6 +125,7 @@ in {
                 all.memcached
                 all.redis
               ]);
+
   lamp_php74 = super.php74.withExtensions ({ enabled, all }:
               enabled ++ [
                 all.bcmath
@@ -139,6 +133,7 @@ in {
                 all.memcached
                 all.redis
               ]);
+
   lamp_php80 = super.php80.withExtensions ({ enabled, all }:
               enabled ++ [
                 all.bcmath

--- a/tests/channel.nix
+++ b/tests/channel.nix
@@ -28,7 +28,6 @@ in {
       };
     };
 
-    
     environment.systemPackages = with pkgs; [
       # Pre-install it to make it possible to install the package in the test script
       # without the need to download stuff (which fails in a test, of course).
@@ -82,6 +81,8 @@ in {
       xorg.lndir
       # Our custom stuff that's needed to rebuild the VM.
       lamp_php73
+      lamp_php56
+      lamp_php56.passthru.extensions.memcached.src
       channel
     ];
 

--- a/versions.json
+++ b/versions.json
@@ -5,11 +5,17 @@
     "rev": "21b696caf392ad6fa513caf3327d0aa0430ffb72",
     "sha256": "1056r3383aaf5zhf7rbvka76gqxb8b7rwqxnmar29vxhs9h56m5k"
   },
-  "nixpkgs_18_03": {
-    "owner": "nixos",
+  "nix-phps": {
+    "owner": "fossar",
+    "repo": "nix-phps",
+    "rev": "31d86400860816d0f20406b336870a9ed31d5fbf",
+    "sha256": "y4OrMnJAorB6Wo1j6CGkc/XAqMIzBOYFTRlPz9rgB8c="
+  },
+  "nix-phps-unstable": {
+    "owner": "NixOS",
     "repo": "nixpkgs",
-    "rev": "3e1be2206b4c1eb3299fb633b8ce9f5ac1c32898",
-    "sha256": "11d01fdb4d1avi7564h7w332h3jjjadsqwzfzpyh5z56s6rfksxc"
+    "rev": "485d0fc9730a9e1d460e00af1d1becc541e2ad4f",
+    "sha256": "zh8iJxPUTD2Br93HzVMfYoVef8HYlNDa2MaIeaeaKsg="
   },
   "nixos-mailserver": {
     "owner": "flyingcircusio",


### PR DESCRIPTION
This includes php56 from github.com/fossar/nix-phps
~~(currently pointing to a PR branch, see fossar/nix-phps#28)~~
now merged, pointing to upstream

NOTE: This adds a requirement on unstable,
since the code requires some exposed functions

Also added @dpausp's fix for the php config which broke due to the php56 config being different, which is now fixed due to php56 being built like all the other phps

Plus the 18.03 dependency can finally be removed

## Release process

Impact:

Changelog:
- php56 now being pulled from fossar/nix-phps and built with current nixpkgs

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - security: remove outdated 18.03 libraries, rebuild with current nixpkgs instead
  - security: fix warning about opcache being loaded twice to prevent warning blindness
- [x] Security requirements tested? (EVIDENCE)
  - no longer any 18.03 dependencies present
  - warning no longer present, tested in test vm
