### PR TITLE
ntp: consistently choose routers as NTP servers

### DIFF
--- a/nixos/platform/static.nix
+++ b/nixos/platform/static.nix
@@ -114,9 +114,10 @@ with lib;
 
       ntpServers = {
         # Those are the routers and backup servers. This needs to move to the
-        # directory service discovery.
-        dev = [ "selma" "eddie" "sherry" ];
-        whq = [ "terri" "bob" "lou" ];
+        # directory service discovery or just make them part of the router and
+        # backup server role.
+        dev = [ "eddie" "kenny00" ];
+        whq = [ "lou" "kenny01" ];
         rzob = [ "kenny06" "kenny07" ];
         rzrl1 = [ "kenny02" "kenny03" ];
       };


### PR DESCRIPTION
Using outdated names (see the comment about service discovery)
caused NTP checks to be spuriously out of date. Fortunately some names
still worked and timedatectl luckily also has fallback servers from
the nixos pool.

Fixes PL-129972 Dev:  NTP CRITICAL: No response from NTP server

@flyingcircusio/release-managers

## Release process

Impact:

n/a

Changelog:

n/a

## Security implications

- [X] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

NTP operations need to be monitored

- [X] Security requirements tested? (EVIDENCE)

Checked manually that the check works properly with the new settings.
