### PR TITLE
Update nixpkgs

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "NixOS",
     "repo": "nixpkgs",
-    "rev": "8b0b81dab17753ab344a44c04be90a61dc55badf",
-    "sha256": "0rj17jpjxjcibcd4qygpxbq79m4px6b35nqq9353pns8w7a984xx"
+    "rev": "83413f47809790e4ca012e314e7782adeae36cf2",
+    "sha256": "0md5ynzxaw9gx81gh4d0120yjb0jrcydvxf0nsym402qfbhpchx0"
   },
   "nixos-mailserver": {
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/",


### PR DESCRIPTION
Notable security updates and version changes:

* apacheHttpd: 2.4.48 -> 2.4.49 (CVE-2021-33193, CVE-2021-34798,
  CVE-2021-36160, CVE-2021-39275, CVE-2021-40438)
* element-web: 1.8.2 -> 1.8.5
* github-runner: 2.279.0 -> 2.282.0
* go_1_16: 1.16.7 -> 1.16.8
* imagemagick: 7.1.0-5 -> 7.1.0-6
* linux: 5.10.62 -> 5.10.67
* matrix-synapse: 1.42.0 -> 1.43.0
* php74: 7.4.21 -> 7.4.23
* postgresql_10: 10.17 -> 10.18
* postgresql_11: 11.12 -> 11.13
* postgresql_12: 12.7 -> 12.8
* postgresql_13: 13.3 -> 13.4
* postgresql_9_6: 9.6.22 -> 9.6.23
* rPackages.RMySQL: fix package
* wget: 1.21.1 -> 1.21.2 (CVE-2021-31879)
* wireguard-tools: 1.0.20210424 -> 1.0.20210914

@flyingcircusio/release-managers

## Release process

Impact:

* [NixoS 21.05] Apache and postgresql will be restarted.

Changelog: (include changes from commit msg here)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - pull in upstream security fixes regularly
- [x] Security requirements tested? (EVIDENCE)
  - most automated test still run (some of them still running), works on test VM
  - checked commit log for fixed CVEs and possible problems with updates