### PR TITLE
Fix link to mailserver documentation inside /etc/lcoal/postfix/README.txt

### DIFF
--- a/nixos/services/mail/stub.nix
+++ b/nixos/services/mail/stub.nix
@@ -39,7 +39,7 @@ let
 
     This role shares some configuration options which the 'mailserver' role:
     mailHost, rootAlias, smtpBind[46], explicitSmtpBind. Refer to
-    https://flyingcircus.io/doc/guide/platform_nixos_2/mailserver.html for
+    https://doc.flyingcircus.io/roles/fc-21.05-production/mailserver.html for
     explanation.
   '';
 


### PR DESCRIPTION
This PR just updates a link to our public documentation to find more details about the mailserver roles.

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - README is still available on VM
  - Link to documentation is correct
- [x] Security requirements tested? (EVIDENCE)
  - Tested on test-vm
