### PR TITLE
LAMP: add composer to systemPackages

### DIFF
--- a/nixos/roles/lamp.nix
+++ b/nixos/roles/lamp.nix
@@ -112,7 +112,10 @@ in {
           # to choose the right one in case someone uses the LAMP role.
           # This used to be in packages.nix but that was too simple minded.
 
-          environment.systemPackages = [ role.php ];
+          environment.systemPackages = [
+            role.php
+            role.php.packages.composer
+          ];
 
       }
 

--- a/tests/lamp.nix
+++ b/tests/lamp.nix
@@ -72,6 +72,9 @@ import ./make-test-python.nix ({ version ? "" , tideways ? "", ... }:
     lamp.succeed('mkdir -p /srv/docroot')
     lamp.succeed('echo "<? phpinfo(); ?>" > /srv/docroot/test.php')
 
+    with subtest("check if composer CLI is installed"):
+      lamp.succeed("su nobody -s /bin/sh -c 'composer --help'")
+
     with subtest("check if PHP support is working as expected in CLI"):
       lamp.succeed("php /srv/docroot/test.php > result")
       print(lamp.succeed('cat result'))


### PR DESCRIPTION
uses cli package from role specified package

also adds test to check if it's there

fixes PL-129819

@flyingcircusio/release-managers

## Release process

Impact:
- system path gets rebuilt

Changelog:
- LAMP: add composer to systemPackages

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
 - composer cli is now installed
- [x] Security requirements tested? (EVIDENCE)
  - tests/lamp.nix tests if that's really the case

