### PR TITLE
k3s: install separate kubectl binary to speed up CLI interaction

### DIFF
--- a/nixos/roles/k3s/server.nix
+++ b/nixos/roles/k3s/server.nix
@@ -33,7 +33,7 @@ let
   defaultKubeconfig = "/etc/kubernetes/cluster-admin.kubeconfig";
 
   kubernetesMakeKubeconfig = let
-    kc = "${config.services.k3s.package}/bin/k3s kubectl";
+    kc = "${pkgs.kubectl}/bin/kubectl";
     remarshal = "${pkgs.remarshal}/bin/remarshal";
   in
   pkgs.writeScriptBin "kubernetes-make-kubeconfig" ''
@@ -72,12 +72,9 @@ in {
 
     environment.variables.KUBECONFIG = defaultKubeconfig;
 
-    environment.shellAliases = {
-      kubectl = "k3s kubectl";
-    };
-
     environment.systemPackages = with pkgs; [
       kubernetes-helm
+      kubectl
       stern
       config.services.k3s.package
       kubernetesMakeKubeconfig


### PR DESCRIPTION
Currently, kubectl is aliased to k3s kubectl which takes some time to
start up because it bundles all kubernetes components. Installing a
separate kubectl binary makes interaction with the CLI much faster.
Still works the same because kubectl interprets KUBECONFIG which is set
to the kubeconfig that k3s kubectl uses.

 #PL-130240

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* kubernetes/k3s: speed up kubectl startup by using a separate binary instead of aliasing `k3s kubectl` (#PL-130240).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - no changes, we only call a separated kubectl but with the same config 
- [x] Security requirements tested? (EVIDENCE)
  - checked in our test cluster that kubectl works for normal users and that kubernetes-make-kubeconfig still works
