### PR TITLE
devhost: clean up, make etc directory name consistent with role name

### DIFF
--- a/nixos/roles/devhost/fc-devhost-clean-containers.py
+++ b/nixos/roles/devhost/fc-devhost-clean-containers.py
@@ -9,7 +9,7 @@ AGE_DESTROY = 30 * 24 * 60 * 60
 
 changes = 0
 
-for filename in glob.glob('/etc/devserver/*.json'):
+for filename in glob.glob('/etc/devhost/*.json'):
     current_stat = os.stat(filename)
     age = time.time() - current_stat.st_mtime
     if age < AGE_SHUTDOWN:


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

none

Changelog:

* devhost: rename the config directory for containers from `/etc/devserver` to `/etc/devhost` to be consistent with the role name.
* 
## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

no specific requirements, reduces confusion and mental load, though

- [x] Security requirements tested? (EVIDENCE)

manually tested