### PR TITLE
graylog: 3.3.9 -> 3.3.15

### DIFF
--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -9,7 +9,7 @@ let
   phps = (import ../nix-phps/pkgs/phps.nix) (../nix-phps)
     {} super;
 
-  inherit (super) lib;
+  inherit (super) fetchurl lib;
 
 in {
   #
@@ -79,6 +79,15 @@ in {
 
   gitlab = super.callPackage ./gitlab { };
   gitlab-workhorse = super.callPackage ./gitlab/gitlab-workhorse { };
+
+  graylog = super.graylog.overrideAttrs(_: rec {
+    version = "3.3.15";
+
+    src = fetchurl {
+      url = "https://packages.graylog2.org/releases/graylog/graylog-${version}.tgz";
+      sha256 = "0zdgy45hdg90a34iv43dy3j9dqqs5djc1sgqylcvm6710a38fh7w";
+    };
+  });
 
   grub2_full = super.callPackage ./grub/2.0x.nix { };
 


### PR DESCRIPTION
Fixes CVE-2021-44228 by updating log4j2.

 #PL-130250

@flyingcircusio/release-managers

Should be released as a hotfix.

## Release process

Impact:

* [NixOS 21.05] Graylog will be restarted.

Changelog:

* [hotfix] graylog: update to 3.3.15 which contains the log4j2 fix for CVE-2021-44228. Systems using Graylog are already protected by the `"-Dlog4j2.formatMsgNoLookups=true"` setting we have rolled out (#PL-130250).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - use graylog version with the latest security patches  
- [x] Security requirements tested? (EVIDENCE)
  - 3.3.15 is the newest version of the 3.3.x branch 
  - looked at changelog for security-relevant changes
  - manually checked on test VM that Graylog is working, automated test still runs