### PR TITLE
Use default upstream PHP when LAMP role is not activated

### DIFF
--- a/nixos/roles/lamp.nix
+++ b/nixos/roles/lamp.nix
@@ -107,22 +107,26 @@ in {
 
     in
 
-      lib.mkMerge [ {
-          # We always provide the PHP cli environment but we need to ensure
-          # to choose the right one in case someone uses the LAMP role.
-          # This used to be in packages.nix but that was too simple minded.
+      lib.mkMerge [
 
+      (lib.mkIf (!role.enable) {
+          # Install the default upstream PHP when the LAMP role is not activated.
           environment.systemPackages = [
-            role.php
-            role.php.packages.composer
+            pkgs.php
           ];
-
-      }
+      })
 
       (lib.mkIf role.enable {
 
           services.httpd.enable = true;
           services.httpd.adminAddr = "admin@flyingcircus.io";
+          # We always provide the PHP cli environment but we need to ensure
+          # to choose the right one in case someone uses the LAMP role.
+          environment.systemPackages = [
+            role.php
+            role.php.packages.composer
+          ];
+
           # Provide a similar PHP config for the PHP CLI as for Apache (httpd).
           # The file referenced by PHPRC is loaded together with the php.ini
           # from the global PHP package which only specifies the extensions.

--- a/tests/channel.nix
+++ b/tests/channel.nix
@@ -80,8 +80,7 @@ in {
       unionfs-fuse
       xorg.lndir
       # Our custom stuff that's needed to rebuild the VM.
-      lamp_php73
-      lamp_php73.packages.composer
+      php
       lamp_php56
       lamp_php56.passthru.extensions.memcached.src
       channel

--- a/tests/haproxy.nix
+++ b/tests/haproxy.nix
@@ -98,8 +98,7 @@ in
           unionfs-fuse
           xorg.lndir
           # Our custom stuff that's needed to rebuild the VM.
-          lamp_php73
-          lamp_php73.packages.composer
+          php
           channel
         ];
 


### PR DESCRIPTION
Before, we installed lamp_php73 with its extensions when
the LAMP role was not activated.
We saves some space and update time.

 #PL-130145

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Install upstream PHP (currently 7.4) globally on machines instead of lamp_php73 and drop composer to reduce installation size and speed up updates. Machines using the lamp role are not affected, they still install the PHP package used by lamp and composer with matching versions globally (#PL-130145).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - keep default platform packages lean for fast updates and less attack surface
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still run, manually checked on test VM with and without lamp role that the wanted PHP/composer is present.
