### PR TITLE
mysql: xtrabackup improvments

### DIFF
--- a/doc/src/mysql.rst
+++ b/doc/src/mysql.rst
@@ -24,4 +24,8 @@ MySQL works out-of-the box without configuration.
 Interaction
 --------
 
+Service users can use :command:`sudo -u mysql -i` to access the
+MySQL super user account to perform administrative commands
+and access logfiles such as the slowlog.
+
 For backup tasks the `xtrabackup` command is provided, along with sudo access for it

--- a/doc/src/mysql.rst
+++ b/doc/src/mysql.rst
@@ -1,0 +1,27 @@
+.. _nixos-mysql:
+
+MySQL
+======
+
+Managed instance of the `MySQL`_ database server.
+
+There's a role for each supported major version, currently:
+
+* mysql56: Percona 5.6.
+* mysql57: Percona 5.7.
+* mysql80: Percona 8.0.
+
+Percona is used instead of the more common MariaDB implementation.
+
+This implementation is feature-compatible with regular Oracle/MariaDB installations
+and provides useful improvments over the Oracle/MariaDB implementations.
+
+Configuration
+-------------
+
+MySQL works out-of-the box without configuration.
+
+Interaction
+--------
+
+For backup tasks the `xtrabackup` command is provided, along with sudo access for it

--- a/nixos/roles/mysql.nix
+++ b/nixos/roles/mysql.nix
@@ -102,6 +102,20 @@ with builtins;
         }
       ];
 
+    users.users.mysql = {
+      shell = "/run/current-system/sw/bin/bash";
+      home = lib.mkForce "/srv/mysql";
+    };
+
+    flyingcircus.passwordlessSudoRules = [
+      # Service users may switch to the mysql system user
+      {
+        commands = [ "ALL" ];
+        groups = [ "sudo-srv" "service" ];
+        runAs = "mysql";
+      }
+    ];
+
     services.percona = {
       enable = true;
       inherit package rootPasswordFile;

--- a/nixos/roles/mysql.nix
+++ b/nixos/roles/mysql.nix
@@ -49,6 +49,12 @@ with builtins;
       "8.0" = percona80;
     };
 
+    xtrabackupPackages = with pkgs; {
+      "5.6" = percona-xtrabackup_2_4;
+      "5.7" = percona-xtrabackup_2_4;
+      "8.0" = percona-xtrabackup_8_0;
+    };
+
     cfg = config.flyingcircus.roles.mysql;
     fclib = config.fclib;
 
@@ -58,7 +64,7 @@ with builtins;
     listenAddresses =
       fclib.network.lo.dualstack.addresses ++
       fclib.network.srv.dualstack.addresses;
-    
+
     localConfigPath = /etc/local/mysql;
 
     rootPasswordFile = "${toString localConfigPath}/mysql.passwd";
@@ -74,6 +80,7 @@ with builtins;
     enabledRolesCount = length (lib.attrNames enabledRoles);
     version = head (lib.attrNames enabledRoles);
     package = mysqlPackages.${version} or null;
+    xtraPackage = xtrabackupPackages.${version};
 
     telegrafPassword = fclib.derivePasswordForHost "mysql-telegraf";
     sensuPassword = fclib.derivePasswordForHost "mysql-sensu";
@@ -290,9 +297,13 @@ with builtins;
       SUBSYSTEM=="block", ACTION=="add|change", KERNEL=="vd[a-z]", ATTR{bdi/read_ahead_kb}="1024", ATTR{queue/read_ahead_kb}="1024"
     '';
 
+    security.sudo.extraRules = [
+      { groups = ["service"]; commands = [ { command = "${xtraPackage}/bin/xtrabackup"; options = [ "NOPASSWD" ]; } ]; }
+    ];
+
     environment.systemPackages = with pkgs; [
       innotop
-      xtrabackup
+      xtraPackage
     ];
 
     flyingcircus.services = {

--- a/tests/mysql.nix
+++ b/tests/mysql.nix
@@ -121,6 +121,9 @@ in
         master.succeed("echo tt > /etc/local/mysql/mysql.passwd")
         master.succeed("systemctl restart mysql")
         master.wait_until_succeeds("mysql mysql -u root -ptt -e 'select 1'")
+
+    with subtest("xtrabackup works"): # sensuclient has service group
+        master.succeed("sudo -u sensuclient sudo xtrabackup --backup")
   '';
 
 })


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

Changelog:
- make right xtrabackup version available
- make sudo xtrabackup work properly

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
 - xtrabackup is granted sudo, as discussed in https://yt.flyingcircus.io/issue/PL-129826
- [x] Security requirements tested? (EVIDENCE)
  - testvm

