### PR TITLE
Make option to change warning and critical threshhold for sensu disk usage check

### DIFF
--- a/nixos/services/sensu/client.nix
+++ b/nixos/services/sensu/client.nix
@@ -183,6 +183,22 @@ in {
           default = 6000;
         };
       };
+      expectedDiskCapacity = {
+        warning = mkOption {
+          type = types.int;
+          description = ''
+            Set the warning limit for disk capacity on this host.
+          '';
+          default = 90;
+        };
+        critical = mkOption {
+          type = types.int;
+          description = ''
+            Set the critical limit for disk capacity on this host.
+          '';
+          default = 95;
+        };
+      };
       expectedLoad = {
         warning = mkOption {
           type = types.str;
@@ -371,7 +387,9 @@ in {
         };
         disk = {
           notification = "Disk usage too high";
-          command = "${sudo} ${fc.sensuplugins}/bin/check_disk -v -w 90 -c 95";
+          command = "${sudo} ${fc.sensuplugins}/bin/check_disk -v " +
+                    "-w ${toString cfg.expectedDiskCapacity.warning} " +
+                    "-c ${toString cfg.expectedDiskCapacity.critical}";
           interval = 300;
         };
         writable = {


### PR DESCRIPTION
In some cases our set percentage of 95% and 90% for disk usage warning
and critical may be to high or to low.
An application may internally implement a diskusage check at lower than
90% and abort an action if that threshhold is passed. In that situation,
our monitoring does not warn us fast enought.
Otherwise a disk may have such high capacity that even at a usage
percentag of 90% there is nothing to worry about for quite a long time
and a warning then would be just noise.

Relates to FogBugz ticket [143476](https://fb.flyingcircus.io/f/cases/143476/).

@flyingcircusio/release-managers

## Release process

Impact: NONE

Changelog: NONE

## Security implications

- [X] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
    - We should be able to reduce noise in our monitoring.

- [X] Security requirements tested? (EVIDENCE)
    - All automated nixos tests where performed.
    - Changes where tested on vm and defaults and changes in the new implemented options work.

