### PR TITLE
[21.05] Integrate fc-disktracker

### DIFF
--- a/nixos/services/default.nix
+++ b/nixos/services/default.nix
@@ -19,6 +19,7 @@ in {
     ./ceph/server.nix
     ./collectdproxy.nix
     ./consul.nix
+    ./disktracker.nix
     ./gitlab
     ./graylog
     ./haproxy

--- a/nixos/services/disktracker.nix
+++ b/nixos/services/disktracker.nix
@@ -34,16 +34,16 @@ with builtins;
       timers = {
         disktracker = {
           description = "Disktracker";
+          wantedBy = [ "timers.target" ];
           timerConfig = {
             OnBootSec = "2m";
-            OnUnitActiveSec = "6h";
+            OnUnitActiveSec = if config.flyingcircus.raid.enable then "10m" else "6h";
           };
         };
       };
       services = {
         disktracker = {
           description = "Disktracker";
-          wantedBy = [ "multi-user.target" ];
           serviceConfig.Type = "oneshot";
           script = "${pkgs.fc.disktracker}/bin/disktracker";
         };

--- a/nixos/services/disktracker.nix
+++ b/nixos/services/disktracker.nix
@@ -1,0 +1,54 @@
+{ config, lib, pkgs, ... }:
+
+let
+  conf = config.flyingcircus.services.disktracker;
+in
+
+with builtins;
+{
+  options = {
+    flyingcircus.services.disktracker = {
+      enable = lib.mkEnableOption "Disktracker service";
+    };
+  };
+
+  config = lib.mkIf conf.enable {
+    environment = {
+      systemPackages = with pkgs; [ fc.disktracker ];
+      etc."disktracker/disktracker.conf".text = ''
+         [snipe.it]
+         url = https://assets.fcstag.fcio.net
+      '';
+    };
+
+    # We used to create the admin key directory from the ENC. However,
+    # this causes the file to become world readable on servers.
+
+   flyingcircus.activationScripts.snipeITTOken = ''
+     # Only allow root to read/write this file
+     umask 066
+     ${pkgs.jq}/bin/jq -r  '.parameters.secrets."snipeit/token"' /etc/nixos/enc.json > /etc/disktracker/token
+   '';
+
+    systemd = {
+      timers.disktracker = {
+        description = "Disktracker";
+        timerConfig = {
+          OnBootSec = "2m";
+          OnUnitActiveSec = "6h";
+        };
+      };
+      services.disktracker = {
+        description = "Disktracker";
+        serviceConfig.Type = "oneshot";
+        script = "${pkgs.fc.disktracker}/bin/disktracker";
+      };
+    };
+
+    services.udev = {
+          extraRules = ''
+            ENV{DEVTYPE}=="disk", ACTION=="add|remove", RUN+="${pkgs.systemd}/bin/systemctl start disktracker"
+          '';
+    };
+  };
+}

--- a/nixos/services/disktracker.nix
+++ b/nixos/services/disktracker.nix
@@ -34,7 +34,7 @@ with builtins;
         wantedBy = [ "timers.target" ];
         timerConfig = {
           OnBootSec = "2m";
-          # For scrupping reasons 6h whould be better, but currently the raidcontroller obscures
+          # For scrubbing reasons 6h whould be better, but currently the raidcontroller obscures
           # the relevant changes in storage devices
           OnUnitActiveSec = "10m";
         };
@@ -50,7 +50,11 @@ with builtins;
        let
          disktracker-udev-script = pkgs.writeShellScript "disktracker-udev-script" ''
            if systemctl is-active multi-user.target; then
-               ${pkgs.systemd}/bin/systemctl start disktracker;
+               SECONDS=0;
+               sleep 8
+               if [ "$SECONDS" -gt "7" ]; then
+                   ${pkgs.systemd}/bin/systemctl start disktracker;
+               fi
            fi
          '';
        in

--- a/nixos/services/disktracker.nix
+++ b/nixos/services/disktracker.nix
@@ -55,8 +55,7 @@ with builtins;
          let
            disktracker-udev-script = pkgs.writeScript "disktracker-udev-script" ''
              #!/bin/sh
-             if [ $(systemctl is-active multi-user.target) == "active" ];
-               then
+             if systemctl is-active multi-user.target; then
                  ${pkgs.systemd}/bin/systemctl start disktracker;
              fi
            '';

--- a/nixos/services/disktracker.nix
+++ b/nixos/services/disktracker.nix
@@ -42,6 +42,7 @@ with builtins;
       services.disktracker = {
         description = "Disktracker";
         serviceConfig.Type = "oneshot";
+        path = [ "${pkgs.smartmontools}" ];
         script = "${pkgs.fc.disktracker}/bin/disktracker";
       };
     };

--- a/pkgs/fc/default.nix
+++ b/pkgs/fc/default.nix
@@ -14,6 +14,7 @@ rec {
   ceph = callPackage ./ceph { inherit blockdev agent; };
   blockdev = callPackage ./blockdev {};
   collectdproxy = callPackage ./collectdproxy {};
+  disktracker = callPackage ./disktracker.nix {};
   roundcube-chpasswd = callPackage ./roundcube-chpasswd {};
   fix-so-rpath = callPackage ./fix-so-rpath {};
   logcheckhelper = callPackage ./logcheckhelper { };

--- a/pkgs/fc/disktracker.nix
+++ b/pkgs/fc/disktracker.nix
@@ -1,13 +1,13 @@
 { lib, fetchgit, python3Packages, smartmontools }:
 
 with python3Packages;
-buildPythonApplication{
+buildPythonApplication rec {
 
   pname = "fc.disktracker";
-  version = "1.0.0";
+  version = "ce905ab";
   src = fetchgit {
     url = "https://gitlab.flyingcircus.io/flyingcircus/fc-disktracker.git";
-    rev = "ce905abb817945164fac6b24f44ff6dc6ba65bf7"; #Commit: Fix disktracker breaking when commandline arguments are missing
+    rev = version; #Commit: Fix disktracker breaking when commandline arguments are missing
     sha256 = "0261a7nrm0499ixkdvliwx38l73aj50yln2s33jg6az5b4l9ism9";
   };
 

--- a/pkgs/fc/disktracker.nix
+++ b/pkgs/fc/disktracker.nix
@@ -1,0 +1,17 @@
+{ lib, fetchgit, python3Packages, smartmontools }:
+
+with python3Packages;
+buildPythonApplication{
+
+  pname = "fc.disktracker";
+  version = "1.0.0";
+  src = fetchgit {
+    url = "https://gitlab.flyingcircus.io/flyingcircus/fc-disktracker.git";
+    rev = "713a847509764fca17232f4d9b0d633142cdeedb"; #Commit: Add ability to print given SnipeIT token and url
+    sha256 = "0ydx4jqzvl2r0kz6p9ydvj8h5grsfgg6xz6dsfd6cp8zxhwyiqyf";
+  };
+
+  dontStrip = true;
+
+  propagatedBuildInputs = [ requests smartmontools ];
+}

--- a/pkgs/fc/disktracker.nix
+++ b/pkgs/fc/disktracker.nix
@@ -7,8 +7,8 @@ buildPythonApplication{
   version = "1.0.0";
   src = fetchgit {
     url = "https://gitlab.flyingcircus.io/flyingcircus/fc-disktracker.git";
-    rev = "713a847509764fca17232f4d9b0d633142cdeedb"; #Commit: Add ability to print given SnipeIT token and url
-    sha256 = "0ydx4jqzvl2r0kz6p9ydvj8h5grsfgg6xz6dsfd6cp8zxhwyiqyf";
+    rev = "ce905abb817945164fac6b24f44ff6dc6ba65bf7"; #Commit: Fix disktracker breaking when commandline arguments are missing
+    sha256 = "0261a7nrm0499ixkdvliwx38l73aj50yln2s33jg6az5b4l9ism9";
   };
 
   dontStrip = true;

--- a/pkgs/fc/disktracker.nix
+++ b/pkgs/fc/disktracker.nix
@@ -4,11 +4,10 @@ with python3Packages;
 buildPythonApplication rec {
 
   pname = "fc.disktracker";
-  version = "5a07742c";
-  src = fetchgit {
-    url = "https://gitlab.flyingcircus.io/flyingcircus/fc-disktracker.git";
-    rev = version; # Commit: Give better information if smartctl failes
-    sha256 = "17bdwipb62g6khzdzwj8w2zr9yawa75z2p6609kglabhqqw3nypp";
+  version = "1.0b1";
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0gbjqgv2ds8my9a43cpw5a1ag7m5whakqprp7wrwdmwgpwdynds9";
   };
 
   dontStrip = true;

--- a/pkgs/fc/disktracker.nix
+++ b/pkgs/fc/disktracker.nix
@@ -4,11 +4,11 @@ with python3Packages;
 buildPythonApplication rec {
 
   pname = "fc.disktracker";
-  version = "ce905ab";
+  version = "5a07742c";
   src = fetchgit {
     url = "https://gitlab.flyingcircus.io/flyingcircus/fc-disktracker.git";
-    rev = version; #Commit: Fix disktracker breaking when commandline arguments are missing
-    sha256 = "0261a7nrm0499ixkdvliwx38l73aj50yln2s33jg6az5b4l9ism9";
+    rev = version; # Commit: Give better information if smartctl failes
+    sha256 = "17bdwipb62g6khzdzwj8w2zr9yawa75z2p6609kglabhqqw3nypp";
   };
 
   dontStrip = true;

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -24,6 +24,7 @@ in {
   channel = callTest ./channel.nix {};
   coturn = callTest ./coturn.nix {};
   docker = callTest (nixpkgs + /nixos/tests/docker.nix) {};
+  disktracker = callTest ./disktracker.nix {};
   elasticsearch6 = callTest ./elasticsearch.nix { version = "6"; };
   elasticsearch7 = callTest ./elasticsearch.nix { version = "7"; };
   fcagent = callTest ./fcagent.nix {};

--- a/tests/disktracker.nix
+++ b/tests/disktracker.nix
@@ -18,12 +18,18 @@ import ./make-test-python.nix ({ ... }:
     machine.wait_for_unit("multi-user.target")
 
     with subtest("Did udev script run withour error"):
-        status = machine.execute('dmesg | grep -E "systemd-udevd.*failed"')
+        status = machine.execute('dmesg | grep -E "systemd-udevd.*disktracker.*failed"')
         if status[0] != 1:
+            print(status[1])
             raise Exception
 
-    with subtest("Disktracker service has to fail"):
-        status = machine.execute('systemctl status disktracker | grep -q "status=1/FAILURE"')
+    with subtest("Disktracker service has to exists"):
+        status = machine.execute('systemctl list-unit-files | grep -q "disktracker.service"')
+        if status[0] != 0:
+            raise Exception
+
+    with subtest("Disktracker timer has to exists and be active"):
+        status = machine.execute('systemctl list-timers | grep -qE "1min.*left.*disktracker.timer"')
         if status[0] != 0:
             raise Exception
 

--- a/tests/disktracker.nix
+++ b/tests/disktracker.nix
@@ -14,7 +14,10 @@ import ./make-test-python.nix ({ ... }:
 
   testScript = ''
     # Waiting long enough to ensure service stops to restart and gain failed status
-    machine.sleep(2)
+    machine.sleep(5)
+
+    with subtest("Ensure /run/disktracker file exists"):
+        machine.succeed("cat /run/disktracker")
 
     with subtest("Disktracker service has to fail"):
         status = machine.execute('systemctl status disktracker | grep -q "status=1/FAILURE"')

--- a/tests/disktracker.nix
+++ b/tests/disktracker.nix
@@ -8,8 +8,6 @@ import ./make-test-python.nix ({ ... }:
 
       environment.etc."nixos/enc.json".text = ''{"parameters": {"secrets": {"snipeit/token": "TOKEN"}}}'';
 
-      flyingcircus.enc.parameters.secrets."snipeit/token" = "TOKEN";
-
       flyingcircus.services.disktracker.enable = true;
       services.telegraf.enable = false;
     };
@@ -18,7 +16,7 @@ import ./make-test-python.nix ({ ... }:
     # Waiting long enough to ensure service stops to restart and gain failed status
     machine.sleep(2)
 
-    with subtest("Disktracker service has to fail, because of missing network connection"):
+    with subtest("Disktracker service has to fail"):
         status = machine.execute('systemctl status disktracker | grep -q "status=1/FAILURE"')
         if status[0] != 0:
             raise Exception

--- a/tests/disktracker.nix
+++ b/tests/disktracker.nix
@@ -1,0 +1,31 @@
+import ./make-test-python.nix ({ ... }:
+
+{
+  name = "disktracker";
+  machine =
+    {
+      imports = [ ../nixos ];
+
+      environment.etc."nixos/enc.json".text = ''{"parameters": {"secrets": {"snipeit/token": "TOKEN"}}}'';
+
+      flyingcircus.enc.parameters.secrets."snipeit/token" = "TOKEN";
+
+      flyingcircus.services.disktracker.enable = true;
+      services.telegraf.enable = false;
+    };
+
+  testScript = ''
+    # Waiting long enough to ensure service stops to restart and gain failed status
+    machine.sleep(2)
+
+    with subtest("Disktracker service has to fail, because of missing network connection"):
+        status = machine.execute('systemctl status disktracker | grep -q "status=1/FAILURE"')
+        if status[0] != 0:
+            raise Exception
+
+    with subtest("Test if SnipeIT url and token are given correctly to disktracker"):
+        output = machine.execute("disktracker --print-config")
+        if output != (0, 'SnipeIT token is:\nTOKEN\nSnipeIT url is:\nhttps://assets.fcstag.fcio.net\n'):
+            raise Exception
+  '';
+})

--- a/tests/disktracker.nix
+++ b/tests/disktracker.nix
@@ -14,9 +14,7 @@ import ./make-test-python.nix ({ ... }:
     };
 
   testScript = ''
-    # Waiting long enough to ensure service stops to restart and gain failed status
     start_all()
-
     machine.wait_for_unit("multi-user.target")
 
     with subtest("Did udev script run withour error"):


### PR DESCRIPTION
@flyingcircusio/release-managers

This adds the [disktracker ](https://gitlab.flyingcircus.io/flyingcircus/fc-disktracker) as a optional service. Directory has to provide the access token for the asset management system.

## Release process

Impact:
    - none relevant for the customer

Changelog:
    - none relevant for the customer

## Security implications

- [X] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
   - Data should be correct
   - Fail safely
- [X] Security requirements tested? (EVIDENCE)
   - A continuous automated tracking of our disks gives us more reliable data than making the changes by hand
   - Nixtest tests multiple scenarios
