### PR TITLE
Add keysize values in openvpn example config

### DIFF
--- a/nixos/roles/external_net/openvpn.nix
+++ b/nixos/roles/external_net/openvpn.nix
@@ -304,6 +304,7 @@ in
         remote-cert-tls server
         auth-user-pass
         auth-nocache
+        keysize 266
 
         # needed for older (2.3.x) clients (please upgrade!), 2.4 can negotiate the best cipher
         #cipher AES-256-CBC


### PR DESCRIPTION
This will keep consistancy between the settings of the client and the
vpn server.

    #PL-129937

@flyingcircusio/release-managers

## Release process

Impact: None

Changelog: None

## Security implications

- [X] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

    - We should reduce log noise to better find relevant problems.

- [X] Security requirements tested? (EVIDENCE)

    - Client was tested with the option set, connection could still be established

