### PR TITLE
Change $http_host to $host in jitsi role

### DIFF
--- a/nixos/roles/jitsi/default.nix
+++ b/nixos/roles/jitsi/default.nix
@@ -275,7 +275,7 @@ in {
                 proxy_busy_buffers_size  256k;
                 proxy_http_version 1.1;
                 proxy_set_header Connection "upgrade";
-                proxy_set_header Host $http_host;
+                proxy_set_header Host $host;
                 proxy_set_header X-Forwarded-For $remote_addr;
                 tcp_nodelay on;
               '';


### PR DESCRIPTION
This change should mitigate a possible host spoofing attack.

@flyingcircusio/release-managers

## Release process

Impact: NONE

Changelog: NONE

## Security implications

- [X] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

    - Possible exploits and attacks should be mitigated
    - Unnecessary monitoring noise should be reduced. In this case its the sensu check for the nginx config gives a warning

- [X] Security requirements tested? (EVIDENCE)

   - Changing use of $host instead of $http_host is strongly encouraged if not explicitly necessary
   - Because of missing jitsi test on fc-nixos the change could NOT be tested in advance.