### PR TITLE
Add PSI Metric to global statshost

### DIFF
--- a/nixos/roles/statshost/global-metrics.nix
+++ b/nixos/roles/statshost/global-metrics.nix
@@ -33,6 +33,7 @@ let
     "system"
     "varnish"
     "conntrack"
+    "psi"
   ];
 
   markAllowedMetrics = map


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Added performance data ingest to global statshost

Impact:

Changelog:

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Added performance data ingest to global statshost which means that Pressure Stall Information shows up in the global statshost which is not security critical data
- [x] Security requirements tested? (EVIDENCE)
  - tested on local VM

