### PR TITLE
[19.03] PL-129972 outdated ntp servers dev and whq

### DIFF
--- a/nixos/platform/static.nix
+++ b/nixos/platform/static.nix
@@ -98,11 +98,12 @@ with lib;
 
       ntpServers = {
         # Those are the routers and backup servers. This needs to move to the
-        # directory service discovery.
-        dev = [ "selma" "eddie" "sherry" ];
-        whq = [ "barbrady01" "terri" "bob" "lou" ];
-        rzob = [ "kenny06" "kenny07" "barbrady02" ];
-        rzrl1 = [ "kenny02" "kenny03" "barbrady03" ];
+        # directory service discovery or just make them part of the router and
+        # backup server role.
+        dev = [ "eddie" "kenny00" ];
+        whq = [ "lou" "kenny01" ];
+        rzob = [ "kenny06" "kenny07" ];
+        rzrl1 = [ "kenny02" "kenny03" ];
       };
 
       adminKeys = {


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

-

Changelog:

-

## Security implications

- [X] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

NTP status needs to be monitored

- [X] Security requirements tested? (EVIDENCE)

manually checked for the 20.09 fix and this is identical
