### PR TITLE
[20.09] Update nixpkgs

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "9be5f52846fad0e4c10ed86697a1425b6c095538",
-    "sha256": "06mz52as3s0xlm978q0z21ssls04icw2jdqp5lag3iccgfkyjd94"
+    "rev": "fdfe2bd57c190971bee9094a5464c93395d300ae",
+    "sha256": "19p9zsxfnqgvd3vswqfbxn1ycnmip3n23izjnkamk7cp6crs22i5"
   },
   "nixpkgs_18_03": {
     "owner": "nixos",


### PR DESCRIPTION
Notable security updates and version changes:

* apacheHttpd: 2.4.46 -> 2.4.48
* dovecot: add patches for CVE-2021-29157 & CVE-2021-33515
* go_1_15: 1.15.10 -> 1.15.13
* go_1_16: 1.16.2 -> 1.16.3
* imagemagick6: 6.9.12-15 -> 6.9.12-17
* imagemagick7: 7.1.0-0 -> 7.1.0-2
* lldpd: add patch for CVE-2020-27827

 #PL-129963

@flyingcircusio/release-managers

## Release process

Impact:

* [NixOS 20.09] Apache will be restarted. VMs will schedule a reboot to activate the new kernel version.

Changelog: (include changes from commit msg here)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - pull in upstream security fixes regularly
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still run, works on test VM
  - checked commit log for fixed CVEs and possible problems with updates
