### PR TITLE
nginx: fix a conditional reload bug

### DIFF
--- a/nixos/services/nginx/base-module.nix
+++ b/nixos/services/nginx/base-module.nix
@@ -203,7 +203,9 @@ let
 
       ${optionalString cfg.statusPage ''
         server {
-          listen 127.0.0.1:80;
+          # Conditional v6 handling, see:
+          # https://stackoverflow.com/a/15101745
+          ${optionalString (enableIPv6 == false) "listen 127.0.0.1:80;" }
           ${optionalString enableIPv6 "listen [::1]:80;" }
 
           server_name localhost;


### PR DESCRIPTION
nginx can not listen on 127.0.0.1 and [::1] at the same time
implicitly because [::1] per default is dual-stack enabled.

@flyingcircusio/release-managers

## Release process

Impact:

n/a

Changelog:

* Fix a conditional nginx reload bug. The internal statuspage and vhosts using the default wildcard address were not properly configured for dual stack operations and may block graceful reloads. 

## Security implications

- [X] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined (WHERE)

nothing specifically security-related (improves availability, though)

- [X] Security requirements tested? (EVIDENCE)

manual test on test36
