### PR TITLE
PL-130158 Construct paths to files in nix store paths safely

### DIFF
--- a/nixos/lib/files.nix
+++ b/nixos/lib/files.nix
@@ -20,7 +20,7 @@ rec {
   # Get all regular files and symlinks with their absolute name
   files = path:
     (map
-      (filename: path + ("/" + filename))
+      (filename: (builtins.toString path) + ("/" + filename))
       (filesRel path));
 
   # Reads the config file if it exists, else returns predefined default


### PR DESCRIPTION
This closes PL-130158 which is caused by constructing nix store paths from files in a folder without sanitization first.

~~This prefixes the nix store paths of those files with `DOT-`.~~

This forces the nix path to a normal string before appending the filenames to construct subpaths

@flyingcircusio/release-managers

## Release process

Impact:
- 

Changelog:

## Security implications

- [ ] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [ ] Security requirements tested? (EVIDENCE)

