### PR TITLE
Update nixpkgs

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "NixOS",
     "repo": "nixpkgs",
-    "rev": "63ee5cd99a2e193d5e4c879feb9683ddec23fa03",
-    "sha256": "0avbsx5chbwr0y55shndkzf0ixx3bznbzq526p5nj8llryxa10af"
+    "rev": "16bf3980bfa0d8929639be93fa8491ebad9d61ec",
+    "sha256": "0azsnd2pjg53siv97n5l62j0c8b5whi5bd5a2wqz1sphkirf3cgq"
   },
   "nixos-mailserver": {
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/",


### PR DESCRIPTION
Notable security updates and version changes:

* containerd: 1.5.1 -> 1.5.2
* docker: 20.10.2 -> 20.10.7, bump runc to 1.0-rc95, fixing CVE-2021-30465
* exif: add patches for CVE-2021-27815
* fetchmail: 6.4.16 -> 6.4.20 (CVE-2021-36386)
* imagemagick6: 6.9.12-17 -> 6.9.12-19
* imagemagick: 7.1.0-2 -> 7.1.0-4
* libgcrypt: 1.9.2 -> 1.9.3
* linux: 5.10.50 -> 5.10.52
* matrix-synapse: 1.38.0 -> 1.39.0
* nixStable: 2.3.12 -> 2.3.15
* nodejs-12_x: 12.22.2 -> 12.22.4
* nodejs-14_x: 14.17.2 -> 14.17.4
* openjdk: 11.0.10+11 -> 11.0.11+9
* openjdk: 11.0.11+9 -> 11.0.12+7
* phpPackages.composer: 2.1.3 -> 2.1.5
* systemd: Patch CVE-2021-33910
* varnish: add patch for CVE-2021-36740

 #PL-130014

@flyingcircusio/release-managers

## Release process

* [NixOS 21.05] Many services will be restarted due to a glibc update. VMs will schedule a reboot to activate the new kernel version.

Changelog: (include changes from commit msg here)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - pull in upstream security fixes regularly
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still run, works on test VM
  - checked commit log for fixed CVEs and possible problems with updates