### PR TITLE
fc-agent, garbage-collect: limit IO and CPU usage via unit settings

### DIFF
--- a/nixos/infrastructure/flyingcircus-virtual.nix
+++ b/nixos/infrastructure/flyingcircus-virtual.nix
@@ -7,9 +7,10 @@ let
   ioScheduler =  if (cfg.infrastructure.preferNoneSchedulerOnSsd && (cfg.enc.parameters.rbd_pool == "rbd.ssd"))
                  then "none"
                  else "bfq";
+  maxIops = attrByPath [ "parameters" "iops" ] 250 cfg.enc;
 in
 mkIf (cfg.infrastructureModule == "flyingcircus") {
- 
+
   boot = {
     initrd.kernelModules = [
       "virtio_blk"
@@ -77,10 +78,34 @@ mkIf (cfg.infrastructureModule == "flyingcircus") {
       };
     };
 
-    services.serial-console-liveness = {
-      description = "Serial console liveness marker";
-      serviceConfig.Type = "oneshot";
-      script = "echo \"$(date) -- SERIAL CONSOLE IS LIVE --\" > /dev/ttyS0";
+    services = {
+      serial-console-liveness = {
+        description = "Serial console liveness marker";
+        serviceConfig.Type = "oneshot";
+        script = "echo \"$(date) -- SERIAL CONSOLE IS LIVE --\" > /dev/ttyS0";
+      };
+
+      fc-agent.serviceConfig =
+        let
+          # Must not consume more than 75% of available IOPS.
+          # The systemd setting is split between read and write but
+          # we only have one IOPS limit for the VM so combined we
+          # could get requests that are over the VM limit.
+          vdaIopsMax = "/dev/vda ${toString (maxIops - maxIops / 4)}";
+        in {
+          IOReadIOPSMax = vdaIopsMax;
+          IOWriteIOPSMax = vdaIopsMax;
+        };
+
+      fc-collect-garbage.serviceConfig =
+        let
+          # Must not consume more than 12.5% of available IOPS.
+          # We don't have a problem with this taking really long.
+          vdaIopsMax = "/dev/vda ${toString (maxIops / 8)}";
+        in {
+          IOReadIOPSMax = vdaIopsMax;
+          IOWriteIOPSMax = vdaIopsMax;
+        };
     };
   };
 

--- a/nixos/platform/agent.nix
+++ b/nixos/platform/agent.nix
@@ -102,6 +102,10 @@ in {
           KillMode = "none";
           # TimeoutSec won't work because of KillMode. The script uses 'timeout'
           # instead.
+          Nice = 18; # 19 is the lowest
+          IOSchedulingClass = "idle";
+          IOSchedulingPriority = 7; #lowest
+          IOWeight = 10; # 1-10000
         };
 
         path = with pkgs; [
@@ -127,7 +131,7 @@ in {
             verbose = lib.optionalString cfg.agent.verbose "-v";
           in ''
             rc=0
-            timeout 14400 ionice -c3 \
+            timeout 14400 \
               fc-manage -E ${cfg.encPath} -i ${interval} \
               ${lazy} ${verbose} ${cfg.agent.steps} || rc=$?
             timeout 900 fc-resize -E ${cfg.encPath} || rc=$?

--- a/nixos/platform/garbagecollect/default.nix
+++ b/nixos/platform/garbagecollect/default.nix
@@ -25,7 +25,7 @@ let
                 continue
             print(f'Scanning {user.pw_dir} as {user.pw_name}')
             p = subprocess.Popen([
-                    "ionice", "-c3", "fc-userscan", "-r", "-c",
+                    "fc-userscan", "-r", "-c",
                     user.pw_dir + "/.cache/fc-userscan.cache", "-L10000000",
                     "--unzip=*.egg", "-E", EXCLUDE, user.pw_dir],
                 stdin=subprocess.DEVNULL,
@@ -42,8 +42,8 @@ let
             sys.exit(1)
         print('Running nix-collect-garbage')
         rc = subprocess.run([
-                "ionice", "-c3", "nix-collect-garbage",
-                "--delete-older-than", "3d", "--max-freed", "250M"],
+                "nix-collect-garbage",
+                "--delete-older-than", "3d"],
             check=True, stdin=subprocess.DEVNULL).returncode
         print('nix-collect-garbage status:', rc)
         open('${log}', 'w').write(str(datetime.datetime.now()) + '\n')
@@ -83,7 +83,18 @@ in {
       systemd.services.fc-collect-garbage = {
         description = "Scan users for Nix store references and collect garbage";
         restartIfChanged = false;
-        serviceConfig.Type = "oneshot";
+        serviceConfig = {
+          Type = "oneshot";
+          # Use the lowest priority settings we can findto make sure that GC
+          # gives way to nearly everything else.
+          CPUSchedulingPolicy= "idle";
+          CPUWeight = 1;
+          IOSchedulingClass = "idle";
+          IOSchedulingPriority = 7;
+          IOWeight = 1;
+          Nice = 19;
+          TimeoutStartSec = "infinity";
+        };
         path = with pkgs; [ fc.userscan nix glibc utillinux ];
         environment = { LANG = "en_US.utf8"; };
         script = "${pkgs.python3.interpreter} ${garbagecollect}";


### PR DESCRIPTION
We experienced some load alerts for short peaks caused by garbage
collection or the agent. This is often caused by iowait and it seems like
that VMs that are mostly idle are affected more than others.

Restrict the number of IOPS on cgroup level depending on the limit for the
VM to avoid requesting much more IOPS for maintenance tasks than the VM can deliver.
The agent gets more because it shouldn't take forever. For the garbage
collection, there's a more restrictive setting because time doesn't
matter here and the timeout is set to infinity now.

We also set other IO and CPU-related unit settings to make sure that regular user
processes have higher priority than our maintenance.

Drop the limitation on how much fc-collect-garbage can collect in one
run because the other limits should prevent problems.

 #PL-130083

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* fc-agent and fc-garbage-collect: apply CPU/IO limitations and low priority settings via SystemD units to avoid load peaks and resulting alerts. This is often caused by iowait on HDD VMs. We tried to limit the impact before by using ionice and by limiting the amount of collected garbage but we still had problems on mostly idle machines or when agent and garbage collection ran at the same time (#PL-130083).  

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - avoid alarm noise
  - prioritize regular user processes over maintenance tasks 
- [x] Security requirements tested? (EVIDENCE)
  - manually checked that the settings are generated and effective on a test VM
  - (doesn't apply to automated tests)

