### PR TITLE
mysql: enable slow log

### DIFF
--- a/nixos/roles/mysql.nix
+++ b/nixos/roles/mysql.nix
@@ -116,6 +116,20 @@ with builtins;
       }
     ];
 
+    systemd.tmpfiles.rules = [
+      "d /var/log/mysql 0755 mysql service -"
+      "f /var/log/mysql/mysql.slow 0640 mysql service -"
+    ];
+
+    services.logrotate.paths.mysql-slowlog = {
+      path = "/var/log/mysql/mysql.slow";
+      extraConfig = ''
+        rotate 2
+        create 0640 mysql service
+        missingok
+      '';
+    };
+
     services.percona = {
       enable = true;
       inherit package rootPasswordFile;
@@ -142,8 +156,16 @@ with builtins;
         default_storage_engine     = InnoDB
         table_definition_cache     = 512
         open_files_limit           = 65535
-        sysdate-is-now             = 1
+        sysdate-is-now             = ON
         sql_mode                   = NO_ENGINE_SUBSTITUTION
+
+        log_slow_verbosity = 'full'
+        slow_query_log = ON
+        long_query_time = 0.1
+        log_slow_slave_statements = ON
+        slow_query_log_file = '/var/log/mysql/mysql.slow'
+        log_slow_admin_statements = ON
+        log_queries_not_using_indexes = ON
 
         init-connect               = 'SET NAMES ${charset} COLLATE ${collation}'
         character-set-server       = ${charset}


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:
- restarts mysql

Changelog:
- enable slow log in mysql

fixes PL-100075

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - log queries that may impact performance, must only be readable by mysql and service users as it may contain sensitive data
- [x] Security requirements tested? (EVIDENCE)
  - automated test still runs, checked that log files are created with the correct permissions
