### PR TITLE
fix: listenAddress(6) in json config has been using frontend addr not any previously

### DIFF
--- a/nixos/services/nginx/default.nix
+++ b/nixos/services/nginx/default.nix
@@ -54,8 +54,7 @@ let
   package = config.services.nginx.package;
   localCfgDir = config.flyingcircus.localConfigPath + "/nginx";
 
-  # only for JSON for backwards-compatibility reasons we set the default addrs to any, nix config uses frontend
-  vhostsJSON = mapAttrs (key: value: ({ listenAddress = "0.0.0.0"; listenAddress6 = "[::]"; } // value)) (fclib.jsonFromDir localCfgDir);
+  vhostsJSON = fclib.jsonFromDir localCfgDir;
 
   mkVanillaVhostFromFCVhost = name: vhost:
     (removeAttrs vhost [ "emailACME" "listenAddress" "listenAddress6" ]);


### PR DESCRIPTION


@flyingcircusio/release-managers

## Release process

Impact:

Changelog:
- listenAddress(6) in nginx json config has been using frontend addr not any previously

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - JSON-definied vhosts were not listening on frontend, instead on any, this is now fixed
- [x] Security requirements tested? (EVIDENCE)
  - tested on vm
