### PR TITLE
Mailserver: fix legacy domain config, Roundcube listen on FE only

### DIFF
--- a/nixos/roles/mailserver.nix
+++ b/nixos/roles/mailserver.nix
@@ -143,7 +143,10 @@ in
               }
           ''
           recursiveUpdate
-            (listToAttrs (map (domain: (nameValuePair domain { enable = true; autoconfig = true;})) v))
+            (listToAttrs (map (domain: (nameValuePair domain {
+              enable = true;
+              autoconfig = true;
+              primary = false; })) v))
             (optionalAttrs (v != []) { "${head v}" = { primary = true; }; })
           else v);
       };

--- a/nixos/services/mail/roundcube.nix
+++ b/nixos/services/mail/roundcube.nix
@@ -3,6 +3,7 @@
 let
   role = config.flyingcircus.roles.mailserver;
   chpasswd = "/run/wrappers/bin/roundcube-chpasswd";
+  fclib = config.fclib;
 
 in lib.mkMerge [
   (lib.mkIf (role.enable && role.webmailHost != null) {
@@ -14,6 +15,11 @@ in lib.mkMerge [
         owner = "vmail";
       };
     };
+
+    services.nginx.virtualHosts.${role.webmailHost} =
+      fclib.mkNginxListen
+        { forceSSL = true; }
+        fclib.network.fe.dualstack.addressesQuoted;
 
     services.roundcube = {
       enable = true;


### PR DESCRIPTION
The legacy domains options broke with more than one list items because
primary wasn't set explicitly for the secondary domains.

Roundcube (webmailHost) now listens on FE only to avoid that Nginx
prefers the autoconfig virtualhosts which use FE and are thus more
specific. Nginx matches by IP first and not by server name!

 #PL-130021

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Mailserver: fix domains option when multiple mail domains are given in a list (#PL-130021).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - no new requirements here, fixes broken domain config and unreachable webmailer  
- [x] Security requirements tested? (EVIDENCE)
  - checked on test mail server that nginx config is generated properly, webmail is reachable and more than one domain works with legacy config
  - automated test still runs 

