### PR TITLE
MySQL/Percona: increase timeout to 15 minutes

### DIFF
--- a/nixos/services/percona.nix
+++ b/nixos/services/percona.nix
@@ -229,7 +229,9 @@ in
       serviceConfig = {
         ExecStart = "${mysql}/bin/mysqld --defaults-extra-file=${myCnf} ${mysqldOptions}";
         Restart = "always";
-        TimeoutSec = 360;
+        # MySQL may have a lot of dirty pages to flush at shutdown or do a
+        # recovery on startup. This value affects both start and stop timeouts.
+        TimeoutSec = "15 min";
       };
 
       preStart = mysqlPreStart;


### PR DESCRIPTION
MySQL may take a very long time to start (recovery) or stop
(flushing dirty pages) and we don't want to interrupt it too
early.

 #PL-130155

@flyingcircusio/release-managers

## Release process

Impact:

* [NixOS 21.05] MySQL will be restarted.

Changelog:

* MySQL/Percona: increase start and stop timeout to 15 minutes to avoid interrupting recovery or flushing of dirty pages (#PL-130155).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - avoid mysql being unavailable due to aborted recoveries and recoveries caused by unclean shutdowns
- [x] Security requirements tested? (EVIDENCE)
  - automated test still runs, checked on test VM that 15min timeouts are effective (smaller than 30min global timeout for reboot)
