### PR TITLE
Pl 130159 update nixpkgs

### DIFF
--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -22,16 +22,6 @@ in {
   #
   # imports from other nixpkgs versions or local definitions
   #
-  apacheHttpd = super.apacheHttpd.overrideAttrs(_: rec {
-
-    pname = "apache-httpd";
-    version = "2.4.51";
-
-    src = super.fetchurl {
-      url = "mirror://apache/httpd/httpd-${version}.tar.bz2";
-      sha256 = "1x1qp10pfh33x1b56liwsjl0jamjm5lkk7j3lj87c1ygzs0ivq10";
-    };
-  });
 
   backy = super.callPackage ./backy.nix { };
   backyExtract = super.callPackage ./backyextract { };

--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "NixOS",
     "repo": "nixpkgs",
-    "rev": "751110a6f65bc23138b804945fd426f1eae1de8b",
-    "sha256": "04bp1v4gmhbkiiy1ix92bvkpm9z4sa4cm28vk1igbja71l6vbl7r"
+    "rev": "83667ff60a88e22b76ef4b0bdf5334670b39c2b6",
+    "sha256": "0i3cl781909mshwh9f5k94z81ixmfk0k4427afajwm6lr2hgp4kp"
   },
   "nixos-mailserver": {
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/",


### PR DESCRIPTION
Notable version changes and security fixes:

* ffmpeg: patch CVE-2021-38171 and CVE-2021-38291
* github-runner: 2.282.0 -> 2.283.3
* grafana: 7.5.10 -> 7.5.11, fix CVE-2021-39226
* linux: 5.10.70 -> 5.10.71
* matrix-synapse: 1.43.0 -> 1.44.0
* nodejs-12_x: 12.22.6 -> 12.22.7
* nodejs-16_x: 16.10.0 -> 16.11.0
* nodejs: 14.17.6 -> 14.18.1

 #PL-130159

@flyingcircusio/release-managers

## Release process

Impact:

* [NixOS 21.05] VMs will schedule a reboot to activate the new kernel version.

Changelog: (include changes from commit msg here)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - pull in upstream security fixes regularly
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still run, works on test VM
  - checked commit log for fixed CVEs and possible problems with updates, looked at changelog of synapse and grafana

