### PR TITLE
[HOTFIX 2021_035] networking/ipv6: enable optimistic dad to improve boot reliability

### DIFF
--- a/nixos/platform/network.nix
+++ b/nixos/platform/network.nix
@@ -249,6 +249,11 @@ in
       "net.ipv4.tcp_congestion_control" = "bbr";
       "net.ipv4.ip_nonlocal_bind" = "1";
       "net.ipv6.ip_nonlocal_bind" = "1";
+      # Ensure that we can use IPv6 as early as possible.
+      # This fixes startup race conditions like 
+      # https://yt.flyingcircus.io/issue/PL-130190
+      "net.ipv6.conf.all.optimistic_dad" = 1;
+      "net.ipv6.conf.all.use_optimistic" = 1;
       "net.ipv4.ip_local_port_range" = "32768 60999";
       "net.ipv4.ip_local_reserved_ports" = "61000-61999";
       "net.core.rmem_max" = 8388608;


### PR DESCRIPTION
A number of VMs that circumstantially did not use our internal
resolver and thus could not resolve internal (private) v4 addresses
ended up trying to use NFS with IPv6 at a point in the boot process
where v6 seems to be still stuck in DAD.

We _could_ make DAD a requirement to pass the address setup unit,
however, I think there may be other circumstances where addresses
might get configured and optimistic DAD seems like a better systemic
approach in our case than to remember to DAD settle every address
every time.

Hotfix for PL-130190

@flyingcircusio/release-managers

## Release process

* [ ] perform cherry pick to staging and production for 2021_035

Impact:

none

Changelog:

* Enable IPv6 optimistic duplicate address detection to iron out an edge case where NFS could not be mounted during boot when using IPv6. (PL-130190)

## Security implications

- [X] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

I reviewed the corresponding RFC for optimistic DAD (https://datatracker.ietf.org/doc/html/rfc4429#page-12) and the security considerations do not imply any additional risk for our scenario. DAD is only a second line of defense in our environment as we have fully managed machines and IPAM anyway.

- [X] Security requirements tested? (EVIDENCE)

nothing to test, tried the fix on an affected VM and it did not break the automated nfs test which reflects our regular scenario.
