### PR TITLE
Update nixpkgs

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "NixOS",
     "repo": "nixpkgs",
-    "rev": "195d5816cddc056e07fd2aa3fe81ee6e3f9d96e2",
-    "sha256": "1yvvfzqmvn9iq5w4v2p9kl60ig9ypspbh868mb9dpf3xgadqcb11"
+    "rev": "2553aee74fed8c2205a4aeb3ffd206ca14ede60f",
+    "sha256": "16v5qjc84gg57yd8pzp9np420h72ahrgpp8hmcnmz4nf8x5alhvy"
   },
   "nixos-mailserver": {
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/",


### PR DESCRIPTION
Update nixpkgs

Pull upstream NixOS changes that include security fixes and other
updates:

* gd: 2.3.0 -> 2.3.2, add patch for partial CVE-2021-40812 fix
* go_1_17: 1.17.2 -> 1.17.3
* imagemagick: 7.1.0-9 -> 7.1.0-13
* linux: 5.10.79 -> 5.10.81
* nginxStable: 1.20.1 -> 1.20.2
* openssh: Fix CVE-2021-41617
* php74: 7.4.25 -> 7.4.26 (CVE-2021-21707)
* php80: 8.0.12 -> 8.0.13 (CVE-2021-21707)
* vim: 8.2.2567 -> 8.2.3451

 #PL-130230


@flyingcircusio/release-managers

## Release process

Impact:

* [NixOS 21.05] VMs will schedule a reboot to activate the new kernel version. Many services will be restarted.

Changelog: (include changes from commit msg here)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - pull in upstream security fixes regularly
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still run, works on test VM
  - checked commit log for fixed CVEs and possible problems with updates, looked at changelog of nginx
