### PR TITLE
Jitsi: fix Jibri recording

### DIFF
--- a/nixos/services/jitsi/jibri.nix
+++ b/nixos/services/jitsi/jibri.nix
@@ -208,11 +208,11 @@ in
         ExecStart = ''
           ${pkgs.icewm}/bin/icewm-session
         '';
-        User = "jibri";
+        DynamicUser = true;
         Group = "jitsi-meet";
         Restart = "on-failure";
 
-        # Security restrictions, systemd-analyze security score is 3.2
+        # Security restrictions, systemd-analyze security score is 3.1
         CapabilityBoundingSet = "";
         LockPersonality = true;
         MemoryDenyWriteExecute = true;
@@ -231,6 +231,9 @@ in
         RestrictRealtime = true;
         RestrictSUIDSGID = true;
         SystemCallArchitectures = "native";
+        SystemCallFilter = [
+          "~@system-service"
+        ];
       };
     };
 
@@ -255,12 +258,12 @@ in
           :0
       '';
       serviceConfig = {
-        User = "jibri";
+        DynamicUser = true;
         LogsDirectory = "jibri-xorg";
         Group = "jitsi-meet";
         Restart = "on-failure";
 
-        # Security restrictions, systemd-analyze security score is 3.2
+        # Security restrictions, systemd-analyze security score is 2.2
         CapabilityBoundingSet = "";
         LockPersonality = true;
         MemoryDenyWriteExecute = true;
@@ -279,6 +282,14 @@ in
         RestrictRealtime = true;
         RestrictSUIDSGID = true;
         SystemCallArchitectures = "native";
+        SystemCallFilter = [
+          "~@clock"
+          "~@debug"
+          "~@module"
+          "~@mount"
+          "~@reboot"
+          "~@swap"
+        ];
       };
     };
 
@@ -313,10 +324,10 @@ in
           "audio"
         ];
 
-        # Security restrictions, systemd-analyze security score is 1.6
+
+        # Security restrictions, systemd-analyze security score is 3.6
         CapabilityBoundingSet = "";
         LockPersonality = true;
-        MemoryDenyWriteExecute = true;
         NoNewPrivileges = true;
         PrivateTmp = true;
         PrivateUsers = true;
@@ -327,16 +338,23 @@ in
         ProtectKernelModules = true;
         ProtectKernelTunables = true;
         ProtectSystem = "strict";
-        RestrictAddressFamilies = [ "AF_INET" "AF_INET6" ];
-        RestrictNamespaces = true;
         RestrictRealtime = true;
         RestrictSUIDSGID = true;
         SystemCallArchitectures = "native";
         SystemCallFilter = [
-          "@basic-io"
-          "@network-io"
+          "~@mount"
+          "~@clock"
+          "~@debug"
+          "~@module"
+          "~@reboot"
+          "~@swap"
+          "chroot"
         ];
       };
+    };
+
+    users.users.jibri = {
+      isSystemUser = true;
     };
 
   };


### PR DESCRIPTION
The security settings for the systemd units had to be changed to
make it work on 21.05.

systemd also complained about the missing jibri user. Adding
the jibri user and using DynamicUser where possible helped.

 #PL-130037

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Jitsi: fix Jibri recordings (#PL-130037).

## Security implications

Had to relax security restrictions for the Jibri services. The settings aren't perfect and could be more restrictive,  but the service isn't that critical and we have other services that are more important to secure.

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - services should have limited privileges
- [x] Security requirements tested? (EVIDENCE)
  - checked if security scores are ok for Jibri services and that recordings work
