### PR TITLE
physical: add mellanox utilities and pciutils

### DIFF
--- a/nixos/infrastructure/flyingcircus-physical.nix
+++ b/nixos/infrastructure/flyingcircus-physical.nix
@@ -30,9 +30,11 @@ mkIf (cfg.infrastructureModule == "flyingcircus-physical") {
     };
 
     environment.systemPackages = with pkgs; [
-      smartmontools
       fc.secure-erase
       fc.util-physical
+      mstflint
+      pciutils
+      smartmontools
     ];
 
     fileSystems = {


### PR DESCRIPTION
Those are needed for firmware updates to Mellanox NICs.

Re PL-129501

@flyingcircusio/release-managers

## Release process

Impact:

-

Changelog:

n/a

## Security implications

- [X] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

Using upstream packages from vendor and established open source package. No services are added, just known CLI tools.

- [X] Security requirements tested? (EVIDENCE)

nothing to test

