### PR TITLE
Update nixpkgs

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "NixOS",
     "repo": "nixpkgs",
-    "rev": "97c5d0cbe76901da0135b05cdbdfc5b068a7942c",
-    "sha256": "05zisan8s08r45jbn9xc3dysnsdh639qn7jhczsd71mjfg85n13v"
+    "rev": "74d017edb6717ad76d38edc02ad3210d4ad66b96",
+    "sha256": "0wvz41izp4djzzr0a6x54hcm3xjr51nlj8vqghfgyrjpk8plyk4s"
   },
   "nixos-mailserver": {
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/",


### PR DESCRIPTION
Notable security updates and version changes:

* ffmpeg: patch CVE-2021-33815 and CVE-2021-38114
* haproxy: 2.3.10 -> 2.3.13
* linux: 5.10.57 -> 5.10.60
* matrix-synapse: 1.39.0 -> 1.41.0

 #PL-130071

@flyingcircusio/release-managers

## Release process

* [NixOS 21.05] VMs will schedule a reboot to activate the new kernel version.

Changelog: (include changes from commit msg here)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - pull in upstream security fixes regularly
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still run, works on test VM
  - checked commit log for fixed CVEs and possible problems with updates