### PR TITLE
Update nixpkgs

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "NixOS",
     "repo": "nixpkgs",
-    "rev": "6613a30c5e3ee59753181512b4bedd4121569925",
-    "sha256": "18v74cwjcl7qkdhgc8xic9fvp3330dsc82ah4xs3qzl5ks2h9d5h"
+    "rev": "21b696caf392ad6fa513caf3327d0aa0430ffb72",
+    "sha256": "1056r3383aaf5zhf7rbvka76gqxb8b7rwqxnmar29vxhs9h56m5k"
   },
   "nixpkgs_18_03": {
     "owner": "nixos",


### PR DESCRIPTION
Notable security updates and version changes:

* consul: 1.9.5 -> 1.9.7
* dovecot: 2.3.14 -> 2.3.15
* go_1_15: 1.15.12 -> 1.15.13
* grafana: 7.5.7 -> 7.5.9
* imagemagick6: 6.9.12-15 -> 6.9.12-17
* jetty: 9.4.39.v20210325 -> 9.4.41.v20210516 (CVE-2021-28169)
* linux: 5.10.44 -> 5.10.45
* matrix-synapse: 1.36.0 -> 1.37.1

 #PL-129959

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

## Security implications
Impact:

* [NixOS 21.05] Apache will be restarted. VMs will schedule a reboot to activate the new kernel version.

Changelog: (include changes from commit msg here)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - pull in upstream security fixes regularly
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still run, works on test VM
  - checked commit log for fixed CVEs and possible problems with updates