### PR TITLE
Update nixpkgs

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "NixOS",
     "repo": "nixpkgs",
-    "rev": "21b696caf392ad6fa513caf3327d0aa0430ffb72",
-    "sha256": "1056r3383aaf5zhf7rbvka76gqxb8b7rwqxnmar29vxhs9h56m5k"
+    "rev": "63ee5cd99a2e193d5e4c879feb9683ddec23fa03",
+    "sha256": "0avbsx5chbwr0y55shndkzf0ixx3bznbzq526p5nj8llryxa10af"
   },
   "nixos-mailserver": {
     "owner": "flyingcircusio",


### PR DESCRIPTION
Notable security updates and version changes:

* glibc: 2.32-46 -> 2.32-48 (CVE-2021-33574)
* go_1_15: 1.15.13 -> 1.15.14
* go_1_16: 1.16.4 -> 1.16.6
* grafana: 7.5.9 -> 7.5.10
* imagemagick: 7.0.11-13 -> 7.1.0-2
* linux: 5.10.45 -> 5.10.50
* matrix-synapse: 1.37.1 -> 1.38.0
* nodejs-12_x: 12.22.1 -> 12.22.2
* nodejs-14_x: 14.17.0 -> 14.17.2
* nodejs-15_x: remove expression
* nodejs-16_x: 16.2.0 -> 16.4.1
* php73: 7.3.28 -> 7.3.29 (CVE-2021-21705, CVE-2021-21704)
* php74: 7.4.20 -> 7.4.21 (CVE-2021-21705, CVE-2021-21704)
* php80: 8.0.7 -> 8.0.8 (CVE-2021-21705, CVE-2021-21704)
* tcpdump: 4.99.0 -> 4.99.1

 #PL-129998

@flyingcircusio/release-managers

## Release process

Impact:

* [NixOS 20.09] Many services will be restarted due to a glibc update. VMs will schedule a reboot to activate the new kernel version.

Changelog: (include changes from commit msg here)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - pull in upstream security fixes regularly
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still run, works on test VM and gitlab staging VM
  - checked commit log for fixed CVEs and possible problems with updates