### PR TITLE
Journalbeat: add fields option, add ENC data for VMs

### DIFF
--- a/nixos/infrastructure/flyingcircus-virtual.nix
+++ b/nixos/infrastructure/flyingcircus-virtual.nix
@@ -33,6 +33,23 @@ mkIf (cfg.infrastructureModule == "flyingcircus") {
     };
   };
 
+  flyingcircus.journalbeat.fields =
+    let encParams = [
+        "kvm_host"
+        "rbd_pool"
+        "environment"
+        "production"
+      ];
+    in
+    lib.optionalAttrs
+      (cfg.enc ? "parameters")
+      (lib.filterAttrs
+        (n: v: v != null)
+        (lib.listToAttrs
+          (map
+            (name: lib.nameValuePair name (cfg.enc.parameters."${name}" or null))
+            encParams)));
+
   fileSystems = {
     "/" = {
       device = "/dev/disk/by-label/root";

--- a/nixos/platform/journalbeat.nix
+++ b/nixos/platform/journalbeat.nix
@@ -101,6 +101,15 @@ in
 {
   options.flyingcircus.journalbeat = with lib; {
 
+    fields = mkOption {
+      type = types.attrs;
+      default = {};
+      description = ''
+        Additional fields that are added to each log message.
+        They appear as field_<name> in the log message.
+      '';
+     };
+
     logTargets = mkOption {
       type = with types; attrsOf (submodule {
         options = {
@@ -140,7 +149,13 @@ in
       (lib.mapAttrs'
         (name: v: lib.nameValuePair
           "journalbeat-${name}"
-          (mkJournalbeatService { inherit name; inherit (v) host port extraSettings; }))
+          (mkJournalbeatService {
+            inherit name;
+            inherit (v) host port;
+            extraSettings =
+              (lib.recursiveUpdate
+                { inherit (cfg) fields; }
+                v.extraSettings); }))
         cfg.logTargets);
   };
 }


### PR DESCRIPTION
flyingcircus.journalbeat.fields can be used to add additional data
to all log messages with the prefix field_.

On VMs, this is used to add ENC data (environment, rbd_pool, kvm_host,
production).

 #PL-130085

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Journalbeat: add option `flyingcircus.journalbeat.fields`. This is used by default to add VM metadata to log messages that are sent out to loghosts/Graylog (#PL-130085).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - add helpful metadata to log messages but don't disclose secrets 
- [x] Security requirements tested? (EVIDENCE)
  - manually checked on test VM, selected metadata (rbd_pool, kvm_host, environment, production) doesn't contain  secrets. Except kvm_host, all can be seen in the customer UI.