### PR TITLE
nixos-rebuild switch: protect built system from being gc-ed

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "fdfe2bd57c190971bee9094a5464c93395d300ae",
-    "sha256": "19p9zsxfnqgvd3vswqfbxn1ycnmip3n23izjnkamk7cp6crs22i5"
+    "rev": "a8220648a012955b111d25091764f4c19ae9a898",
+    "sha256": "0a9x02nihlwlfigl4b4128zcda39das082r793ci4gk11bj6vc6a"
   },
   "nixpkgs_18_03": {
     "owner": "nixos",


### PR DESCRIPTION
Update nixpkgs to fix #PL-130042

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Fix a race condition between a system rebuild and automatic garbage collection that can possibly damage the system. (#PL-130042). 

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - avoid breaking the system on system rebuilds  
- [x] Security requirements tested? (EVIDENCE)
  - executed nixos-rebuild/fc-manage on test VM and checked if temporary output link is created

