### PR TITLE
apache: 2.4.50 -> 2.4.51

### DIFF
--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -25,11 +25,11 @@ in {
   apacheHttpd = super.apacheHttpd.overrideAttrs(_: rec {
 
     pname = "apache-httpd";
-    version = "2.4.50";
+    version = "2.4.51";
 
     src = super.fetchurl {
       url = "mirror://apache/httpd/httpd-${version}.tar.bz2";
-      sha256 = "6a2817c070c606682eb53ed963511407d3c3d7a379cdf855971467b00fb3890f";
+      sha256 = "1x1qp10pfh33x1b56liwsjl0jamjm5lkk7j3lj87c1ygzs0ivq10";
     };
   });
 


### PR DESCRIPTION
Fixes CVE-2021-42013

 #PL-130135

@flyingcircusio/release-managers

## Release process

Will be released as hotfix for 21.05-production.

Impact:

* [NixOS 21.05] Apache will be restarted.

Changelog:

* Apache: security update 2.4.49 -> 2.4.51 (CVE-2021-41773, CVE-2021-42013) (#PL-130135).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - use a recent version of Apache 
- [x] Security requirements tested? (EVIDENCE)
  - 2.4.51 is the current version and fixes a problematic CVE
  - automated LAMP tests still run, checked on test VM that lamp role works and apache is reachable 
