### PR TITLE
nixpkgs: security update from upstream 21.09 fixes #142516

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "NixOS",
     "repo": "nixpkgs",
-    "rev": "74d017edb6717ad76d38edc02ad3210d4ad66b96",
-    "sha256": "0wvz41izp4djzzr0a6x54hcm3xjr51nlj8vqghfgyrjpk8plyk4s"
+    "rev": "8b0b81dab17753ab344a44c04be90a61dc55badf",
+    "sha256": "0rj17jpjxjcibcd4qygpxbq79m4px6b35nqq9353pns8w7a984xx"
   },
   "nixos-mailserver": {
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/",


### PR DESCRIPTION
@flyingcircusio/release-managers

Notable security updates and version changes:

python: 3.8.9 -> 3.8.11, 3.6.13 -> 3.6.14, 3.7.10 -> 3.7.11, 3.9.4 -> 3.9.6
glibc: 2.32-48 2.32-54
nss: 3.68 -> 3.70
openssl: 1.1.1k -> 1.1.1l
nodejs: 12.22.4 -> 12.22.6, 14.17.4 -> 14.17.6, 16.4.1 -> 16.8.0
linux: 5.10.60 -> 5.10.62

## Release process

Impact:

* [NixOS 21.05] VMs will schedule a reboot to activate the new kernel version.

Changelog:


## Security implications

- [X] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

regular updates

- [X] Security requirements tested? (EVIDENCE)

reviewed the nixpkgs update commit by scanning it visually

