### PR TITLE
Allow service users to use the DEV containers

### DIFF
--- a/nixos/roles/devhost/default.nix
+++ b/nixos/roles/devhost/default.nix
@@ -145,7 +145,7 @@ in
 
       security.sudo.extraRules = lib.mkAfter [
           { commands = [ { command = "${container_script}/bin/fc-build-dev-container"; options = [ "NOPASSWD" ]; } ];
-            groups = [ "users" ]; 
+            groups = [ "service" "users" ];
           } ];
 
       systemd.tmpfiles.rules = [


### PR DESCRIPTION
@flyingcircusio/release-managers

Rationale: Service users are used in CI/CD to test e.g. deployments

## Release process

Impact:

n/a

Changelog: 

Allow service users to use dev containers.

## Security implications

- [ ] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [ ] Security requirements tested? (EVIDENCE): I have *not* yet tested that this actually works, lacking the infrastructure.
