### PR TITLE
sensuserver: increase kernel neighbor table size/gc limits

### DIFF
--- a/nixos/roles/sensuserver.nix
+++ b/nixos/roles/sensuserver.nix
@@ -29,6 +29,17 @@ in
 
   config = lib.mkIf config.flyingcircus.roles.sensuserver.enable {
 
+      # Sensu talks to all VMs in a location permanently, so there are
+      # a lot of entries in the neighbour table. Increase numbers
+      # to avoid unneccessary garbage collecting and table overflows.
+      boot.kernel.sysctl = {
+        "net.ipv4.neigh.default.gc_thresh1" = 1024;
+        "net.ipv4.neigh.default.gc_thresh2" = 4096;
+        "net.ipv4.neigh.default.gc_thresh3" = 8192;
+        "net.ipv6.neigh.default.gc_thresh1" = 1024;
+        "net.ipv6.neigh.default.gc_thresh2" = 4096;
+        "net.ipv6.neigh.default.gc_thresh3" = 8192;
+      };
       flyingcircus.roles.rabbitmq.enable = true;
       flyingcircus.services.nginx.enable = true;
       flyingcircus.services.rabbitmq.listenAddress = lib.mkOverride 90 "::";


### PR DESCRIPTION
We hit the default size limit of the table that caches ARP responses on
our rzob sensu machine because it talks to a lot of machines now.
This may have been the cause for sensu API timeouts and produces
error messages in dmesg on the sensu server:

neighbour: ndisc_cache: neighbor table overflow!

Increasing the limits also avoids unneccessary garbage collection.

 #PL-130235

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Sensu server: increase kernel neighbor table (ARP cache) size/gc limits to avoid overflows and unneccessary garbage collection (#PL-130235).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - make sure Sensu API is available for clients so we don't lose monitoring information
- [x] Security requirements tested? (EVIDENCE)
  - we already use the settings in production, no overflows anymore
  - automated test still runs
