### PR TITLE
fix: fc-get-current-channel-url

### DIFF
--- a/fc-get-current-channel-url.sh
+++ b/fc-get-current-channel-url.sh
@@ -1,3 +1,13 @@
 #!/usr/bin/env bash
 
-curl --silent --head https://hydra.flyingcircus.io/channel/custom/flyingcircus/fc-19.03-$1/release/nixexprs.tar.xz | grep Location | cut -f 2 -d " "
+set -euo pipefail
+
+if [ $# -lt 2 ]; then
+  echo "Usage: $0 <release> <channel>" >&2
+  exit 2
+fi
+
+RELEASE="$1"
+CHANNEL="$2"
+
+curl --silent --head https://hydra.flyingcircus.io/channel/custom/flyingcircus/fc-$RELEASE-$CHANNEL/release/nixexprs.tar.xz | grep "[Ll]ocation" | cut -f 2 -d " "


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:
- none

Changelog:
- fixed fc-get-current-channel-url script
  - made release parameter chooseable
  - added error if no params
  - support for h2 (lowercase headers)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [x] Security requirements tested? (EVIDENCE)

