### PR TITLE
PL-120471 stathost: Review varnish relabeling rules; Fix varnish regex

### DIFF
--- a/nixos/roles/webproxy.nix
+++ b/nixos/roles/webproxy.nix
@@ -192,7 +192,7 @@ in
         }
         {
           source_labels = [ "__name__" ];
-          regex = "varnish_(\1\w+)_(.+)__(\\d+)__(.+)";
+          regex = "varnish_(\\w+)_(.+)__(\\d+)__(.+)";
           replacement = "varnish_\${4}";
           target_label = "__name__";
         }


### PR DESCRIPTION
@flyingcircusio/release-managers

This fixes the varnish regex so that metrics in prometheus don't contain a partial nix store path anymore.

## Release process

Impact:
- none

Changelog:
- prometheus metrics don't contain a partial nix store path for varnish configuration anymore


## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Prometheus metrics from varnish don't contain a partial nix store path of the configuration file so less data is exposed to prometheus
- [x] Security requirements tested? (EVIDENCE)
  - made metrics with unwanted name show up with the same varnish configuration file as affected machine and make them disappear by changing the regex

