### PR TITLE
Pl 130214 fc agent error output

### DIFF
--- a/pkgs/fc/agent/fc/util/nixos.py
+++ b/pkgs/fc/agent/fc/util/nixos.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 from subprocess import PIPE, STDOUT
+from fc.util.subprocess_helper import get_popen_stderr_lines, get_popen_stdout_lines
 import json
 import os
 import os.path as p
@@ -210,7 +211,6 @@ def update_system_channel(channel_url, log=_log):
         except subprocess.SubprocessError as e:
             raise ChannelUpdateFailed(stdout=e.stdout, stderr=e.stderr)
 
-    stdout_lines = []
     proc = subprocess.Popen(['nix-channel', '--update', "nixos"],
                             stdout=PIPE,
                             stderr=PIPE,
@@ -219,13 +219,10 @@ def update_system_channel(channel_url, log=_log):
         "system-channel-update-started",
         _replace_msg="Channel update command started with PID: {cmd_pid}",
         cmd_pid=proc.pid)
-    while proc.poll() is None:
-        line = proc.stdout.readline()
-        log.trace(
-            "system-channel-update-out", cmd_output_line=line.strip("\n"))
-        stdout_lines.append(line)
 
+    stdout_lines = get_popen_stdout_lines(proc, log, "system-channel-update-out")
     stdout = "".join(stdout_lines)
+    proc.wait()
 
     if proc.returncode == 0:
         log.debug("system-channel-update-succeeded")
@@ -317,18 +314,15 @@ def build_system(channel_url, build_options=None, out_link=None, log=_log):
 
     log.debug("system-build-command", cmd=" ".join(cmd))
 
-    stderr_lines = []
     proc = subprocess.Popen(cmd, stdout=PIPE, stderr=PIPE, text=True)
     log.info(
         "system-build-started",
         _replace_msg="Nix build command started with PID: {cmd_pid}",
         cmd_pid=proc.pid)
-    while proc.poll() is None:
-        line = proc.stderr.readline()
-        log.trace("system-build-out", cmd_output_line=line.strip("\n"))
-        stderr_lines.append(line)
 
+    stderr_lines = get_popen_stderr_lines(proc, log, "system-build-out")
     stderr = "".join(stderr_lines).strip()
+    proc.wait()
 
     if stderr:
         changed = True
@@ -385,18 +379,15 @@ def switch_to_system(system_path, lazy, log=_log):
 
     log.debug("system-switch-command", cmd=" ".join(cmd))
 
-    stdout_lines = []
     proc = subprocess.Popen(cmd, stdout=PIPE, stderr=STDOUT, text=True)
     log.info(
         "system-switch-started",
         _replace_msg="Switch command started with PID: {cmd_pid}",
         cmd_pid=proc.pid)
-    while proc.poll() is None:
-        line = proc.stdout.readline()
-        log.trace("system-switch-out", cmd_output_line=line.strip("\n"))
-        stdout_lines.append(line)
 
+    stdout_lines = get_popen_stdout_lines(proc, log, "system-switch-out")
     stdout = "".join(stdout_lines)
+    proc.wait()
 
     if proc.returncode == 0:
         log.info(
@@ -423,12 +414,9 @@ def dry_activate_system(system_path, log=_log):
         system=system_path)
     log.debug("system-dry-activate-cmd", cmd=" ".join(cmd))
 
-    stdout_lines = []
     proc = subprocess.Popen(cmd, stdout=PIPE, stderr=STDOUT, text=True)
-    while proc.poll() is None:
-        line = proc.stdout.readline()
-        log.trace("system-dry-activate-out", cmd_output_line=line.strip())
-        stdout_lines.append(line)
+    stdout_lines = get_popen_stdout_lines(proc, log, "system-dry-activate-out")
+    proc.wait()
 
     if proc.returncode != 0:
         log.error(

--- a/pkgs/fc/agent/fc/util/subprocess_helper.py
+++ b/pkgs/fc/agent/fc/util/subprocess_helper.py
@@ -1,0 +1,44 @@
+"""Helpers for dealing with subprocesses"""
+
+def get_popen_stdout_lines(popen, log, log_event):
+    """Reads stdout line-by-line from a Popen object until the stream ends
+    and returns a list of all received lines.
+    Every line logged at trace level as it appears.
+
+    WARNING: this is intended for (Nix) commands that return their main output
+    on stdout and not much on stderr.
+
+    Using it for a command that has a lot of output on stderr, too, may lead to
+    deadlocks due to OS pipe buffers filling up! Use Popen.communicate() or
+    something similar for such cases.
+    """
+    stdout_lines = []
+    line = popen.stdout.readline()
+    while line:
+        log.trace(log_event, cmd_output_line=line.strip("\n"))
+        stdout_lines.append(line)
+        line = popen.stdout.readline()
+
+    return stdout_lines
+
+
+def get_popen_stderr_lines(popen, log, log_event):
+    """Reads stderr line-by-line from a Popen object until the stream ends
+    and returns a list of all received lines.
+    Every line logged at trace level as it appears.
+
+    WARNING: this is intended for (Nix) commands that return their main output
+    on stderr and not much on stdout.
+
+    Using it for a command that has a lot of output on stdout, too, may lead to
+    deadlocks due to OS pipe buffers filling up! Use Popen.communicate() or
+    something similar for such cases.
+    """
+    stderr_lines = []
+    line = popen.stderr.readline()
+    while line:
+        log.trace(log_event, cmd_output_line=line.strip("\n"))
+        stderr_lines.append(line)
+        line = popen.stderr.readline()
+
+    return stderr_lines

--- a/pkgs/fc/agent/fc/util/tests/test_nixos.py
+++ b/pkgs/fc/agent/fc/util/tests/test_nixos.py
@@ -13,16 +13,12 @@ class FakeCmdStream:
     def __init__(self, content):
         self.content = content
         self.line_gen = (l for l in content.splitlines(keepends=True))
-        self.finished = False
-
-    def read_next(self):
-        try:
-            self.next_line = next(self.line_gen)
-        except StopIteration:
-            self.finished = True
 
     def readline(self):
-        return self.next_line
+        try:
+            return next(self.line_gen)
+        except StopIteration:
+            return ''
 
     def read(self):
         return self.content
@@ -44,16 +40,8 @@ class PollingFakePopen:
         self.pid = pid
         self._poll = poll
 
-    def poll(self):
-        if self._poll == 'stdout':
-            self.stdout.read_next()
-            if self.stdout.finished:
-                return self.returncode
-
-        if self._poll == 'stderr':
-            self.stderr.read_next()
-            if self.stderr.finished:
-                return self.returncode
+    def wait(self):
+        pass
 
 
 def test_build_system_with_changes(log, monkeypatch):

--- a/pkgs/fc/agent/fc/util/tests/test_nixos.py
+++ b/pkgs/fc/agent/fc/util/tests/test_nixos.py
@@ -227,3 +227,23 @@ def test_find_nix_build_error_syntax():
     """)
     expected = "syntax error, unexpected '}', expecting ';', at /etc/local/nixos/dev_vm.nix:190:1"
     assert nixos.find_nix_build_error(stderr) == expected
+
+
+def test_find_nix_build_error_builder_failed():
+
+    stderr = textwrap.dedent("""\
+    /nix/store/bf8jb44sc2ad88895g7ki43iyzai9zaj-nixos-system-test-21.05.1534.06a1226.drv
+    building '/nix/store/wxjjd4z2f8z8badd1mzqbh8xxq3zq288-system-path.drv'...
+    building '/nix/store/ckkdla5pg582i83d0v2w99mxny2jqxk3-unit-script-acme--domain_name--start.drv'...
+    builder for '/nix/store/ckkdla5pg582i83d0v2w99mxny2jqxk3-unit-script-acme--domain_name--start.drv' failed with exit code 127; last 1 log lines:
+    /build/.attr-0: line 1: domain_name: command not found
+    cannot build derivation '/nix/store/5wi39jva4fn0fg72rw26813vmdwg69d4-unit-acme--domain_name-.service.drv': 1 dependencies couldn't be built
+    building '/nix/store/nwk2j3xp1rv51n6r98gfn6zdncsf54xb-unit-script-acme-selfsigned--domain_name--start.drv'...
+    cannot build derivation '/nix/store/7krvm44hsqasdrgk14ybyp15riz3h57f-system-units.drv': 1 dependencies couldn't be built
+    cannot build derivation '/nix/store/iak0907qnlnjj3j5xrnw3m431a1ymdvm-etc.drv': 1 dependencies couldn't be built
+    cannot build derivation '/nix/store/bf8jb44sc2ad88895g7ki43iyzai9zaj-nixos-system-test-21.05.1534.06a1226.drv': 1 dependencies couldn't be built
+    error: build of '/nix/store/bf8jb44sc2ad88895g7ki43iyzai9zaj-nixos-system-test-21.05.1534.06a1226.drv' failed
+    """)
+
+    expected = "builder for '/nix/store/ckkdla5pg582i83d0v2w99mxny2jqxk3-unit-script-acme--domain_name--start.drv' failed with exit code 127"
+    assert nixos.find_nix_build_error(stderr) == expected


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* fc-agent: improve error handling: extract Nix builder errors properly for logging, fix problem that sometimes caused the loss of lines of command output at the end. (#PL-130214).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - nothing new here, we want to have proper logging for fc-agent errors  
- [x] Security requirements tested? (EVIDENCE)
  - ran fc-manage commands and looked at error output for different cases, automated test check Nix build error extraction
