### PR TITLE
Update nixpkgs

### DIFF
--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -125,6 +125,17 @@ in {
     };
   });
 
+  matrix-synapse = super.matrix-synapse.overrideAttrs(orig: rec {
+    pname = "matrix-synapse";
+    version = "1.46.0";
+    name = "${pname}-${version}";
+
+    src = super.python3Packages.fetchPypi {
+      inherit pname version;
+      sha256 = "15az88sj12c9hfm3kcfmrvni4vw7v0m9ybp58cy92bgz4r2pxh25";
+    };
+  });
+
   kibana7 = super.kibana7.overrideAttrs(_: rec {
     version = elk7Version;
     name = "kibana-${version}";

--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "NixOS",
     "repo": "nixpkgs",
-    "rev": "83667ff60a88e22b76ef4b0bdf5334670b39c2b6",
-    "sha256": "0i3cl781909mshwh9f5k94z81ixmfk0k4427afajwm6lr2hgp4kp"
+    "rev": "b239cf7ba017c1abb1d5f0421bc360f9612cac58",
+    "sha256": "0s07vr4b3ry7dnxvvmidysxd0z7wsjnq16n4w88q2w2c80shcqcv"
   },
   "nixos-mailserver": {
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/",


### PR DESCRIPTION
Pull upstream NixOS changes that include security fixes and other updates:

* containerd: 1.5.4 -> 1.5.7 (CVE-2021-41103)
* element-web: 1.9.0 -> 1.9.2
* go_1_17: init at 1.17.2
* imagemagick6: 6.9.12-19 -> 6.9.12-26
* imagemagick: 7.1.0-8 -> 7.1.0-9
* linux: 5.10.71 -> 5.10.76
* matrix-synapse: 1.44.0 -> 1.46.0
* nix: 2.3.15 -> 2.3.16
* php74: 7.4.24 -> 7.4.25 (CVE-2021-21703)
* php80: 8.0.11 -> 8.0.12 (CVE-2021-21703)
* qemu: patch CVE-2021-3544, CVE-2021-3527, CVE-2021-3682, CVE-2021-3713

matrix-synapse update fixes a performance regression starting with 1.44.
The nixpkgs update has 1.45.1, add the override for 1.46.0 here so we
don't have to update Matrix twice.


@flyingcircusio/release-managers

## Release process

Impact:

* [NixOS 21.05] VMs will schedule a reboot to activate the new kernel version. Matrix Synapse will be restarted.

Changelog: (include changes from commit msg here)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - pull in upstream security fixes regularly
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still run, works on test VM
  - checked commit log for fixed CVEs and possible problems with updates, looked at changelog of synapse, tested synapse on staging VM


