### PR TITLE
apache: 2.4.49 -> 2.4.50

### DIFF
--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -22,6 +22,17 @@ in {
   #
   # imports from other nixpkgs versions or local definitions
   #
+  apacheHttpd = super.apacheHttpd.overrideAttrs(_: rec {
+
+    pname = "apache-httpd";
+    version = "2.4.50";
+
+    src = super.fetchurl {
+      url = "mirror://apache/httpd/httpd-${version}.tar.bz2";
+      sha256 = "6a2817c070c606682eb53ed963511407d3c3d7a379cdf855971467b00fb3890f";
+    };
+  });
+
   backy = super.callPackage ./backy.nix { };
   backyExtract = super.callPackage ./backyextract { };
 


### PR DESCRIPTION
Fixes https://nvd.nist.gov/vuln/detail/CVE-2021-41773

 #PL-130135

@flyingcircusio/release-managers

## Release process

Will be released as hotfix for 21.05-production.

Impact:

* [NixOS 21.05] Apache will be restarted.

Changelog:

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - use a recent version of Apache 
- [x] Security requirements tested? (EVIDENCE)
  - 2.4.50 is the current version and fixes a problematic CVE
  - automated tests still run, checked on test VM that lamp role works and apache is reachable 

