### PR TITLE
Update nixpkgs

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "NixOS",
     "repo": "nixpkgs",
-    "rev": "2553aee74fed8c2205a4aeb3ffd206ca14ede60f",
-    "sha256": "16v5qjc84gg57yd8pzp9np420h72ahrgpp8hmcnmz4nf8x5alhvy"
+    "rev": "c5f1ee982246d09ae7f119c13aafcce90286221d",
+    "sha256": "0wzbc1hgjy6x5qzpbk001g3a72xbih1vk61mm0i05jp4m2rafqkb"
   },
   "nixos-mailserver": {
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/",


### PR DESCRIPTION
Pull upstream NixOS changes that include security fixes and other
updates:

 * nss: 3.64 -> 3.68.1
 * nss_latest: 3.71 -> 3.73
 * nspr: 4.30 -> 4.32
 * strace: 5.14 -> 5.15
 * grafana: 7.5.11 -> 7.5.12 (CVE-2021-43813)

 #PL-130255

@flyingcircusio/release-managers

## Release process

Impact:

* [NixOS 21.05] Elasticsearch, Grafana and Graylog will be restarted.

Changelog: (include changes from commit msg here)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - pull in upstream security fixes regularly
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still run, works on test VM
  - checked commit log for fixed CVEs and possible problems with updates, looked at changelog of grafana
