### PR TITLE
Mailserver: fix config.json.example when there's no primary domain yet

### DIFF
--- a/nixos/services/mail/default.nix
+++ b/nixos/services/mail/default.nix
@@ -16,11 +16,10 @@ let
   role = config.flyingcircus.roles.mailserver;
   svc = config.flyingcircus.services.mail;
   fclib = config.fclib;
+  primaryDomainCandidates = attrNames (filterAttrs (domain: config: config.enable && config.primary) role.domains);
   primaryDomain =
-    let firstPrimary =
-      head (attrNames (filterAttrs (domain: config: config.enable && config.primary) role.domains));
-    in
-    if firstPrimary != null then firstPrimary
+    if primaryDomainCandidates != []
+    then head primaryDomainCandidates
     else "example.org";
   domains = (attrNames (filterAttrs (domain: config: config.enable) role.domains));
   vmailDir = "/srv/mail";
@@ -56,7 +55,7 @@ in {
     (lib.mkIf (domains != []) {
       assertions = [
         {
-          assertion = builtins.length (attrNames (filterAttrs (domain: config: config.enable && config.primary) role.domains)) == 1;
+          assertion = builtins.length primaryDomainCandidates == 1;
           message = ''
             It is required that there is exactly one primary domain.
             Set flyingcircus.roles.mail.domains."domain".primary = true; for exactly one domain.


### PR DESCRIPTION
Bootstrapping the mailserver role didn't work. Fixed the default value
for the primary domain if there's no config, yet.

 #PL-130086

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Mailserver: fix building the example config if there's no config file, yet (#PL-130086).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - build shouldn't break when there's no config yet 
- [x] Security requirements tested? (EVIDENCE)
  - manually checkd on test VM for cases with zero, one or two primary domain, automated test still works 
