### PR TITLE
Update jitsi-videobridge, jicofo and jitsi-meet to latest stable

### DIFF
--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -87,9 +87,34 @@ in {
   innotop = super.callPackage ./percona/innotop.nix { };
 
   jibri = super.callPackage ./jibri { jre_headless = super.jre8_headless; };
-  jicofo = super.callPackage ./jicofo { jre_headless = super.jre8_headless; };
-  jitsi-meet = super.callPackage ./jitsi-meet { };
-  jitsi-videobridge = super.callPackage ./jitsi-videobridge { jre_headless = super.jre8_headless; };
+
+  jicofo = super.jicofo.overrideAttrs(oldAttrs: rec {
+    pname = "jicofo";
+    version = "1.0-798";
+    src = super.fetchurl {
+      url = "https://download.jitsi.org/stable/${pname}_${version}-1_all.deb";
+      sha256 = "55JagMfiBbBw0nqRxcMmfiwGF7B/1LA+pb5n6ZOZvag=";
+    };
+  });
+
+  jitsi-meet = super.jitsi-meet.overrideAttrs(oldAttrs: rec {
+    pname = "jitsi-meet";
+    version = "1.0.5307";
+    src = super.fetchurl {
+      url = "https://download.jitsi.org/jitsi-meet/src/jitsi-meet-${version}.tar.bz2";
+      sha256 = "epdVQnuL5dJ7DmoqyjfiLEfZxr4IQwkFEla/Y034sgg=";
+    };
+
+  });
+
+  jitsi-videobridge = super.jitsi-videobridge.overrideAttrs(oldAttrs: rec {
+    pname = "jitsi-videobridge2";
+    version = "2.1-551-g2ad6eb0b";
+    src = super.fetchurl {
+      url = "https://download.jitsi.org/stable/${pname}_${version}-1_all.deb";
+      sha256 = "XwVcjvBtJkZP46kGMnE4R1ax7Re725GMoV+pCnCNpak=";
+    };
+  });
 
   haproxy = super.haproxy.overrideAttrs(orig: rec {
     version = "2.3.14";


### PR DESCRIPTION
Upstream 21.05 has quite recent packages now so we just override
the versions with the latest stable versions which are already in
nixos-unstable.

 #PL-130110

@flyingcircusio/release-managers

## Release process

Impact:

* [NixOS 21.05] Jitsi will be restarted and unavailable for a short amount of time.

Changelog:

* Jitsi: update jitsi-videobridge, jicofo and jitsi-meet to latest stable versions (#PL-130110).

## Security implications

End-to-end encryption is working now with these versions, must be enabled explicitly.

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - use recent Jitsi package versions 
- [x] Security requirements tested? (EVIDENCE)
  - we have the latest stable version now
  - tested that Jitsi conferences, recording and authentication still work