### PR TITLE
dev-setup: ensure PWD is script directory before doing anything

### DIFF
--- a/dev-setup
+++ b/dev-setup
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 # Usage: eval `./dev-setup`
 set -e
+
+# ensure PWD is the directory this script resides in (allows calls like ../dev-setup or $HOME/fc-nixos/dev-setup)
+cd "$(dirname "$(readlink -f "$0")")"
+
 base=$PWD
 # preserve nixos-config
 config=$(nix-instantiate --find-file nixos-config 2>/dev/null) || true


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact: none

Changelog:
- dev-setup: ensure PWD is script directory before doing anything
  allows calls like ../dev-setup or $HOME/fc-nixos/dev-setup


## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [x] Security requirements tested? (EVIDENCE)

