### PR TITLE
gitlab: 13.12.7 -> 13.12.10

### DIFF
--- a/pkgs/gitlab/data.json
+++ b/pkgs/gitlab/data.json
@@ -1,13 +1,13 @@
 {
-  "version": "13.12.7",
-  "repo_hash": "1dg3hhzn1q0l4fc5f22mnc53xlvykfysx0kas5ggwhk2bvbgzjla",
+  "version": "13.12.10",
+  "repo_hash": "0jx45sgqj94q9f3z0jb5q8cz8df24f7b4r2s18qdj43rvvclgsbq",
   "owner": "gitlab-org",
   "repo": "gitlab",
-  "rev": "v13.12.7-ee",
+  "rev": "v13.12.10-ee",
   "passthru": {
-    "GITALY_SERVER_VERSION": "13.12.7",
+    "GITALY_SERVER_VERSION": "13.12.10",
     "GITLAB_PAGES_VERSION": "1.39.0",
-    "GITLAB_SHELL_VERSION": "13.18.0",
-    "GITLAB_WORKHORSE_VERSION": "13.12.7"
+    "GITLAB_SHELL_VERSION": "13.18.1",
+    "GITLAB_WORKHORSE_VERSION": "13.12.10"
   }
 }

--- a/pkgs/gitlab/default.nix
+++ b/pkgs/gitlab/default.nix
@@ -1,7 +1,7 @@
 { stdenv, lib, fetchurl, fetchpatch, fetchFromGitLab, bundlerEnv
 , ruby, tzdata, git, nettools, nixosTests, nodejs, openssl
 , gitlabEnterprise ? false, callPackage, yarn
-, fixup_yarn_lock, replace, file
+, fixup_yarn_lock, replace, file, cacert
 }:
 
 let
@@ -51,7 +51,7 @@ let
     pname = "gitlab-assets";
     inherit version src;
 
-    nativeBuildInputs = [ rubyEnv.wrappedRuby rubyEnv.bundler nodejs yarn git ];
+    nativeBuildInputs = [ rubyEnv.wrappedRuby rubyEnv.bundler nodejs yarn git cacert ];
 
     # Since version 12.6.0, the rake tasks need the location of git,
     # so we have to apply the location patches here too.

--- a/pkgs/gitlab/gitaly/default.nix
+++ b/pkgs/gitlab/gitaly/default.nix
@@ -21,14 +21,14 @@ let
       };
   };
 in buildGoModule rec {
-  version = "13.12.7";
+  version = "13.12.10";
   pname = "gitaly";
 
   src = fetchFromGitLab {
     owner = "gitlab-org";
     repo = "gitaly";
     rev = "v${version}";
-    sha256 = "sha256-TNBQCgaBGdgKrX7ENGojuYVXFEsUtItNAjvTzAWXmTI=";
+    sha256 = "sha256-tPiMfxCETeQZeUtkjESI25bIWtQMIfEfSUfjp/O9Tm0=";
   };
 
   vendorSha256 = "sha256-drS0L0olEFHYJVC0VYwEZeNYa8fjwrfxlhrEQa4pqzY=";

--- a/pkgs/gitlab/gitlab-shell/default.nix
+++ b/pkgs/gitlab/gitlab-shell/default.nix
@@ -2,12 +2,12 @@
 
 buildGoModule rec {
   pname = "gitlab-shell";
-  version = "13.18.0";
+  version = "13.18.1";
   src = fetchFromGitLab {
     owner = "gitlab-org";
     repo = "gitlab-shell";
     rev = "v${version}";
-    sha256 = "sha256-TPe2quDg/ljI2v1HciDajosSPm4Z/iT2skeveNdrKdo=";
+    sha256 = "sha256-H4nX93kl7CxJbzjXU7nUun9fyOvNeT++V/jxqDycS74=";
   };
 
   buildInputs = [ ruby ];

--- a/pkgs/gitlab/gitlab-workhorse/default.nix
+++ b/pkgs/gitlab/gitlab-workhorse/default.nix
@@ -5,7 +5,7 @@ in
 buildGoModule rec {
   pname = "gitlab-workhorse";
 
-  version = "13.12.7";
+  version = "13.12.10";
 
   src = fetchFromGitLab {
     owner = data.owner;

--- a/pkgs/gitlab/rubyEnv/Gemfile.lock
+++ b/pkgs/gitlab/rubyEnv/Gemfile.lock
@@ -784,7 +784,7 @@ GEM
       nenv (~> 0.1)
       shellany (~> 0.0)
     numerizer (0.2.0)
-    oauth (0.5.4)
+    oauth (0.5.6)
     oauth2 (1.4.4)
       faraday (>= 0.8, < 2.0)
       jwt (>= 1.0, < 3.0)

--- a/pkgs/gitlab/rubyEnv/gemset.nix
+++ b/pkgs/gitlab/rubyEnv/gemset.nix
@@ -176,7 +176,7 @@
   };
   addressable = {
     dependencies = ["public_suffix"];
-    groups = ["default" "development" "test"];
+    groups = ["danger" "default" "development" "test"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
@@ -1510,7 +1510,7 @@
   };
   faraday = {
     dependencies = ["multipart-post"];
-    groups = ["default" "development"];
+    groups = ["danger" "default" "development" "test"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
@@ -3386,10 +3386,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1zszdg8q1b135z7l7crjj234k4j0m347hywp5kj6zsq7q78pw09y";
+      sha256 = "1zwd6v39yqfdrpg1p3d9jvzs9ljg55ana2p06m0l7qn5w0lgx1a0";
       type = "gem";
     };
-    version = "0.5.4";
+    version = "0.5.6";
   };
   oauth2 = {
     dependencies = ["faraday" "jwt" "multi_json" "multi_xml" "rack"];


### PR DESCRIPTION
 #PL-130053

@flyingcircusio/release-managers

Impact:

* [NixOS 21.05] Gitlab will be restarted and unavailable for some minutes.

Changelog:

* Gitlab: update to 13.12.10 security release (#PL-130053).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - use a current Gitlab version with the latest security fixes
- [x] Security requirements tested? (EVIDENCE)
  - 13.12.10 is the most recent patch release
  - manually tested on staging Gitlab instance
  - automated test checks basic functionality
