### PR TITLE
Update nixpkgs

### DIFF
--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -125,17 +125,6 @@ in {
     };
   });
 
-  matrix-synapse = super.matrix-synapse.overrideAttrs(orig: rec {
-    pname = "matrix-synapse";
-    version = "1.46.0";
-    name = "${pname}-${version}";
-
-    src = super.python3Packages.fetchPypi {
-      inherit pname version;
-      sha256 = "15az88sj12c9hfm3kcfmrvni4vw7v0m9ybp58cy92bgz4r2pxh25";
-    };
-  });
-
   kibana7 = super.kibana7.overrideAttrs(_: rec {
     version = elk7Version;
     name = "kibana-${version}";

--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "NixOS",
     "repo": "nixpkgs",
-    "rev": "b239cf7ba017c1abb1d5f0421bc360f9612cac58",
-    "sha256": "0s07vr4b3ry7dnxvvmidysxd0z7wsjnq16n4w88q2w2c80shcqcv"
+    "rev": "195d5816cddc056e07fd2aa3fe81ee6e3f9d96e2",
+    "sha256": "1yvvfzqmvn9iq5w4v2p9kl60ig9ypspbh868mb9dpf3xgadqcb11"
   },
   "nixos-mailserver": {
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/",


### PR DESCRIPTION
Pull upstream NixOS changes that include security fixes and other updates:

* linux: 5.10.76 -> 5.10.79
* mariadb: 10.5.10 -> 10.5.13 (CVE-2021-35604)
* roundcube: 1.4.11 -> 1.4.12

 #PL-130210

Remove matrix-synapse override as it is in nixpkgs now.


@flyingcircusio/release-managers

## Release process

Impact:

* [NixOS 21.05] VMs will schedule a reboot to activate the new kernel version. Roundcube Webmail will be restarted.

Changelog: (include changes from commit msg here)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - pull in upstream security fixes regularly
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still run, works on test VM
  - checked commit log for fixed CVEs and possible problems with updates, looked at changelog of roundcube
