### PR TITLE
testlib: network & config template, test keys

### DIFF
--- a/nixos/infrastructure/testing.nix
+++ b/nixos/infrastructure/testing.nix
@@ -18,11 +18,19 @@
     services.openssh.enable = lib.mkOverride 60 false;
     # build-vms.nix from NixOS automatically generates numbered interface
     # configs with default IPs. We rename the devices to fe and srv early so
-    # the services wait for eth1 and eth2 for 5 minutes and time out.
+    # the services wait for the interfaces for 5 minutes and time out.
     # This is annoying when other services depend on network.target.
     systemd.services = lib.mkIf (config.flyingcircus.enc.parameters ? interfaces) {
+      network-addresses-eth0 = lib.mkForce {};
       network-addresses-eth1 = lib.mkForce {};
       network-addresses-eth2 = lib.mkForce {};
+      network-addresses-eth3 = lib.mkForce {};
+      network-addresses-eth4 = lib.mkForce {};
+      network-addresses-eth5 = lib.mkForce {};
+      network-addresses-eth6 = lib.mkForce {};
+      network-addresses-eth7 = lib.mkForce {};
+      network-addresses-eth8 = lib.mkForce {};
+      network-addresses-eth9 = lib.mkForce {};
     };
   };
 }

--- a/tests/elasticsearch.nix
+++ b/tests/elasticsearch.nix
@@ -1,7 +1,7 @@
 import ./make-test-python.nix ({ version ? "7", pkgs, testlib, ... }:
 let
-  ipv4 = "192.168.1.1";
-  ipv6 = "2001:db8:1::1";
+  ipv4 = testlib.fcIP.noquote.srv4 1;
+  ipv6 = testlib.fcIP.noquote.srv6 1;
 in
 {
   name = "elasticsearch";
@@ -9,21 +9,9 @@ in
   machine =
     { pkgs, config, ... }:
     {
-
-      imports = [ ../nixos ../nixos/roles ];
-
-      flyingcircus.enc.parameters = {
-        resource_group = "test";
-        interfaces.srv = {
-          mac = "52:54:00:12:34:56";
-          bridged = false;
-          networks = {
-            "2001:db8:1::/64" = [ ipv6 ];
-            "192.168.1.0/24" = [ ipv4 ];
-          };
-          gateways = {};
-        };
-      };
+      imports = [
+        (testlib.fcConfig { })
+      ];
 
       networking.domain = "test";
       networking.extraHosts = ''

--- a/tests/testlib.nix
+++ b/tests/testlib.nix
@@ -1,5 +1,26 @@
 { lib }:
-{
+
+with lib;
+
+rec {
+  static = import ../nixos/platform/static.nix { inherit lib; };
+  vlans = static.config.flyingcircus.static.vlanIds;
+
+  testkey = {
+    priv = ''
+      -----BEGIN OPENSSH PRIVATE KEY-----
+      b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+      QyNTUxOQAAACDEL3cs6kZncaVSHZ+DvTMkiohC3j7MP3ad7Jh40Js6twAAAJjFq84bxavO
+      GwAAAAtzc2gtZWQyNTUxOQAAACDEL3cs6kZncaVSHZ+DvTMkiohC3j7MP3ad7Jh40Js6tw
+      AAAEDbcHXRiL0+aMh1TaEhnXKqjVpOru/jyfW1Zb6ENAGOcsQvdyzqRmdxpVIdn4O9MySK
+      iELePsw/dp3smHjQmzq3AAAAEG1hY2llakBta2ctcmF6ZXIBAgMEBQ==
+      -----END OPENSSH PRIVATE KEY-----
+    '';
+    pub = ''
+      ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMQvdyzqRmdxpVIdn4O9MySKiELePsw/dp3smHjQmzq3 testkey@localhost
+    '';
+  };
+
   derivePasswordForHost = prefix:
     builtins.hashString "sha256" (lib.concatStringsSep "/" [
       prefix
@@ -14,4 +35,88 @@
         ["\\" "\n"]
         ["" " "]
         machine.config.flyingcircus.services.sensu-client.checks.${checkName}.command;
+
+  /*
+    Get a basic configuration for a virtual machine
+
+    Parameters:
+      id = Order of server in the list of servers when alphabetically ordered, starting from 1.
+        With the following servers the following ids would be assigned respectively: annetta=1, berta=2, claus=3
+        (You can also look at the suffix of eth1 MAC using server.execute("ip a >&2") to get the ID)
+      net.sto/stb/fe = Boolean flag to enable/disable this particular interface. Default fe/srv=true, rest false
+      resource_group/location = String flag to set resource_group/location
+      secrets = Attrset flag to set extra secrets
+
+    Example usage:
+      {
+        imports = [
+          (testlib.fcConfig {
+            id = 1;
+            net.fe = false; net.stb = true;
+            secrets."test" = "test";
+          })
+        ]
+      }
+
+  */
+
+  fcConfig = {
+    id ? 1,
+    net ? {},
+    resource_group ? "test", location ? "test", secrets ? {},
+  }: { config, ... }:
+  {
+    imports = [
+      ../nixos
+      ../nixos/roles
+    ];
+
+    config = {
+      virtualisation.vlans = map (vlan: vlans.${vlan}) (attrNames config.flyingcircus.enc.parameters.interfaces);
+
+      flyingcircus.enc.parameters = {
+        inherit resource_group location secrets;
+
+        interfaces = mapAttrs (name: vid: {
+          mac = "52:54:00:12:0${toString vid}:0${toString id}";
+          bridged = false;
+          networks = {
+            "192.168.${toString vid}.0/24" = [ "192.168.${toString vid}.${toString id}" ];
+            "2001:db8:${toString vid}::/64" = [ "2001:db8:${toString vid}::${toString id}" ];
+          };
+          gateways = {};
+        })
+          (filterAttrs (name: vid: (!(net ? ${name}) && (name == "srv" || name == "fe")) || net ? ${name} && net.${name}) vlans);
+      };
+    };
+  };
+
+  fcIPMap = listToAttrs (concatLists (mapAttrsToList (name: vid: [
+    (nameValuePair "${name}4" {
+      quote = false;
+      prefix = "192.168.${toString vid}.";
+    })
+    (nameValuePair "${name}6" {
+      quote = false;
+      prefix = "2001:db8:${toString vid}::";
+    })
+  ]) vlans));
+
+  /*
+    Get IP from server id
+    Examples:
+      fcIP.srv6 1 -> "[2001:db8:3::1]"
+      fcIP.noquote.srv6 -> "2001:db8:3::1"
+  */
+  fcIP =
+    (mapAttrs (type: typeconf: (
+      id:
+        if typeconf.quote then "[${typeconf.prefix}${toString id}]"
+        else "${typeconf.prefix}${toString id}"
+    )) fcIPMap) // {
+      noquote = mapAttrs (type: typeconf: (
+        id: "${typeconf.prefix}${toString id}"
+      )) fcIPMap;
+    };
+
 }


### PR DESCRIPTION

@flyingcircusio/release-managers

## Release process

Impact: none

Changelog:
- A SSH testkey is now provided as testkey.priv/pub
- Network configuration template is provided, documentation in 
testlib.nix


## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - only testing affected, no security req
- [x] Security requirements tested? (EVIDENCE)

