### PR TITLE
Sensu server: fix breaking rabbitmq update script

### DIFF
--- a/nixos/services/sensu/server.nix
+++ b/nixos/services/sensu/server.nix
@@ -127,7 +127,7 @@ in {
               ];
             in ''
               # Configure user and permissions for ${node}:
-              rabbitmqctl list_users | grep ${node} || \
+              rabbitmqctl list_users | grep ^${node} || \
                 rabbitmqctl add_user ${node} ${password}
 
               rabbitmqctl change_password ${client.node} ${password}


### PR DESCRIPTION
The check for existing users (name is the fqdn of the node)
was only doing a partial match which could match the wrong node fqdn,
thinking that the client already exists. Skipping the user creation
breaks the script in the next step. Matching from the beginning of the line
fixes it.

This affected even more new nodes that are sorted after the breaking node.

 #PL-130123

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

## Security implications

- [n/a] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [n/a] Security requirements tested? (EVIDENCE)

