### PR TITLE
[20.09] haproxy: 2.2.2 -> 2.2.17

### DIFF
--- a/doc/src/webgateway.rst
+++ b/doc/src/webgateway.rst
@@ -10,7 +10,7 @@ failover support.
 Versions
 --------
 
-* HAProxy: 2.2.2
+* HAProxy: 2.2.17
 * Nginx: 1.18.0
 
 Role architecture

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -71,6 +71,14 @@ in {
   jitsi-meet = super.callPackage ./jitsi-meet { };
   jitsi-videobridge = super.callPackage ./jitsi-videobridge { };
 
+  haproxy = super.haproxy.overrideAttrs(orig: rec {
+    version = "2.2.17";
+    src = super.fetchurl {
+      url = "https://www.haproxy.org/download/${lib.versions.majorMinor version}/src/${orig.pname}-${version}.tar.gz";
+      sha256 = "1q2vv0hcqqj8b1cr15w5l7vsq1ifzdbyvl3np4lrz73xh2ilmbv8";
+    };
+  });
+
   kibana7 = super.kibana7.overrideAttrs(_: rec {
     version = elk7Version;
     name = "kibana-${version}";


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* webgateway: update haproxy to 2.2.17 for a critical security fix (CVE-2021-40346) (#PL-130098).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - use current haproxy version to fix security issues 
- [x] Security requirements tested? (EVIDENCE)
  - manually checked on VM that haproxy works, automated test still runs