### PR TITLE
Build PRs in Hydra

### DIFF
--- a/.hydra/config.json
+++ b/.hydra/config.json
@@ -1,0 +1,21 @@
+{
+    "input_name": "fc",
+    "input_path": "release",
+    "inputs": {
+        "nixpkgs": {
+            "type": "git",
+            "value": "git://github.com/flyingcircusio/nixpkgs.git nixos-21.05",
+            "emailresponsible": false
+        },
+        "platformDoc": {
+            "type": "git",
+            "value": "git://github.com/flyingcircusio/doc.git master",
+            "emailresponsible": false
+        },
+        "branch": {
+            "type": "string",
+            "value": "fc-21.05-dev",
+            "emailresponsible": false
+        }
+    }
+}

--- a/.hydra/project.json
+++ b/.hydra/project.json
@@ -1,0 +1,39 @@
+{
+    "enabled": 1,
+    "hidden": false,
+    "description": "GitHub Pull Request Jobset Generator",
+    "nixexprinput": "generator",
+    "nixexprpath": "jobset/generate.nix",
+    "checkinterval": 300,
+    "schedulingshares": 100,
+    "enableemail": false,
+    "emailoverride": "",
+    "keepnr": 3,
+    "inputs": {
+        "generator_config": {
+            "type": "git",
+            "value": "https://github.com/flyingcircusio/fc-nixos.git fc-21.05-dev",
+            "emailresponsible": false
+        },
+        "inputPath": {
+            "type": "string",
+            "value": "release",
+            "emailresponsible": false
+        },
+        "generator": {
+            "type": "git",
+            "value": "https://github.com/DeterminateSystems/hydra-github-jobsets-generator.git main",
+            "emailresponsible": false
+        },
+        "nixpkgs": {
+            "type": "git",
+            "value": "git://github.com/NixOS/nixpkgs.git nixos-unstable-small",
+            "emailresponsible": false
+        },
+        "pull_requests": {
+            "type": "githubpulls",
+            "value": "flyingcircusio fc-nixos",
+            "emailresponsible": false
+        }
+    }
+}


### PR DESCRIPTION
This commit creates a couple of .hydra configuration files.

The project.json defines a jobset called ".jobset", which will run
a program (hydra-github-jobsets-generator) to generate all the
other jobsets.

That program loads the list of pull requests provided by the
githubpulls input, and the `.hydra/config.json` file from the
generator_config input to produce a jobset per PR.

@flyingcircusio/release-managers

## Release process

(unsure)

Impact:

Changelog:

## Security implications

(unsure)

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined?
  - building things on our Hydra should only be allowed for trusted users
- [x] Security requirements tested? (EVIDENCE)
  - creating PRs in the fc-nixos repo on Github is limited to collaborators and organization members (for 6 months)