### PR TITLE
Percona80: fix xtrabackup

### DIFF
--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -268,6 +268,12 @@ in {
   percona57 = super.callPackage ./percona/5.7.nix { boost = self.boost159; };
   percona80 = super.callPackage ./percona/8.0.nix { boost = self.boost173; };
 
+  # We use 2.4 from upstream for older Percona versions.
+  # Percona 8.0 needs a newer version than upstream provides.
+  percona-xtrabackup_8_0 = super.callPackage ./percona/xtrabackup.nix {
+    boost = self.boost173;
+  };
+
   postgis_2_5 = super.postgis.overrideAttrs(_: rec {
     version = "2.5.5";
     src = super.fetchurl {
@@ -308,9 +314,5 @@ in {
   wkhtmltopdf_0_12_6 = super.callPackage ./wkhtmltopdf/0_12_6.nix { };
   wkhtmltopdf = self.wkhtmltopdf_0_12_6;
 
-  xtrabackup = super.callPackage ./percona/xtrabackup.nix {
-    inherit (self) percona;
-    boost = self.boost172;
-  };
-
+  xtrabackup = self.percona-xtrabackup_8_0;
 }

--- a/pkgs/percona/xtrabackup.nix
+++ b/pkgs/percona/xtrabackup.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "xtrabackup-${version}";
-  version = "8.0.14";
+  version = "8.0.26-18";
 
   src = fetchurl {
     url = "https://www.percona.com/downloads/Percona-XtraBackup-8.0/Percona-XtraBackup-${version}/source/tarball/percona-xtrabackup-${version}.tar.gz";
-    sha256 = "0p9xlzapn88id6m8viycaf9c0mdxplp5hhj99gr6n0bbd8n6v3fv";
+    sha256 = "0iiqdy78wq9mlknqz5qxlmm5xqsjl9hy2f71wi4hhq2d0xz6sv42";
   };
 
   buildInputs = with pkgs; [

--- a/tests/mysql.nix
+++ b/tests/mysql.nix
@@ -123,7 +123,8 @@ in
         master.wait_until_succeeds("mysql mysql -u root -ptt -e 'select 1'")
 
     with subtest("xtrabackup works"): # sensuclient has service group
-        master.succeed("sudo -u sensuclient sudo xtrabackup --backup")
+        master.succeed("sudo -u sensuclient sudo xtrabackup --backup -S /run/mysqld/mysqld.sock")
+        master.succeed("grep uuid /tmp/xtrabackup_backupfiles/xtrabackup_info")
   '';
 
 })


### PR DESCRIPTION
Improved the test to look at the backup info file to see that it
actually ran a backup.

 #PL-130139

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Fix xtrabackup for Percona 8 (#PL-130139).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - we need a working database backup tool 
- [x] Security requirements tested? (EVIDENCE)
  - automated test checks if backup works, checked on test VM that it can run a backup.
