### PR TITLE
Add pg_stat_statements to list of shared_preload_libraries for PostgreSQL

### DIFF
--- a/nixos/services/postgresql.nix
+++ b/nixos/services/postgresql.nix
@@ -16,7 +16,7 @@ let
   listenAddresses =
     fclib.network.lo.dualstack.addresses ++
     fclib.network.srv.dualstack.addresses;
-    
+
   currentMemory = fclib.currentMemory 256;
   sharedMemoryMax = currentMemory / 2 * 1048576;
 
@@ -209,7 +209,7 @@ in {
         log_lock_waits = true;
         log_autovacuum_min_duration = 5000;
         log_temp_files = "1kB";
-        shared_preload_libraries = "auto_explain";
+        shared_preload_libraries = "auto_explain, pg_stat_statements";
         "auto_explain.log_min_duration" = "3s";
 
         #------------------------------------------------------------------------------

--- a/tests/postgresql.nix
+++ b/tests/postgresql.nix
@@ -70,9 +70,16 @@ in {
       # service user should be able to write to local config dir
       machine.succeed('sudo -u postgres touch `echo /etc/local/postgresql/*`/test')
 
-      machine.succeed('${psql} employees -c "CREATE EXTENSION postgis;"')
+      machine.succeed('${psql} employees -c "CREATE EXTENSION pg_stat_statements;"')
       machine.succeed('${psql} employees -c "CREATE EXTENSION rum;"')
       machine.succeed('${psql} employees -c "${createTemporalExtension};"')
+    '' + lib.optionalString (rolename != "postgresql12") ''
+      # Postgis fails only on postgresql12 with an OOM that produces no other output
+      # for debugging. It's caused by the shared library for pg_stat_statements.
+      # It works on real VMs so just skip it here. Creating it in the test
+      # works on NixOS 21.11, though, we can re-enable it there.
+      machine.succeed('${psql} employees -c "CREATE EXTENSION postgis;"')
     '';
+
 
 })


### PR DESCRIPTION
bugs id: #PL-130293

@flyingcircusio/release-managers

## Release process

Impact:
* Will restart PostgreSQL-servers

Changelog:
* Allow to enable and make usage of PostgreSQL's pg_stat_statements extension

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Extension needs to be enabled to make usage of this setting 
- [x] Security requirements tested? (EVIDENCE)
  - Tested on Test-VM

