### PR TITLE
mail: allow finegrained control of mail domains

### DIFF
--- a/doc/src/mailserver.rst
+++ b/doc/src/mailserver.rst
@@ -59,18 +59,38 @@ and *test2.fcio.net*::
   {
     "mailHost": "mail.test.fcio.net",
     "webmailHost": "webmail.test.fcio.net",
-    "domains": [
-      "test.fcio.net",
-      "test2.fcio.net"
-    ]
+    "domains": {
+      "test.fcio.net": {
+        "primary": true
+      },
+      "test2.fcio.net": {}
+    }
   }
 
 Run :command:`sudo fc-manage -b` to have everything configured on the system.
+
+NOTE: There must always be exactly one domain with the primary option set
 
 Afterwards, a generated file :file:`/etc/local/mail/dns.zone` contains all
 necessary DNS settings for your mail server. Insert the records found in this
 file into the appropriate DNS zones and don't forget to check reverses.
 
+If you wish to disable certain services for certain mail domains,
+you can do so by specifying additional options per domain
+
+  {
+    "domains": {
+      "test.fcio.net": {
+        "autoconfig": false
+      }
+    }
+  }
+
+Currently available options:
+  - enable (boolean, default true): Enable or disable a domain
+    that has been loaded from another configuration file
+  - autoconfig (boolean, default true): Enable or disable autoconfig service at autoconfig.$domain
+  - primary (boolean, default true): Make this the primary domain for internal services (bounce emails, etc)
 
 How do I create users?
 ----------------------

--- a/nixos/services/mail/zone.nix
+++ b/nixos/services/mail/zone.nix
@@ -1,6 +1,7 @@
 { config, lib }:
 
 with builtins;
+with lib;
 with config.flyingcircus.roles.mailserver;
 
 let
@@ -29,4 +30,4 @@ in
     autoconfig.${d}. CNAME ${mailHost}.
     _dmarc.${d}. TXT "v=DMARC1; p=none"
   '' + replaceStrings ["mail._domainkey"] ["mail._domainkey.${d}."] (readDKIM d)
-)) domains))
+)) (attrNames (filterAttrs (domain: config: config.enable) domains))))


### PR DESCRIPTION
    This changes several things
    
    - mailserver.domains is an attrset with a submodule
    - mailserver.domains = ["example.tld"] is transparently mapped to
    mailserver.domains."example.tld" = { enable = true; }
    - deperate domains as list, make attrset the default in docs
    - the user can now disable (enabled by default) autoconfig
    mailserver.domains."example.tld".autoconfig = false;
    - update docs to reflect the changes
    
    Note: this is fully backwards compatible, but using a list is now discouraged
    and deperacted
    
    fixes PL-130003


@flyingcircusio/release-managers

## Release process

Impact:
- none

Changelog:
- mailserver.domains is now an attrset
- mailserver.domains."domain".autoconfig/primary can now be used to change whether autoconfig is enabled/which domain is primary
- map mailserver.domains (list) to mailserver.domains (attrset) to be backwards compatible
- add message about mailserver.domains (list) being deperacted

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  -  fix cert renewal caused by domain where autoconfig went unused, but was still enabled
- [x] Security requirements tested? (EVIDENCE)
  - tested on test vm
