### PR TITLE
Use OpenSSH 8.7 for ssh/sshd

### DIFF
--- a/nixos/platform/default.nix
+++ b/nixos/platform/default.nix
@@ -231,6 +231,8 @@ in {
       agent.collect-garbage = true;
     };
 
+    programs.ssh.package = pkgs.openssh_8_7;
+
     # implementation for flyingcircus.passwordlessSudoRules
     security.sudo.extraRules = let
       nopasswd = [ "NOPASSWD" ];

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -226,6 +226,17 @@ in {
     ];
   });
 
+  openssh_8_7 = super.openssh.overrideAttrs(_: rec {
+    version = "8.7p1";
+    name = "openssh-${version}";
+
+    src = super.fetchurl {
+      url = "mirror://openbsd/OpenSSH/portable/openssh-${version}.tar.gz";
+      sha256 = "090yxpi03pxxzb4ppx8g8hdpw7c4nf8p0avr6c7ybsaana5lp8vw";
+    };
+
+  });
+
   percona = self.percona80;
   percona-toolkit = super.perlPackages.PerconaToolkit.overrideAttrs(oldAttrs: {
     # The script uses usr/bin/env perl and the Perl builder adds PERL5LIB to it.


### PR DESCRIPTION
Use the newest openssh version to fix frequent sshd subprocess crashes
which are caused by failing malicious connection attempts.

sshd tries to log something after a timeout but is killed
because syscall 31 is blocked by seccomp.

This doesn't override the openssh package globally because this
would cause a big rebuild. We just use it for ssh and sshd by
setting programs.ssh.package.

 #PL-130095

@flyingcircusio/release-managers

## Release process

Impact:

* [NixOS 21.05] sshd will be restarted.

Changelog:

* Use OpenSSH 8.7 for ssh/sshd. This fixes frequent sshd crashes caused by malicious connection attempts that fail. This update has potentially imcompatible changes that won't affect common use of ssh. See https://www.openssh.com/releasenotes.html for details (#PL-130095).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - reduce log noise that could distract from real security issues with ssh 
  - use a current openssh version 
- [x] Security requirements tested? (EVIDENCE)
  - 8.7p1 is the newest openssh version
  - checked openssh release notes
  - checked manually with a test VM that ssh login still works, automated tests still run 
