### PR TITLE
mysql: allow service user to "just login"

### DIFF
--- a/nixos/roles/mysql.nix
+++ b/nixos/roles/mysql.nix
@@ -105,6 +105,8 @@ with builtins;
     users.users.mysql = {
       shell = "/run/current-system/sw/bin/bash";
       home = lib.mkForce "/srv/mysql";
+      # ensure we can properly set things up first time
+      createHome = true;
     };
 
     flyingcircus.passwordlessSudoRules = [

--- a/nixos/services/percona.nix
+++ b/nixos/services/percona.nix
@@ -64,6 +64,8 @@ let
     user = root
     __EOT__
     chmod 440 /root/.my.cnf
+    cp -p /root/.my.cnf /srv/mysql/.my.cnf
+    chown mysql:mysql /srv/mysql/.my.cnf
 
     # write init file for mysqld to set the root password
     cat > ${initFile} <<__EOT__


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:
- mysql service will be restarted

Changelog:
- mysql service user can now "just login" by typing "mysql" command, similar to root

fixes PL-115620

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [x] Security requirements tested? (EVIDENCE)

