### PR TITLE
Integrate custom nixos configs provided by ENC.

### DIFF
--- a/nixos/platform/default.nix
+++ b/nixos/platform/default.nix
@@ -6,15 +6,14 @@ let
   cfg = config.flyingcircus;
   fclib = config.fclib;
   enc_services = fclib.jsonFromFile cfg.enc_services_path "[]";
-  localModulesDir = "/etc/local/nixos";
-  localModules =
-    if builtins.pathExists localModulesDir
+  additionalModules = path:
+    if builtins.pathExists path
     then
       map
-        (name: "${localModulesDir}/${name}")
+        (name: "${path}/${name}")
         (filter
           (fn: lib.hasSuffix ".nix" fn)
-          (lib.attrNames (builtins.readDir "/etc/local/nixos")))
+          (lib.attrNames (builtins.readDir path)))
     else [];
 
 in {
@@ -40,7 +39,9 @@ in {
     ./systemd.nix
     ./upgrade.nix
     ./users.nix
-  ] ++ localModules;
+  ] ++ 
+    (additionalModules "/etc/nixos/enc-configs") ++
+    (additionalModules "/etc/local/nixos");
 
   options = with lib.types; {
 


### PR DESCRIPTION
Re PL-129625

@flyingcircusio/release-managers

## Release process

Impact:

none

Changelog:

* We can now provision custom NixOS configuration for all machines per customer, resourcegroup, and invididually for each machine through our configuration database. (PL-129625)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

We considered the various implications about shipping custom config through the directory  (like shipping arbitrary system configs, but that's already possible by shipping a custom channel URL). We decided that in the long run there should be a separate mechanism, but for now, allowing our (super) admins to store this config and ship it through the ENC is considered sufficient. The longer term aspects are documented here: https://yt.flyingcircus.io/issue/PL-130199

- [x] Security requirements tested? (EVIDENCE)

The directory API is tested and we do not ship the config through the customer API. 