### PR TITLE
haproxy: 2.3.13 -> 2.3.14

### DIFF
--- a/doc/src/webgateway.rst
+++ b/doc/src/webgateway.rst
@@ -10,8 +10,8 @@ failover support.
 Versions
 --------
 
-* HAProxy: 2.3.10
-* Nginx: 1.18.0
+* HAProxy: 2.3.14
+* Nginx: 1.20.1
 
 Role architecture
 -----------------

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -90,6 +90,14 @@ in {
   jitsi-meet = super.callPackage ./jitsi-meet { };
   jitsi-videobridge = super.callPackage ./jitsi-videobridge { jre_headless = super.jre8_headless; };
 
+  haproxy = super.haproxy.overrideAttrs(orig: rec {
+    version = "2.3.14";
+    src = super.fetchurl {
+      url = "https://www.haproxy.org/download/${lib.versions.majorMinor version}/src/${orig.pname}-${version}.tar.gz";
+      sha256 = "0ah6xsxlk1a7jsxdg0pbdhzhssz9ysrfxd3bs5hm1shql1jmqzh4";
+    };
+  });
+
   kibana7 = super.kibana7.overrideAttrs(_: rec {
     version = elk7Version;
     name = "kibana-${version}";


### PR DESCRIPTION
Also update version numbers for webgateway docs.

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* webgateway: update haproxy to 2.3.14 for a critical security fix (CVE-2021-40346) (#PL-130098).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - use current haproxy version to fix security issues 
- [x] Security requirements tested? (EVIDENCE)
  - manually checked on VM that haproxy works, automated test still runs
