### PR TITLE
Change uchiwa access to login group

### DIFF
--- a/nixos/services/sensu/uchiwa.nix
+++ b/nixos/services/sensu/uchiwa.nix
@@ -84,7 +84,7 @@ in {
     flyingcircus.services.uchiwa.users =
       toJSON (
         map (user: { username = user; password = "{crypt}${config.users.users."${user}".hashedPassword}"; })
-        config.users.groups.sudo-srv.members);
+        config.users.groups.login.members);
 
     users.extraGroups.uchiwa.gid = config.ids.gids.uchiwa;
 

--- a/tests/sensu.nix
+++ b/tests/sensu.nix
@@ -125,7 +125,7 @@ in {
         networking.domain = "gocept.net";
 
         users.groups = {
-          sudo-srv = {
+          login = {
             members = [ "test" ];
           };
         };


### PR DESCRIPTION
This changes the right to login to uchiwa, that it does not require the user to have the login permission defined in directory.

    #PL-129780

@flyingcircusio/release-managers

## Release process

Impact: NONE

Changelog: NONE

## Security implications

- [X] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

    - Separation of duties and Principle of Least privilege: More people need access to sensu, but they do not need to have admin rights, so it makes sense to lower the threshold for uchiwa access instead of giving out more admin privileges.

- [X] Security requirements tested? (EVIDENCE)

    - The lowering of privilege level to access was discussed and decided in the Standup on 01.07.2021. See ticket.
    - Nixos test for sensu works with the changes.

