### PR TITLE
backup: use backy-extract with optimized locking and memory usage

### DIFF
--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -24,7 +24,16 @@ in {
   #
 
   backy = super.callPackage ./backy.nix { };
-  backyExtract = super.callPackage ./backyextract { };
+
+  backyExtract = let
+    src = super.fetchFromGitHub {
+      rev = "3c9a7b7a3ebfad2bcb2ee4ffebf71669038ba2c9";
+      owner = "flyingcircusio";
+      repo = "backy-extract";
+      sha256 = "01q212p22jwy8vwfqp8a62anfq587q3g1sc30va6sdfxzni4lvgm";
+    };
+    in
+      super.callPackage src { pkgs = super; };
 
   bundlerSensuPlugin = super.callPackage ./sensuplugins-rb/bundler-sensu-plugin.nix { };
   busybox = super.busybox.overrideAttrs (oldAttrs: {


### PR DESCRIPTION
This solves PL-130044 and PL-129786

@flyingcircusio/release-managers

## Release process

Impact:

none

Changelog:

* Improve backup restore utilities to allow restore operations while backups are running (PL-129786)
* Improve backup restore utilities memory usage to allow single file restore working on extremely large multi-terabyte volumes. (PL-130044)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

no specific new requirements

- [x] Security requirements tested? (EVIDENCE)

skimmed the code change by KC in backy-extract 