### PR TITLE
docs: remove mention of DB super users being able to do fc-manage

### DIFF
--- a/doc/src/mysql.rst
+++ b/doc/src/mysql.rst
@@ -28,8 +28,8 @@ Service users can use :command:`sudo -u mysql -i` to access the
 MySQL super user account to perform administrative commands
 and access log files such as the slowlog.
 
-Both service users and the `mysql` DB super user may invoke :command:`sudo
-fc-manage --build` to apply configuration changes and restart the MySQL
+Service users may invoke :command:`sudo fc-manage --build`
+to apply configuration changes and restart the MySQL
 server (if necessary).
 
 For backup tasks the :command:`xtrabackup` command is provided, along with sudo

--- a/doc/src/postgresql.rst
+++ b/doc/src/postgresql.rst
@@ -57,8 +57,8 @@ Service users can use :command:`sudo -u postgres -i` to access the
 PostgreSQL super user account to perform administrative commands like
 :command:`createdb` and :command:`createuser`.
 
-Both service users and the `postgres` DB super user may invoke :command:`sudo
-fc-manage --build` to apply configuration changes and restart the PostgreSQL
+Service users may invoke :command:`sudo fc-manage --build`
+to apply configuration changes and restart the PostgreSQL
 server (if necessary).
 
 


### PR DESCRIPTION

fixes PL-130171

@flyingcircusio/release-managers

## Release process

Impact: none

Changelog:
- remove mention of DB super users being able to do fc-manage

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [x] Security requirements tested? (EVIDENCE)

