### PR TITLE
hardware/md: silence unused broken mdmonitor, fix check_md_raid

### DIFF
--- a/nixos/services/raid/default.nix
+++ b/nixos/services/raid/default.nix
@@ -14,6 +14,10 @@
 
     # Software RAID
 
+    # Silence unused but broken-by-default mdmonitor
+    # https://github.com/NixOS/nixpkgs/issues/72394
+    systemd.services.mdmonitor.enable = false;
+
     flyingcircus.services.sensu-client.checks.raid_md = {
       notification = "RAID (md) status";
       command = "${pkgs.check_md_raid}/bin/check_md_raid";

--- a/pkgs/check_md_raid/check_md_raid.sh
+++ b/pkgs/check_md_raid/check_md_raid.sh
@@ -1,17 +1,19 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Created by Sebastian Grewe, Jammicron Technology
 #
 
+set -e
+
 # Get count of raid arrays
-RAID_DEVICES=`grep ^md -c /proc/mdstat`
+RAID_DEVICES=`grep ^md -c /proc/mdstat || true`
 
 # Get count of degraded arrays
-RAID_STATUS=`grep "\[.*_.*\]" /proc/mdstat -c`
+RAID_STATUS=`grep "\[.*_.*\]" /proc/mdstat -c || true`
 
 # Is an array currently recovering, get percentage of recovery
-RAID_RECOVER=`grep recovery /proc/mdstat | awk '{print $4}'`
-RAID_RESYNC=`grep resync /proc/mdstat | awk '{print $4}'`
+RAID_RECOVER=`grep recovery /proc/mdstat | awk '{print $4}' || true`
+RAID_RESYNC=`grep resync /proc/mdstat | awk '{print $4}' || true`
 
 # Check raid status
 # RAID recovers --> Warning

--- a/pkgs/check_md_raid/default.nix
+++ b/pkgs/check_md_raid/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, gawk, bash }:
+{ lib, stdenv, gawk, gnugrep, makeWrapper, bash }:
 
 
 stdenv.mkDerivation rec {
@@ -11,11 +11,14 @@ stdenv.mkDerivation rec {
   dontConfigure = true;
 
   propagatedBuildInputs = [ bash gawk ];
+  nativeBuildInputs = [ makeWrapper ];
 
   installPhase = ''
     mkdir -p $out/bin
     cp ${src} $out/bin/check_md_raid
     chmod +x $out/bin/check_md_raid
+    wrapProgram $out/bin/check_md_raid \
+      --set PATH "${lib.makeBinPath [ gnugrep bash gawk ]}"
   '';
 
   meta = with lib; {


### PR DESCRIPTION
Fixes PL-129830 barbrady04: mdmonitor.services fails

@flyingcircusio/release-managers

## Release process

Impact:

-

Changelog:

-

## Security implications

- [X] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

noise causes alert fatigue

- [X] Security requirements tested? (EVIDENCE)

manually tested on patty

