### PR TITLE
mail: autoconfig listen only on FE

### DIFF
--- a/nixos/lib/utils.nix
+++ b/nixos/lib/utils.nix
@@ -115,6 +115,13 @@ rec {
         config.flyingcircus.users.userData
       );
 
+  nginxDefaultListen = vhost: addr:
+    (lib.optional ((vhost ? addSSL && vhost.addSSL) || (vhost ? onlySSL && vhost.onlySSL) || (vhost ? forceSSL && vhost.forceSSL)) { inherit addr; port = 443; ssl = true; })
+      ++ (lib.optional (!(vhost ? onlySSL && vhost.onlySSL)) { inherit addr; port = 80; ssl = false; });
+
+  mkNginxListen = vhost: addrs:
+    { listen = lib.flatten (map (nginxDefaultListen vhost) addrs); } // vhost;
+
   writePrettyJSON = name: x:
   let json = pkgs.writeText "write-pretty-json-input" (toJSON x);
   in pkgs.runCommand name { preferLocalBuild = true; } ''

--- a/nixos/services/mail/default.nix
+++ b/nixos/services/mail/default.nix
@@ -192,14 +192,14 @@ in {
       services.nginx.virtualHosts =
         let
           cfgForDomain = domain:
-          lib.nameValuePair "autoconfig.${domain}" {
+          lib.nameValuePair "autoconfig.${domain}" (fclib.mkNginxListen {
             addSSL = true;
             enableACME = true;
             locations."=/mail/config-v1.1.xml".alias = (import ./autoconfig.nix {
               inherit domain pkgs lib;
               inherit (role) mailHost webmailHost;
             });
-          };
+          } config.fclib.network.fe.dualstack.addressesQuoted);
         in listToAttrs (map cfgForDomain role.domains);
 
       services.postfix = {

--- a/nixos/services/nginx/default.nix
+++ b/nixos/services/nginx/default.nix
@@ -60,9 +60,6 @@ let
   let
     onlySSL = vhost.onlySSL or false || vhost.enableSSL or false;
     hasSSL = onlySSL || vhost.addSSL or false || vhost.forceSSL or false;
-    defaultListen = addr:
-      (lib.optional hasSSL { inherit addr; port = 443; ssl = true; })
-        ++ (lib.optional (!onlySSL) { inherit addr; port = 80;  ssl = false; });
     addrs =
       if (vhost ? "listenAddress" || vhost ? "listenAddress6")
       then filter (x: x != null) [
@@ -72,7 +69,7 @@ let
       else fclib.network.fe.dualstack.addressesQuoted;
   in
     # listen and enableACME defaults are overridden if the JSON spec has them.
-    { listen = lib.flatten (map defaultListen addrs); }
+    { listen = lib.flatten (map fclib.nginxDefaultListen addrs); }
     // (lib.optionalAttrs hasSSL { enableACME = true; })
     // (removeAttrs vhost [ "emailACME" "listenAddress" "listenAddress6" ]);
 


### PR DESCRIPTION
fixes PL-129209

also adds fclib.mkNginxListen through which a vhost can be passed and 
listen properly added

@flyingcircusio/release-managers

## Release process

Impact:
- nginx reload

Changelog:
- make nginx listen only on FE instead of all interfaces
- introduce fclib.mkNginxListen `<vhost> <addrs[]>` function

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - nginx autoconfig not listening on srv and thus serving proper certificate
- [x] Security requirements tested? (EVIDENCE)
  - test vm
