### PR TITLE
networking: add wireguard into our base platform, generate one key pair

### DIFF
--- a/nixos/platform/network.nix
+++ b/nixos/platform/network.nix
@@ -113,6 +113,30 @@ in
       extraHosts = lib.optionalString
         (cfg.encAddresses != [])
         (hostsFromEncAddresses cfg.encAddresses);
+
+
+      wireguard.enable = true;
+
+    };
+
+    flyingcircus.activationScripts = {
+
+      prepare-wireguard-keys = ''
+        install -d -g root /var/lib/wireguard
+        umask 077
+        cd /var/lib/wireguard
+        if [ ! -e "privatekey" ]; then
+          ${pkgs.wireguard-tools}/bin/wg genkey > privatekey
+        fi
+        chmod u=rw,g-rwx,o-rwx privatekey
+        if [ ! -e "publickey" ]; then
+          ${pkgs.wireguard-tools}/bin/wg pubkey < privatekey > publickey
+        fi
+        chgrp service publickey
+        chmod u=rw,g=r,o-rwx publickey
+        ${pkgs.acl}/bin/setfacl -m g:sudo-srv:r publickey
+      '';
+
     };
 
     services.udev.extraRules = lib.concatMapStrings

--- a/nixos/platform/users.nix
+++ b/nixos/platform/users.nix
@@ -165,7 +165,45 @@ in
 
     flyingcircus.users = with lib; {
       userData = mkDefault (fclib.jsonFromFile cfg.userDataPath "[]");
-      permissions = mkDefault (fclib.jsonFromFile cfg.permissionsPath "[]");
+      # The way we handle permissions is not ideal. We allow defining them
+      # dynamically from the ENC but we really need and rely on them all
+      # over the place. Keeping this in sync with the tests is really hard
+      # so I took a snapshot of the current permissions (they change 
+      # very very rarely) and use it as adefault here.
+      permissions = mkDefault (fclib.jsonFromFile cfg.permissionsPath ''
+[
+ {
+  "description": "commit to VCS repository",
+  "id": 2029,
+  "name": "code"
+ },
+ {
+  "description": "perform interactive or web logins (e.g., ssh, monitoring)",
+  "id": 502,
+  "name": "login"
+ },
+ {
+  "description": "access web statistics",
+  "id": 2046,
+  "name": "stats"
+ },
+ {
+  "description": "sudo to service user",
+  "id": 2028,
+  "name": "sudo-srv"
+ },
+ {
+  "description": "sudo to root",
+  "id": 10,
+  "name": "wheel"
+ },
+ {
+  "description": "Manage users of RG",
+  "id": 2272,
+  "name": "manager"
+ }
+]
+'');
       adminsGroup = mkDefault (fclib.jsonFromFile cfg.adminsGroupPath "{}");
     };
 


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

none

Changelog:

* Provide a basic reusable wireguard installation and always generate one key pair with appropriate permissions.

## Security implications

- [X] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

Key data needs to be properly protected: private key for wireguard tunnels are only root-readable, public keys readable by service users (and sudo-srv)

- [X] Security requirements tested? (EVIDENCE)

Manually checked and wrote a hydra test.
