### PR TITLE
Pl 130249 update jitsi, video options

### DIFF
--- a/nixos/roles/jitsi/default.nix
+++ b/nixos/roles/jitsi/default.nix
@@ -83,6 +83,15 @@ in {
         default = false;
       };
 
+      enablePrejoinPage = mkOption {
+        description =  ''
+          Shows a page after opening a conference where users can change
+          settings and enter their name before joining the conference.
+        '';
+        type = types.bool;
+        default = false;
+      };
+
       enableRoomAuthentication = mkOption {
         description =  ''
           Require a username and password to create new rooms.
@@ -227,9 +236,14 @@ in {
           enableAutomaticUrlCopy = true;
           enableLayerSuspension = true;
           openBridgeChannel = "websocket";
+          prejoinPageEnabled = cfg.enablePrejoinPage;
+          useNewBandwidthAllocationStrategy = true;
           desktopSharingFrameRate = {
             min = 5;
-            max = 20;
+            max = 10;
+          };
+          videoQuality = {
+            preferredCodec = "VP9";
           };
           p2p.enabled = false;
           inherit (cfg) resolution;

--- a/pkgs/jibri/default.nix
+++ b/pkgs/jibri/default.nix
@@ -11,10 +11,10 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "jibri";
-  version = "8.0-83-g204354d";
+  version = "8.0-93-g51fe7a2";
   src = fetchurl {
     url = "https://download.jitsi.org/stable/${pname}_${version}-1_all.deb";
-    sha256 = "0407zfd14y9l1021l3fqs3qnlvq2j7prsf8dzfhj9gnkrshb7cnn";
+    sha256 = "1w78aa3rfdc4frb68ymykrbazxqrcv8mcdayqmcb72q1aa854c7j";
   };
   dontBuild = true;
   buildInputs = [ pkgs.makeWrapper ];

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -107,10 +107,10 @@ in {
 
   jitsi-videobridge = super.jitsi-videobridge.overrideAttrs(oldAttrs: rec {
     pname = "jitsi-videobridge2";
-    version = "2.1-592-g1e2879e0";
+    version = "2.1-595-g3637fda4";
     src = super.fetchurl {
       url = "https://download.jitsi.org/stable/${pname}_${version}-1_all.deb";
-      sha256 = "0qw29x03rmy8i7xkcajyggbksghv34676zw4l22dlp048p5d3vwh";
+      sha256 = "18x00lazyjcff8n7pn4h43cxlskv0d9vnh0cmf40ihrpqc5zs2dz";
     };
   });
 

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -88,29 +88,29 @@ in {
 
   jicofo = super.jicofo.overrideAttrs(oldAttrs: rec {
     pname = "jicofo";
-    version = "1.0-813";
+    version = "1.0-830";
     src = super.fetchurl {
       url = "https://download.jitsi.org/stable/${pname}_${version}-1_all.deb";
-      sha256 = "16g04p26j70hgb76jzv3z1s1z086wibm63yn0av5cyvld47lcn9i";
+      sha256 = "1q3lx0xaxpw7ycxaaphwr1mxv12yskh84frrxv1r27z1gkcdgd3f";
     };
   });
 
   jitsi-meet = super.jitsi-meet.overrideAttrs(oldAttrs: rec {
     pname = "jitsi-meet";
-    version = "1.0.5415";
+    version = "1.0.5638";
     src = super.fetchurl {
       url = "https://download.jitsi.org/jitsi-meet/src/jitsi-meet-${version}.tar.bz2";
-      sha256 = "0xzf6g95bgrrli855azpk6jv8siiq3ylsff94pvqq30083c3x68c";
+      sha256 = "1nahja4i8400445zymqmpq7g1gmwxvjrbvinhmpzi42alzvw3kw6";
     };
 
   });
 
   jitsi-videobridge = super.jitsi-videobridge.overrideAttrs(oldAttrs: rec {
     pname = "jitsi-videobridge2";
-    version = "2.1-570-gb802be83";
+    version = "2.1-592-g1e2879e0";
     src = super.fetchurl {
       url = "https://download.jitsi.org/stable/${pname}_${version}-1_all.deb";
-      sha256 = "0bng0js1j3cw1sz7xahm2qf4g5221qzwn8gb4bz6ydyci04dl8ni";
+      sha256 = "0qw29x03rmy8i7xkcajyggbksghv34676zw4l22dlp048p5d3vwh";
     };
   });
 


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

* [NixOS 21.05] Jitsi will be restarted and running conferences will be interrupted for some seconds.

Changelog:

* Jitsi: update package versions to latest stable release and tune video stream settings to improve quality and stability. Add an option to activate the pre-join page which allows users to check their audio/video and change settings before the conference starts (#PL-130249).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - use latest versions of Jitsi packages
- [x] Security requirements tested? (EVIDENCE)
  - we are using the latest stable versions  
  - Checked on our test instance that Jitsi conferences, including authentication work