### PR TITLE
graylog: 3.3.15 -> 3.3.16

### DIFF
--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -81,11 +81,11 @@ in {
   gitlab-workhorse = super.callPackage ./gitlab/gitlab-workhorse { };
 
   graylog = super.graylog.overrideAttrs(_: rec {
-    version = "3.3.15";
+    version = "3.3.16";
 
     src = fetchurl {
       url = "https://packages.graylog2.org/releases/graylog/graylog-${version}.tgz";
-      sha256 = "0zdgy45hdg90a34iv43dy3j9dqqs5djc1sgqylcvm6710a38fh7w";
+      sha256 = "17nxvj6haf5an6yj6zdjvcaxlliamcl16bca1z1jjcd7h9yjgxrz";
     };
   });
 


### PR DESCRIPTION
Graylog 3.3.16 has log4j2 2.16.0 which fixes the follow-up
CVE-2021-45046.

 #PL-130264

@flyingcircusio/release-managers

Should be released as a hotfix.

## Release process

Impact:

* [NixOS 21.05] Graylog will be restarted.

Changelog:

* [hotfix] graylog: update to 3.3.16 which contains the follow-up log4j2 fix for CVE-2021-45046. (#PL-130264).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - use graylog version with the latest security patches  
- [x] Security requirements tested? (EVIDENCE)
  - 3.3.16 is the newest version of the 3.3.x branch 
  - looked at changelog for security-relevant changes
  - manually checked on test VM that Graylog is working, automated test still runs