### PR TITLE
devhost: fix container startup to reliably start all containers

### DIFF
--- a/nixos/roles/devhost/default.nix
+++ b/nixos/roles/devhost/default.nix
@@ -207,7 +207,16 @@ in
 
          path = [ pkgs.nixos-container ];
          script = ''
-           # Start enabled containers.
+           # Start all enabled containers.
+
+           # be verbose about what you're doing
+           set -x 
+
+           # Allow individual containers to have problems but start 
+           # all others. We have to set +e here explicitly as the script
+           # will be generated with a #!.../bin/bash -e header
+           set +e
+
          '' + lib.concatMapStringsSep "\n" 
            (container: "nixos-container start ${container.name}")
            enabledContainers;


### PR DESCRIPTION
Previously, if a single container failed (e.g. because it was deleted
manuall) we would not start any further containers after that.

We now show more explicit progress in our output and we also continue
after errors.

Tested with a manual version of the script.

Fixes PL-130323

@flyingcircusio/release-managers

## Release process

Impact:

none

Changelog:

* Bugfix for devhosts: start all containers even if some fail to start. (PL-130323)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

no specific requirements, improves availability,

- [x] Security requirements tested? (EVIDENCE)

none to test