### PR TITLE
mail: allow user to redirect FQDN hostname to imprint

### DIFF
--- a/doc/src/mailserver.rst
+++ b/doc/src/mailserver.rst
@@ -48,6 +48,14 @@ which will be advertised as MX name on your mail domain. This host name (called
 **mailHost** from here on) must resolve to the FE addresses with both forward
 and reverse lookups.
 
+Additionally, some mail providers (namely [Telekom/T-Online](https://postmaster.t-online.de/#t4.1))
+may require that your mailserver has an imprint served at its hostname.
+
+For this you can either set imprintUrl to the location of your existing imprint,
+or use imprintText to specify an imprint in HTML format
+
+Note that it is not possible to set both imprintUrl and imprintText and imprint cannot be used if you serve webmail under the mailHost (meaning mailHost and webmailHost cannot be the same)
+
 .. warning::
 
   Incorrect DNS setup is the most frequent source of delivery problems. Let our
@@ -68,7 +76,8 @@ and *test2.fcio.net*::
       "test2.fcio.net": {
         "autoconfig": false
       }
-    }
+    },
+    "imprintUrl": "your-company.tld/imprint"
   }
 
 .. note::

--- a/nixos/lib/utils.nix
+++ b/nixos/lib/utils.nix
@@ -115,13 +115,6 @@ rec {
         config.flyingcircus.users.userData
       );
 
-  nginxDefaultListen = vhost: addr:
-    (lib.optional ((vhost ? addSSL && vhost.addSSL) || (vhost ? onlySSL && vhost.onlySSL) || (vhost ? forceSSL && vhost.forceSSL)) { inherit addr; port = 443; ssl = true; })
-      ++ (lib.optional (!(vhost ? onlySSL && vhost.onlySSL)) { inherit addr; port = 80; ssl = false; });
-
-  mkNginxListen = vhost: addrs:
-    { listen = lib.flatten (map (nginxDefaultListen vhost) addrs); } // vhost;
-
   writePrettyJSON = name: x:
   let json = pkgs.writeText "write-pretty-json-input" (toJSON x);
   in pkgs.runCommand name { preferLocalBuild = true; } ''

--- a/nixos/roles/mailserver.nix
+++ b/nixos/roles/mailserver.nix
@@ -151,6 +151,24 @@ in
           else v);
       };
 
+      imprintUrl = mkOption {
+        type = with types; nullOr str;
+        description = ''
+          Webaddress of your imprint to be in compilance with T-Online Postmaster Rules
+          You can instead provide your imprint in text form using the imprintText option
+        '';
+        default = null;
+      };
+
+      imprintText = mkOption {
+        type = with types; nullOr str;
+        description = ''
+          Imprint as HTML text to be in compilance with T-Online Postmaster Rules
+          You can instead provide the webaddress to your imprint using the imprintUrl option
+        '';
+        default = null;
+      };
+
       webmailHost = mkOption {
         type = with types; nullOr str;
         description = "(Virtual) host name of the webmail service.";

--- a/nixos/services/mail/roundcube.nix
+++ b/nixos/services/mail/roundcube.nix
@@ -16,10 +16,11 @@ in lib.mkMerge [
       };
     };
 
-    services.nginx.virtualHosts.${role.webmailHost} =
-      fclib.mkNginxListen
-        { forceSSL = true; }
-        fclib.network.fe.dualstack.addressesQuoted;
+    services.nginx.virtualHosts.${role.webmailHost} = {
+      forceSSL = true;
+      enableACME = true;
+      listenAddresses = fclib.network.fe.dualstack.addressesQuoted;
+    };
 
     services.roundcube = {
       enable = true;
@@ -51,10 +52,5 @@ in lib.mkMerge [
         "zipdownload"
       ];
     };
-  })
-
-  (lib.mkIf (role.webmailHost != null && role.webmailHost != role.mailHost) {
-    services.nginx.virtualHosts.${role.mailHost}.globalRedirect =
-      role.webmailHost;
   })
 ]

--- a/nixos/services/nginx/default.nix
+++ b/nixos/services/nginx/default.nix
@@ -54,7 +54,8 @@ let
   package = config.services.nginx.package;
   localCfgDir = config.flyingcircus.localConfigPath + "/nginx";
 
-  vhostsJSON = fclib.jsonFromDir localCfgDir;
+  # only for JSON for backwards-compatibility reasons we set the default addrs to any, nix config uses frontend
+  vhostsJSON = mapAttrs (key: value: ({ listenAddress = "0.0.0.0"; listenAddress6 = "[::]"; } // value)) (fclib.jsonFromDir localCfgDir);
 
   mkVanillaVhostFromFCVhost = name: vhost:
     (removeAttrs vhost [ "emailACME" "listenAddress" "listenAddress6" ]);
@@ -183,23 +184,25 @@ in
           listenAddress = mkOption {
             type = types.str;
             description = ''
-              IPv4 address to listen to. Defaults to 0.0.0.0.
-              If you need more options, use <option>listen</option>.
+              IPv4 address to listen on.
+              If neither <option>listenAddress</option> nor <option>listenAddress6</option> is set,
+              the service listens on the frontend addresses.
 
+              If you need more options, use <option>listen</option>.
               If you want to configure any number of IPs use <literal>listenAddresses</literal>.
             '';
-            default = "0.0.0.0";
           };
 
           listenAddress6 = mkOption {
             type = types.str;
             description = ''
-              IPv6 address to listen to. Defaults to [::].
-              If you need more options, use <option>listen</option>.
+              IPv6 address to listen on.
+              If neither <option>listenAddress</option> nor <option>listenAddress6</option> is set,
+              the service listens on the frontend addresses.
 
+              If you need more options, use <option>listen</option>.
               If you want to configure any number of IPs use <literal>listenAddresses</literal>.
             '';
-            default = "[::]";
           };
 
           emailACME = mkOption {

--- a/tests/mail/default.nix
+++ b/tests/mail/default.nix
@@ -30,7 +30,11 @@ in
             flyingcircus.roles.mailserver = {
               enable = true;
               mailHost = "mail.example.local";
-              domains = [ "example.local" ];
+              domains = {
+                "example.local" = {
+                  primary = true;
+                };
+              };
               rootAlias = "user2@example.local";
             };
 


### PR DESCRIPTION


fixes PL-129598

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:
- adds imprintUrl and imprintText to allow the user to specify either a bunch of HTML or a link to redirect the FQDN to so that t-online has an imprint to look at

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - imprint is served over tls
- [x] Security requirements tested? (EVIDENCE)
  - addSSL is set, tested on testvm
