### PR TITLE
PL-130029 fc agent structlog and refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ share/
 target/
 tmp/
 /*.sublime-*
+.envrc
+pkgs/fc/agent/.envrc
+pyenv

--- a/nixos/platform/agent.nix
+++ b/nixos/platform/agent.nix
@@ -142,6 +142,7 @@ in {
         "d /root 0711"
         "d /var/lib/fc-manage"
         "r /var/lib/fc-manage/stamp-channel-update"
+        "d /var/log/fc-agent - - - 180d"
         "d /var/spool/maintenance/archive - - - 180d"
       ];
 

--- a/nixos/platform/default.nix
+++ b/nixos/platform/default.nix
@@ -223,6 +223,8 @@ in {
       }
     '';
 
+    environment.etc."fcio_environment_name".text = config.flyingcircus.enc.parameters.environment or "";
+
     flyingcircus = {
       enc_services = enc_services;
       logrotate.enable = true;

--- a/pkgs/fc/agent/default.nix
+++ b/pkgs/fc/agent/default.nix
@@ -1,4 +1,5 @@
 { lib
+, stdenv
 , dmidecode
 , gitMinimal
 , gptfdisk
@@ -43,10 +44,7 @@ py.buildPythonPackage rec {
     py.responses
   ];
   propagatedBuildInputs = [
-    dmidecode
     gitMinimal
-    gptfdisk
-    multipath_tools
     nix
     py.click
     py.dateutil
@@ -56,6 +54,11 @@ py.buildPythonPackage rec {
     py.shortuuid
     pyyaml
     utillinux
+  ] ++ lib.optionals stdenv.isLinux [
+    dmidecode
+    gptfdisk
+    multipath_tools
+    py.systemd
     xfsprogs
   ];
   dontStrip = true;

--- a/pkgs/fc/agent/default.nix
+++ b/pkgs/fc/agent/default.nix
@@ -1,5 +1,6 @@
 { lib
 , stdenv
+, fetchFromGitHub
 , dmidecode
 , gitMinimal
 , gptfdisk
@@ -30,6 +31,20 @@ let
     };
   };
 
+  pytest-structlog = py.buildPythonPackage rec {
+    pname = "pytest-structlog";
+    version = "0.4";
+
+    src = fetchFromGitHub {
+      owner = "wimglenn";
+      repo = "pytest-structlog";
+      rev = "b71518015109b292bc6584b8637264939b44af62";
+      sha256 = "00g2ivgj4y398d0y60lk710zz62pj80r9ya3b4iqijkp4j8nh4gp";
+    };
+
+    buildInputs = [ py.pytest py.structlog ];
+  };
+
 in
 py.buildPythonPackage rec {
   name = "fc-agent-${version}";
@@ -42,16 +57,21 @@ py.buildPythonPackage rec {
     py.pytestcov
     py.pytestrunner
     py.responses
+    py.pytest-mock
+    py.pytest-subprocess
+    pytest-structlog
   ];
   propagatedBuildInputs = [
     gitMinimal
     nix
     py.click
+    py.colorama
     py.dateutil
     py.iso8601
     py.pytz
     py.requests
     py.shortuuid
+    py.structlog
     pyyaml
     utillinux
   ] ++ lib.optionals stdenv.isLinux [

--- a/pkgs/fc/agent/fc/maintenance/lib/reboot.py
+++ b/pkgs/fc/agent/fc/maintenance/lib/reboot.py
@@ -60,8 +60,8 @@ class RebootActivity(Activity):
         """
         try:
             for req in self.request.other_requests():
-                if (isinstance(req.activity, RebootActivity) and
-                        req.activity.coldboot):
+                if (isinstance(req.activity, RebootActivity)
+                        and req.activity.coldboot):
                     return req
         except AttributeError:  # self.request has not been set
             pass
@@ -89,12 +89,24 @@ class RebootActivity(Activity):
 
 def main():
     a = argparse.ArgumentParser(description=__doc__)
-    a.add_argument('-c', '--comment', metavar='TEXT', default=None,
-                   help='announce upcoming reboot with this message')
-    a.add_argument('-p', '--poweroff', default=False, action='store_true',
-                   help='power off instead of reboot')
-    a.add_argument('-d', '--spooldir', metavar='DIR', default=DEFAULT_DIR,
-                   help='request spool dir (default: %(default)s)')
+    a.add_argument(
+        '-c',
+        '--comment',
+        metavar='TEXT',
+        default=None,
+        help='announce upcoming reboot with this message')
+    a.add_argument(
+        '-p',
+        '--poweroff',
+        default=False,
+        action='store_true',
+        help='power off instead of reboot')
+    a.add_argument(
+        '-d',
+        '--spooldir',
+        metavar='DIR',
+        default=DEFAULT_DIR,
+        help='request spool dir (default: %(default)s)')
     a.add_argument('-v', '--verbose', action='store_true', default=False)
     args = a.parse_args()
     setup_logging(args.verbose)
@@ -104,6 +116,7 @@ def main():
         'cold boot' if args.poweroff else 'reboot')
     with ReqManager(spooldir=args.spooldir) as rm:
         rm.scan()
-        rm.add(Request(RebootActivity(action),
-                       900 if args.poweroff else 600,
-                       args.comment if args.comment else defaultcomment))
+        rm.add(
+            Request(
+                RebootActivity(action), 900 if args.poweroff else 600,
+                args.comment if args.comment else defaultcomment))

--- a/pkgs/fc/agent/fc/maintenance/lib/shellscript.py
+++ b/pkgs/fc/agent/fc/maintenance/lib/shellscript.py
@@ -30,31 +30,52 @@ class ShellScriptActivity(Activity):
             os.fchmod(f.fileno(), 0o755)
 
         script = os.path.join(os.getcwd(), 'script')
-        p = subprocess.Popen(
-            [script], stdin=subprocess.PIPE, stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE)
+        p = subprocess.Popen([script],
+                             stdin=subprocess.PIPE,
+                             stdout=subprocess.PIPE,
+                             stderr=subprocess.PIPE)
         (self.stdout, self.stderr) = [s.decode() for s in p.communicate()]
         self.returncode = p.returncode
 
 
 def main():
-    a = argparse.ArgumentParser(description=__doc__, epilog="""
+    a = argparse.ArgumentParser(
+        description=__doc__,
+        epilog="""
 If neither a script file or --exec is given, read the activity script from
 stdin.
 """)
-    a.add_argument('-c', '--comment', metavar='TEXT', default='',
-                   help='announce upcoming maintenance with this message')
-    a.add_argument('-d', '--spooldir', metavar='DIR', default=DEFAULT_DIR,
-                   help='request spool dir (default: %(default)s)')
-    a.add_argument('estimate', metavar='ESTIMATE',
-                   help='estimate activity duration (suffixes: s, m, h)')
+    a.add_argument(
+        '-c',
+        '--comment',
+        metavar='TEXT',
+        default='',
+        help='announce upcoming maintenance with this message')
+    a.add_argument(
+        '-d',
+        '--spooldir',
+        metavar='DIR',
+        default=DEFAULT_DIR,
+        help='request spool dir (default: %(default)s)')
+    a.add_argument(
+        'estimate',
+        metavar='ESTIMATE',
+        help='estimate activity duration (suffixes: s, m, h)')
     a.add_argument('-v', '--verbose', action='store_true', default=False)
     g = a.add_mutually_exclusive_group()
-    g.add_argument('-e', '--exec', metavar='SHELLCMD', default=False,
-                   help='execute shell command as maintenance activity')
-    g.add_argument('file', metavar='FILE', default=None, nargs='?',
-                   type=argparse.FileType('r'),
-                   help='execute FILE as maintenance activity')
+    g.add_argument(
+        '-e',
+        '--exec',
+        metavar='SHELLCMD',
+        default=False,
+        help='execute shell command as maintenance activity')
+    g.add_argument(
+        'file',
+        metavar='FILE',
+        default=None,
+        nargs='?',
+        type=argparse.FileType('r'),
+        help='execute FILE as maintenance activity')
     args = a.parse_args()
     setup_logging(args.verbose)
     if args.file:
@@ -66,5 +87,6 @@ stdin.
 
     with ReqManager(spooldir=args.spooldir) as rm:
         rm.scan()
-        rm.add(Request(
-            ShellScriptActivity(act), args.estimate, comment=args.comment))
+        rm.add(
+            Request(
+                ShellScriptActivity(act), args.estimate, comment=args.comment))

--- a/pkgs/fc/agent/fc/maintenance/lib/tests/reboot_test.py
+++ b/pkgs/fc/agent/fc/maintenance/lib/tests/reboot_test.py
@@ -18,6 +18,7 @@ def reqdir(tmpdir, monkeypatch):
     monkeypatch.chdir(tmpdir)
     return tmpdir
 
+
 @pytest.fixture
 def boottime(monkeypatch):
     """Simulate fixed boottime (i.e., no intermediary reboots)."""
@@ -47,8 +48,8 @@ def comments(spooldir):
         return [req.comment for req in rm.requests.values()]
 
 
-def test_dont_perfom_warm_reboot_if_cold_reboot_pending(reqdir, defused_boom,
-                                                        boottime):
+def test_dont_perfom_warm_reboot_if_cold_reboot_pending(
+        reqdir, defused_boom, boottime):
     for type_ in [[], ['--poweroff']]:
         sys.argv = [
             'reboot',
@@ -60,8 +61,10 @@ def test_dont_perfom_warm_reboot_if_cold_reboot_pending(reqdir, defused_boom,
     with ReqManager(str(reqdir)) as rm:
         rm.scan()
         # run soft reboot first
-        reqs = sorted(rm.requests.values(), key=lambda r: r.activity.action,
-                      reverse=True)
+        reqs = sorted(
+            rm.requests.values(),
+            key=lambda r: r.activity.action,
+            reverse=True)
         reqs[0].execute()
         reqs[0].save()
         assert defused_boom.call_count == 0

--- a/pkgs/fc/agent/fc/maintenance/lib/tests/shellscript_test.py
+++ b/pkgs/fc/agent/fc/maintenance/lib/tests/shellscript_test.py
@@ -15,8 +15,9 @@ def test_sh_script(tmpdir):
     assert a.returncode == 5
 
 
-@pytest.mark.skipif(not os.path.exists('/usr/bin/env'),
-                    reason='not expected to run inside a chroot')
+@pytest.mark.skipif(
+    not os.path.exists('/usr/bin/env'),
+    reason='not expected to run inside a chroot')
 def test_python_script(tmpdir):
     os.chdir(str(tmpdir))
     script = io.StringIO("""\

--- a/pkgs/fc/agent/fc/maintenance/request.py
+++ b/pkgs/fc/agent/fc/maintenance/request.py
@@ -1,7 +1,6 @@
 from .estimate import Estimate
 from .state import State, evaluate_state
 
-
 import contextlib
 import copy
 import datetime
@@ -162,8 +161,8 @@ class Request:
 
     def update_state(self):
         """Updates time-dependent request state."""
-        if (self.state in (State.pending, State.postpone) and
-                self.next_due and utcnow() >= self.next_due):
+        if (self.state in (State.pending, State.postpone) and self.next_due
+                and utcnow() >= self.next_due):
             self.state = State.due
         if len(self.attempts) > self.MAX_RETRIES:
             self.state = State.retrylimit
@@ -171,8 +170,10 @@ class Request:
 
     def other_requests(self):
         """Lists other requests currently active in the ReqManager."""
-        return [r for r in self._reqmanager.requests.values()
-                if r._reqid != self._reqid]
+        return [
+            r for r in self._reqmanager.requests.values()
+            if r._reqid != self._reqid
+        ]
 
 
 def request_representer(dumper, data):
@@ -201,8 +202,9 @@ class Attempt:
     def record(self, activity):
         """Logs activity outcomes so they may be overwritten later."""
         self.finished = utcnow()
-        (self.stdout, self.stderr, self.returncode) = (
-            activity.stdout, activity.stderr, activity.returncode)
+        (self.stdout, self.stderr,
+         self.returncode) = (activity.stdout, activity.stderr,
+                             activity.returncode)
         if activity.duration:
             self.duration = activity.duration
         elif self.started and not self.duration:

--- a/pkgs/fc/agent/fc/maintenance/tests/estimate_test.py
+++ b/pkgs/fc/agent/fc/maintenance/tests/estimate_test.py
@@ -5,13 +5,9 @@ import pytest
 
 
 def test_str_to_estimate():
-    for (spec, result) in [
-            ('0.7', .7),
-            ('3s', 3),
-            ('5m', 5 * 60),
-            ('3h', 3 * 60 * 60),
-            ('6h 4s', 6 * 60 * 60 + 4),
-            ('4m 2s', 4 * 60 + 2)]:
+    for (spec, result) in [('0.7', .7), ('3s', 3), ('5m', 5 * 60),
+                           ('3h', 3 * 60 * 60), ('6h 4s', 6 * 60 * 60 + 4),
+                           ('4m 2s', 4 * 60 + 2)]:
         assert float(Estimate(spec)) == result
 
 
@@ -26,9 +22,7 @@ def test_datetime():
 
 
 def test_estimate_to_str():
-    for (duration, result) in [
-            (3302, '55m 2s'),
-            (5860, '1h 37m 40s')]:
+    for (duration, result) in [(3302, '55m 2s'), (5860, '1h 37m 40s')]:
         assert str(Estimate(duration)) == result
 
 

--- a/pkgs/fc/agent/fc/maintenance/tests/reqmanager_test.py
+++ b/pkgs/fc/agent/fc/maintenance/tests/reqmanager_test.py
@@ -110,8 +110,9 @@ def test_dont_add_two_reqs_with_identical_comments(reqmanager):
 def test_do_add_two_reqs_with_identical_comments(reqmanager):
     with reqmanager as rm:
         assert rm.add(Request(Activity(), 1, 'comment 1')) is not None
-        assert rm.add(Request(Activity(), 1, 'comment 1'),
-                      skip_same_comment=False) is not None
+        assert rm.add(
+            Request(Activity(), 1, 'comment 1'),
+            skip_same_comment=False) is not None
         assert len(rm.requests) == 2
 
 
@@ -128,8 +129,11 @@ def test_schedule_requests(connect, reqmanager):
     rpccall = connect().schedule_maintenance
     rpccall.return_value = {req.id: {'time': '2016-04-20T15:12:40.9+00:00'}}
     reqmanager.schedule()
-    rpccall.assert_called_once_with({
-        req.id: {'estimate': 1, 'comment': 'comment'}})
+    rpccall.assert_called_once_with(
+        {req.id: {
+            'estimate': 1,
+            'comment': 'comment'
+        }})
     assert req.next_due == datetime.datetime(
         2016, 4, 20, 15, 12, 40, 900000, tzinfo=pytz.UTC)
 
@@ -139,8 +143,12 @@ def test_delete_disappeared_requests(connect, reqmanager):
     req = reqmanager.add(Request(Activity(), 1, 'comment'))
     sched = connect().schedule_maintenance
     sched.return_value = {
-        req.id: {'time': '2016-04-20T15:12:40.9+00:00'},
-        '123abc': {'time': None},
+        req.id: {
+            'time': '2016-04-20T15:12:40.9+00:00'
+        },
+        '123abc': {
+            'time': None
+        },
     }
     endm = connect().end_maintenance
     reqmanager.schedule()
@@ -154,7 +162,10 @@ def test_explicitly_deleted(connect, reqmanager):
     arch = connect().end_maintenance
     reqmanager.archive()
     arch.assert_called_once_with(
-        {req.id: {'duration': None, 'result': 'deleted'}})
+        {req.id: {
+            'duration': None,
+            'result': 'deleted'
+        }})
 
 
 @unittest.mock.patch('fc.util.directory.connect')
@@ -237,10 +248,22 @@ def test_archive(connect, tmpdir):
             req.save()
         rm.archive()
         endm.assert_called_once_with({
-            'success': {'duration': 5, 'result': 'success'},
-            'error': {'duration': 5, 'result': 'error'},
-            'retrylimit': {'duration': 5, 'result': 'retrylimit'},
-            'deleted': {'duration': 5, 'result': 'deleted'},
+            'success': {
+                'duration': 5,
+                'result': 'success'
+            },
+            'error': {
+                'duration': 5,
+                'result': 'error'
+            },
+            'retrylimit': {
+                'duration': 5,
+                'result': 'retrylimit'
+            },
+            'deleted': {
+                'duration': 5,
+                'result': 'deleted'
+            },
         })
         for r in reqs[0:3]:
             assert 'archive/' in r.dir
@@ -267,9 +290,15 @@ def test_end_to_end(connect, tmpdir):
     endm = connect().end_maintenance
     postp = connect().postpone_maintenance
     sched.return_value = {
-        reqs[0].id: {'time': '2016-04-20T11:58:00.0+00:00'},
-        reqs[1].id: {'time': '2016-04-20T11:59:00.0+00:00'},
-        reqs[2].id: {'time': '2016-04-20T12:01:00.0+00:00'},
+        reqs[0].id: {
+            'time': '2016-04-20T11:58:00.0+00:00'
+        },
+        reqs[1].id: {
+            'time': '2016-04-20T11:59:00.0+00:00'
+        },
+        reqs[2].id: {
+            'time': '2016-04-20T12:01:00.0+00:00'
+        },
         'deleted_req': {},
     }
     sys.argv = ['fc-maintenance', '--spooldir', str(tmpdir)]
@@ -304,7 +333,8 @@ St Id       Scheduled             Estimate  Comment
 e  {id3}  2016-04-20 11:00 UTC  1m 30s    error request (duration: 1m 15s)
 *  {id2}  2016-04-20 12:00 UTC  2h        due request
 -  {id1}  --- TBA ---           14m       pending request\
-""".format(id1=r1.id[:7], id2=r2.id[:7], id3=r3.id[:7])
+""".format(
+        id1=r1.id[:7], id2=r2.id[:7], id3=r3.id[:7])
 
 
 def test_delete_end_to_end(tmpdir):

--- a/pkgs/fc/agent/fc/manage/backy.py
+++ b/pkgs/fc/agent/fc/manage/backy.py
@@ -93,8 +93,8 @@ class BackyConfig(object):
         with open(global_conf) as f:
             config = yaml.safe_load(f)
         config['jobs'] = self.job_config()
-        output = fc.util.configfile.ConfigFile(self.prefix + '/etc/backy.conf',
-                                               mode=0o640)
+        output = fc.util.configfile.ConfigFile(
+            self.prefix + '/etc/backy.conf', mode=0o640)
         output.write("# Managed by fc-backy, do not edit\n\n")
         yaml.safe_dump(config, output)
         self.changed = output.commit()
@@ -112,11 +112,12 @@ class BackyConfig(object):
 
 def main():
     a = argparse.ArgumentParser(description=__doc__)
-    a.add_argument('-r',
-                   '--restart',
-                   default=False,
-                   action='store_true',
-                   help='restart backy on config changes')
+    a.add_argument(
+        '-r',
+        '--restart',
+        default=False,
+        action='store_true',
+        help='restart backy on config changes')
     args = a.parse_args()
 
     h = logging.handlers.SysLogHandler(facility=syslog.LOG_LOCAL4)

--- a/pkgs/fc/agent/fc/manage/graylog.py
+++ b/pkgs/fc/agent/fc/manage/graylog.py
@@ -30,7 +30,6 @@ import os.path
 import socket
 import time
 
-
 logging.basicConfig(format='%(levelname)s:%(message)s', level=logging.INFO)
 
 log = logging.getLogger('fc-graylog')
@@ -39,9 +38,17 @@ log = logging.getLogger('fc-graylog')
 @click.group()
 @click.option('-u', '--user', default='admin', show_default=True)
 @click.option('-p', '--password')
-@click.option('-P', '--password-file', default='/etc/local/graylog/password', show_default=True)
+@click.option(
+    '-P',
+    '--password-file',
+    default='/etc/local/graylog/password',
+    show_default=True)
 @click.option('--api', '-a')
-@click.option('-A', '--api-file', default='/etc/local/graylog/api_url', show_default=True)
+@click.option(
+    '-A',
+    '--api-file',
+    default='/etc/local/graylog/api_url',
+    show_default=True)
 @click.pass_context
 def main(ctx, api, user, password, password_file, api_file):
     graylog = requests.Session()
@@ -81,9 +88,8 @@ def configure(graylog, input, raw_path, raw_data):
         response.raise_for_status()
         for _input in response.json()['inputs']:
             if _input['title'] == data['title']:
-                log.info(
-                    'Graylog input already configured. Updating: %s',
-                    data['title'])
+                log.info('Graylog input already configured. Updating: %s',
+                         data['title'])
                 response = graylog.put(
                     api + '/system/inputs/%s' % _input['id'], json=data)
                 response.raise_for_status()
@@ -128,16 +134,14 @@ main.add_command(collect_journal_age_metric)
 
 def handle_api_response(response, expected_status=[200], log_response=True):
     if response.status_code in expected_status:
-        log.info("%s (%d) %s", response.url,
-                 response.status_code,
+        log.info("%s (%d) %s", response.url, response.status_code,
                  response.text if log_response else '')
         if response.text:
             return response.json()
     elif response.status_code == 400:
         log.error("%s bad request: %s", response.url, response.text)
     else:
-        log.warning("%s unexpected status: %d",
-                    response.url,
+        log.warning("%s unexpected status: %d", response.url,
                     response.status_code)
 
     response.raise_for_status()
@@ -184,10 +188,7 @@ def ensure_role(graylog, name, config):
     roles_url = f'{graylog.api}/roles'
     role_url = f'{roles_url}/{name}'
     resp = graylog.get(role_url)
-    data = {
-        'name': name,
-        **json.loads(config)
-    }
+    data = {'name': name, **json.loads(config)}
 
     handle_api_response(resp, [200, 404])
 
@@ -208,7 +209,8 @@ main.add_command(ensure_role)
 @click.argument('path')
 @click.argument('raw')
 @click.option('--method', type=click.Choice(['POST', 'PUT']), default='PUT')
-@click.option('--expected-status', '-s', multiple=True, default=[200], type=int)
+@click.option(
+    '--expected-status', '-s', multiple=True, default=[200], type=int)
 @click.pass_obj
 def call(graylog, path, raw, method, expected_status):
     """Runs an arbitrary API PUT/POST request."""
@@ -233,7 +235,6 @@ def get(graylog, path, expected_status, log_response):
 
 
 main.add_command(get)
-
 
 if __name__ == '__main__':
     main()

--- a/pkgs/fc/agent/fc/manage/manage.py
+++ b/pkgs/fc/agent/fc/manage/manage.py
@@ -45,6 +45,7 @@ nixos-rebuild switch || nixos-rebuild switch
 rm -rf {NEXT_SYSTEM}
 """
 
+
 class ChannelException(Exception):
     pass
 
@@ -59,6 +60,7 @@ class SwitchFailed(ChannelException):
 
 class RegisterFailed(ChannelException):
     pass
+
 
 class DryActivateFailed(ChannelException):
     pass
@@ -96,7 +98,8 @@ class Channel:
             return "local-checkout"
         label_comp = [
             '/root/.nix-defexpr/channels/{}/{}'.format(self.name, c)
-            for c in ['.version', '.version-suffix']]
+            for c in ['.version', '.version-suffix']
+        ]
         if all(p.exists(f) for f in label_comp):
             return ''.join(open(f).read() for f in label_comp)
 
@@ -140,8 +143,7 @@ class Channel:
             _log.warn(
                 "Expected NIX_PATH element 'fc' not found in %s. Did you "
                 "create a 'channels' directory via `dev-setup` and point "
-                "the channel URL towards that directory?",
-                self.resolved_url)
+                "the channel URL towards that directory?", self.resolved_url)
 
     def switch(self, build_options, lazy=False):
         """
@@ -166,8 +168,7 @@ class Channel:
         """
         _log.info('Building %s', self)
         cmd = [
-            "nix-build", "--no-build-output",
-            "<nixpkgs/nixos>", "-A", "system"
+            "nix-build", "--no-build-output", "<nixpkgs/nixos>", "-A", "system"
         ]
 
         if out_link:
@@ -239,7 +240,8 @@ class Channel:
         _log.debug("Register command is: %s", " ".join(cmd))
 
         try:
-            subprocess.run(cmd, check=True, stdout=PIPE, stderr=STDOUT, text=True)
+            subprocess.run(
+                cmd, check=True, stdout=PIPE, stderr=STDOUT, text=True)
         except subprocess.CalledProcessError as e:
             _log.error("Registering the new system in the profile failed:\n%s",
                        e.stdout)
@@ -252,10 +254,8 @@ class Channel:
             os.mkdir(NEXT_SYSTEM)
 
         cmd = [
-            'nixos-rebuild',
-            '-I', '/root/.nix-defexpr/channels/next',
-            '--no-build-output',
-            'dry-activate'
+            'nixos-rebuild', '-I', '/root/.nix-defexpr/channels/next',
+            '--no-build-output', 'dry-activate'
         ]
         _log.debug("Dry-activate (pre-build) command is: %s", " ".join(cmd))
 
@@ -294,18 +294,19 @@ class Channel:
         return changes
 
     def register_maintenance(self, changes):
+
         def notify(category):
             services = changes.get(category, [])
             if services:
                 return '{}: {}'.format(
                     category.capitalize(),
-                    ', '.join(s.replace('.service', '', 1)
-                              for s in services))
+                    ', '.join(s.replace('.service', '', 1) for s in services))
             else:
                 return ''
 
-        notifications = list(filter(None, (
-            notify(cat) for cat in ['stop', 'restart', 'start', 'reload'])))
+        notifications = list(
+            filter(None, (notify(cat)
+                          for cat in ['stop', 'restart', 'start', 'reload'])))
         msg = [
             f'System update to {self.version()}',
             f'Environment: {self.environment}',
@@ -316,7 +317,8 @@ class Channel:
         next_kernel = kernel_version('/run/next-system/result/kernel')
 
         if current_kernel != next_kernel:
-            msg.append("Will schedule a reboot to activate the changed kernel.")
+            msg.append(
+                "Will schedule a reboot to activate the changed kernel.")
 
         if len(msg) > 1:  # add trailing newline if output is multi-line
             msg += ['']
@@ -327,9 +329,11 @@ class Channel:
         _log.debug("update script:\n%s", script.getvalue())
         _log.debug("message:\n%s", msg)
         with fc.maintenance.ReqManager() as rm:
-            rm.add(fc.maintenance.Request(
-                fc.maintenance.lib.shellscript.ShellScriptActivity(script),
-                600, comment='\n'.join(msg)))
+            rm.add(
+                fc.maintenance.Request(
+                    fc.maintenance.lib.shellscript.ShellScriptActivity(script),
+                    600,
+                    comment='\n'.join(msg)))
 
 
 def load_enc(enc_path='/etc/nixos/enc.json'):
@@ -349,12 +353,15 @@ def load_enc(enc_path='/etc/nixos/enc.json'):
 def conditional_update(filename, data):
     """Updates JSON file on disk only if there is different content."""
     with tempfile.NamedTemporaryFile(
-            mode='w', suffix='.tmp', prefix=p.basename(filename),
-            dir=p.dirname(filename), delete=False) as tf:
+            mode='w',
+            suffix='.tmp',
+            prefix=p.basename(filename),
+            dir=p.dirname(filename),
+            delete=False) as tf:
         json.dump(data, tf, ensure_ascii=False, indent=1, sort_keys=True)
         tf.write('\n')
         os.chmod(tf.fileno(), 0o640)
-    if not(p.exists(filename)) or not(filecmp.cmp(filename, tf.name)):
+    if not (p.exists(filename)) or not (filecmp.cmp(filename, tf.name)):
         with open(tf.name, 'a') as f:
             os.fsync(f.fileno())
         os.rename(tf.name, filename)
@@ -397,6 +404,7 @@ def write_json(calls):
 
 
 def system_state():
+
     def load_system_state():
         result = {}
         try:
@@ -425,8 +433,8 @@ def system_state():
 
 
 def update_inventory():
-    if (not enc or not enc.get('parameters') or
-            not enc['parameters'].get('directory_password')):
+    if (not enc or not enc.get('parameters')
+            or not enc['parameters'].get('directory_password')):
         _log.warning('No directory password. Not updating inventory.')
         return
     try:
@@ -440,8 +448,8 @@ def update_inventory():
 
     write_json([
         (lambda: directory.lookup_node(enc['name']), 'enc.json'),
-        (lambda: directory.list_nodes_addresses(
-            enc['parameters']['location'], 'srv'), 'addresses_srv.json'),
+        (lambda: directory.list_nodes_addresses(enc['parameters']['location'],
+                                                'srv'), 'addresses_srv.json'),
         (lambda: directory.list_permissions(), 'permissions.json'),
         (lambda: directory.list_service_clients(), 'service_clients.json'),
         (lambda: directory.list_services(), 'services.json'),
@@ -481,12 +489,13 @@ def build_channel_with_maintenance(build_options, spread, lazy):
     current_channel = Channel.current('nixos')
     if next_channel != current_channel:
         next_channel.load('next')
-        _log.info('Preparing switch from %s to %s.',
-                  current_channel, next_channel)
+        _log.info('Preparing switch from %s to %s.', current_channel,
+                  next_channel)
         try:
             next_channel.prepare_maintenance()
         except DryActivateFailed:
-            subprocess.run(["nix-channel", "--remove", "next"], capture_output=True)
+            subprocess.run(["nix-channel", "--remove", "next"],
+                           capture_output=True)
             sys.exit(3)
     else:
         _log.info('Current channel is still up-to-date.')
@@ -542,47 +551,102 @@ def exit_timeout(signum, frame):
 
 def parse_args():
     a = argparse.ArgumentParser(description=__doc__)
-    a.add_argument('-E', '--enc-path', default='/etc/nixos/enc.json',
-                   help='path to enc.json (default: %(default)s)')
-    a.add_argument('--show-trace', default=False, action='store_true',
-                   help='instruct nixos-rebuild to dump tracebacks on failure')
-    a.add_argument('--fast', default=False, action='store_true',
-                   help='instruct nixos-rebuild to perform a fast rebuild')
-    a.add_argument('-e', '--directory', default=False, action='store_true',
-                   help='refresh local ENC copy')
-    a.add_argument('-s', '--system-state', default=False, action='store_true',
-                   help='dump local system information (like memory size) '
-                   'to system_state.json')
-    a.add_argument('-m', '--maintenance', default=False, action='store_true',
-                   help='run scheduled maintenance')
-    a.add_argument('-l', '--lazy', default=False, action='store_true',
-                   help="only switch to new system if build result changed")
-    a.add_argument('-t', '--timeout', default=3600, type=int,
-                   help='abort execution after <TIMEOUT> seconds')
-    a.add_argument('-i', '--interval', default=120, type=int, metavar='INT',
-                   help='automatic mode: channel update every <INT> minutes')
-    a.add_argument('-f', '--stampfile', metavar='PATH',
-                   default='/var/lib/fc-manage/fc-manage.stamp',
-                   help='automatic mode: save last execution date to <PATH> '
-                   '(default: (%(default)s)')
-    a.add_argument('-a', '--automatic', default=False, action='store_true',
-                   help='channel update every I minutes, local builds '
-                   'all other times (see also -i and -f). Must be used in '
-                   'conjunction with --channel or --channel-with-maintenance.')
+    a.add_argument(
+        '-E',
+        '--enc-path',
+        default='/etc/nixos/enc.json',
+        help='path to enc.json (default: %(default)s)')
+    a.add_argument(
+        '--show-trace',
+        default=False,
+        action='store_true',
+        help='instruct nixos-rebuild to dump tracebacks on failure')
+    a.add_argument(
+        '--fast',
+        default=False,
+        action='store_true',
+        help='instruct nixos-rebuild to perform a fast rebuild')
+    a.add_argument(
+        '-e',
+        '--directory',
+        default=False,
+        action='store_true',
+        help='refresh local ENC copy')
+    a.add_argument(
+        '-s',
+        '--system-state',
+        default=False,
+        action='store_true',
+        help='dump local system information (like memory size) '
+        'to system_state.json')
+    a.add_argument(
+        '-m',
+        '--maintenance',
+        default=False,
+        action='store_true',
+        help='run scheduled maintenance')
+    a.add_argument(
+        '-l',
+        '--lazy',
+        default=False,
+        action='store_true',
+        help="only switch to new system if build result changed")
+    a.add_argument(
+        '-t',
+        '--timeout',
+        default=3600,
+        type=int,
+        help='abort execution after <TIMEOUT> seconds')
+    a.add_argument(
+        '-i',
+        '--interval',
+        default=120,
+        type=int,
+        metavar='INT',
+        help='automatic mode: channel update every <INT> minutes')
+    a.add_argument(
+        '-f',
+        '--stampfile',
+        metavar='PATH',
+        default='/var/lib/fc-manage/fc-manage.stamp',
+        help='automatic mode: save last execution date to <PATH> '
+        '(default: (%(default)s)')
+    a.add_argument(
+        '-a',
+        '--automatic',
+        default=False,
+        action='store_true',
+        help='channel update every I minutes, local builds '
+        'all other times (see also -i and -f). Must be used in '
+        'conjunction with --channel or --channel-with-maintenance.')
 
     build = a.add_mutually_exclusive_group()
-    build.add_argument('-c', '--channel', default=False, dest='build',
-                       action='store_const', const='build_channel',
-                       help='switch machine to FCIO channel')
-    build.add_argument('-C', '--channel-with-maintenance', default=False,
-                       dest='build', action='store_const',
-                       const='build_channel_with_maintenance',
-                       help='switch machine to FCIO channel during scheduled '
-                       'maintenance')
-    build.add_argument('-b', '--build', default=False, dest='build',
-                       action='store_const', const='build_no_update',
-                       help='rebuild channel or local checkout whatever '
-                       'is currently active')
+    build.add_argument(
+        '-c',
+        '--channel',
+        default=False,
+        dest='build',
+        action='store_const',
+        const='build_channel',
+        help='switch machine to FCIO channel')
+    build.add_argument(
+        '-C',
+        '--channel-with-maintenance',
+        default=False,
+        dest='build',
+        action='store_const',
+        const='build_channel_with_maintenance',
+        help='switch machine to FCIO channel during scheduled '
+        'maintenance')
+    build.add_argument(
+        '-b',
+        '--build',
+        default=False,
+        dest='build',
+        action='store_const',
+        const='build_no_update',
+        help='rebuild channel or local checkout whatever '
+        'is currently active')
     a.add_argument('-v', '--verbose', action='store_true', default=False)
 
     args = a.parse_args()
@@ -609,7 +673,8 @@ def transaction(args):
     load_enc(args.enc_path)
 
     if args.automatic:
-        spread = Spread(args.stampfile, args.interval * 60, 'Channel update check')
+        spread = Spread(args.stampfile, args.interval * 60,
+                        'Channel update check')
         spread.configure()
     else:
         spread = NullSpread()
@@ -626,8 +691,9 @@ def main():
     signal.signal(signal.SIGALRM, exit_timeout)
     signal.alarm(args.timeout)
 
-    logging.basicConfig(format='%(levelname)s: %(message)s',
-                        level=logging.DEBUG if args.verbose else logging.INFO)
+    logging.basicConfig(
+        format='%(levelname)s: %(message)s',
+        level=logging.DEBUG if args.verbose else logging.INFO)
     # this is really annoying
     logging.getLogger('iso8601').setLevel(logging.WARNING)
     logging.getLogger('requests').setLevel(logging.WARNING)

--- a/pkgs/fc/agent/fc/manage/monitor.py
+++ b/pkgs/fc/agent/fc/manage/monitor.py
@@ -17,8 +17,9 @@ def get_directory(enc, url):
     parts = urllib.parse.urlsplit(url)
     if not socket.getdefaulttimeout():
         socket.setdefaulttimeout(300)
-    return xmlrpc.client.ServerProxy('%s://%s:%s@%s%s' % (
-        parts.scheme, user, password, parts.netloc, parts.path))
+    return xmlrpc.client.ServerProxy(
+        '%s://%s:%s@%s%s' %
+        (parts.scheme, user, password, parts.netloc, parts.path))
 
 
 def get_sensucheck_configuration(servicechecks):
@@ -27,15 +28,12 @@ def get_sensucheck_configuration(servicechecks):
 
     for servicecheck in servicechecks:
         name = 'directory.servicecheck.{rg}.{id}'.format(
-            rg=servicecheck['resource_group'],
-            id=servicecheck['id'])
+            rg=servicecheck['resource_group'], id=servicecheck['id'])
 
         url = urllib.parse.urlsplit(servicecheck['url'])
         path = '?'.join([p for p in [url.path, url.query] if p])
 
-        command = [
-            'check_http', '-4',
-            '-H', shlex.quote(url.hostname)]
+        command = ['check_http', '-4', '-H', shlex.quote(url.hostname)]
         if url.port:
             command.extend(['-p', str(url.port)])
         if path:
@@ -83,20 +81,25 @@ def handle_result(directory=None, enc=None, **kw):
             result=check['output'],
             state=check['status'],
             last_check=datetime.datetime.fromtimestamp(
-                check['executed']).isoformat())])
+                check['executed']).isoformat())
+    ])
 
 
 def main():
     parser = argparse.ArgumentParser(description='Flying Circus Monitoring')
-    parser.add_argument('-E', '--enc', default='/etc/nixos/enc.json',
-                        help='Path to enc.json (default: %(default)s)')
-    subparsers = parser.add_subparsers(help='sub-command help',
-                                       dest='subparser_name')
+    parser.add_argument(
+        '-E',
+        '--enc',
+        default='/etc/nixos/enc.json',
+        help='Path to enc.json (default: %(default)s)')
+    subparsers = parser.add_subparsers(
+        help='sub-command help', dest='subparser_name')
 
     checks_parser = subparsers.add_parser('configure-checks')
     checks_parser.set_defaults(func=write_checks)
     checks_parser.add_argument(
-        '-c', '--config-file',
+        '-c',
+        '--config-file',
         help='Where to put the check configuration (default: %(default)s)',
         default='/etc/local/sensu-client/directory_servicechecks.json')
 
@@ -110,9 +113,8 @@ def main():
 
     with open(args.enc) as f:
         enc = json.load(f)
-    directory = get_directory(
-        enc,
-        'https://directory.fcio.net/v2/api')  # RING0
+    directory = get_directory(enc,
+                              'https://directory.fcio.net/v2/api')  # RING0
     kw = vars(args)
     kw.pop('enc', None)
 

--- a/pkgs/fc/agent/fc/manage/spread.py
+++ b/pkgs/fc/agent/fc/manage/spread.py
@@ -13,7 +13,7 @@ def _fmt_time(timestamp, sep=' '):
 
 class Spread:
 
-    def __init__(self, stampfile, interval=120*60, jobname='Job'):
+    def __init__(self, stampfile, interval=120 * 60, jobname='Job'):
         self.stampfile = stampfile
         self.interval = interval
         self.jobname = jobname

--- a/pkgs/fc/agent/fc/manage/tests/test_dmi_memory.py
+++ b/pkgs/fc/agent/fc/manage/tests/test_dmi_memory.py
@@ -6,19 +6,24 @@ from unittest import mock
 
 
 def test_calc_mem():
-    modules = [{'Size': '0MB'},
-               {'Size': '512MB'},
-               {'Size': '2048    MB'},
-               {'Size': '    9096 mb'}]
+    modules = [{
+        'Size': '0MB'
+    }, {
+        'Size': '512MB'
+    }, {
+        'Size': '2048    MB'
+    }, {
+        'Size': '    9096 mb'
+    }]
     res = calc_mem(modules)
     assert res == 11656
 
 
 def test_get_device():
-    entry = ['Memory Device',
-             'Total Width: Unknown',
-             'Type: Ram',
-             'Locator: DIMM: 0']
+    entry = [
+        'Memory Device', 'Total Width: Unknown', 'Type: Ram',
+        'Locator: DIMM: 0'
+    ]
     res = get_device(entry)
     assert res == {'Total Width': ' Unknown', 'Type': ' Ram'}
 

--- a/pkgs/fc/agent/fc/manage/tests/test_manage.py
+++ b/pkgs/fc/agent/fc/manage/tests/test_manage.py
@@ -24,7 +24,8 @@ def test_channel_eq():
 
 def test_channel_str_local_checkout():
     channel = Channel('file://1', name='name', environment='env')
-    assert str(channel) == '<Channel name=name, version=local-checkout, from=1>'
+    assert str(
+        channel) == '<Channel name=name, version=local-checkout, from=1>'
 
 
 def test_channel_str(mocked_responses):
@@ -46,8 +47,10 @@ def test_channel_from_url_with_redirect(mocked_responses):
     final_url = 'https://hydra.flyingcircus.io/build/54715/download/1/nixexprs.tar.xz'
 
     mocked_responses.add(
-        responses.HEAD, expr_url(url), status=302, headers={'Location': final_url}
-    )
+        responses.HEAD,
+        expr_url(url),
+        status=302,
+        headers={'Location': final_url})
     mocked_responses.add(responses.HEAD, final_url)
     ch = Channel(url)
     assert ch.resolved_url == final_url

--- a/pkgs/fc/agent/fc/manage/tests/test_manage.py
+++ b/pkgs/fc/agent/fc/manage/tests/test_manage.py
@@ -1,8 +1,10 @@
-from requests import HTTPError
-from pytest import raises, fixture
-import responses
-from responses import HEAD
 from fc.manage.manage import Channel
+from pytest import raises, fixture
+from requests import HTTPError
+from unittest.mock import Mock, MagicMock
+import responses
+import structlog
+import textwrap
 
 
 @fixture
@@ -11,38 +13,43 @@ def mocked_responses():
         yield rsps
 
 
+@fixture
+def logger():
+    return structlog.get_logger()
+
+
 def expr_url(url):
     return url + 'nixexprs.tar.xz'
 
 
-def test_channel_eq():
-    ch1 = Channel('file://1')
-    ch2 = Channel('file://2')
+def test_channel_eq(logger):
+    ch1 = Channel(logger, 'file://1')
+    ch2 = Channel(logger, 'file://2')
     assert ch1 == ch1
     assert ch1 != ch2
 
 
-def test_channel_str_local_checkout():
-    channel = Channel('file://1', name='name', environment='env')
+def test_channel_str_local_checkout(logger):
+    channel = Channel(logger, 'file://1', name='name', environment='env')
     assert str(
         channel) == '<Channel name=name, version=local-checkout, from=1>'
 
 
-def test_channel_str(mocked_responses):
+def test_channel_str(logger, mocked_responses):
     url = 'https://hydra.flyingcircus.io/build/54522/download/1/nixexprs.tar.xz'
     mocked_responses.add(responses.HEAD, url)
-    channel = Channel(url, name='name', environment='env')
+    channel = Channel(logger, url, name='name', environment='env')
     assert str(channel) == f'<Channel name=name, version=unknown, from={url}>'
 
 
-def test_channel_from_expr_url(mocked_responses):
+def test_channel_from_expr_url(logger, mocked_responses):
     url = 'https://hydra.flyingcircus.io/build/54522/download/1/nixexprs.tar.xz'
     mocked_responses.add(responses.HEAD, url)
-    ch = Channel(url)
+    ch = Channel(logger, url)
     assert ch.resolved_url == url
 
 
-def test_channel_from_url_with_redirect(mocked_responses):
+def test_channel_from_url_with_redirect(logger, mocked_responses):
     url = 'https://hydra.flyingcircus.io/channel/custom/flyingcircus/fc-19.03-staging/release/'
     final_url = 'https://hydra.flyingcircus.io/build/54715/download/1/nixexprs.tar.xz'
 
@@ -52,13 +59,77 @@ def test_channel_from_url_with_redirect(mocked_responses):
         status=302,
         headers={'Location': final_url})
     mocked_responses.add(responses.HEAD, final_url)
-    ch = Channel(url)
+    ch = Channel(logger, url)
     assert ch.resolved_url == final_url
 
 
-def test_channel_wrong_url_should_raise(mocked_responses):
+def test_channel_wrong_url_should_raise(logger, mocked_responses):
     url = 'https://nothing.here/'
     mocked_responses.add(responses.HEAD, expr_url(url), status=404)
 
     with raises(HTTPError):
-        Channel(url)
+        Channel(logger, url)
+
+
+def test_channel_prepare_maintenance(log, mocked_responses, logger,
+                                     monkeypatch, tmp_path):
+    channel_url = "https://hydra.flyingcircus.io/build/93222/download/1/nixexprs.tar.xz"
+    version = "21.05.1367.817a5b0"
+    environment = "fc-21.05-dev"
+    system_path = f"/nix/store/v49jzgwblcn9vkrmpz92kzw5pkbsn0vz-nixos-system-test-{version}"
+    changes = {
+        "reload": ["nginx.service"],
+        "restart": ["telegraf.service"],
+        "start": ["postgresql.service"],
+        "stop": ["postgresql.service"],
+    }
+
+    expected_request_comment = textwrap.dedent(f"""\
+        System update to {version}
+        Environment: {environment}
+        Channel URL: {channel_url}
+        Stop: postgresql
+        Restart: telegraf
+        Start: postgresql
+        Reload: nginx
+        Will schedule a reboot to activate the changed kernel.
+    """)
+
+    mocked_responses.add(responses.HEAD, channel_url)
+    monkeypatch.setattr("fc.manage.manage.NEXT_SYSTEM", tmp_path)
+    build_system_mock = Mock(return_value=system_path)
+    monkeypatch.setattr("fc.util.nixos.build_system", build_system_mock)
+    dry_activate_system_mock = Mock(return_value=changes)
+    monkeypatch.setattr("fc.util.nixos.dry_activate_system",
+                        dry_activate_system_mock)
+
+    def fake_changed_kernel_version(path):
+        if path == '/run/current-system/kernel':
+            return "5.10.45"
+        elif path == '/run/next-system/result/kernel':
+            return "5.10.50"
+
+    monkeypatch.setattr("fc.util.nixos.kernel_version",
+                        fake_changed_kernel_version)
+
+    req_manager_mock = MagicMock()
+    req_manager_mock.return_value.__enter__.return_value.add = rm_add_mock = Mock(
+    )
+    monkeypatch.setattr("fc.maintenance.ReqManager", req_manager_mock)
+
+    channel = Channel(logger, channel_url, environment=environment)
+    channel.version = lambda: version
+
+    channel.prepare_maintenance()
+
+    build_system_mock.assert_called_once_with(
+        "/root/.nix-defexpr/channels/next",
+        out_link=tmp_path / "result",
+        log=channel.log)
+    dry_activate_system_mock.assert_called_once_with(system_path, channel.log)
+    assert log.has("channel-prepare-maintenance-start")
+    # Check maintenance request.
+    rm_add_mock.assert_called_once()
+    req = rm_add_mock.call_args[0][0]
+    assert req.comment == expected_request_comment
+    assert channel_url in req.activity.script

--- a/pkgs/fc/agent/fc/util/configfile.py
+++ b/pkgs/fc/agent/fc/util/configfile.py
@@ -37,9 +37,10 @@ class ConfigFile(object):
     def _diff(self):
         """Dump diff between old and new to stdout."""
         self.io.seek(0)
-        self.stdout.writelines(difflib.unified_diff(
-            open(self.filename).readlines(), self.io.readlines(),
-            self.filename + ' (old)', self.filename + ' (new)'))
+        self.stdout.writelines(
+            difflib.unified_diff(
+                open(self.filename).readlines(), self.io.readlines(),
+                self.filename + ' (old)', self.filename + ' (new)'))
 
     def _writeout(self, outfile):
         """Write contents unconditionally to file."""

--- a/pkgs/fc/agent/fc/util/logging.py
+++ b/pkgs/fc/agent/fc/util/logging.py
@@ -1,0 +1,524 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the MIT License.  See the LICENSE file in the root of this
+# repository for complete details.
+
+from datetime import datetime
+import io
+import json
+import os
+import string
+import structlog
+import sys
+import syslog
+
+try:
+    import colorama
+except ImportError:
+    colorama = None
+
+try:
+    import systemd.journal as journal
+except ImportError:
+    journal = None
+
+_MISSING = "{who} requires the {package} package installed."
+_EVENT_WIDTH = 30  # pad the event name to so many characters
+
+if sys.stdout.isatty() and colorama:
+    RESET_ALL = colorama.Style.RESET_ALL
+    BRIGHT = colorama.Style.BRIGHT
+    DIM = colorama.Style.DIM
+    RED = colorama.Fore.RED
+    BACKRED = colorama.Back.RED
+    BLUE = colorama.Fore.BLUE
+    CYAN = colorama.Fore.CYAN
+    MAGENTA = colorama.Fore.MAGENTA
+    YELLOW = colorama.Fore.YELLOW
+    GREEN = colorama.Fore.GREEN
+else:
+    RESET_ALL = ''
+    BRIGHT = ''
+    DIM = ''
+    RED = ''
+    BACKRED = ''
+    BLUE = ''
+    CYAN = ''
+    MAGENTA = ''
+    YELLOW = ''
+    GREEN = ''
+
+
+class PartialFormatter(string.Formatter):
+    """
+    A string formatter that doesn't break if values are missing or formats are wrong.
+    Missing values and bad formats are replaced by a fixed string that can be set
+    when constructing an formatter object.
+
+    formatter = PartialFormatter(missing='<missing>', bad_format='<bad format'>)
+    formatted_str = formatter.format("{exists} {missing}", exists=1)
+    formatted_str == "1 <missing>"
+    """
+
+    def __init__(self, missing='<missing>', bad_format='<bad format>'):
+        self.missing = missing
+        self.bad_format = bad_format
+
+    def get_field(self, field_name, args, kwargs):
+        try:
+            val = super().get_field(field_name, args, kwargs)
+        except (KeyError, AttributeError):
+            val = (None, field_name)
+        return val
+
+    def format_field(self, value, format_spec):
+        if value is None:
+            return self.missing
+        try:
+            return super().format_field(value, format_spec)
+        except ValueError:
+            self.bad_format
+
+
+class MultiOptimisticLoggerFactory:
+
+    def __init__(self, **factories):
+        self.factories = factories
+
+    def __call__(self, *args):
+        loggers = {k: f() for k, f in self.factories.items()}
+        return MultiOptimisticLogger(loggers)
+
+
+class MultiOptimisticLogger:
+    """
+    A logger which distributes messages to multiple loggers.
+    It's initialized with a logger dict where the keys are the logger names
+    which correspond to the keyword arguments given to the msg method.
+    If the logger's name is not present in the arguments, the logger is skipped.
+    Errors in sub loggers are ignored silently.
+    """
+
+    def __init__(self, loggers):
+        self.loggers = loggers
+
+    def __repr__(self):
+        return '<MultiOptimisticLogger {}>'.format(
+            [repr(l) for l in self.loggers])
+
+    def msg(self, **messages):
+        for name, logger in self.loggers.items():
+            try:
+                line = messages.get(name)
+                if line:
+                    logger.msg(line)
+            except Exception:
+                # We're being really optimistic: we want the calling program
+                # to continue even if we face huge troubles logging stuff.
+                pass
+
+    def __getattr__(self, name):
+        return self.msg
+
+
+class DummyJournalLogger:
+
+    def msg(self, message):
+        pass
+
+
+class JournalLogger:
+
+    def msg(self, message):
+        journal.send(**message)
+
+
+class JournalLoggerFactory:
+
+    def __init__(self):
+
+        if journal is None:
+            print(
+                _MISSING.format(
+                    who=self.__class__.__name__, package="systemd"))
+
+    def __call__(self, *args):
+        if journal is None:
+            return DummyJournalLogger()
+        else:
+            return JournalLogger()
+
+
+class CmdOutputFileRenderer:
+
+    def __call__(self, logger, method_name, event_dict):
+
+        line = event_dict.pop('cmd_output_line', None)
+        if line is not None:
+            return {'cmd_output_file': line}
+        else:
+            return {}
+
+
+def prefix(prefix, line):
+    return '{}>\t'.format(prefix) + line.replace('\n',
+                                                 '\n{}>\t'.format(prefix))
+
+
+def _pad(s, l):
+    """
+    Pads *s* to length *l*.
+    """
+    missing = l - len(s)
+    return s + " " * (missing if missing > 0 else 0)
+
+
+class ConsoleFileRenderer:
+    """
+    Render `event_dict` nicely aligned, in colors, and ordered with
+    specific knowledge about fc.agent structures.
+    """
+
+    LEVELS = [
+        'exception', 'critical', 'error', 'warn', 'warning', 'info', 'debug',
+        'trace'
+    ]
+
+    def __init__(self,
+                 min_level,
+                 show_caller_info=False,
+                 pad_event=_EVENT_WIDTH):
+        self.min_level = self.LEVELS.index(min_level.lower())
+        self.show_caller_info = show_caller_info
+        if colorama is None:
+            print(
+                _MISSING.format(
+                    who=self.__class__.__name__, package="colorama"))
+        if sys.stdout.isatty():
+            colorama.init()
+
+        self._pad_event = pad_event
+        self._level_to_color = {
+            "critical": RED,
+            "exception": RED,
+            "error": RED,
+            "warn": YELLOW,
+            "warning": YELLOW,
+            "info": GREEN,
+            "debug": GREEN,
+            "trace": GREEN,
+            "notset": BACKRED,
+        }
+        for key in self._level_to_color.keys():
+            self._level_to_color[key] += BRIGHT
+        self._longest_level = len(
+            max(self._level_to_color.keys(), key=lambda e: len(e)))
+
+    def __call__(self, logger, method_name, event_dict):
+        console_io = io.StringIO()
+        log_io = io.StringIO()
+
+        def write(line):
+            console_io.write(line)
+            if RESET_ALL:
+                for SYMB in [
+                        RESET_ALL, BRIGHT, DIM, RED, BACKRED, BLUE, CYAN,
+                        MAGENTA, YELLOW, GREEN
+                ]:
+                    line = line.replace(SYMB, '')
+            log_io.write(line)
+
+        replace_msg = event_dict.pop("_replace_msg", None)
+        if replace_msg:
+            formatter = PartialFormatter()
+            formatted_replace_msg = formatter.format(replace_msg, **event_dict)
+        else:
+            formatted_replace_msg = None
+
+        if not self.show_caller_info:
+            event_dict.pop('code_file', None)
+            event_dict.pop('code_func', None)
+            event_dict.pop('code_lineno', None)
+            event_dict.pop('code_module', None)
+
+        ts = event_dict.pop("timestamp", None)
+        if ts is not None:
+            write(
+                # can be a number if timestamp is UNIXy
+                DIM + str(ts) + RESET_ALL + " ")
+
+        event_dict.pop("pid", None)
+
+        level = event_dict.pop("level", None)
+        if level is not None:
+            write(self._level_to_color[level] + level[0].upper() + RESET_ALL +
+                  ' ')
+
+        event = event_dict.pop("event")
+        write(BRIGHT + _pad(event, self._pad_event) + RESET_ALL + " ")
+
+        logger_name = event_dict.pop("logger", None)
+        if logger_name is not None:
+            write("[" + BLUE + BRIGHT + logger_name + RESET_ALL + "] ")
+
+        cmd_output_line = event_dict.pop("cmd_output_line", None)
+        stdout = event_dict.pop("stdout", None)
+        stderr = event_dict.pop("stderr", None)
+        stack = event_dict.pop("stack", None)
+        exception_traceback = event_dict.pop("exception_traceback", None)
+
+        if formatted_replace_msg:
+            write(formatted_replace_msg)
+        else:
+            write(" ".join(CYAN + key + RESET_ALL + "=" + MAGENTA +
+                           repr(event_dict[key]) + RESET_ALL
+                           for key in sorted(event_dict.keys())))
+
+        if cmd_output_line is not None:
+            write(DIM + "> " + cmd_output_line + RESET_ALL)
+
+        if stdout is not None:
+            write('\n' + DIM + prefix("out", "\n" + stdout + "\n") + RESET_ALL)
+
+        if stderr is not None:
+            write('\n' + prefix("err", "\n" + stderr + "\n") + RESET_ALL)
+
+        if stack is not None:
+            write("\n" + prefix("stack", stack))
+            if exception_traceback is not None:
+                write("\n" + "=" * 79 + "\n")
+
+        if exception_traceback is not None:
+            write("\n" + prefix("exception", exception_traceback))
+
+        # Filter according to the -v switch when outputting to the
+        # console.
+        if self.LEVELS.index(method_name.lower()) > self.min_level:
+            console_io.seek(0)
+            console_io.truncate()
+
+        message = {'console': console_io.getvalue(), 'file': log_io.getvalue()}
+        return message
+
+
+class MultiRenderer:
+    """
+    Calls multiple renderers with a shallow copy of the event dict and collects
+    their messages in a dict with the renderer names as keys and their
+    rendered output as values. It doesn't care about the rendered messages
+    so different logger types can get different types of messages.
+    Normally, this should be placed last in the processors chain.
+    Errors in renderers are ignored silently.
+    """
+
+    def __init__(self, **renderers):
+        self.renderers = renderers
+
+    def __repr__(self):
+        return '<MultiRenderer {}>'.format([repr(l) for l in self.renderers])
+
+    def __call__(self, logger, method_name, event_dict):
+        merged_messages = {}
+        for renderer in self.renderers.values():
+            try:
+                messages = renderer(logger, method_name, event_dict.copy())
+                merged_messages.update(messages)
+            except Exception:
+                # We're being really optimistic: we want the calling program
+                # to continue even if we face huge troubles logging stuff.
+                raise
+
+        return merged_messages
+
+
+def add_pid(logger, method_name, event_dict):
+    event_dict['pid'] = os.getpid()
+    return event_dict
+
+
+def add_caller_info(logger, method_name, event_dict):
+    frame, module_str = structlog._frames._find_first_app_frame_and_name(
+        additional_ignores=[__name__])
+    event_dict['code_file'] = frame.f_code.co_filename
+    event_dict['code_func'] = frame.f_code.co_name
+    event_dict['code_lineno'] = frame.f_lineno
+    event_dict['code_module'] = module_str
+    return event_dict
+
+
+def add_pid(logger, method_name, event_dict):
+    event_dict['pid'] = os.getpid()
+    return event_dict
+
+
+JOURNAL_LEVELS = {
+    'exception': syslog.LOG_ALERT,
+    'critical': syslog.LOG_CRIT,
+    'error': syslog.LOG_ERR,
+    'warn': syslog.LOG_WARNING,
+    'warning': syslog.LOG_WARNING,
+    'info': syslog.LOG_INFO,
+    'debug': syslog.LOG_DEBUG,
+    'trace': syslog.LOG_DEBUG,
+}
+
+KEYS_TO_SKIP_IN_JOURNAL_MESSAGE = [
+    "_replace_msg",
+    "code_file",
+    "code_func",
+    "code_lineno",
+    "code_module",
+    "event",
+    "exception_traceback",
+    "invocation_id",
+    "level",
+    "message",
+    "output",
+    "pid",
+    "timestamp",
+]
+
+
+class SystemdJournalRenderer:
+
+    def __init__(self, syslog_identifier, syslog_facility=syslog.LOG_LOCAL0):
+        self.syslog_identifier = syslog_identifier
+        self.syslog_facility = syslog_facility
+
+    def __call__(self, logger, method_name, event_dict):
+
+        if method_name == 'trace':
+            return {}
+
+        kv_renderer = structlog.processors.KeyValueRenderer(sort_keys=True)
+        event_dict["message"] = event_dict["event"]
+        replace_msg = event_dict.pop("_replace_msg", None)
+
+        if replace_msg is not None:
+            formatter = PartialFormatter()
+            formatted_replace_msg = formatter.format(replace_msg, **event_dict)
+            event_dict["message"] += ": " + formatted_replace_msg
+        else:
+
+            kv = kv_renderer(
+                None, None, {
+                    k: v
+                    for k, v in event_dict.items()
+                    if k not in KEYS_TO_SKIP_IN_JOURNAL_MESSAGE
+                })
+
+            if kv:
+                event_dict["message"] += ": " + kv
+
+        event_dict.pop("timestamp", None)
+        event_dict.pop("pid", None)
+        code_lineno = event_dict.pop("code_lineno", None)
+
+        event_dict = {
+            k.upper(): self.dump_for_journal(v)
+            for k, v in event_dict.items()
+        }
+
+        event_dict['PRIORITY'] = JOURNAL_LEVELS.get(
+            event_dict.get("LEVEL"), syslog.LOG_INFO)
+        event_dict['SYSLOG_FACILITY'] = self.syslog_facility
+        event_dict['SYSLOG_IDENTIFIER'] = self.syslog_identifier
+        event_dict['CODE_LINE'] = code_lineno
+
+        return {"journal": event_dict}
+
+    def handle_json_fallback(self, obj):
+        """Same as structlog's json fallback.
+        Supports obj.__structlog__() for custom object serialization.
+        """
+        try:
+            return obj.__structlog__()
+        except AttributeError:
+            return repr(obj)
+
+    def dump_for_journal(self, obj):
+        """Encode values as JSON, except strings.
+        We keep strings unchanged to display line breaks properly in journalctl
+        and graylog.
+        """
+        if isinstance(obj, str):
+            return obj
+        elif isinstance(obj, datetime):
+            return datetime.isoformat(obj)
+        else:
+            return json.dumps(obj, default=self.handle_json_fallback)
+
+
+def process_exc_info(logger, name, event_dict):
+    """Transforms exc_info to the exception tuple format returned by
+    sys.exc_info(). Uses the the same logic as as structlog's format_exc_info()
+    to unify the different types exc_info could contain but doesn't render
+    the exception yet.
+    """
+    exc_info = event_dict.get("exc_info", None)
+
+    if isinstance(exc_info, BaseException):
+        event_dict["exc_info"] = (exc_info.__class__, exc_info,
+                                  exc_info.__traceback__)
+    elif isinstance(exc_info, tuple):
+        pass
+    elif exc_info:
+        event_dict["exc_info"] = sys.exc_info()
+
+    return event_dict
+
+
+def format_exc_info(logger, name, event_dict):
+    """Renders exc_info if it's present.
+    Expects the tuple format returned by sys.exc_info().
+    Compared to structlog's format_exc_info(), this renders the exception
+    information separately which is better for structured logging targets.
+    """
+    exc_info = event_dict.pop("exc_info", None)
+    if exc_info is not None:
+        exception_class = exc_info[0]
+        formatted_traceback = structlog.processors._format_exception(exc_info)
+        event_dict["exception_traceback"] = formatted_traceback
+        event_dict["exception_msg"] = str(exc_info[1])
+        event_dict[
+            "exception_class"] = exception_class.__module__ + "." + exception_class.__name__
+
+    return event_dict
+
+
+def init_logging(verbose, main_log_file, cmd_log_file):
+
+    multi_renderer = MultiRenderer(
+        journal=SystemdJournalRenderer("fc-agent", syslog.LOG_LOCAL1),
+        cmd_output_file=CmdOutputFileRenderer(),
+        text=ConsoleFileRenderer(
+            min_level='debug' if verbose else 'info',
+            show_caller_info=verbose))
+
+    processors = [
+        add_pid,
+        structlog.processors.add_log_level,
+        process_exc_info,
+        format_exc_info,
+        structlog.processors.StackInfoRenderer(),
+        structlog.processors.TimeStamper(fmt='iso', utc=False),
+        add_caller_info,
+        multi_renderer,
+    ]
+
+    loggers = {
+        "cmd_output_file": structlog.PrintLoggerFactory(cmd_log_file),
+        "file": structlog.PrintLoggerFactory(main_log_file),
+    }
+
+    if journal:
+        loggers["journal"] = JournalLoggerFactory()
+
+    # If the journal module is available and stdout is connected to journal, we
+    # shouldn't log to console because output would be duplicated in the journal.
+    if journal and not os.environ.get("JOURNAL_STREAM"):
+        loggers["console"] = structlog.PrintLoggerFactory()
+
+    structlog.configure(
+        processors=processors,
+        wrapper_class=structlog.BoundLogger,
+        logger_factory=MultiOptimisticLoggerFactory(**loggers))

--- a/pkgs/fc/agent/fc/util/nixos.py
+++ b/pkgs/fc/agent/fc/util/nixos.py
@@ -1,8 +1,51 @@
 """Helpers for interaction with the NixOS system"""
 
-import logging
+from pathlib import Path
+from subprocess import PIPE, STDOUT
+import json
 import os
 import os.path as p
+import re
+import requests
+import structlog
+import subprocess
+
+_log = structlog.get_logger()
+
+requests_session = requests.session()
+
+PHRASES = re.compile(r'would (\w+) the following units: (.*)$')
+FC_ENV_FILE = "/etc/fcio_environment"
+
+
+class Channel:
+
+    def __init__(self, url) -> None:
+        self.url = url
+
+
+class ChannelException(Exception):
+    pass
+
+
+class ChannelUpdateFailed(ChannelException):
+    pass
+
+
+class BuildFailed(ChannelException):
+    pass
+
+
+class SwitchFailed(ChannelException):
+    pass
+
+
+class RegisterFailed(ChannelException):
+    pass
+
+
+class DryActivateFailed(ChannelException):
+    pass
 
 
 def kernel_version(kernel):
@@ -23,3 +66,315 @@ def kernel_version(kernel):
             'modules subdir does not contain exactly '
             'one item', moddir)
     return moddir[0]
+
+
+def current_fc_environment_name(log=_log):
+    env_path = Path(FC_ENV_FILE)
+    if env_path.exists():
+        environment = env_path.read_text()
+        log.debug("fc-environment", env=environment)
+        return environment
+    else:
+        log.debug("fc-environment-env-file-missing", filename=FC_ENV_FILE)
+
+
+def channel_version(channel_url, log=_log):
+    log.debug("channel_version", channel=channel_url)
+    final_channel_url = resolve_url_redirects(channel_url)
+    try:
+        nixpkgs_path = subprocess.run(
+            ["nix-instantiate", "-I", final_channel_url, "--find-file", "."],
+            check=True,
+            capture_output=True,
+            text=True).stdout.strip()
+    except subprocess.CalledProcessError as e:
+        log.exception(
+            "channel-version-failed",
+            msg="getting version file from channel failed",
+            stderr=e.stderr)
+        raise
+
+    version = Path(nixpkgs_path, ".version").read_text()
+    suffix = Path(nixpkgs_path, ".version-suffix").read_text()
+
+    return version + suffix
+
+
+def running_system_version():
+    version_json = subprocess.run(["nixos-version", "--json"],
+                                  check=True,
+                                  capture_output=True,
+                                  text=True).stdout
+
+    return json.loads(version_json)["nixosVersion"]
+
+
+def current_nixos_channel_version():
+    is_local = False
+    if is_local:
+        return "local-checkout"
+
+    label_comp = [
+        '/root/.nix-defexpr/channels/nixos/{}'.format(c)
+        for c in ['.version', '.version-suffix']
+    ]
+
+    return ''.join(open(f).read() for f in label_comp)
+
+
+def current_nixos_channel_url(log=_log):
+    if not p.exists('/root/.nix-channels'):
+        log.debug("/root/.nix-channels does not exist, doing nothing")
+        return
+    try:
+        with open('/root/.nix-channels') as f:
+            for line in f.readlines():
+                url, name = line.strip().split(' ', 1)
+                if name == "nixos":
+                    log.debug("found nixos channel", channel=url)
+                    return url
+    except OSError:
+        log.exception('Failed to read .nix-channels')
+
+
+def resolve_url_redirects(url):
+    if not url.endswith("nixexprs.tar.xz"):
+        url = p.join(url, 'nixexprs.tar.xz')
+
+    res = requests_session.head(url, allow_redirects=True)
+    res.raise_for_status()
+
+    return res.url
+
+
+def detect_systemd_unit_changes(dry_activate_lines):
+    changes = {}
+    for line in dry_activate_lines:
+        m = PHRASES.match(line)
+        if m is not None:
+            action = m.group(1)
+            units = [unit.strip() for unit in m.group(2).split(',')]
+            changes[action] = units
+    return changes
+
+
+def update_system_channel(channel_url, log=_log):
+    """Update nixos channel URL if changed and fetch new contents.
+    """
+    current_channel_url = current_nixos_channel_url(log)
+
+    if current_channel_url == channel_url:
+        log.debug("system-channel-url-unchanged")
+    else:
+        log.info(
+            "system-channel-url-changed",
+            _replace_msg=
+            "System channel URL changed from {current_channel_url} to {new_channel_url}",
+            current_channel_url=current_channel_url,
+            new_channel_url=channel_url)
+        subprocess.run(['nix-channel', '--add', channel_url, "nixos"],
+                       check=True,
+                       capture_output=True,
+                       text=True)
+
+    stdout_lines = []
+    proc = subprocess.Popen(['nix-channel', '--update', "nixos"],
+                            check=True,
+                            capture_output=True,
+                            text=True)
+    log.info(
+        "system-channel-update-started",
+        _replace_msg="Channel update command started with PID: {cmd_pid}",
+        cmd_pid=proc.pid)
+    while proc.poll() is None:
+        line = proc.stdout.readline()
+        log.trace(
+            "system-channel-update-out", cmd_output_line=line.strip("\n"))
+        stdout_lines.append(line)
+
+    stdout = "".join(stdout_lines)
+
+    if proc.returncode == 0:
+        log.debug("system-channel-update-succeeded")
+    else:
+        log.error(
+            "system-channel-update-failed",
+            _replace_msg=
+            "System channel update failed, see command output for details.",
+            update_output=stdout)
+        raise ChannelUpdateFailed()
+
+
+def switch_to_channel(channel_url, lazy=False, log=_log):
+    final_channel_url = resolve_url_redirects(channel_url)
+    """
+    Build system with this channel and switch to it.
+    Replicates the behaviour of nixos-rebuild switch and adds an optional
+    lazy mode which only switches to the built system if it actually changed.
+    """
+    log.info(
+        "channel-switch",
+        channel=channel_url,
+        resolved_channel=final_channel_url)
+    # Put a temporary result link in /run to avoid a race condition
+    # with the garbage collector which may remove the system we just built.
+    # If register fails, we still hold a GC root until the next reboot.
+    out_link = "/run/fc-agent-built-system"
+    built_system = build_system(final_channel_url, out_link)
+    register_system_profile(built_system)
+    # New system is registered, delete the temporary result link.
+    os.unlink(out_link)
+    return switch_to_system(built_system, lazy)
+
+
+def build_system(channel_url, build_options=None, out_link=None, log=_log):
+    """
+    Build system with this channel. Works like nixos-rebuild build.
+    Does not modify the running system.
+    """
+    log.debug('system-build-start', channel=channel_url)
+    cmd = [
+        "nix-build", "--no-build-output", "--show-trace", "-I", channel_url,
+        "<nixpkgs/nixos>", "-A", "system"
+    ]
+
+    if out_link:
+        cmd.extend(["--out-link", str(out_link)])
+    else:
+        cmd.append("--no-out-link")
+
+    if build_options is not None:
+        cmd.extend(build_options)
+
+    log.debug("system-build-command", cmd=" ".join(cmd))
+
+    stderr_lines = []
+    proc = subprocess.Popen(cmd, stdout=PIPE, stderr=PIPE, text=True)
+    log.info(
+        "system-build-started",
+        _replace_msg="Nix build command started with PID: {cmd_pid}",
+        cmd_pid=proc.pid)
+    while proc.poll() is None:
+        line = proc.stderr.readline()
+        log.trace("system-build-out", cmd_output_line=line.strip("\n"))
+        stderr_lines.append(line)
+
+    stderr = "".join(stderr_lines).strip()
+
+    if stderr:
+        changed = True
+    else:
+        stderr = None
+        changed = False
+
+    if proc.returncode == 0:
+        if changed:
+            msg = "Successfully built new system."
+        else:
+            msg = "Built system, no changes."
+        log.info(
+            "system-build-succeeded",
+            _replace_msg=msg,
+            changed=changed,
+            build_output=stderr)
+    else:
+        log.error(
+            "system-build-failed",
+            _replace_msg="Building the system failed!",
+            stdout=proc.stdout.read().strip() or None,
+            stderr=stderr)
+        raise BuildFailed()
+
+    system_path = proc.stdout.read().strip()
+    log.debug("system-build-finished", system=system_path)
+    assert system_path.startswith("/nix/store/"), \
+        f"Output doesn't look like a Nix store path: {system_path}"
+
+    return system_path
+
+
+def switch_to_system(system_path, lazy, log=_log):
+    if lazy and p.realpath("/run/current-system") == system_path:
+        log.info(
+            "system-switch-skip",
+            _replace_msg="Lazy: system config did not change, skipping switch.",
+            system=system_path)
+        return False
+
+    log.info(
+        "system-switch-start",
+        _replace_msg="Switching to new system configuration: {system}",
+        system=system_path)
+
+    cmd = [f"{system_path}/bin/switch-to-configuration", "switch"]
+
+    log.debug("system-switch-command", cmd=" ".join(cmd))
+
+    stdout_lines = []
+    proc = subprocess.Popen(cmd, stdout=PIPE, stderr=STDOUT, text=True)
+    log.info(
+        "system-switch-started",
+        _replace_msg="Switch command started with PID: {cmd_pid}",
+        cmd_pid=proc.pid)
+    while proc.poll() is None:
+        line = proc.stdout.readline()
+        log.trace("system-switch-out", cmd_output_line=line.strip("\n"))
+        stdout_lines.append(line)
+
+    stdout = "".join(stdout_lines)
+
+    if proc.returncode == 0:
+        log.info(
+            "system-switch-succeeded",
+            _replace_msg="Completed switch to new system configuration.",
+            switch_output=stdout,
+            system=system_path)
+    else:
+        log.error(
+            "system-switch-failed",
+            _replace_msg="Switching to new system failed!",
+            stdout=stdout,
+            system_path=system_path)
+        raise SwitchFailed()
+
+    return True
+
+
+def dry_activate_system(system_path, log=_log):
+    cmd = [f"{system_path}/bin/switch-to-configuration", "dry-activate"]
+    log.info("system-dry-activate-start", system=system_path)
+    log.debug("system-dry-activate-cmd", cmd=" ".join(cmd))
+
+    stdout_lines = []
+    proc = subprocess.Popen(cmd, stdout=PIPE, stderr=STDOUT, text=True)
+    while proc.poll() is None:
+        line = proc.stdout.readline()
+        log.trace("system-dry-activate-out", cmd_output_line=line.strip())
+        stdout_lines.append(line)
+
+    if proc.returncode != 0:
+        log.error(
+            "system-dry-activate-failed",
+            msg="Dry-activating the new system failed!",
+            stdout="\n".join(stdout_lines))
+        raise DryActivateFailed()
+
+    return detect_systemd_unit_changes(stdout_lines)
+
+
+def register_system_profile(system_path, log=_log):
+    cmd = [
+        "nix-env", "--profile", "/nix/var/nix/profiles/system", "--set",
+        system_path
+    ]
+    log.debug("register-system-profile-command", cmd=" ".join(cmd))
+
+    try:
+        subprocess.run(cmd, check=True, capture_output=True, text=True)
+    except subprocess.CalledProcessError as e:
+        log.error(
+            "register-system-profile-failed",
+            _replace_msg="Registering the new system in the profile failed!",
+            stdout=e.stdout,
+            stderr=e.stderr)
+        raise RegisterFailed()

--- a/pkgs/fc/agent/fc/util/nixos.py
+++ b/pkgs/fc/agent/fc/util/nixos.py
@@ -19,6 +19,7 @@ def kernel_version(kernel):
     bzImage = os.readlink(kernel)
     moddir = os.listdir(p.join(p.dirname(bzImage), 'lib', 'modules'))
     if len(moddir) != 1:
-        raise RuntimeError('modules subdir does not contain exactly '
-                           'one item', moddir)
+        raise RuntimeError(
+            'modules subdir does not contain exactly '
+            'one item', moddir)
     return moddir[0]

--- a/pkgs/fc/agent/fc/util/tests/test_configfile.py
+++ b/pkgs/fc/agent/fc/util/tests/test_configfile.py
@@ -12,8 +12,8 @@ import unittest
 class TestConfigFile(unittest.TestCase):
 
     def setUp(self):
-        self.tf = tempfile.NamedTemporaryFile(suffix='test_configfile',
-                                              delete=False)
+        self.tf = tempfile.NamedTemporaryFile(
+            suffix='test_configfile', delete=False)
         self.diffout = io.StringIO()
 
     def tearDown(self):
@@ -51,7 +51,8 @@ class TestConfigFile(unittest.TestCase):
         print('hello world 1', file=c)
         print('hello world 2', file=c)
         c.commit()
-        self.assertEqual(self.diffout.getvalue(), """\
+        self.assertEqual(
+            self.diffout.getvalue(), """\
 --- {fn} (old)
 +++ {fn} (new)
 @@ -1,2 +1,2 @@

--- a/pkgs/fc/agent/fc/util/tests/test_logging.py
+++ b/pkgs/fc/agent/fc/util/tests/test_logging.py
@@ -1,0 +1,85 @@
+import datetime
+import pytest
+import syslog
+
+try:
+    from systemd import journal
+except ImportError:
+    journal = None
+
+from fc.util.logging import JournalLoggerFactory, JournalLogger, SystemdJournalRenderer
+
+
+@pytest.mark.skipif(journal is None, reason='systemd package not available')
+def test_journal_logger():
+    factory = JournalLoggerFactory()
+    logger = factory()
+    assert isinstance(logger, JournalLogger)
+
+
+@pytest.fixture
+def journald_renderer():
+    return SystemdJournalRenderer("test")
+
+
+def test_journal_renderer(journald_renderer):
+    event_dict = {
+        "event": "test-event",
+        "pid": 123,
+        "timestamp": 1000000,
+        "code_lineno": 2,
+        "code_file": "file",
+        "code_func": "func",
+        "output": "output",
+        "code_module": "module",
+        "bool_var": True,
+        "level": "debug",
+        "none": None,
+        "emptystring": "",
+        "a_list": ["a", "b"],
+        "a_tuple": ("a", "b"),
+        "a_dict": dict(a=1, b=2),
+        "multiline": "multi\nline"
+    }
+
+    message = (
+        "test-event: a_dict={'a': 1, 'b': 2} a_list=['a', 'b'] a_tuple=('a', 'b') "
+        + "bool_var=True emptystring='' multiline='multi\\nline' none=None")
+
+    expected_journal_msg = {
+        "SYSLOG_IDENTIFIER": "test",
+        "SYSLOG_FACILITY": syslog.LOG_LOCAL0,
+        "EVENT": "test-event",
+        "CODE_LINE": 2,
+        "CODE_FILE": "file",
+        "CODE_FUNC": "func",
+        "OUTPUT": "output",
+        "CODE_MODULE": "module",
+        "EMPTYSTRING": "",
+        "LEVEL": "debug",
+        "MESSAGE": message,
+        "PRIORITY": syslog.LOG_DEBUG,
+        "A_DICT": '{"a": 1, "b": 2}',
+        "A_TUPLE": '["a", "b"]',
+        "A_LIST": '["a", "b"]',
+        "NONE": "null",
+        "BOOL_VAR": "true",
+        "MULTILINE": "multi\nline"
+    }
+
+    rendered = journald_renderer(None, None, event_dict)
+    assert "journal" in rendered
+    assert rendered["journal"] == expected_journal_msg
+
+
+def test_journal_renderer_replace_msg(journald_renderer):
+    event_dict = {
+        "event": "test-event",
+        "pid": 123,
+        "_replace_msg": "test msg with pid {pid}"
+    }
+
+    rendered = journald_renderer(None, None, event_dict)
+    assert "journal" in rendered
+    assert rendered["journal"][
+        "MESSAGE"] == "test-event: test msg with pid 123"

--- a/pkgs/fc/agent/fc/util/tests/test_nixos.py
+++ b/pkgs/fc/agent/fc/util/tests/test_nixos.py
@@ -1,0 +1,179 @@
+import pytest
+import shlex
+from fc.util import nixos
+from unittest import mock
+import structlog
+import textwrap
+
+structlog.configure(wrapper_class=structlog.BoundLogger)
+
+
+class FakeCmdStream:
+
+    def __init__(self, content):
+        self.content = content
+        self.line_gen = (l for l in content.splitlines(keepends=True))
+        self.finished = False
+
+    def read_next(self):
+        try:
+            self.next_line = next(self.line_gen)
+        except StopIteration:
+            self.finished = True
+
+    def readline(self):
+        return self.next_line
+
+    def read(self):
+        return self.content
+
+
+class PollingFakePopen:
+
+    def __init__(self,
+                 cmd,
+                 stdout='',
+                 stderr='',
+                 poll='stdout',
+                 returncode=0,
+                 pid=123):
+        self.cmd = cmd
+        self.stdout = FakeCmdStream(stdout)
+        self.stderr = FakeCmdStream(stderr)
+        self.returncode = returncode
+        self.pid = pid
+        self._poll = poll
+
+    def poll(self):
+        if self._poll == 'stdout':
+            self.stdout.read_next()
+            if self.stdout.finished:
+                return self.returncode
+
+        if self._poll == 'stderr':
+            self.stderr.read_next()
+            if self.stderr.finished:
+                return self.returncode
+
+
+def test_build_system_with_changes(log, monkeypatch):
+    channel = "https://hydra.flyingcircus.io/build/93222/download/1/nixexprs.tar.xz"
+    system_path = "/nix/store/v49jzgwblcn9vkrmpz92kzw5pkbsn0vz-nixos-system-test-21.05.1367.817a5b0"
+    build_output = textwrap.dedent("""
+        these derivations will be built:
+        /nix/store/0yrw0jdjrwfkjdpxqf3rbd902c6waxim-system-path.drv
+        /nix/store/a69b25l5y6pgbb9r71fa0c4lhrhjsj85-nixos-system-test55-21.05pre-git.drv
+        building '/nix/store/0yrw0jdjrwfkjdpxqf3rbd902c6waxim-system-path.drv'...
+        building '/nix/store/a69b25l5y6pgbb9r71fa0c4lhrhjsj85-nixos-system-test55-21.05pre-git.drv'...
+    """)
+
+    cmd = shlex.split(
+        f"nix-build --no-build-output --show-trace -I {channel} <nixpkgs/nixos> -A system --out-link /run/fc-agent-test -v"
+    )
+
+    nix_build_fake = PollingFakePopen(
+        cmd, stdout=system_path, stderr=build_output, poll='stderr')
+
+    popen_mock = mock.Mock(return_value=nix_build_fake)
+    monkeypatch.setattr("subprocess.Popen", popen_mock)
+
+    built_system_path = nixos.build_system(
+        channel, build_options=["-v"], out_link="/run/fc-agent-test")
+
+    popen_mock.assert_called_once_with(cmd, stdout=-1, stderr=-1, text=True)
+    assert built_system_path == system_path
+    assert log.has(
+        "system-build-succeeded",
+        changed=True,
+        build_output=build_output.strip())
+
+
+def test_build_system_unchanged(log, monkeypatch):
+    channel = "https://hydra.flyingcircus.io/build/93222/download/1/nixexprs.tar.xz"
+    system_path = "/nix/store/v49jzgwblcn9vkrmpz92kzw5pkbsn0vz-nixos-system-test-21.05.1367.817a5b0"
+    build_output = "\n"
+
+    cmd = shlex.split(
+        f"nix-build --no-build-output --show-trace -I {channel} <nixpkgs/nixos> -A system --no-out-link"
+    )
+
+    nix_build_fake = PollingFakePopen(
+        cmd, stdout=system_path, stderr=build_output, poll='stderr')
+
+    popen_mock = mock.Mock(return_value=nix_build_fake)
+    monkeypatch.setattr("subprocess.Popen", popen_mock)
+
+    built_system_path = nixos.build_system(channel)
+
+    assert built_system_path == system_path
+    popen_mock.assert_called_once_with(cmd, stdout=-1, stderr=-1, text=True)
+    assert log.has("system-build-succeeded", changed=False)
+
+
+def test_build_system_fail(log, monkeypatch):
+    channel = "https://hydra.flyingcircus.io/build/93222/download/1/nixexprs.tar.xz"
+    system_path = "/nix/store/v49jzgwblcn9vkrmpz92kzw5pkbsn0vz-nixos-system-test-21.05.1367.817a5b0"
+    build_output = textwrap.dedent("""
+        error: The option `wrongOption' does not exist. Definition values:
+        - In `/etc/local/nixos/dev_vm.nix': true
+        (use '--show-trace' to show detailed location information)
+    """)
+
+    cmd = shlex.split(
+        f"nix-build --no-build-output -I {channel} <nixpkgs/nixos> -A system --no-out-link"
+    )
+
+    nix_build_fake = PollingFakePopen(
+        cmd,
+        stdout=system_path,
+        stderr=build_output,
+        poll='stderr',
+        returncode=1)
+
+    popen_mock = mock.Mock(return_value=nix_build_fake)
+    monkeypatch.setattr("subprocess.Popen", popen_mock)
+
+    with pytest.raises(nixos.BuildFailed):
+        nixos.build_system(channel)
+
+    assert log.has("system-build-failed", stderr=build_output.strip())
+
+
+def test_switch_to_system(log, monkeypatch):
+    system_path = "/nix/store/v49jzgwblcn9vkrmpz92kzw5pkbsn0vz-nixos-system-test-21.05.1367.817a5b0"
+    switch_output = textwrap.dedent("""
+        updating GRUB 2 menu...
+        activating the configuration...
+        setting up /etc...
+        reloading user units for ts...
+        setting up tmpfiles
+        reloading the following units: dbus.service
+        restarting the following units: polkit.service
+    """)
+
+    cmd = shlex.split(f"{system_path}/bin/switch_to_system")
+
+    switch_fake = PollingFakePopen(
+        cmd, stdout=switch_output, poll='stdout', returncode=0)
+
+    popen_mock = mock.Mock(return_value=switch_fake)
+    monkeypatch.setattr("subprocess.Popen", popen_mock)
+    monkeypatch.setattr("os.path.realpath", lambda p: "other")
+
+    changed = nixos.switch_to_system(system_path, lazy=True)
+    assert changed
+
+
+def test_switch_to_system_lazy_unchanged(log, monkeypatch):
+    system_path = "/nix/store/v49jzgwblcn9vkrmpz92kzw5pkbsn0vz-nixos-system-test-21.05.1367.817a5b0"
+    monkeypatch.setattr("os.path.realpath", lambda p: system_path)
+
+    changed = nixos.switch_to_system(system_path, lazy=True)
+    assert not changed
+    assert log.has("system-switch-skip")
+
+
+def test_update_nixos_channel(monkeypatch):
+    current_channel = "https://hydra.flyingcircus.io/build/93111/download/1/nixexprs.tar.xz"
+    monkeypatch.setattr("fc.util.nixos.current_nixos_channel_url",
+                        (lambda: current_channel))

--- a/pkgs/fc/agent/python_dev_env.nix
+++ b/pkgs/fc/agent/python_dev_env.nix
@@ -1,0 +1,10 @@
+#!/usr/bin/env -S nix-build -o pyenv
+# Used for IDE integration (tested with VSCode, Pycharm).
+# Run this file with ./python_dev_env.nix.
+# It creates a directory 'pyenv' that is similar to a Python virtualenv.
+# The 'pyenv' should be picked up py IDE as a possible project interpreter (restart may be required).
+{ pkgs ? import <nixpkgs> {} }:
+let
+ agent = pkgs.callPackage ./. {};
+
+in pkgs.python3.withPackages (ps: [ agent ])

--- a/pkgs/fc/agent/setup.cfg
+++ b/pkgs/fc/agent/setup.cfg
@@ -6,3 +6,10 @@ test=pytest
 
 [tool:pytest]
 addopts = -v --showlocals --ignore=lib --ignore=lib64 fc
+
+[yapf]
+based_on_style = pep8
+column_limit = 79
+split_before_expression_after_opening_paren = true
+split_before_closing_bracket = true
+blank_line_before_nested_class_or_def = true

--- a/pkgs/fc/agent/setup.py
+++ b/pkgs/fc/agent/setup.py
@@ -10,14 +10,12 @@ here = path.abspath(path.dirname(__file__))
 with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
-
 test_deps = [
     'freezegun>=0.3',
     'responses',
     'pytest>=3',
     'pytest-cov',
 ]
-
 
 setup(
     name='fc.agent',

--- a/pkgs/fc/agent/setup.py
+++ b/pkgs/fc/agent/setup.py
@@ -14,6 +14,8 @@ test_deps = [
     'freezegun>=0.3',
     'responses',
     'pytest>=3',
+    'pytest-mock',
+    'pytest-structlog',
     'pytest-cov',
 ]
 


### PR DESCRIPTION
* Python dev env, Python 3.9
  * Package dependencies that only work on Linux are added conditionally so it can be built on MacOS now.
* fc-agent: format Python code with yapf, Yapf settings were taken from the backy project.
* factor out reusable system management code and clean up manage.py a bit
* adapt structlog logging code for console/file from fc-qemu
* structlog to systemd journal renderer/logger
* use structlog in manage.py and nixos.py
* output from nix commands/switch-to-configuration is written line-by-line
  to separate files in /var/log/fc-agent:
  * interactive uses the same file /var/log/fc-agent/build-output.log
    and overwrites it with each run
  * when called from a systemd unit, files with unique names (date +
    systemd invocation id) are kept if something has changed for 180 days
* /var/log/fc-agent.log logs everything (mainly for agent debugging
  purposes)
* test important functionality from nixos.py and Channel.prepare_maintenance
* current fc environment name is now written to /etc/fcio_environment_name

 #PL-130029


@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* fc-agent: add structured logging output for better error reporting and more insights into what automated updates are doing. This also changes the output of the fc-manage command when run manually to give better user feedback. Structured logging output can be explored with journalctl or graylog (loghost) (#PL-130029).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - have proper logging and error reporting to find problems early
- [x] Security requirements tested? (EVIDENCE)
  - tested on multiple test VMs with and without production flag
  - automatic NixOS tests still run (except ceph test where Python tests break with an fc.util import error)
