### PR TITLE
agent: add nopasswd rule to allow service users to use sudo fc-manage properly again

### DIFF
--- a/nixos/platform/agent.nix
+++ b/nixos/platform/agent.nix
@@ -83,7 +83,8 @@ in {
 
       flyingcircus.passwordlessSudoRules = [
         {
-          commands = [ "${pkgs.fc.agent}/bin/fc-manage" ];
+          # we need NOPASSWD here as service users have no password
+          commands = [ { command = "${pkgs.fc.agent}/bin/fc-manage"; options = [ "NOPASSWD" ]; } ];
           groups = [ "sudo-srv" "service" ];
         }
       ];


### PR DESCRIPTION

fixes PL-130171

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:
- set nopasswd for fc-manage sudo rule

## Security implications

- [ ] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - unsure allowing fc-manage with nopasswd, but without it doesn't really make sense as service users don't really have passwords
- [ ] Security requirements tested? (EVIDENCE)

