### PR TITLE
htop: don't show userland threads by default

### DIFF
--- a/pkgs/hide-userland.patch
+++ b/pkgs/hide-userland.patch
@@ -1,0 +1,24 @@
+From 27b970cd23610bfbdacb00873e15caa758052b09 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Maciej=20Kr=C3=BCger?= <mkg20001@gmail.com>
+Date: Thu, 15 Jul 2021 09:41:07 +0200
+Subject: [PATCH] Hide userland threads by default
+
+---
+ Settings.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/Settings.c b/Settings.c
+index ca8253e..a8cdfa7 100644
+--- a/Settings.c
++++ b/Settings.c
+@@ -461,6 +461,7 @@ Settings* Settings_new(unsigned int initialCpuCount) {
+    if (!ok) {
+       Settings_defaultMeters(this, initialCpuCount);
+       this->hideKernelThreads = true;
++      this->hideUserlandThreads = true;
+       this->highlightMegabytes = true;
+       this->highlightThreads = true;
+       this->findCommInCmdline = true;
+-- 
+2.32.0
+

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -112,6 +112,13 @@ in {
 
   kubernetes-dashboard = super.callPackage ./kubernetes-dashboard.nix { };
 
+  htop = super.htop.overrideAttrs(a: a // {
+    patches = [
+      # Hide userland process threads by default
+      ./hide-userland.patch
+    ];
+  });
+
   # Import old php versions from nix-phps
   # NOTE: php7.3 is already removed on unstable
   inherit (phps) php56;


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact: none

Changelog:
- make htop hide userland threads by default

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - not touching anything critical, no reqs
- [x] Security requirements tested? (EVIDENCE)

