### PR TITLE
Remove `cipher` option from openvpn

### DIFF
--- a/nixos/roles/external_net/openvpn.nix
+++ b/nixos/roles/external_net/openvpn.nix
@@ -179,9 +179,6 @@ let
     plugin ${openvpn}/lib/openvpn/plugins/openvpn-plugin-auth-pam.so openvpn
     management localhost ${mgmPort} ${pkgs.writeText "openvpn-mgm-psk" mgmPsk}
 
-    # Since 21.05 cipher must be set. Previously it defaulted to BF-CBC as fallback
-    cipher AES-256-GCM
-
     user nobody
     group nogroup
 
@@ -304,9 +301,6 @@ in
         remote-cert-tls server
         auth-user-pass
         auth-nocache
-
-        # needed for older (2.3.x) clients (please upgrade!), 2.4 can negotiate the best cipher
-        #cipher AES-256-CBC
 
         ca [inline]
         cert [inline]


### PR DESCRIPTION
This option is deprecated for server-client mode (see openvpn man page).
   #PL-129937

@flyingcircusio/release-managers

## Release process

Impact: May require restart of openvpn.

Changelog: Remove --cipher option in openvpn server and client config.

## Security implications

- [X] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
   
     - Deprecated options should not be used. 

- [X] Security requirements tested? (EVIDENCE)

    - Openvpn test exited without error.