### PR TITLE
Nginx: don't generate/remove dhparam file

### DIFF
--- a/doc/src/webgateway.rst
+++ b/doc/src/webgateway.rst
@@ -224,10 +224,11 @@ Overriding the key type can be done per certificate:
 Using two certificates to support both kinds of ciphers is possible with Nginx
 but needs manual configuration.
 
-For ciphers using DHE, an RSA certificate must be used and dhparams must be set:
+For ciphers using DHE, an RSA certificate must be used. *dhparams* must be generated and set:
 
 .. code-block:: nix
 
+    security.dhparams.params.nginx = {};
     services.nginx.sslDhparam = config.security.dhparams.params.nginx.path;
 
 This enables the following TLS 1.2 ciphers:
@@ -235,6 +236,8 @@ This enables the following TLS 1.2 ciphers:
 * TLS_DHE_RSA_WITH_AES_128_GCM_SHA256
 * TLS_DHE_RSA_WITH_AES_256_GCM_SHA384
 
+The DH param file is located at /var/lib/dhparams/nginx.pem.
+This path can be referenced from Nix code by `security.dhparams.params.nginx.path` as shown in the config example above.
 
 The `services.nginx.sslCiphers <https://search.nixos.org/options?channel=21.05&show=services.nginx.sslCiphers&from=0&size=50&sort=relevance&query=sslCiphers>`_
 option can be used to change the cipher list.

--- a/nixos/services/nginx/README.txt
+++ b/nixos/services/nginx/README.txt
@@ -146,15 +146,18 @@ security.acme.certs."test.fcio.net".keyType = "rsa2048";
 Using two certificates to support both kinds of ciphers is possible with Nginx
 but needs manual configuration.
 
-For ciphers using DHE, an RSA certificate must be used and dhparams must be set:
+For ciphers using DHE, an RSA certificate must be used. *dhparams* must be generated and set:
 
+security.dhparams.params.nginx = {};
 services.nginx.sslDhparam = config.security.dhparams.params.nginx.path;
 
 This enables the following TLS 1.2 ciphers:
 
-TLS_DHE_RSA_WITH_AES_128_GCM_SHA256
-TLS_DHE_RSA_WITH_AES_256_GCM_SHA384
+* TLS_DHE_RSA_WITH_AES_128_GCM_SHA256
+* TLS_DHE_RSA_WITH_AES_256_GCM_SHA384
 
+The DH param file is located at /var/lib/dhparams/nginx.pem.
+This path can be referenced from Nix code by `security.dhparams.params.nginx.path` as shown in the config example above.
 
 The services.nginx.sslCiphers option can be used to change the cipher list:
 

--- a/nixos/services/nginx/default.nix
+++ b/nixos/services/nginx/default.nix
@@ -335,11 +335,6 @@ in
 
       security.acme.certs = acmeSettings;
 
-      # DH param file is located at /var/lib/dhparams/nginx.pem.
-      # The path can also be referenced from Nix code by `security.dhparams.params.nginx.path`;
-      security.dhparams.params = {
-        nginx = {};
-      };
 
       flyingcircus.passwordlessSudoRules = [
         {

--- a/tests/nginx.nix
+++ b/tests/nginx.nix
@@ -242,9 +242,5 @@ in {
     with subtest("status check should be red after shutting down nginx"):
       server.systemctl('stop nginx')
       server.fail("${sensuCheck "nginx_status"}")
-
-    with subtest("dhparams file should contain something"):
-      server.wait_for_unit("dhparams-init.service")
-      server.succeed("test -s /var/lib/dhparams/nginx.pem")
   '';
 })


### PR DESCRIPTION
Clients don't use DHE ciphers typically but this wastes a lot of time,
especially in NixOS containers. Our default nginx config already doesn't
support DHE ciphers because we generate an EC Letsencrypt cert which
can't be used for DHE ciphers (they all use RSA).

The behaviour can be restored after this change with:

`security.dhparams.params.nginx = {};`

Add a hint to the webgateway role doc and nginx readme how to re-enable
this, if needed.

 #PL-130114

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Nginx: don't generate dhparam file by default anymore. Existing dhparam files will be removed. This file is only needed for DHE ciphers which are not used except by legacy clients like IE11 on older Windows versions. See the webgateway docs or /etc/local/nginx/README.txt for info on how to keep or re-enable if needed. (#PL-130114).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Use modern SSL ciphers by default. The change doesn't actually modify the cipher selection, it just requires an additional step to enable DHE ciphers
- [x] Security requirements tested? (EVIDENCE)
  - checked on test VM if dhparams file is removed, automated test still runs