### PR TITLE
Update nixpkgs

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "NixOS",
     "repo": "nixpkgs",
-    "rev": "c5f1ee982246d09ae7f119c13aafcce90286221d",
-    "sha256": "0wzbc1hgjy6x5qzpbk001g3a72xbih1vk61mm0i05jp4m2rafqkb"
+    "rev": "932ec35ff8ac0fef5667ad2b0db4a009440255a9",
+    "sha256": "0q1gidyk8ncpas0gq08x0n2hcwhjz7m4bx8sln060cbf10pcdj95"
   },
   "nixos-mailserver": {
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/",


### PR DESCRIPTION
Pull upstream NixOS changes that include security fixes and other
updates:

* element-web: 1.9.2 -> 1.9.7
* imagemagick: 7.1.0-13 -> 7.1.0-19
* linux: 5.10.81 -> 5.10.88

 #PL-130280


@flyingcircusio/release-managers

## Release process

Impact:

[NixOS 21.05]: VMs will schedule a reboot to activate the changed kernel.  

Changelog: (include changes from commit msg here)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - pull in upstream security fixes regularly
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still run, works on test VM
  - checked commit log for fixed CVEs and possible problems with updates
