### PR TITLE
Pl 130129 update nixpkgs

### DIFF
--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -88,34 +88,6 @@ in {
 
   jibri = super.callPackage ./jibri { jre_headless = super.jre8_headless; };
 
-  jicofo = super.jicofo.overrideAttrs(oldAttrs: rec {
-    pname = "jicofo";
-    version = "1.0-798";
-    src = super.fetchurl {
-      url = "https://download.jitsi.org/stable/${pname}_${version}-1_all.deb";
-      sha256 = "55JagMfiBbBw0nqRxcMmfiwGF7B/1LA+pb5n6ZOZvag=";
-    };
-  });
-
-  jitsi-meet = super.jitsi-meet.overrideAttrs(oldAttrs: rec {
-    pname = "jitsi-meet";
-    version = "1.0.5307";
-    src = super.fetchurl {
-      url = "https://download.jitsi.org/jitsi-meet/src/jitsi-meet-${version}.tar.bz2";
-      sha256 = "epdVQnuL5dJ7DmoqyjfiLEfZxr4IQwkFEla/Y034sgg=";
-    };
-
-  });
-
-  jitsi-videobridge = super.jitsi-videobridge.overrideAttrs(oldAttrs: rec {
-    pname = "jitsi-videobridge2";
-    version = "2.1-551-g2ad6eb0b";
-    src = super.fetchurl {
-      url = "https://download.jitsi.org/stable/${pname}_${version}-1_all.deb";
-      sha256 = "XwVcjvBtJkZP46kGMnE4R1ax7Re725GMoV+pCnCNpak=";
-    };
-  });
-
   haproxy = super.haproxy.overrideAttrs(orig: rec {
     version = "2.3.14";
     src = super.fetchurl {

--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "NixOS",
     "repo": "nixpkgs",
-    "rev": "83413f47809790e4ca012e314e7782adeae36cf2",
-    "sha256": "0md5ynzxaw9gx81gh4d0120yjb0jrcydvxf0nsym402qfbhpchx0"
+    "rev": "751110a6f65bc23138b804945fd426f1eae1de8b",
+    "sha256": "04bp1v4gmhbkiiy1ix92bvkpm9z4sa4cm28vk1igbja71l6vbl7r"
   },
   "nixos-mailserver": {
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/",


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

* [NixOS 21.05] VMs will schedule a reboot to activate the new kernel version.

Changelog: (include changes from commit msg here)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - pull in upstream security fixes regularly
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still run, works on test VM
  - checked commit log for fixed CVEs and possible problems with updates
