### PR TITLE
Update nixpkgs

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "NixOS",
     "repo": "nixpkgs",
-    "rev": "16bf3980bfa0d8929639be93fa8491ebad9d61ec",
-    "sha256": "0azsnd2pjg53siv97n5l62j0c8b5whi5bd5a2wqz1sphkirf3cgq"
+    "rev": "97c5d0cbe76901da0135b05cdbdfc5b068a7942c",
+    "sha256": "05zisan8s08r45jbn9xc3dysnsdh639qn7jhczsd71mjfg85n13v"
   },
   "nixos-mailserver": {
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/",


### PR DESCRIPTION
Notable security updates and version changes:

* clamav: 0.103.2 -> 0.103.3
* containerd: 1.5.2 -> 1.5.4
* dovecot: 2.3.15 -> 2.3.16
* dovecot_pigeonhole: 0.5.15 -> 0.5.16
* go_1_15: 1.15.14 -> 1.15.15
* go_1_16: 1.16.6 -> 1.16.7
* linux: 5.10.52 -> 5.10.57
* prosody: 0.11.9 -> 0.11.10
* rabbitmq-server: add patches for CVE-2021-22116, CVE-2021-32718 and CVE-2021-32719

 #PL-130050

@flyingcircusio/release-managers

## Release process

Impact:

* [NixOS 21.05] VMs will schedule a reboot to activate the new kernel version.

Changelog: (include changes from commit msg here)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - pull in upstream security fixes regularly
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still run, works on test VM
  - checked commit log for fixed CVEs and possible problems with updates