### PR TITLE
Journalbeat: add VM resources info from ENC as fields

### DIFF
--- a/nixos/infrastructure/flyingcircus-virtual.nix
+++ b/nixos/infrastructure/flyingcircus-virtual.nix
@@ -36,10 +36,14 @@ mkIf (cfg.infrastructureModule == "flyingcircus") {
 
   flyingcircus.journalbeat.fields =
     let encParams = [
-        "kvm_host"
-        "rbd_pool"
+        "cores"
+        "disk"
         "environment"
+        "iops"
+        "kvm_host"
+        "memory"
         "production"
+        "rbd_pool"
       ];
     in
     lib.optionalAttrs


### PR DESCRIPTION
iops, memory, disk and cores

 #PL-130097

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Jornalbeat: add VM resources info (cores, disk, iops, memory) to log messages (#PL-130097). 

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - add helpful metadata to log messages but don't disclose secrets 
- [x] Security requirements tested? (EVIDENCE)
  - manually checked on test VM, selected metadata (iops, memory, disk, cores) doesn't contain secrets. Except iops, all can be seen in the customer UI.