### PR TITLE
mail: upgrade mailserver fork

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -6,9 +6,11 @@
     "sha256": "0avbsx5chbwr0y55shndkzf0ixx3bznbzq526p5nj8llryxa10af"
   },
   "nixos-mailserver": {
-    "owner": "flyingcircusio",
-    "repo": "nixos-mailserver",
-    "rev": "d4566383b01c081bed866d397909a9e4fbefc7e2",
-    "sha256": "0hl31fjn0jf6j2rhf8g799q9vgmixyyy5j9srfa1njhy1npb04v3"
+    "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/",
+    "rev": "32c90985be7ae42736716044f00c28435492a462",
+    "sha256": "0cvpvq13ballwfi0qcq82dc977j5qmgqmwvhrja950wsfkh68dwm",
+    "fetchSubmodules": false,
+    "deepClone": false,
+    "leaveDotGit": false
   }
 }

--- a/versions.nix
+++ b/versions.nix
@@ -10,6 +10,12 @@ let
       name: repoInfo:
       # Hydra expects fixed length rev ids
       assert stringLength repoInfo.rev == 40;
+
+      if repoInfo ? url then
+        pkgs.fetchgit repoInfo // {
+          name = "${name}-${substring 0 11 repoInfo.rev}";
+        }
+      else
       pkgs.fetchFromGitHub {
         inherit (repoInfo) owner repo rev sha256;
         name = "${name}-${substring 0 11 repoInfo.rev}";


### PR DESCRIPTION
Note: Currently referencing my own fork, re-hosted on git.mkg since
github doesn't like the 100mb files of upstream and import failed last
week when I tried it

I've rebased all commits from christian kauhaus, you can review the list
here
https://git.mkg20001.io/mkg20001/fc-nixos-mailserver/-/commits/fc-rebase

@flyingcircusio/release-managers

## Release process

Impact:
- maybe mailservices will be restarted

Changelog:
- upgrade nixos-mailserver to latest master

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - upgrade nixos-mailserver
- [x] Security requirements tested? (EVIDENCE)
  - tested using tests and testvm
