### PR TITLE
hydra PR jobset generator: replace git:// URLs

### DIFF
--- a/.hydra/config.json
+++ b/.hydra/config.json
@@ -4,12 +4,12 @@
     "inputs": {
         "nixpkgs": {
             "type": "git",
-            "value": "git://github.com/flyingcircusio/nixpkgs.git nixos-21.05",
+            "value": "https://github.com/flyingcircusio/nixpkgs.git nixos-21.05",
             "emailresponsible": false
         },
         "platformDoc": {
             "type": "git",
-            "value": "git://github.com/flyingcircusio/doc.git master",
+            "value": "https://github.com/flyingcircusio/doc.git master",
             "emailresponsible": false
         },
         "branch": {

--- a/.hydra/project.json
+++ b/.hydra/project.json
@@ -27,7 +27,7 @@
         },
         "nixpkgs": {
             "type": "git",
-            "value": "git://github.com/NixOS/nixpkgs.git nixos-unstable-small",
+            "value": "https://github.com/NixOS/nixpkgs.git nixos-unstable-small",
             "emailresponsible": false
         },
         "pull_requests": {


### PR DESCRIPTION
Github won't support the old git:// URLs anymore so we
change to HTTPS.

 #PL-130307

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - use secure git via HTTPS instead of the unencrypted old git protocol 
- [x] Security requirements tested? (EVIDENCE)
  - not possible to test this
