### PR TITLE
Matrix-synapse: 1.46.0 -> 1.47.1

### DIFF
--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -195,6 +195,18 @@ in {
                 all.redis
               ]);
 
+
+  matrix-synapse = super.matrix-synapse.overrideAttrs(orig: rec {
+    pname = "matrix-synapse";
+    version = "1.47.1";
+    name = "${pname}-${version}";
+
+    src = super.python3Packages.fetchPypi {
+      inherit pname version;
+      sha256 = "17l4cq2295lwm35zy6bm6ljqd2f6mlgc14q8g9p9s58s4gikbncm";
+    };
+  });
+
   mc = super.callPackage ./mc.nix { };
 
   mongodb-3_6 = super.mongodb-3_6.overrideAttrs(_: rec {


### PR DESCRIPTION
Fixes a critical security issue where attackers are able to place files
on the Matrix server outside of the media store (but they don't control the
last part of the location).

 #PL-130224

@flyingcircusio/release-managers

## Release process

Impact:

* [NixOS 21.05] matrix-synapse will be restarted.

Changelog:

* Matrix: update synapse to 1.47.1 to fix a security issue (CVE-2021-41281) (#PL-130224).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  -  use a matrix-synapse version with the latest security fixes  
- [x] Security requirements tested? (EVIDENCE)
  - checked release notes for significant changes
  - 1.47.1 is the latest version
  - manually tested on staging VM, chatting with people on other homeservers works

