### PR TITLE
nixos-rebuild: restore the result link for build-only actions

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "a8220648a012955b111d25091764f4c19ae9a898",
-    "sha256": "0a9x02nihlwlfigl4b4128zcda39das082r793ci4gk11bj6vc6a"
+    "rev": "0afb909d2d0ccf359a5f469d485f184b447c93fc",
+    "sha256": "1iv2mf4prs9l8fz9bm4b6pjfhz78niivrgmbcssvp0ivb1i54v5f"
   },
   "nixpkgs_18_03": {
     "owner": "nixos",


### PR DESCRIPTION
Update nixpkgs to restore the standard behaviour from upstream.
We don't actually need this in production but the change introduced
by the last commit broke the haproxy test which uses nixos-rebuild
build to get a result link for the new system.

 #PL-130040

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE) 
  - tests should work  
  - use upstream NixOS behaviour as much as possible
- [x] Security requirements tested? (EVIDENCE)
  - checked on test VM that output link is created by nixos-rebuild build
  - automated haproxy test which builds the system works
