### PR TITLE
raid: disable check for other error count

### DIFF
--- a/nixos/services/raid/default.nix
+++ b/nixos/services/raid/default.nix
@@ -45,7 +45,7 @@
 
     flyingcircus.services.sensu-client.checks.megaraid = {
       notification = "RAID (MegaRAID) status";
-      command = "sudo ${pkgs.check_megaraid}/bin/check_megaraid";
+      command = "sudo ${pkgs.check_megaraid}/bin/check_megaraid --disable-other-error-count";
     };
 
     flyingcircus.services.sensu-client.checks.megaraid_cache = {


### PR DESCRIPTION
The check triggers at "1 other error count" which is way too tight.
We have enough redundancy concepts to wait for actual problems and
Thomas Krenn used to say "we change disks at 50 errors and up".

The script is too hard to refactor for the 50 errors rule, so we
just use the existing toggle to disable the "other error" count.

Fixes PL-130057

@flyingcircusio/release-managers

## Release process

Impact:

none

Changelog:

- Ignore "other error" count on drives controlled by MegaRAID controllers to reduce monitoring noise. (PL-130057)

## Security implications

- [X] [Security requirements] (https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

Improve monitoring to avoid fatigue and ignore non-critical issues that are covered by other techniques.

- [X] Security requirements tested? (EVIDENCE)

Manual test on bob.

