### PR TITLE
Change login to uchiwa to allow all staff

### DIFF
--- a/nixos/services/sensu/uchiwa.nix
+++ b/nixos/services/sensu/uchiwa.nix
@@ -84,7 +84,7 @@ in {
     flyingcircus.services.uchiwa.users =
       toJSON (
         map (user: { username = user; password = "{crypt}${config.users.users."${user}".hashedPassword}"; })
-        config.users.groups.admins.members);
+        config.users.groups.crew.members);
 
     users.extraGroups.uchiwa.gid = config.ids.gids.uchiwa;
 

--- a/tests/sensu.nix
+++ b/tests/sensu.nix
@@ -122,7 +122,7 @@ in {
         networking.domain = "gocept.net";
 
         users.groups = {
-          admins = {
+          crew = {
             members = [ "test" ];
           };
         };


### PR DESCRIPTION
This changes the right to login to uchiwa, that it does not require the user to have the admin role but just the crew role. All [staff](https://wiki.flyingcircus.io/Staff) have the crew roll.

    #PL-129780

@flyingcircusio/release-managers

## Release process

Impact: None

Changelog:  None

## Security implications

- [X] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
    - Separation of duties and Principle of Least privilege: More people need access to sensu, but they do not need to have admin rights, so it makes sense to lower the threshold for uchiwa access instead of giving out more admin privileges.

- [X] Security requirements tested? (EVIDENCE)
    - The lowering of privilege level to access was discussed and decided in the Standup on 01.07.2021. See [ticket.](https://yt.flyingcircus.io/issue/PL-129780)
    - Nixos test for sensu works with the changes.

