### PR TITLE
matomo: upgrade to v4.5.0

### DIFF
--- a/pkgs/matomo.nix
+++ b/pkgs/matomo.nix
@@ -1,0 +1,110 @@
+{ lib, stdenv, fetchurl, makeWrapper, php }:
+
+let
+  versions = {
+    matomo = {
+      version = "4.5.0";
+      sha256 = "sha256-OyjdzY+ENYxOTVjDLjj2unJbpaGODIH2I5Acmt45HDA=";
+    };
+
+    matomo-beta = {
+      version = "4.6.0";
+      # `beta` examples: "b1", "rc1", null
+      # when updating: use null if stable version is >= latest beta or release candidate
+      beta = "b2";
+      sha256 = "sha256-7p/ZPtr5a/tBjrM27ILF3rNfxDIWuzWKCXNom3HlyL8=";
+    };
+  };
+  common = pname: { version, sha256, beta ? null }:
+    let
+      fullVersion = version + lib.optionalString (beta != null) "-${toString beta}";
+      name = "${pname}-${fullVersion}";
+    in
+
+      stdenv.mkDerivation rec {
+        inherit name;
+        version = fullVersion;
+
+        src = fetchurl {
+          url = "https://builds.matomo.org/matomo-${version}.tar.gz";
+          inherit sha256;
+        };
+
+        nativeBuildInputs = [ makeWrapper ];
+
+        # make-localhost-default-database-server.patch:
+        #   This changes the default value of the database server field
+        #   from 127.0.0.1 to localhost.
+        #   unix socket authentication only works with localhost,
+        #   but password-based SQL authentication works with both.
+        # TODO: is upstream interested in this?
+        # -> discussion at https://github.com/matomo-org/matomo/issues/12646
+        patches = [ ./make-localhost-default-database-host.patch ];
+
+        # this bootstrap.php adds support for getting PIWIK_USER_PATH
+        # from an environment variable. Point it to a mutable location
+        # to be able to use matomo read-only from the nix store
+        postPatch = ''
+          cp ${./bootstrap.php} bootstrap.php
+        '';
+
+        # TODO: future versions might rename the PIWIK_… variables to MATOMO_…
+        # TODO: Move more unnecessary files from share/, especially using PIWIK_INCLUDE_PATH.
+        #       See https://forum.matomo.org/t/bootstrap-php/5926/10 and
+        #       https://github.com/matomo-org/matomo/issues/11654#issuecomment-297730843
+        installPhase = ''
+          runHook preInstall
+
+          # copy everything to share/, used as webroot folder, and then remove what's known to be not needed
+          mkdir -p $out/share
+          cp -ra * $out/share/
+          # tmp/ is created by matomo in PIWIK_USER_PATH
+          rmdir $out/share/tmp
+          # config/ needs to be accessed by PIWIK_USER_PATH anyway
+          ln -s $out/share/config $out/
+
+          makeWrapper ${php}/bin/php $out/bin/matomo-console \
+            --add-flags "$out/share/console"
+
+          runHook postInstall
+        '';
+
+        filesToFix = [
+          "misc/composer/build-xhprof.sh"
+          "misc/composer/clean-xhprof.sh"
+          "misc/cron/archive.sh"
+          "plugins/Installation/FormDatabaseSetup.php"
+          "vendor/pear/archive_tar/sync-php4"
+          "vendor/szymach/c-pchart/coverage.sh"
+          "vendor/matomo/matomo-php-tracker/run_tests.sh"
+          "vendor/twig/twig/drupal_test.sh"
+        ];
+
+        # This fixes the consistency check in the admin interface
+        #
+        # The filesToFix list may contain files that are exclusive to only one of the versions we build
+        # make sure to test for existence to avoid erroring on an incompatible version and failing
+        postFixup = ''
+          pushd $out/share > /dev/null
+          for f in $filesToFix; do
+            if [ -f "$f" ]; then
+              length="$(wc -c "$f" | cut -d' ' -f1)"
+              hash="$(md5sum "$f" | cut -d' ' -f1)"
+              sed -i "s:\\(\"$f\"[^(]*(\\).*:\\1\"$length\", \"$hash\"),:g" config/manifest.inc.php
+            else
+              echo "INFO(files-to-fix): $f does not exist in this version"
+            fi
+          done
+          popd > /dev/null
+        '';
+
+        meta = with lib; {
+          description = "A real-time web analytics application";
+          license = licenses.gpl3Plus;
+          homepage = "https://matomo.org/";
+          platforms = platforms.all;
+          maintainers = with maintainers; [ florianjacob kiwi sebbel ];
+        };
+      };
+in
+lib.mapAttrs common versions

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -136,6 +136,10 @@ in {
     meta.license = null;
   });
 
+  inherit (callPackages ./matomo.nix {})
+    matomo
+    matomo-beta;
+
   kubernetes-dashboard = super.callPackage ./kubernetes-dashboard.nix { };
 
   # Import old php versions from nix-phps


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:
- matomo will be restarted

Changelog:
- upgrade matomo to v4.5.0

NOTE: It is required to delete /var/lib/matomo/tmp before upgrade

This has already been fixed upstream and will be unnecesarry starting with 21.11

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - [dpausp] check changelog for security-relevant changes, use recent Matomo version
- [x] Security requirements tested? (EVIDENCE)
  - [dpausp] checked changelog, 4.5.0 is the newest version, tested upgrade from 4.3.1 to 4.5.0
