### PR TITLE
Pl-130260 role for mongo db 42

### DIFF
--- a/doc/src/mongodb.rst
+++ b/doc/src/mongodb.rst
@@ -30,7 +30,7 @@ as perform administrative operations.
 Upgrade
 -------
 
-.. warning:: Upgrade paths must include all major versions: 3.2 -> 3.4 -> 3.6 -> 4.0.
+.. warning:: Upgrade paths must include all major versions: 3.2 -> 3.4 -> 3.6 -> 4.0 -> 4.2.
    Before each upgrade step, the feature compatibility version must be set to the
    current running mongodb version.
 

--- a/doc/src/mongodb.rst
+++ b/doc/src/mongodb.rst
@@ -8,6 +8,7 @@ There's a role for each supported major version, currently:
 
 * mongodb36
 * mongodb40
+* mongodb42
 
 
 3.2 and 3.4 are end-of-life and should be upgraded.

--- a/nixos/roles/graylog.nix
+++ b/nixos/roles/graylog.nix
@@ -160,14 +160,14 @@ in
         wantedBy = [ "mongodb.service" ];
         after = [ "mongodb.service" ];
         script = let
-          mongoCmd = "${pkgs.mongodb-4_0}/bin/mongo";
-          js = pkgs.writeText "mongodb_set_feature_compat_version_4_0.js" ''
+          mongoCmd = "${pkgs.mongodb-4_2}/bin/mongo";
+          js = pkgs.writeText "mongodb_set_feature_compat_version_4_2.js" ''
             res = db.adminCommand({"getParameter": 1, "featureCompatibilityVersion": 1});
             compat_version = res["featureCompatibilityVersion"]["version"];
 
-            if (db.version().startsWith("4.0") && compat_version == "3.6") {
-                print("MongoDB: current feature compat version is 3.6, updating to 4.0");
-                db.adminCommand( { setFeatureCompatibilityVersion: "4.0" } );
+            if (db.version().startsWith("4.2") && compat_version == "4.0") {
+                print("MongoDB: current feature compat version is 4.0, updating to 4.2");
+                db.adminCommand( { setFeatureCompatibilityVersion: "4.2" } );
             }
           '';
         in ''

--- a/nixos/roles/mongodb.nix
+++ b/nixos/roles/mongodb.nix
@@ -43,6 +43,7 @@ let
     "3.4" = mongodb34.enable;
     "3.6" = mongodb36.enable;
     "4.0" = mongodb40.enable;
+    "4.2" = mongodb42.enable;
   };
   enabledRoles = lib.filterAttrs (n: v: v) mongodbRoles;
   enabledRolesCount = length (lib.attrNames enabledRoles);
@@ -60,6 +61,7 @@ in {
       mongodb34 = mkRole "3.4";
       mongodb36 = mkRole "3.6";
       mongodb40 = mkRole "4.0";
+      mongodb42 = mkRole "4.2";
     };
   };
 

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -234,6 +234,15 @@ in {
       sha256 = "1kbw8vjbwlh94y58am0cxdz92mpb4amf575x0p456h1k3kh87rjg";
     };
   });
+  mongodb-4_2 = super.mongodb-4_2.overrideAttrs(_: rec {
+    meta.license = null;
+    version = "4.2.18";
+    name = "mongodb-${version}";
+    src = super.fetchurl {
+      url = "https://fastdl.mongodb.org/src/mongodb-src-r${version}.tar.gz";
+      sha256 = "1fl555n8nnp3qpgx2hppz6yjh9w697kryzgkv73qld8zrikrbfsv";
+    };
+  });
 
 
   libmodsecurity = super.libmodsecurity.overrideAttrs(_: rec {

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -65,6 +65,7 @@ in {
   mongodb34 = callTest ./mongodb.nix { version = "3.4"; };
   mongodb36 = callTest ./mongodb.nix { version = "3.6"; };
   mongodb40 = callTest ./mongodb.nix { version = "4.0"; };
+  mongodb42 = callTest ./mongodb.nix { version = "4.2"; };
   mysql57 = callTest ./mysql.nix { rolename = "mysql57"; };
   network = callSubTests ./network {};
   nfs = callTest ./nfs.nix {};

--- a/tests/mongodb.nix
+++ b/tests/mongodb.nix
@@ -1,4 +1,4 @@
-import ./make-test-python.nix ({ version ? "4.0", lib, pkgs, testlib, ... }:
+import ./make-test-python.nix ({ version ? "4.2", lib, pkgs, testlib, ... }:
 let
   ipv4 = "192.168.101.1";
   ipv6 = "2001:db8:f030:1c3::1";


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

- Updates the Graylog MongoDB database from 4.0 to 4.2
- Adds MongoDB 4.2
- MongoDB 4.2 removes the deprecated MMAPv1 storage engine.
If your 4.0 deployment uses MMAPv1, you must change the deployment to WiredTiger Storage Engine before upgrading to MongoDB 4.2.
See: https://docs.mongodb.com/manual/release-notes/4.2/#removed-mmapv1-storage-engine
- removed some commands



Removed Command | Removed Method | Notes
-- | -- | --
group | db.collection.group() | Use db.collection.aggregate() with the $group stage instead.
eval |   | The MongoDB 4.2 mongo shell methods db.eval() and db.collection.copyTo() can only be run when connected to MongoDB 4.0 or earlier.
copydb |   | The corresponding mongo shell helpers db.copyDatabase() can only be run when connected to MongoDB 4.0 or earlier.As an alternative, users can use mongodump and mongorestore (see Copy/Clone a Database) or write a script using the drivers.
clone |   | The corresponding mongo shell helpers db.cloneDatabase() can only be run when connected to MongoDB 4.0 or earlier.As an alternative, users can use mongodump and mongorestore (see Copy/Clone a Database) or write a script using the drivers.
geoNear |   | Use db.collection.aggregate() with the $geoNear stage instead.For more information, see Remove Support for the geoNear Command.
parallelCollectionScan |   |  
repairDatabase | db.repairDatabase() | For more information, see Remove Support for the repairDatabase Command.
getPrevError | db.getPrevError()

see https://docs.mongodb.com/manual/release-notes/4.2/#removed-commands-and-methods

- New TLS Options
MongoDB 4.2 adds TLS options for the mongod, the mongos, and the mongo shell to replace the corresponding SSL options (deprecated in 4.2). The new TLS options provide identical functionality as the deprecated SSL options as MongoDB has always supported TLS 1.0 and later.
See: https://docs.mongodb.com/manual/release-notes/4.2/#new-tls-options

- 4.2+ compatible Drivers Retry Writes by Default
    MongoDB 3.6 introduced support for Retryable Writes, but most official MongoDB 3.6 and 4.0-compatible drivers disabled this feature by default. For such drivers, retryable writes could be enabled per connection by including the retryWrites=true option in the connection string for that connection. Refer to the MongoDB Driver Documentation to determine the correct default state of retryWrites for your specific driver and version.The official MongoDB 4.2+ compatible drivers enable Retryable Writes by default. Applications upgrading to the 4.2+ compatible drivers that require retryable writes may omit the retryWrites=true option. Applications upgrading to the 4.2+ compatible drivers that require disabling retryable writes must include retryWrites=false in the connection string.

See https://docs.mongodb.com/manual/release-notes/4.2/ for full changelog



Changelog:
MongoDB 4.2 added, graylog runs on MongoDB 4.2 by default now
See [changelog of MongoDB](https://docs.mongodb.com/manual/release-notes/4.2/)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
 - new version of existing software added, no vendor changes and new version is also supported
 - update has no impact on most common deployments of MongoDB
- [x] Security requirements tested? (EVIDENCE)
 - nixos tests run, package builds (albeit slowly)
