### PR TITLE
users: write out htpasswd files for each permission/group

### DIFF
--- a/nixos/roles/kubernetes/master.nix
+++ b/nixos/roles/kubernetes/master.nix
@@ -384,7 +384,7 @@ in
         serverAliases = tail addresses;
         extraConfig = ''
           auth_basic "FCIO";
-          auth_basic_user_file /etc/local/nginx/htpasswd_fcio_users;
+          auth_basic_user_file /etc/local/nginx/htpasswd_fcio_users.sudo-srv;
         '';
         forceSSL = true;
         locations = {

--- a/nixos/services/nginx/default.nix
+++ b/nixos/services/nginx/default.nix
@@ -281,7 +281,7 @@ in
 
         # file has moved; link back to the old location for compatibility reasons
         "local/nginx/htpasswd_fcio_users" = {
-          source = "/etc/local/htpasswd_fcio_users";
+          source = "/etc/local/htpasswd_fcio_users.login";
         };
 
         "local/nginx/example-configuration".text =

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -85,6 +85,7 @@ in {
   statshost-master = callTest ./statshost/statshost-master.nix {};
   sudo = callTest ./sudo.nix {};
   systemd-service-cycles = callTest ./systemd-service-cycles.nix {};
+  users = callTest ./users.nix {};
   vxlan = callTest ./vxlan.nix {};
   webproxy = callTest ./webproxy.nix {};
   wkhtmltopdf = callTest ./wkhtmltopdf.nix {};

--- a/tests/users.nix
+++ b/tests/users.nix
@@ -1,0 +1,79 @@
+import ./make-test-python.nix ({ lib, ... }:
+
+{
+  name = "users";
+  machine =
+    { pkgs, lib, config, ... }:
+    {
+      imports = [ ../nixos ../nixos/roles ];
+
+      users.groups = {
+        login = { members = [ "u1001" ]; };
+        manager = { members = [ "u1002" ]; };
+        sudo-srv = { members = [ "u1003" ]; };
+        wheel = { members = [ "u1004" ]; };
+      };
+
+      flyingcircus.enc.parameters.interfaces.srv = {
+        mac = "52:54:00:12:34:56";
+        bridged = false;
+        networks = {
+          "192.168.101.0/24" = [ "192.168.101.1" ];
+          "2001:db8:f030:1c3::/64" = [ "2001:db8:f030:1c3::1" ];
+        };
+        gateways = {};
+      };
+
+      users.users =
+        lib.mapAttrs'
+          (id: groups:
+            lib.nameValuePair
+              "u${id}"
+              {
+                uid = builtins.fromJSON id;
+                extraGroups = groups;
+                isNormalUser = true;
+                name = "u${id}";
+                hashedPassword = "*";
+              }
+          )
+          {
+            "1000" = [ ];
+            "1001" = [ "login" ];
+            "1002" = [ "manager" ];
+            "1003" = [ "sudo-srv" ];
+            "1004" = [ "wheel" ];
+          };
+    };
+
+  testScript = ''
+    machine.wait_for_unit('multi-user.target')
+
+    def get(cmd):
+      print(f"$ {cmd}")
+      _, result = machine.execute(cmd)
+      print(result)
+      return result
+
+    def cmp(a, b):
+      if a == b:
+        return
+      print("Comparison failed")
+      print(a)
+      print(" != ")
+      print(b)
+      raise AssertionError()
+
+    cmp(set(get("ls /etc/local/htpasswd*").split()), {
+      '/etc/local/htpasswd_fcio_users',
+      '/etc/local/htpasswd_fcio_users.login',
+      '/etc/local/htpasswd_fcio_users.manager',
+      '/etc/local/htpasswd_fcio_users.sudo-srv',
+      '/etc/local/htpasswd_fcio_users.wheel'})
+
+    assert get("cat /etc/local/htpasswd_fcio_users.login") == "u1001:*"
+    assert get("cat /etc/local/htpasswd_fcio_users.manager")== "u1002:*"
+    assert get("cat /etc/local/htpasswd_fcio_users.sudo-srv") == "u1003:*"
+    assert get("cat /etc/local/htpasswd_fcio_users.wheel")== "u1004:*"
+  '';
+})


### PR DESCRIPTION
kubernetes: require sudo-srv for accessing the dashboard

PL-130213

@flyingcircusio/release-managers

## Release process

Impact:

none

Changelog:

* Extend the mechanism that writes a `htpasswd` file for users with `login` permission to provide a `htpasswd` file for each permission within the resource group (`/etc/local/htpasswd_fcio_users.*`)

* Limit access to the Kubernetes dashboard to users with the `sudo-srv` permission. (PL-130213)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

Only grant permissions that are needed for a job. This improvement allows finer control in general and makes access to the Kubernetes dashboard more consistent: kubectl is only allowed for users with `sudo-srv` permission and having the dashboard accessible with `login` is inconsistent.

- [x] Security requirements tested? (EVIDENCE)

* Automated check for the rendering of the various htpasswd files
* only visually inspected the kubernetes change
