### PR TITLE
PL-130253 Adding new vm caused nfs server outage - Reload NFS service instead of restarting

### DIFF
--- a/nixos/roles/nfs.nix
+++ b/nixos/roles/nfs.nix
@@ -92,6 +92,12 @@ in
         install -d -g service -m 775 ${export}
         ${pkgs.nfs-utils}/bin/exportfs -ra
       '';
+      systemd.services.nfs-mountd.reloadIfChanged = true;
+      systemd.services.nfs-server.reloadIfChanged = true;
+      # reload script for nfs-mountd so that it does not fail when reloading
+      systemd.services.nfs-mountd.reload = ''
+        ${pkgs.nfs-utils}/bin/exportfs -ra
+      '';
     })
 
   ];


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
 - Only service restarting/reloading is changed
- [x] Security requirements tested? (EVIDENCE)
 - No new services added, server succesfully reloads nfs services after adding a vm

