### PR TITLE
Fix matomo 4.5.0, run upstream test

### DIFF
--- a/pkgs/matomo/bootstrap.php
+++ b/pkgs/matomo/bootstrap.php
@@ -1,0 +1,6 @@
+<?php
+// get PIWIK_USER_PATH from environment variable,
+// so this bootstrap.php can be read-only but still configure PIWIK_USER_PATH at runtime
+if ($path = getenv('PIWIK_USER_PATH')) {
+  define('PIWIK_USER_PATH', $path);
+}

--- a/pkgs/matomo/default.nix
+++ b/pkgs/matomo/default.nix
@@ -103,7 +103,7 @@ let
           license = licenses.gpl3Plus;
           homepage = "https://matomo.org/";
           platforms = platforms.all;
-          maintainers = with maintainers; [ florianjacob kiwi sebbel ];
+          maintainers = with maintainers; [ florianjacob kiwi ];
         };
       };
 in

--- a/pkgs/matomo/make-localhost-default-database-host.patch
+++ b/pkgs/matomo/make-localhost-default-database-host.patch
@@ -1,0 +1,13 @@
+diff --git a/plugins/Installation/FormDatabaseSetup.php b/plugins/Installation/FormDatabaseSetup.php
+index 74de2535b4..bc172ad0eb 100644
+--- a/plugins/Installation/FormDatabaseSetup.php
++++ b/plugins/Installation/FormDatabaseSetup.php
+@@ -82,7 +82,7 @@ class FormDatabaseSetup extends QuickForm2
+ 
+ 
+         $defaults = array(
+-            'host'          => '127.0.0.1',
++            'host'          => 'localhost',
+             'type'          => $defaultDatabaseType,
+             'tables_prefix' => 'matomo_',
+         );

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -147,7 +147,7 @@ in {
     meta.license = null;
   });
 
-  inherit (callPackages ./matomo.nix {})
+  inherit (super.callPackages ./matomo {})
     matomo
     matomo-beta;
 

--- a/release/default.nix
+++ b/release/default.nix
@@ -291,9 +291,15 @@ let
     };
   };
 
+  # run upstream tests against our overlay
+  upstreamTests = {
+    inherit (pkgs.nixosTests)
+      matomo;
+  };
+
   tested = with lib; pkgs.releaseTools.aggregate {
     name = "tested";
-    constituents = collect isDerivation (jobs // { inherit channels; });
+    constituents = collect isDerivation (jobs // { inherit channels; } // upstreamTests );
     meta.description = "Indication that pkgs, tests and channels are fine";
   };
 

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -20,6 +20,10 @@ let
   in discover (importTest fn args system);
 
 in {
+  # run upstream tests against our overlay
+  inherit (pkgs.nixosTests)
+    matomo;
+
   antivirus = callTest ./antivirus.nix {};
   channel = callTest ./channel.nix {};
   coturn = callTest ./coturn.nix {};


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

Changelog:
- matomo is now tested by hydra
## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [x] Security requirements tested? (EVIDENCE)

