### PR TITLE
PL 129843 Nginx should be fully configurable via Nix code

### DIFF
--- a/nixos/services/nginx/README.txt
+++ b/nixos/services/nginx/README.txt
@@ -52,7 +52,7 @@ Options provided by NixOS are documented at
 https://search.nixos.org/options?query=services.nginx.virtualHosts.&from=0&size=50&sort=relevance&channel=21.05
 
 We support the following custom options:
-* `emailACME`: set the contact address for Let's Encrypt, defaults to none.
+* `emailACME`: set the contact address for Let's Encrypt (certificate expiry, policy changes), defaults to none.
 * `listenAddress`: Single IPv4 address for vhost.
 * `listenAddress6`: Single IPv6 address for vhost.
 

--- a/nixos/services/nginx/default.nix
+++ b/nixos/services/nginx/default.nix
@@ -4,7 +4,7 @@
 # This may also affect other services that use reloading.
 { lib, config, pkgs, ... }:
 
-with builtins;
+with builtins; with lib;
 
 let
   cfg = config.flyingcircus.services.nginx;
@@ -56,31 +56,17 @@ let
 
   vhostsJSON = fclib.jsonFromDir localCfgDir;
 
-  mkVhostFromJSON = name: vhost:
-  let
-    onlySSL = vhost.onlySSL or false || vhost.enableSSL or false;
-    addSSL = onlySSL || vhost.addSSL or false || vhost.forceSSL or false;
-    addrs =
-      if (vhost ? "listenAddress" || vhost ? "listenAddress6")
-      then filter (x: x != null) [
-        (vhost.listenAddress or null)
-        (vhost.listenAddress6 or null)
-      ]
-      else fclib.network.fe.dualstack.addressesQuoted;
-  in
-    # listen and enableACME defaults are overridden if the JSON spec has them.
-    { listen = lib.flatten (map (fclib.nginxDefaultListen { inherit addSSL onlySSL; }) addrs); }
-    // (lib.optionalAttrs addSSL { enableACME = true; })
-    // (removeAttrs vhost [ "emailACME" "listenAddress" "listenAddress6" ]);
+  mkVanillaVhostFromFCVhost = name: vhost:
+    (removeAttrs vhost [ "emailACME" "listenAddress" "listenAddress6" ]);
 
-  virtualHosts = lib.mapAttrs mkVhostFromJSON vhostsJSON;
+  virtualHosts = lib.mapAttrs mkVanillaVhostFromFCVhost cfg.virtualHosts;
 
   # only email setting supported at the moment
   acmeSettings =
     lib.mapAttrs (name: val: { email = val.emailACME; })
-    (lib.filterAttrs (_: val: val ? emailACME ) vhostsJSON);
+    (lib.filterAttrs (_: val: val ? emailACME && val.emailACME != null ) cfg.virtualHosts);
 
-  acmeVhosts = (lib.filterAttrs (_: val: val ? enableACME ) vhostsJSON);
+  acmeVhosts = (lib.filterAttrs (_: val: val ? enableACME ) cfg.virtualHosts);
 
   mainConfig = ''
     worker_processes ${toString (fclib.currentCores 1)};
@@ -101,7 +87,6 @@ let
 
   baseHttpConfig = ''
     # === Defaults ===
-    default_type application/octet-stream;
     charset UTF-8;
 
     # === Logging ===
@@ -187,6 +172,73 @@ in
       '';
     };
 
+    # FIXME: use upstream
+    virtualHosts = mkOption {
+      type = let
+        vhost = import ./vhost-options.nix {
+          inherit config lib;
+        };
+      in types.attrsOf (types.submodule ({ config, ... }: {
+        options = vhost.options // {
+          listenAddress = mkOption {
+            type = types.str;
+            description = ''
+              IPv4 address to listen to. Defaults to 0.0.0.0.
+              If you need more options, use <option>listen</option>.
+
+              If you want to configure any number of IPs use <literal>listenAddresses</literal>.
+            '';
+            default = "0.0.0.0";
+          };
+
+          listenAddress6 = mkOption {
+            type = types.str;
+            description = ''
+              IPv6 address to listen to. Defaults to [::].
+              If you need more options, use <option>listen</option>.
+
+              If you want to configure any number of IPs use <literal>listenAddresses</literal>.
+            '';
+            default = "[::]";
+          };
+
+          emailACME = mkOption {
+            type = types.nullOr types.str;
+            description = ''
+              Set the contact address for Let's Encrypt (certificate expiry, policy changes).
+              Defaults to none.
+            '';
+            default = null;
+          };
+
+          enableACME = vhost.options.enableACME // {
+            default = config.onlySSL or false || config.enableSSL or false || config.addSSL or false || config.forceSSL or false;
+          };
+
+          listenAddresses = vhost.options.listenAddresses // {
+            default = if (config ? "listenAddress" || config ? "listenAddress6")
+              then filter (x: x != null) [
+                (config.listenAddress or null)
+                (config.listenAddress6 or null)
+              ]
+              else fclib.network.fe.dualstack.addressesQuoted;
+          };
+        };
+      }));
+      default = {};
+      example = literalExample ''
+        {
+          "hydra.example.com" = {
+            forceSSL = true;
+            enableACME = true;
+            locations."/" = {
+              proxyPass = "http://localhost:3000";
+            };
+          };
+        };
+      '';
+      description = "Declarative vhost config";
+    };
 
   };
 
@@ -234,6 +286,8 @@ in
         "local/nginx/modsecurity/unicode.mapping".source =
           "${pkgs.libmodsecurity.src}/unicode.mapping";
       };
+
+      flyingcircus.services.nginx.virtualHosts = vhostsJSON;
 
       flyingcircus.services.telegraf.inputs = {
         nginx = [ {

--- a/nixos/services/nginx/vhost-options.nix
+++ b/nixos/services/nginx/vhost-options.nix
@@ -1,8 +1,6 @@
 # Taken from upstream branch nixos-19.03.
 # Modifications:
-# * listenAddress and listenAddress6 options
-
-# This file defines the options that can be used both for the Apache
+# This file defines the options that can be used both for the Nginx
 # main server configuration, and for the virtual hosts.  (The latter
 # has additional options that affect the web server as a whole, like
 # the user/group to run under.)
@@ -48,25 +46,24 @@ with lib;
         IPv6 addresses must be enclosed in square brackets.
         Note: this option overrides <literal>addSSL</literal>
         and <literal>onlySSL</literal>.
+
+        If you only want to set the addresses manually and not
+        the ports, take a look at <literal>listenAddresses</literal>
       '';
     };
 
-    listenAddress = mkOption {
-      type = types.str;
-      description = ''
-        IPv4 address to listen to. Defaults to 0.0.0.0.
-        If you need more options, use <option>listen</option>.
-      '';
-      default = "0.0.0.0";
-    };
+    listenAddresses = mkOption {
+      type = with types; listOf str;
 
-    listenAddress6 = mkOption {
-      type = types.str;
       description = ''
-        IPv6 address to listen to. Defaults to [::].
-        If you need more options, use <option>listen</option>.
+        Listen addresses for this virtual host.
+        Compared to <literal>listen</literal> this only sets the addreses
+        and the ports are choosen automatically.
+
+        Note: This option overrides <literal>enableIPv6</literal>
       '';
-      default = "[::]";
+      default = [];
+      example = [ "127.0.0.1" "::1" ];
     };
 
     enableACME = mkOption {
@@ -141,6 +138,18 @@ with lib;
       '';
     };
 
+    rejectSSL = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Whether to listen for and reject all HTTPS connections to this vhost. Useful in
+        <link linkend="opt-services.nginx.virtualHosts._name_.default">default</link>
+        server blocks to avoid serving the certificate for another vhost. Uses the
+        <literal>ssl_reject_handshake</literal> directive available in nginx versions
+        1.19.4 and above.
+      '';
+    };
+
     sslCertificate = mkOption {
       type = types.path;
       example = "/var/host.cert";
@@ -156,7 +165,7 @@ with lib;
     sslTrustedCertificate = mkOption {
       type = types.nullOr types.path;
       default = null;
-      example = "/var/root.cert";
+      example = "\${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
       description = "Path to root SSL certificate for stapling and client certificates.";
     };
 
@@ -180,7 +189,7 @@ with lib;
       description = ''
         Whether to enable HTTP 3.
         This requires using <literal>pkgs.nginxQuic</literal> package
-        which can be achived by setting <literal>services.nginx.package = pkgs.nginxQuic;</literal>.
+        which can be achieved by setting <literal>services.nginx.package = pkgs.nginxQuic;</literal>.
         Note that HTTP 3 support is experimental and
         *not* yet recommended for production.
         Read more at https://quic.nginx.org/
@@ -234,7 +243,7 @@ with lib;
         Basic Auth protection for a vhost.
 
         WARNING: This is implemented to store the password in plain text in the
-        nix store.
+        Nix store.
       '';
     };
 


### PR DESCRIPTION
**upstream sync moved to PR #349**

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:
- flyingcircus nginx configurations can now be written in pure nix language now

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - no security related changes
- [x] Security requirements tested? (EVIDENCE)

