### PR TITLE
ACME: avoid hitting hourly rate limit of Letsencrypt with our retries

### DIFF
--- a/nixos/platform/acme.nix
+++ b/nixos/platform/acme.nix
@@ -19,10 +19,11 @@
       RestartSec = 30;
     };
 
-    # Allow 5 retries/starts per day.
+    # Allow 3 retries/starts per hour to not hit the rate limit
+    # of 5 per hour so we have two left to try manually.
     unitConfig = {
-      StartLimitIntervalSec = "24h";
-      StartLimitBurst = 5;
+      StartLimitIntervalSec = "1h";
+      StartLimitBurst = 3;
     };
   in
     lib.listToAttrs


### PR DESCRIPTION
At the moment, we retry 5 times a day if getting the acme cert service
failed. The rate limit of Letsencrypt is 5 per hour so we hit the rate
limit with our 5 tries and don't try again for the whole day.
Use a hourly limit instead and leave 2 tries for manual retries.

 #PL-130150

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* The ACME cert renewal service now tries to run three times per hour on failure to avoid hitting the Letsencrypt rate limit (5 failed authorizations per hour) (#PL-130150).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - avoid hitting letsencrypt rate limits and try every hour to allow faster recovery
- [x] Security requirements tested? (EVIDENCE)
  - checked on test VM that acme service still works and changes are present in the unit file
