### PR TITLE
Ceph: wrap up NixOS integration, lots of fixes and add test coverage

### DIFF
--- a/nixos/infrastructure/flyingcircus-physical.nix
+++ b/nixos/infrastructure/flyingcircus-physical.nix
@@ -27,6 +27,10 @@ mkIf (cfg.infrastructureModule == "flyingcircus-physical") {
         fsIdentifier = "provided";
         gfxmodeBios = "text";
       };
+
+      # Wanted by backy and Ceph servers
+      kernel.sysctl."vm.vfs_cache_pressure" = 10;
+
     };
 
     environment.systemPackages = with pkgs; [

--- a/nixos/platform/shell.nix
+++ b/nixos/platform/shell.nix
@@ -78,7 +78,14 @@ in
     (opt (parameters ? service_description)
       ''
         Services:   ${parameters.service_description}${opt isProd "  [production]"}
-      '');
+      '') + 
+      (let
+         roles = lib.concatStringsSep ", " (enc.roles or []);
+      in
+        ''
+          Roles:      ${roles}
+
+        '');
 
     programs.bash.promptInit =
       let

--- a/nixos/roles/backyserver.nix
+++ b/nixos/roles/backyserver.nix
@@ -13,6 +13,7 @@ let
     src = pkgs.fetchFromGitHub {
       owner = "flyingcircusio";
       repo = "backy-extract";
+      # 1.1.0
       rev = "5fd4c02e757918e22b634b16ae86927b82eb9f2a";
       sha256 = "1msg4p4h6ksj3vrsshhh5msfwgllai42jczyvd4nvrsqpncg12ik";
     };
@@ -58,8 +59,9 @@ in
     };
 
     boot = {
-      kernel.sysctl."vm.vfs_cache_pressure" = 10;
-      kernelModules = [ "mq_deadline" ];
+      # Extracted to flyingcircus-physical.nix
+      # kernel.sysctl."vm.vfs_cache_pressure" = 10;
+      kernelModules = [ "mq_deadline" ]; 
     };
 
     environment.etc."backy.global.conf".text = ''
@@ -89,7 +91,7 @@ in
     systemd.services.backy = {
         description = "Backy backup server";
         wantedBy = [ "multi-user.target" ];
-        path = [ pkgs.backy pkgs.fc.agent ];
+        path = [ backy pkgs.fc.agent ];
 
         environment = {
           CEPH_ARGS = "--id ${enc.name}";
@@ -99,33 +101,16 @@ in
           ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
         };
 
-        # Theory of operation: raising write_expire timeouts means that
-        # requests are much more unlikely to get into 'expired' state which effectively
-        # means FIFO which means thrashing under high load.
         script = ''
             set -e
 
             # Delete old logs from pre-journal days.
             rm -f /var/log/backy.log*
 
-            for device in /sys/block/*; do
-                if ! [[ -d ''${device} ]]; then
-                    continue
-                fi
-
-                case ''${device##*/} in
-                    sd?)
-                        echo "mq-deadline" > "''${device}/queue/scheduler"
-                        sleep 0.1
-                        echo 50000 > "''${device}/queue/iosched/write_expire"  # default: 5000
-                    ;;
-                esac
-            done
-
             if ! [[ -f /etc/backy.conf ]]; then
               fc-backy
             fi
-            exec ${pkgs.backy}/bin/backy scheduler
+            exec ${backy}/bin/backy scheduler
         '';
 
     };
@@ -139,13 +124,13 @@ in
 
       backy_sla = {
         notification = "Backy SLA conformance";
-        command = "sudo ${pkgs.backy}/bin/backy check";
+        command = "sudo ${backy}/bin/backy check";
       };
 
     };
 
     flyingcircus.passwordlessSudoRules = [
-      { commands = [ "${pkgs.backy}/bin/backy check" ];
+      { commands = [ "${backy}/bin/backy check" ];
         groups = [ "sensuclient" ];
       }
     ];

--- a/nixos/roles/ceph/osd.nix
+++ b/nixos/roles/ceph/osd.nix
@@ -133,6 +133,8 @@ in
   config = lib.mkIf role.enable {
 
     flyingcircus.services.ceph.server.enable = true;
+    
+    flyingcircus.services.ceph.cluster_network = head fclib.network.stb.v4.networks;
 
     environment.etc."ceph/ceph.conf".text = lib.mkAfter role.config;
 

--- a/nixos/roles/ceph/rgw.nix
+++ b/nixos/roles/ceph/rgw.nix
@@ -85,6 +85,19 @@ in
         };
       };
 
+      networking.firewall.extraCommands = let
+        srv = fclib.network.srv;
+      in ''
+        # Accept traffic from S3 gateways from within the SRV network.
+
+      '' + (lib.concatMapStringsSep "\n"
+              (net: "iptables -A nixos-fw -i ${srv.device} -s ${net} -p tcp --dport 7480 -j ACCEPT")
+              srv.v4.networks
+      ) + "\n" +
+      (lib.concatMapStringsSep "\n"
+              (net: "ip6tables -A nixos-fw -i ${srv.device} -s ${net} -p tcp --dport 7480 -j ACCEPT")
+              srv.v6.networks);
+
       systemd.services.fc-ceph-rgw-update-stats = {
         description = "Update RGW stats";
         serviceConfig.Type = "oneshot";

--- a/nixos/roles/ceph/rgw.nix
+++ b/nixos/roles/ceph/rgw.nix
@@ -41,9 +41,9 @@ in
           admin socket = /run/ceph/radosgw.asok
           rgw data = /srv/ceph/radosgw/ceph-$id
           rgw enable ops log = false
-          debug rgw = 4 5
-          debug civetweb = 4 5
-          debug rados = 4 5
+          debug rgw = 0 5
+          debug civetweb = 1 5
+          debug rados = 1 5
           '';
         description = ''
           Contents of the Ceph config file for RGWs.
@@ -77,6 +77,7 @@ in
         };
 
         restartIfChanged = true;
+        restartTriggers = [ config.environment.etc."ceph/ceph.conf".source ];
 
         serviceConfig = {
             Type = "simple";

--- a/nixos/roles/ceph/rgw.nix
+++ b/nixos/roles/ceph/rgw.nix
@@ -111,6 +111,15 @@ in
         '';
       }; 
 
+    services.logrotate.extraConfig = ''
+      /var/log/ceph/client.radosgw.log {
+          create 0644 root adm
+          postrotate
+            systemctl kill -s SIGHUP fc-ceph-rgw
+          endscript
+      }
+    '';
+
     })
 
     (lib.mkIf (role.enable && role.primary) {

--- a/nixos/services/ceph/client.nix
+++ b/nixos/services/ceph/client.nix
@@ -121,7 +121,15 @@ in
 
     flyingcircus.activationScripts.ceph-client-keyring = ''
        ${pkgs.fc.ceph}/bin/fc-ceph keys generate-client-keyring
-     '';
+    '';
+
+    services.logrotate.extraConfig = ''
+      /var/log/ceph/client.log {
+          rotate 30
+          create 0644 root adm
+          copytruncate
+      }
+    '';
 
   };
 

--- a/nixos/services/ceph/client.nix
+++ b/nixos/services/ceph/client.nix
@@ -63,6 +63,13 @@ in
           for all Ceph daemons and binaries.
         '';
       };
+      extraConfig = lib.mkOption {
+        type = lib.types.lines;
+        default = "";
+        description = ''
+          Extra config in the [global] section.
+        '';
+      };
       cluster_network = lib.mkOption {
         type = lib.types.nullOr lib.types.str;
         default = null;
@@ -108,7 +115,7 @@ in
     '';
 
     environment.etc."ceph/ceph.conf".text = 
-        (cfg.config + "\n"+ cfg.client.config);
+        (cfg.config + "\n" + cfg.extraConfig + "\n" + cfg.client.config);
 
     environment.variables.CEPH_ARGS = fclib.mkPlatform "--id ${config.networking.hostName}";
 

--- a/nixos/services/ceph/client.nix
+++ b/nixos/services/ceph/client.nix
@@ -29,12 +29,16 @@ in
           ${if cfg.cluster_network != null then "cluster network = " + cfg.cluster_network else "; cluster network not available on pure clients"}
 
           pid file = /run/ceph/$type-$id.pid
+          admin socket = /run/ceph/$cluster-$name.asok
 
           # Needs to correspond with daemon startup ulimit
           max open files = 262144
 
           osd pool default min size = 2
           osd pool default size = 3
+
+          osd pool default pg num = 64
+          osd pool default pgp num = 64
 
           setuser match path = /srv/ceph/$type/ceph-$id
 
@@ -48,6 +52,11 @@ in
           mon host = ${mons}
           mon osd down out interval = 900  # Allow 15 min for reboots to happen without backfilling.
           mon osd nearfull ratio = .9
+
+          mon data = /srv/ceph/mon/$cluster-$id
+          mon osd allow primary affinity = true
+          mon pg warn max per osd = 3000
+
           '';
         description = ''
           Global config of the Ceph config file. Will be used

--- a/nixos/services/ceph/server.nix
+++ b/nixos/services/ceph/server.nix
@@ -102,7 +102,8 @@ in
       "vm.dirty_background_ratio" = "10";
       "vm.dirty_ratio" = "40";
       "vm.max_map_count" = "524288";
-      "vm.vfs_cache_pressure" = "10";
+      # Extracted to flyingcircus-physical.nix
+      # kernel.sysctl."vm.vfs_cache_pressure" = 10;
 
       # 10G tuning for OSDs
       "vm.min_free_kbytes" = "513690";

--- a/nixos/services/ceph/server.nix
+++ b/nixos/services/ceph/server.nix
@@ -22,10 +22,7 @@ in
 
   config = lib.mkIf cfg.enable {
 
-    flyingcircus.services.ceph.cluster_network = head fclib.network.stb.v4.networks;
-    # mkPlatform is 900 and this is slightly higher prio but a regular 
-    # assignment will override again easily.
-    environment.variables.CEPH_ARGS = lib.mkOverride 899 "";
+    environment.variables.CEPH_ARGS = fclib.mkPlatformOverride "";
 
     flyingcircus.services.ceph.client.enable = true;
 

--- a/nixos/services/ceph/server.nix
+++ b/nixos/services/ceph/server.nix
@@ -29,6 +29,11 @@ in
 
     flyingcircus.services.ceph.client.enable = true;
 
+    flyingcircus.agent.maintenance.ceph = {
+      enter = "${pkgs.fc.ceph}/bin/fc-ceph maintenance enter";
+      leave = "${pkgs.fc.ceph}/bin/fc-ceph maintenance leave";
+    };
+
     # We used to create the admin key directory from the ENC. However,
     # this causes the file to become world readable on Ceph servers.
 

--- a/nixos/services/ceph/server.nix
+++ b/nixos/services/ceph/server.nix
@@ -131,8 +131,6 @@ in
       "net.ipv4.tcp_tw_recycle" = "1";
       "net.ipv4.tcp_tw_reuse" = "1";
 
-      "net.netfilter.nf_conntrack_max" = "262144";
-
       # Supposedly this doesn't do much good anymore, but in one of my tests
       # (too many, can't prove right now.) this appeared to have been helpful.
       "net.ipv4.tcp_low_latency" = "1";

--- a/nixos/services/ceph/server.nix
+++ b/nixos/services/ceph/server.nix
@@ -46,8 +46,8 @@ in
      ];
 
     services.logrotate.extraConfig = ''
-      /var/log/ceph/admin.log
       /var/log/ceph/ceph.log
+      /var/log/ceph/ceph.audit.log
       /var/log/ceph/ceph-mon.*.log
       /var/log/ceph/ceph-osd.*.log
       {

--- a/pkgs/fc/agent/fc/maintenance/reqmanager.py
+++ b/pkgs/fc/agent/fc/maintenance/reqmanager.py
@@ -1,19 +1,22 @@
 """Manage maintenance requests."""
 
-from fc.maintenance.activity import RebootType
-from .request import Request
-from .state import State, ARCHIVE
-from fc.util.logging import init_logging
 import argparse
-import fc.util.directory
+import configparser
 import fcntl
 import glob
 import json
 import os
 import os.path as p
 import socket
-import structlog
 import subprocess
+
+import fc.util.directory
+import structlog
+from fc.maintenance.activity import RebootType
+from fc.util.logging import init_logging
+
+from .request import Request
+from .state import ARCHIVE, State
 
 DEFAULT_DIR = '/var/spool/maintenance'
 
@@ -52,9 +55,12 @@ class ReqManager:
 
     directory = None
     lockfile = None
-    in_maintenance = False  # 'maintenance' flag set in directory
 
-    def __init__(self, spooldir=DEFAULT_DIR, enc_path=None, log=_log):
+    def __init__(self,
+                 spooldir=DEFAULT_DIR,
+                 enc_path=None,
+                 config_file=None,
+                 log=_log):
         """Initialize ReqManager and create directories if necessary."""
         self.spooldir = spooldir
         self.requestsdir = p.join(self.spooldir, 'requests')
@@ -63,6 +69,7 @@ class ReqManager:
             if not p.exists(d):
                 os.mkdir(d)
         self.enc_path = enc_path
+        self.config_file = config_file
         self.log = log
         self.requests = {}
 
@@ -75,6 +82,9 @@ class ReqManager:
         print(os.getpid(), file=self.lockfile)
         self.lockfile.flush()
         self.scan()
+        self.config = configparser.ConfigParser()
+        if self.config_file:
+            self.config.read(self.config_file)
         return self
 
     def __exit__(self, exc_type, exc_value, exc_tb):
@@ -205,39 +215,63 @@ class ReqManager:
         yield from sorted(requests)
 
     def enter_maintenance(self):
-        """Set myself in 'maintenance' mode.
+        """Set this node in 'temporary maintenance' mode.
 
-        This method is idempotent since we need to call it for every
-        request. ReqManager's current design does not allow to query if
-        there are runnable requests at all without causing side effects
-        (humm). Tolerates directory failures as there a some maintenance
+        Tolerates directory failures as there a some maintenance
         actions that need to proceed anyway.
+
         """
-        if self.in_maintenance:
-            self.log.debug("enter-maintenance-skip")
-            return
         try:
             self.log.debug("enter-maintenance")
             self.directory.mark_node_service_status(socket.gethostname(),
                                                     False)
-            self.in_maintenance = True
         except socket.error:
             self.log.error(
                 "enter-maintenance-error",
-                _replace_msg=
-                "Failed to set 'out of service' directory flag. See exception for details.",
+                _replace_msg="Failed to set 'out of service' directory flag. "
+                "See exception for details.",
                 exc_info=True)
+        for name, command in self.config['maintenance-enter'].items():
+            if not command.strip():
+                continue
+            self.log.info(
+                "enter-maintenance-subsystem", subsystem=name, command=command)
+            try:
+                subprocess.run(command, shell=True, check=True)
+            except Exception:
+                # Stop, if entering a subystem's maintenance mode fails.
+                self.log.error(
+                    "enter-maintenance-subsystem-error",
+                    _replace_msg=
+                    "Entering maintenance for {subsystem} failed. Aborting.",
+                    subsystem=name)
+                return False
+        return True
 
     def leave_maintenance(self):
+        for name, command in self.config['maintenance-leave'].items():
+            if not command.strip():
+                continue
+            self.log.info(
+                "leave-maintenance-subsystem", subsystem=name, command=command)
+            try:
+                # Leaving maintenance modes is opportunistic. Report errors
+                # but continue.
+                subprocess.run(command, shell=True, check=True)
+            except Exception:
+                self.log.error(
+                    "leave-maintenance-subsystem-error",
+                    _replace_msg=
+                    "leaving maintenance for {subsystem} failed. Continuing.",
+                    subsystem=name)
         try:
             self.log.debug('leave-maintenance')
             self.directory.mark_node_service_status(socket.gethostname(), True)
-            self.in_maintenance = False
         except socket.error:
             self.log.error(
                 "leave-maintenance-error",
-                _replace_msg=
-                "Failed to set 'in service' directory flag. See exception for details.",
+                _replace_msg="Failed to set 'in service' directory flag. "
+                "See exception for details.",
                 exc_info=True)
 
     @require_directory
@@ -257,76 +291,40 @@ class ReqManager:
             runnable_requests = list(self.requests.values())
         else:
             runnable_requests = list(self.runnable())
-        if runnable_requests:
-            runnable_count = len(runnable_requests)
-            if runnable_count == 1:
-                msg = "Executing one runnable maintenance request."
-            else:
-                msg = "Executing {runnable_count} runnable maintenance requests."
-            self.log.info(
-                "execute-requests-runnable",
-                _replace_msg=msg,
-                runnable_count=runnable_count)
-        else:
+
+        if not runnable_requests:
             self.log.info(
                 "execute-requests-empty",
                 _replace_msg="No runnable maintenance requests.")
+            self.leave_maintenance()
+            return
+
+        runnable_count = len(runnable_requests)
+        if runnable_count == 1:
+            msg = "Executing one runnable maintenance request."
+        else:
+            msg = "Executing {runnable_count} runnable maintenance requests."
+        self.log.info(
+            "execute-requests-runnable",
+            _replace_msg=msg,
+            runnable_count=runnable_count)
 
         requested_reboots = set()
+        if not self.enter_maintenance():
+            # Something failed. Errors were already reported. Return silently.
+            # We do not leave maintenance as the failure may be transient
+            # and in some cases (like evacuating virtual machines) it is
+            # more expensive to not make continuous progress and keep retrying.
+            return
+
         try:
             for req in runnable_requests:
-                self.log.info(
-                    "execute-request-start",
-                    _replace_msg="Starting execution of request: {request}",
-                    request=req.id)
-                self.enter_maintenance()
-                try:
-                    req.execute()
-                except Exception:
-                    self.log.error(
-                        "execute-request-failed",
-                        _replace_msg=
-                        "Executing request {request} failed. See exception for details.",
-                        request=req.id,
-                        exc_info=True)
-                    req.state = State.error
-                    execution_finished = False
-                else:
-                    execution_finished = True
-                try:
-                    req.save()
-                except Exception:
-                    # This was ignored before.
-                    # At least log what's happening here even if it's not critical.
-                    self.log.debug(
-                        "execute-save-request-failed", exc_info=True)
+                req.execute()
+                if req.state == State.success:
+                    requested_reboots.add(req.activity.reboot_needed)
 
-                if execution_finished:
-                    attempt = req.attempts[-1]
-                    if req.state == State.error:
-                        self.log.info(
-                            "execute-request-finished-error",
-                            _replace_msg="Error executing request {request}.",
-                            request=req.id,
-                            stdout=attempt.stdout,
-                            stderr=attempt.stderr,
-                            duration=attempt.duration,
-                            returncode=attempt.returncode)
-                    else:
-                        if req.activity.reboot_needed is not None:
-                            requested_reboots.add(req.activity.reboot_needed)
-                        self.log.info(
-                            "execute-request-finished",
-                            _replace_msg=
-                            "Executed request {request} (state: {state}).",
-                            request=req.id,
-                            state=req.state,
-                            duration=attempt.duration)
-
-            if requested_reboots:
-                # Rebooting while still in maintenance.
-                self.reboot(requested_reboots)
-            else:
+            # Execute any reboots while still in maintenance.
+            if not self.reboot(requested_reboots):
                 self.leave_maintenance()
                 self.log.debug("no-reboot-requested")
 
@@ -418,20 +416,24 @@ class ReqManager:
                 "Doing a cold boot now to finish maintenance activities.")
             subprocess.run(
                 "poweroff", check=True, capture_output=True, text=True)
+            return True
         elif RebootType.WARM in requested_reboots:
             self.log.info(
                 "maintenance-reboot",
                 _replace_msg="Rebooting now to finish maintenance activities.")
             subprocess.run(
                 "reboot", check=True, capture_output=True, text=True)
+            return True
+        return False
 
 
 def transaction(spooldir=DEFAULT_DIR,
                 enc_path=None,
                 do_scheduling=True,
                 run_all_now=False,
+                config_file=None,
                 log=_log):
-    with ReqManager(spooldir, enc_path, log=log) as rm:
+    with ReqManager(spooldir, enc_path, config_file, log=log) as rm:
         if do_scheduling:
             rm.schedule()
         rm.execute(run_all_now)
@@ -439,14 +441,19 @@ def transaction(spooldir=DEFAULT_DIR,
         rm.archive()
 
 
-def delete(reqid, spooldir=DEFAULT_DIR, enc_path=None, log=_log):
-    with ReqManager(spooldir, enc_path, log=log) as rm:
+def delete(reqid,
+           spooldir=DEFAULT_DIR,
+           enc_path=None,
+           config_file=None,
+           log=_log):
+    with ReqManager(
+            spooldir, enc_path, config_file=config_file, log=log) as rm:
         rm.delete(reqid)
         rm.archive()
 
 
-def listreqs(spooldir=DEFAULT_DIR, log=_log):
-    rm = ReqManager(spooldir, log=log)
+def listreqs(spooldir=DEFAULT_DIR, config_file=None, log=_log):
+    rm = ReqManager(spooldir, config_file=config_file, log=log)
     rm.scan()
     out = str(rm)
     if out:
@@ -487,6 +494,12 @@ Managed local maintenance requests.
         help='Just run every maintenance request now, even if it is not due')
 
     a.add_argument(
+        '-c',
+        '--config-file',
+        metavar='PATH',
+        default='/etc/fc-agent.conf',
+        help='full path to agent configuration file')
+    a.add_argument(
         '-E',
         '--enc-path',
         metavar='PATH',
@@ -509,13 +522,13 @@ Managed local maintenance requests.
     if args.delete and args.list:
         a.error('multually exclusive actions: list + delete')
     if args.delete:
-        delete(args.delete, args.spooldir, args.enc_path)
+        delete(args.delete, args.spooldir, args.enc_path, args.config_file)
     elif args.list:
-        listreqs(args.spooldir)
+        listreqs(args.spooldir, args.config_file)
     else:
         _log.info("fc-maintenance-start")
         transaction(args.spooldir, args.enc_path, not args.no_scheduling,
-                    args.run_all_now)
+                    args.run_all_now, args.config_file)
         _log.info("fc-maintenance-finished")
 
 
@@ -533,8 +546,14 @@ retrylimit exceeded (r), hard error (e), deleted (d), postponed (p).
         metavar='DIR',
         default=DEFAULT_DIR,
         help='spool dir for requests (default: %(default)s)')
+    a.add_argument(
+        '-c',
+        '--config-file',
+        metavar='PATH',
+        default='/etc/fc-agent.conf',
+        help='full path to agent configuration file')
     args = a.parse_args()
-    listreqs(args.spooldir)
+    listreqs(args.spooldir, args.config_file)
 
 
 if __name__ == '__main__':

--- a/pkgs/fc/agent/fc/maintenance/request.py
+++ b/pkgs/fc/agent/fc/maintenance/request.py
@@ -1,17 +1,18 @@
-from .estimate import Estimate
-from .state import State, evaluate_state
-
 import contextlib
 import copy
 import datetime
-import iso8601
 import os
 import os.path as p
+import tempfile
+
+import iso8601
 import pytz
 import shortuuid
 import structlog
-import tempfile
 import yaml
+
+from .estimate import Estimate
+from .state import State, evaluate_state
 
 _log = structlog.get_logger()
 
@@ -146,18 +147,55 @@ class Request:
         Each attempt records outcomes so that the Activity object may
         overwrite stdout, stderr, and returncode after each attempt.
         """
-        self.state = State.running
-        self.save()
-        attempt = Attempt()  # sets start time
-        with cd(self.dir):
-            try:
-                self.activity.run()
-                attempt.record(self.activity)
-            except Exception as e:
-                attempt.returncode = 70  # EX_SOFTWARE
-                attempt.stderr = str(e)
-        self.attempts.append(attempt)
-        self.state = evaluate_state(self.activity.returncode)
+        self.log.info(
+            "execute-request-start",
+            _replace_msg="Starting execution of request: {request}",
+            request=self.id)
+        try:
+            self.state = State.running
+            self.save()
+            attempt = Attempt()  # sets start time
+            with cd(self.dir):
+                try:
+                    self.activity.run()
+                    attempt.record(self.activity)
+                except Exception as e:
+                    attempt.returncode = 70  # EX_SOFTWARE
+                    attempt.stderr = str(e)
+            self.attempts.append(attempt)
+            self.state = evaluate_state(self.activity.returncode)
+        except Exception:
+            self.log.error(
+                "execute-request-failed",
+                _replace_msg=
+                "Executing request {request} failed. See exception for details.",
+                request=self.id,
+                exc_info=True)
+            self.state = State.error
+
+        if self.state == State.error:
+            self.log.info(
+                "execute-request-finished-error",
+                _replace_msg="Error executing request {request}.",
+                request=self.id,
+                stdout=attempt.stdout,
+                stderr=attempt.stderr,
+                duration=attempt.duration,
+                returncode=attempt.returncode)
+        else:
+            self.log.info(
+                "execute-request-finished",
+                _replace_msg="Executed request {request} (state: {state}).",
+                request=self.id,
+                state=self.state,
+                duration=attempt.duration)
+
+        try:
+            self.save()
+        except Exception:
+            # This was ignored before.
+            # At least log what's happening here even if it's not critical.
+            self.log.debug("execute-save-request-failed", exc_info=True)
 
     def update_due(self, due):
         """Sets next_due to a datetime object or ISO 8601 literal.

--- a/pkgs/fc/agent/fc/manage/backy.py
+++ b/pkgs/fc/agent/fc/manage/backy.py
@@ -1,11 +1,9 @@
 """Generates /etc/backy.conf from directory data."""
 
 import argparse
-import copy
 import json
 import logging
 import logging.handlers
-import os
 import os.path as p
 import shutil
 import socket

--- a/pkgs/fc/agent/fc/manage/manage.py
+++ b/pkgs/fc/agent/fc/manage/manage.py
@@ -493,10 +493,10 @@ def switch_no_update(log, build_options, spread, lazy):
     return switch(log, build_options, spread, lazy, update=False)
 
 
-def maintenance(log):
+def maintenance(log, config_file):
     log.info('maintenance-perform')
     import fc.maintenance.reqmanager
-    fc.maintenance.reqmanager.transaction()
+    fc.maintenance.reqmanager.transaction(log=log, config_file=config_file)
 
 
 def seed_enc(path):
@@ -581,6 +581,10 @@ def parse_args():
         help='channel update every I minutes, local builds '
         'all other times (see also -i and -f). Must be used in '
         'conjunction with --channel or --channel-with-maintenance.')
+    a.add_argument(
+        '--config-file',
+        default='/etc/fc-agent.conf',
+        help='Config file to use.')
 
     build = a.add_mutually_exclusive_group()
     build.add_argument(
@@ -647,7 +651,7 @@ def transaction(log, args):
                                                 args.lazy)
 
     if args.maintenance:
-        maintenance(log)
+        maintenance(log, args.config_file)
 
     return keep_cmd_output
 

--- a/pkgs/fc/agent/fc/util/directory.py
+++ b/pkgs/fc/agent/fc/util/directory.py
@@ -36,7 +36,7 @@ def connect(enc_data=None, ring=1):
     Selects ring0/ring1 API according to the `ring` parameter. Giving `max`
     results in selecting the highest ring available according to the ENC.
     """
-    if not xmlrpc.client.ProtocolError is ScreenedProtocolError:
+    if xmlrpc.client.ProtocolError is not ScreenedProtocolError:
         xmlrpc.client.ProtocolError = ScreenedProtocolError
     if not enc_data:
         enc_data = load_default_enc_json()

--- a/pkgs/fc/blockdev/fc-blockdev.py
+++ b/pkgs/fc/blockdev/fc-blockdev.py
@@ -2,7 +2,6 @@
 """Apply kernel ioscheduler and LSI settings based on device heuristics."""
 
 import argparse
-import datetime
 import logging
 import logging.handlers
 import os

--- a/pkgs/fc/ceph/fc/ceph/main.py
+++ b/pkgs/fc/ceph/fc/ceph/main.py
@@ -176,6 +176,14 @@ requests. Useful for identifying slacky OSDs.""")
         'clean-deleted-vms', help='Remove disks from deleted VMs.')
     parser_clean_deleted_vms.set_defaults(action='clean_deleted_vms')
 
+    parser_enter = maint_sub.add_parser(
+        'enter', help='Enter maintenance mode.')
+    parser_enter.set_defaults(action='enter')
+
+    parser_leave = maint_sub.add_parser(
+        'leave', help='Leave maintenance mode.')
+    parser_leave.set_defaults(action='leave')
+
     args = vars(parser.parse_args(args))
 
     subsystem = args.pop('subsystem')

--- a/pkgs/fc/ceph/fc/ceph/main.py
+++ b/pkgs/fc/ceph/fc/ceph/main.py
@@ -47,7 +47,9 @@ def main(args=sys.argv[1:]):
         choices=['external', 'internal'],
         help='Type of journal (on same disk or external)')
     parser_activate.add_argument(
-        '--journal-size', default=0, type=int, help='Size of journal.')
+        '--journal-size',
+        default=fc.ceph.manage.OSD.DEFAULT_JOURNAL_SIZE,
+        help='Size of journal (LVM size units allowed).')
     parser_activate.add_argument(
         '--crush-location', default=f'host={hostname}')
     parser_activate.set_defaults(action='create')
@@ -77,6 +79,10 @@ def main(args=sys.argv[1:]):
 
     parser_rebuild = osd_sub.add_parser(
         'rebuild', help='Rebuild an OSD by destroying and creating it again.')
+    parser_rebuild.add_argument(
+        '--journal-size',
+        default=fc.ceph.manage.OSD.DEFAULT_JOURNAL_SIZE,
+        help='Size of journal (LVM size units allowed).')
     parser_rebuild.add_argument(
         'ids',
         help='IDs of OSD to migrate. Use `all` to rebuild all local OSDs.')

--- a/pkgs/fc/ceph/fc/ceph/manage.py
+++ b/pkgs/fc/ceph/fc/ceph/manage.py
@@ -52,12 +52,19 @@ def lvs():
     return run_json(['lvs', '--reportformat', 'json'])['report'][0]['lv']
 
 
-def find_journal_vgs():
-    result = []
+def find_vg_for_mon():
+    vgsys = False
     for vg in vgs():
         if vg['vg_name'].startswith('vgjnl'):
-            result.append(vg)
-    return result
+            return vg['vg_name']
+        if vg['vg_name'] == 'vgsys':
+            vgsys = True
+
+    if vgsys:
+        print('WARNING: using volume group `vgsys` because no journal '
+              'volume group was found.')
+        return 'vgsys'
+    raise IndexError("No suitable volume group found.")
 
 
 def find_lv_path(name):
@@ -578,9 +585,6 @@ class Monitor(object):
         print(f'Activating MON {self.id}...')
         resource.setrlimit(resource.RLIMIT_NOFILE, (270000, 270000))
 
-        if not os.path.exists(self.mon_dir):
-            os.makedirs(self.mon_dir)
-
         if not is_mounted(self.mon_dir):
             run([
                 'mount', '-t', 'xfs', '-o', 'defaults,nodev,nosuid',
@@ -600,7 +604,7 @@ class Monitor(object):
             pass
         self.activate()
 
-    def create(self, size='8g'):
+    def create(self, size='8g', lvm_vg=None, bootstrap_cluster=False):
         print(f'Creating MON {self.id}...')
 
         if os.path.exists(self.mon_dir):
@@ -611,14 +615,15 @@ class Monitor(object):
         if not os.path.exists(self.mon_dir):
             os.makedirs(self.mon_dir)
 
-        try:
-            lvm_vg = find_journal_vgs()[0]['vg_name']
-        except IndexError:
-            print('Could not find a journal VG. Please prepare a journal '
-                  'VG first using `fc-ceph osd prepare-journal`.')
-            sys.exit(1)
+        if not lvm_vg:
+            try:
+                lvm_vg = find_vg_for_mon()
+            except IndexError:
+                print('Could not find a journal VG. Please prepare a journal '
+                      'VG first using `fc-ceph osd prepare-journal`.')
+                sys.exit(1)
 
-        lvm_lv = f'ceph-mon'
+        lvm_lv = 'ceph-mon'
         lvm_data_device = f'/dev/{lvm_vg}/{lvm_lv}'
 
         print(f'creating new mon volume {lvm_data_device}')
@@ -632,24 +637,43 @@ class Monitor(object):
             check=True)
 
         tmpdir = tempfile.mkdtemp()
-        mon_mkfs_args = ['ceph-mon', '-i', self.id, '--mkfs']
-        try:
-            run(['ceph', 'auth', 'get', f'mon.', '-o', f'{tmpdir}/keyring'],
+
+        config = configparser.ConfigParser()
+        with open('/etc/ceph/ceph.conf') as f:
+            config.read_file(f)
+        if bootstrap_cluster:
+            # Generate initial mon keyring
+            run([
+                'ceph-authtool', '-g', '-n', 'mon.', '--create-keyring',
+                f'{tmpdir}/keyring', '--set-uid=0', '--cap', 'mon', 'allow *'],
                 check=True)
-            mon_mkfs_args += ['--keyring', f'{tmpdir}/keyring']
-        except subprocess.CalledProcessError:
-            # Looks like we are initializing a new cluster
-            config = configparser.ConfigParser()
-            with open('/etc/ceph/ceph.conf') as f:
-                config.read_file(f)
+            # Import admin keyring
+            run([
+                'ceph-authtool', f'{tmpdir}/keyring', '--import-keyring',
+                '/etc/ceph/ceph.client.admin.keyring', '--cap', 'mds',
+                'allow *', '--cap', 'mon', 'allow *', '--cap', 'osd',
+                'allow *'])
+            # Generate initial monmap
             fsid = config['global']['fsid']
-            mon_mkfs_args += ['--fsid', fsid]
+            run(['monmaptool', '--create', '--fsid', fsid, f'{tmpdir}/monmap'])
         else:
+            # Retrieve mon key and monmap
+            run([
+                'ceph', '-n', 'client.admin', 'auth', 'get', 'mon.', '-o',
+                f'{tmpdir}/keyring'],
+                check=True)
             run(['ceph', 'mon', 'getmap', '-o', f'{tmpdir}/monmap'],
                 check=True)
-            mon_mkfs_args += ['--monmap', f'{tmpdir}/monmap']
-
-        run(mon_mkfs_args, check=True)
+        # Add yourself to the monmap
+        run([
+            'monmaptool', '--add', self.id,
+            config[f'mon.{self.id}']['public addr'], f'{tmpdir}/monmap'],
+            check=True)
+        # Create mon on disk structures
+        run([
+            'ceph-mon', '-i', self.id, '--mkfs', '--keyring',
+            f'{tmpdir}/keyring', '--monmap', f'{tmpdir}/monmap'],
+            check=True)
 
         shutil.rmtree(tmpdir)
 

--- a/tests/ceph.nix
+++ b/tests/ceph.nix
@@ -1,91 +1,241 @@
 import ./make-test-python.nix ({ ... }:
+let
+  getIPForVLAN = vlan: id: "192.168.${toString vlan}.${toString (5 + id)}";
+
+  makeCephHostConfig = { id }:
+    { config, ... }:
+    {
+
+      virtualisation.memorySize = 3000;
+      virtualisation.vlans = with config.flyingcircus.static.vlanIds; [ srv sto stb ];
+      virtualisation.emptyDiskImages = [ 4000 4000 ];
+      imports = [ ../nixos ../nixos/roles ];
+
+      flyingcircus.static.mtus.sto = 1500;
+      flyingcircus.static.mtus.stb = 1500;
+
+      flyingcircus.encServices = [
+        {
+          address = "host1.fcio.net";
+          ips = [ (getIPForVLAN 4 1) ];
+          location = "test";
+          service = "ceph_mon-mon";
+        }        {
+          address = "host2.fcio.net";
+          ips = [ (getIPForVLAN 4 2) ];
+          location = "test";
+          service = "ceph_mon-mon";
+        }        {
+          address = "host3.fcio.net";
+          ips = [ (getIPForVLAN 4 3) ];
+          location = "test";
+          service = "ceph_mon-mon";
+        }
+      ];
+
+      flyingcircus.services.ceph.extraConfig = ''
+            mon clock drift allowed = 1
+      '';
+
+      # We need this in the enc files as well so that timer jobs can update
+      # the keys etc.
+      environment.etc."nixos/services.json".text = builtins.toJSON config.flyingcircus.encServices;
+
+      flyingcircus.roles.ceph_osd.enable = true;
+      flyingcircus.roles.ceph_mon.enable = true;
+      flyingcircus.roles.ceph_rgw.enable = true;
+
+      flyingcircus.static.ceph.fsids.test.test = "d118a9a4-8be5-4703-84c1-87eada2e6b60";
+
+      environment.etc."nixos/enc.json".text = builtins.toJSON {
+        name =  "host${toString id}";
+        roles = [ "ceph_mon" "ceph_osd" "ceph_rgw" ];
+        parameters = { 
+          location = "test";
+          resource_group = "services";
+          secret_salt = "salt-for-host-${toString id}-dhkasjy9";
+          secrets = { "ceph/admin_key" = "AQBFJa9hAAAAABAAtdggM3mhVBAEYw3+Loehqw=="; };
+        };
+      };
+
+      # Not perfect but avoids triggering the 'established' rule which can
+      # lead to massive/weird Ceph instabilities.
+      networking.firewall.trustedInterfaces = [ "ethsto" "ethstb" ];
+      networking.extraHosts = ''
+        ${getIPForVLAN 4 1} host1.sto.test.ipv4.gocept.net 
+        ${getIPForVLAN 4 2} host2.sto.test.ipv4.gocept.net 
+        ${getIPForVLAN 4 3} host3.sto.test.ipv4.gocept.net 
+      '';
+
+      flyingcircus.enc.parameters = {
+        location = "test";
+        resource_group = "test";
+        interfaces.srv = {
+          mac = "52:54:00:12:03:0${toString id}";
+          bridged = false;
+          networks = {
+            "192.168.3.0/24" = [ (getIPForVLAN 3 id) ];
+          };
+          gateways = {};
+        };
+        interfaces.sto = {
+          mac = "52:54:00:12:04:0${toString id}";
+          bridged = false;
+          networks = {
+            "192.168.4.0/24" = [ (getIPForVLAN 4 id) ];
+          };
+          gateways = {};
+        };
+        interfaces.stb = {
+          mac = "52:54:00:12:08:0${toString id}";
+          bridged = false;
+          networks = {
+            "192.168.8.0/24" = [ (getIPForVLAN 8 id) ];
+          };
+          gateways = {};
+        };
+      };
+    };
+in
 {
   name = "ceph";
   nodes = {
-    host1 =
-      { config, ... }:
-      {
-
-        virtualisation.memorySize = 3000;
-        virtualisation.vlans = with config.flyingcircus.static.vlanIds; [ srv sto stb ];
-        virtualisation.emptyDiskImages = [ 2000 2000 ];
-
-        imports = [ ../nixos ../nixos/roles ];
-
-
-        environment.etc."nixos/enc.json".text = ''
-          {"name": "host1", "parameters": {"secret_salt": "fdmsajkfhr93gf9udahukdhg78923tgiuvbdiafdsa"}}
-          '';
-        environment.etc."nixos/services.json".text = ''
-           [{
-            "address": "host1.gocept.net",
-            "ips": [
-             "192.168.4.5",
-            ],
-            "location": "test",
-            "password": "this-is-not-used",
-            "service": "ceph_mon-mon"
-           }]
-          '';
-
-        flyingcircus.roles.ceph_osd.enable = true;
-        flyingcircus.roles.ceph_mon.enable = true;
-
-        flyingcircus.static.ceph.fsids.test.test = "d118a9a4-8be5-4703-84c1-87eada2e6b60";
-
-        flyingcircus.enc.parameters = {
-          secrets."ceph/admin_key" = "asdf";
-          location = "test";
-          resource_group = "test";
-          interfaces.srv = {
-            mac = "52:54:00:12:03:01";
-            bridged = false;
-            networks = {
-              "192.168.3.0/24" = [ "192.168.1.5" ];
-            };
-            gateways = {};
-          };
-          interfaces.sto = {
-            mac = "52:54:00:12:04:01";
-            bridged = false;
-            networks = {
-              "192.168.4.0/24" = [ "192.168.4.5" ];
-            };
-            gateways = {};
-          };
-          interfaces.stb = {
-            mac = "52:54:00:12:08:01";
-            bridged = false;
-            networks = {
-              "192.168.8.0/24" = [ "192.168.8.5" ];
-            };
-            gateways = {};
-          };
-        };
-      };
+    host1 = makeCephHostConfig { id = 1; };
+    host2 = makeCephHostConfig { id = 2; };
+    host3 = makeCephHostConfig { id = 3; };
   };
 
   testScript = ''
+    time_waiting = 0
+    start_all()
 
-    def host1_show(cmd):
-      print(host1.execute(cmd)[1])
+    import time
+    def show(host, cmd):
+        result = host.execute(cmd)[1]
+        print(result)
+        return result
 
-    host1_show('ip l')
-    host1_show('ls -lah /etc/ceph/')
-    host1_show('cat /etc/ceph/ceph.client.osd.keyring')
-    host1_show('cat /etc/ceph/ceph.conf')
-    host1_show('cat /etc/ceph/ceph.osd.conf')
-    host1_show('cat /etc/ceph/ceph.mon.conf')
-    host1_show('lsblk')
-    host1_show('sfdisk -J /dev/vdb')
+    def assert_clean_cluster(host, mons, osds, pgs):
+      global time_waiting
+      print("Waiting for clean cluster ...")
+      start = time.time()
+      # Allow HEALTH_WARN as we do not correctly cover clock skew
+      # currently
+      tries = 1
+      while True:
+        status = show(host1, 'ceph -s')
+        show(host, 'ceph health detail | tail')
 
-    host1.succeed("fc-ceph osd prepare-journal /dev/vdb")
-    host1.succeed("fc-ceph mon create --size 1g")
-    host1.succeed("ceph -s")
+        try:
+          assert 'HEALTH_OK' in status or 'HEALTH_WARN' in status
+          assert f'{mons} mons at' in status
+          assert f'{osds} osds: {osds} up, {osds} in' in status
+          assert f'{pgs} active+clean' in status
+          break
+        except AssertionError:
+          if time.time() - start < 60:
+            time_waiting += tries*2
+            time.sleep(tries*2)
+          else:
+             raise
 
-    # XXX this currently breaks when seeding the initial mon keyring
-    # i guess we are still using puppet to generate mon keys?!?!
-    # at least the flow is a bit unclear at the moment.
+    show(host1, 'ip l')
+    show(host1, 'iptables -L -n -v')
+    show(host1, 'ls -lah /etc/ceph/')
+    show(host1, 'cat /etc/ceph/ceph.client.osd.keyring')
+    show(host1, 'cat /etc/ceph/ceph.conf')
+    
+    show(host1, 'lsblk')
+    show(host1, 'sfdisk -J /dev/vdb')
 
+    host1.execute("systemctl stop fc-ceph-rgw")
+    host2.execute("systemctl stop fc-ceph-rgw")
+    host3.execute("systemctl stop fc-ceph-rgw")
+
+    with subtest("Initialize first mon"):
+      host1.succeed('fc-ceph osd prepare-journal /dev/vdb')
+      host1.execute('fc-ceph mon create --size 500m --bootstrap-cluster &> /dev/kmsg')
+      show(host1, 'lsblk')
+      show(host1, 'journalctl -u fc-ceph-mon')
+      host1.sleep(10)
+      show(host1, 'cat /var/log/ceph/*mon*')
+
+      host1.succeed('ceph -s &> /dev/kmsg')
+
+      host1.succeed('fc-ceph keys mon-update-single-client host1 ceph_osd,ceph_mon,ceph_rgw salt-for-host-1-dhkasjy9')
+      host1.succeed('fc-ceph keys mon-update-single-client host2 ceph_osd,ceph_mon salt-for-host-2-dhkasjy9')
+      host1.succeed('fc-ceph keys mon-update-single-client host3 ceph_osd,ceph_mon salt-for-host-3-dhkasjy9')
+
+    with subtest("Initialize first OSD"):
+      host1.execute('fc-ceph osd create --journal-size=500m /dev/vdc')
+
+    with subtest("Initialize second MON and OSD"):
+      host2.succeed('fc-ceph osd prepare-journal /dev/vdb')
+      host2.succeed('fc-ceph mon create --size 500m &> /dev/kmsg')
+      host2.succeed('fc-ceph osd create --journal-size=500m /dev/vdc')
+
+    with subtest("Initialize thirst MON and OSD"):
+      host3.succeed('fc-ceph osd prepare-journal /dev/vdb')
+      host3.succeed('fc-ceph mon create --size 500m')
+      host3.succeed('fc-ceph osd create --journal-size=500m /dev/vdc')
+
+    with subtest("Move OSDs to correct crush location"):
+      host1.succeed('ceph osd crush move host1 root=default')
+      host1.succeed('ceph osd crush move host2 root=default')
+      host1.succeed('ceph osd crush move host3 root=default')
+      # Let things settle for a bit, otherwise things are in weird
+      # intermediate states like pgs not created, time not in sync,
+      # mons not accessible, ...
+      show(host1, 'ceph osd df tree')
+      assert_clean_cluster(host1, 3, 3, 64)
+      assert_clean_cluster(host2, 3, 3, 64)
+      assert_clean_cluster(host3, 3, 3, 64)
+
+    # Now that we have a working cluster, lets exercise:
+
+    with subtest("Check RGW works"):
+      host1.execute("systemctl restart fc-ceph-rgw")
+      host1.wait_for_unit("fc-ceph-rgw.service")
+      host1.succeed("radosgw-admin user create --uid=user --display-name=user")
+      result = host1.succeed("radosgw-admin metadata list user")
+      assert '"user"' in result
+      # New pools = more PGs
+      assert_clean_cluster(host2, 3, 3, 512)
+
+    with subtest("Destroy and re-create first mon"):
+      host1.succeed('fc-ceph mon destroy')
+      show(host1, 'rm /var/log/ceph/*mon*')
+      show(host1, 'lsblk')
+
+      assert_clean_cluster(host2, 2, 3, 512)
+
+      host1.succeed('fc-ceph mon create --size 500m &> /dev/kmsg')
+      host1.sleep(5)
+      show(host1, 'tail -n 500 /var/log/ceph/*mon*')
+
+      assert_clean_cluster(host2, 3, 3, 512)
+
+    with subtest("Reactivate all OSDs on host1"):
+      host1.succeed('fc-ceph osd reactivate all')
+      assert_clean_cluster(host2, 3, 3, 512)
+
+    with subtest("Rebuild all OSDs on host 1"):
+      host1.succeed('fc-ceph osd rebuild --journal-size=500m all &> /dev/kmsg')
+      show(host1, "lsblk")
+      show(host1, "vgs")
+      assert_clean_cluster(host2, 3, 3, 512)
+
+    with subtest("Deactivate and activate single OSD on host 1"):
+      host1.succeed('fc-ceph osd deactivate 0')
+      host1.succeed('fc-ceph osd activate 0')
+      status = show(host2, 'ceph -s')
+      assert_clean_cluster(host2, 3, 3, 512)
+
+    with subtest("Destroy and create OSD on host1"):
+      host1.succeed('fc-ceph osd destroy 0')
+      host1.succeed('fc-ceph osd create --journal-size=500m /dev/vdc')
+      assert_clean_cluster(host2, 3, 3, 512)
+
+    print("Time spent waiting", time_waiting)
   '';
 })

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -26,6 +26,7 @@ in {
 
   antivirus = callTest ./antivirus.nix {};
   audit = callTest ./audit.nix {};
+  backyserver = callTest ./backyserver.nix {};
   channel = callTest ./channel.nix {};
   coturn = callTest ./coturn.nix {};
   devhost = callTest ./devhost.nix {};

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -28,6 +28,7 @@ in {
   audit = callTest ./audit.nix {};
   backyserver = callTest ./backyserver.nix {};
   channel = callTest ./channel.nix {};
+  ceph = callTest ./ceph.nix {};
   coturn = callTest ./coturn.nix {};
   devhost = callTest ./devhost.nix {};
   docker = callTest (nixpkgs + /nixos/tests/docker.nix) {};


### PR DESCRIPTION
@flyingcircusio/release-managers


## Release process

Impact:

none

Changelog:

* Our Ceph infrastructure has been fully ported to NixOS now. (PL-127635)
 
## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

No specific new requirements have been found as this is pretty straight 1:1 port of the Gentoo-based management features with a number of simplifications.

I have improved the key management that now includes purging old keys, which we didn't do before. It's not perfect yet, but there's a ticket in youtrack that follows up on the remaining ideas.

I have also automated the creation of firewall rules to grant access to the RGW servers from within the SRV network.

There is also new functionality for running explicit enter/exit scripts before and after maintenances which is a generic feature for the whole platform. service users can register those scripts through the existing system config mechanism and run them as root, however, that's a known and intentional vector anyways.

- [x] Security requirements tested? (EVIDENCE)

All of the functions have been tested manually and a good part is now also exercised by Hydra tests.