### PR TITLE
Follow-up on data center rollout and migration experience.

### DIFF
--- a/nixos/infrastructure/flyingcircus-physical.nix
+++ b/nixos/infrastructure/flyingcircus-physical.nix
@@ -31,6 +31,7 @@ mkIf (cfg.infrastructureModule == "flyingcircus-physical") {
 
     environment.systemPackages = with pkgs; [
       smartmontools
+      fc.secure-erase
     ];
 
     fileSystems = {

--- a/nixos/roles/ceph/mon.nix
+++ b/nixos/roles/ceph/mon.nix
@@ -8,7 +8,9 @@ let
   enc = config.flyingcircus.enc;
   mon_port = "6789";
 
-  first_mon = head (lib.splitString "." (head (sort lessThan (map (service: service.address) (fclib.findServices "ceph_mon-mon")))));
+  mons = (sort lessThan (map (service: service.address) (fclib.findServices "ceph_mon-mon")));
+  # We do not have service data during bootstrapping.
+  first_mon = if mons == [] then "" else head (lib.splitString "." (head mons));
 in
 {
   options = {

--- a/pkgs/fc/default.nix
+++ b/pkgs/fc/default.nix
@@ -18,6 +18,7 @@ rec {
   logcheckhelper = callPackage ./logcheckhelper { };
   megacli = callPackage ./megacli { };
   multiping = callPackage ./multiping.nix {};
+  secure-erase = callPackage ./secure-erase {};
   sensuplugins = callPackage ./sensuplugins {};
   sensusyntax = callPackage ./sensusyntax {};
   userscan = callPackage ./userscan.nix {};

--- a/pkgs/fc/secure-erase/default.nix
+++ b/pkgs/fc/secure-erase/default.nix
@@ -1,0 +1,26 @@
+{ lib, stdenv, cryptsetup, bash }:
+
+stdenv.mkDerivation rec {
+  version = "0.1";
+  name = "fc-secure-erase";
+
+  src = ./secure-erase.sh;
+  unpackPhase = ":";
+  dontBuild = true;
+  dontConfigure = true;
+
+  propagatedBuildInputs = [ bash cryptsetup ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp ${src} $out/bin/fc-secure-erase
+    chmod +x $out/bin/fc-secure-erase
+  '';
+
+  meta = with lib; {
+    description = "fc-secure-erase";
+    maintainers = [ maintainers.theuni ];
+    platforms = platforms.unix;
+  };
+
+}

--- a/pkgs/fc/secure-erase/secure-erase.sh
+++ b/pkgs/fc/secure-erase/secure-erase.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -ex
+
+target="${1?need target device to erase}"
+name="${target//\//}"
+cryptsetup open --type plain -d /dev/urandom $target $name
+dd if=/dev/zero of=/dev/mapper/$name bs=4M status=progress || true
+cryptsetup close $name

--- a/release/default.nix
+++ b/release/default.nix
@@ -316,7 +316,7 @@ let
      modules = [
        "${nixpkgs_}/nixos/modules/installer/netboot/netboot-minimal.nix"
        (import version_nix {})
-       (import ./netboot-installer-config.nix {})
+       ./netboot-installer.nix
      ];
     });
 

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -64,6 +64,7 @@ in {
   nginx = callTest ./nginx.nix {};
   openvpn = callTest ./openvpn.nix {};
   percona80 = callTest ./mysql.nix { rolename = "percona80"; };
+  physical-installer = callTest ./physical-installer.nix { inherit nixpkgs; };
   postgresql10 = callTest ./postgresql.nix { rolename = "postgresql10"; };
   postgresql11 = callTest ./postgresql.nix { rolename = "postgresql11"; };
   postgresql12 = callTest ./postgresql.nix { rolename = "postgresql12"; };

--- a/tests/physical-installer.nix
+++ b/tests/physical-installer.nix
@@ -1,0 +1,88 @@
+import ./make-test-python.nix ({ nixpkgs, ... }:
+{
+  name = "physical-installer";
+  machine = 
+    { pkgs, ... }:
+    { 
+      virtualisation.emptyDiskImages = [ 70000 100 ];
+      imports = [ 
+        "${nixpkgs}/nixos/modules/installer/netboot/netboot-minimal.nix"
+        ../release/netboot-installer.nix
+      ];
+
+      system.activationScripts.dummy_enc = let 
+        dummy_wormhole = pkgs.writeText "enc.json" ''
+          {"parameters": {"environment_url": "http://asdf" } }
+        ''; in
+        ''
+          ln -s ${dummy_wormhole} /tmp/wormhole.json
+        '';
+
+    };
+
+  testScript = ''
+    machine.wait_for_unit('multi-user.target')
+    machine.succeed("systemctl status lldpd")
+    result = machine.succeed("show-interfaces")
+    print(result)
+
+    assert result == """\
+    INTERFACE           | MAC               | SWITCH               | ADDRESSES
+    --------------------+-------------------+----------------------+-----------------------------------
+    eth0                | 52:54:00:12:34:56 | None/None            | 10.0.2.15
+    eth1                | 52:54:00:12:01:01 | None/None            | 192.168.1.1
+
+    NOTE: If you are missing interface data, wait 30s and run `show-interfaces` again.
+
+    """
+
+    print(machine.succeed("lsblk"))
+    print(machine.succeed("fc-secure-erase /dev/vdc"))
+
+    machine.wait_until_tty_matches(1, "nixos@machine")
+
+    machine.screenshot('01boot')
+
+    machine.send_chars("sudo -i\n")
+    machine.wait_until_tty_matches(1, "root@machine")
+
+    machine.screenshot('02sudo')
+
+    machine.send_chars("fc-install\n")
+    machine.wait_until_tty_matches(1, "52:54:00:12:34:56")
+    machine.wait_until_tty_matches(1, "Ready to continue")
+    machine.screenshot('03lldp')
+    machine.send_chars("\n")
+
+    machine.wait_until_tty_matches(1, "ENC wormhole URL")
+    machine.send_chars("file:///tmp/wormhole.json\n")
+    machine.screenshot('04wormhole')
+
+    machine.wait_until_tty_matches(1, "Root disk")
+    # Erase the default
+    for x in "sda":
+      machine.send_key("backspace")
+    machine.send_chars("vdb\n")
+    machine.screenshot('05rootdisk')
+
+    machine.wait_until_tty_matches(1, "Root password:")
+    machine.send_chars("asdf\n")
+    machine.wait_until_tty_matches(1, "IPMI password:")
+    machine.send_chars("asdf2\n")
+    machine.screenshot("06passwords")
+    machine.wait_until_tty_matches(1, "Wipe whole disk?")
+
+    machine.execute("ln -sf /dev/vdb /dev/disk/by-id/wwn-34789374891")
+
+    machine.send_chars("y\n")
+    machine.screenshot("07wipedisk")
+
+    # This is how far I got creating a test. We now would have to create
+    # a fake server serving the channel and the nix store... 
+    machine.wait_until_tty_matches(1, "error: unable to download")
+
+    machine.screenshot("99finish")
+
+
+  '';
+})


### PR DESCRIPTION
1. Add `fc-secure-erase` helper script for erasing HDDs.

Uses cryptsetup to ensure properly cryptographically secure erasure
of disks.

Available in the netboot installer and on physical hosts. Two
separate implementations right now because I don't have access to
the overlay in the netboot environment.

2. Add smoke test for installer environment

3. Fix installer crash if LLDP discovery returns no data.

4. Fix installer crash if mon role has no ENC service data.

@flyingcircusio/release-managers

## Release process

Impact:

-

Changelog:

- (non-customer visible)

## Security implications

- [X] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

- provide automated "secure erasure" script to allow easily wiping disks when needed
- improve test coverage for higher confidence
- fixed bugs are better overall ;)

- [X] Security requirements tested? (EVIDENCE)

- added automated test coverage for the affected parts
- manual testing during rollout last week

