### PR TITLE
[20.09] elasticsearch: set -Dlog4j2.formatMsgNoLookups=true

### DIFF
--- a/nixos/roles/elasticsearch.nix
+++ b/nixos/roles/elasticsearch.nix
@@ -149,6 +149,7 @@ in
         # Appending the next two lines overrides the former.
         "-Xms${toString esHeap}m"
         "-Xmx${toString esHeap}m"
+        "-Dlog4j2.formatMsgNoLookups=true"
         # Use new ES7 style for the publish address to avoid the annoying warning in ES6/7.
         (lib.optionalString (esVersion == "6") "-Des.http.cname_in_publish_address=true")
         (lib.optionalString (esVersion == "7") "-Des.transport.cname_in_publish_address=true")


### PR DESCRIPTION
Elasticsearch is not susceptible to remote code execution
via the log4j2 CVE-2021-44228 but we should close this attack vector anyways.

 #PL-130251

@flyingcircusio/release-managers

## Release process

Impact:

* Elasticsearch will be restarted.

Changelog:

* Elasticsearch: fix log4j2 CVE-2021-44228 by setting `-Dlog4j2.formatMsgNoLookups=true`. Without this, Elasticsearch is susceptible to a minor information leak about the system environment. Remote code execution was never possible via Elasticsearch (#PL-130251).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - prevent information leaks about the system environment
- [x] Security requirements tested? (EVIDENCE)
  - we use the measures recommended by Elasticsearch to fix the issue 
  - checked manually on test VM if ES works with that and the flag is present
  - automated tests still run
