### PR TITLE
devhost/nfs: do not use 127.0.0.1 as nfs address

### DIFF
--- a/nixos/infrastructure/container.nix
+++ b/nixos/infrastructure/container.nix
@@ -116,13 +116,13 @@ in
 
       flyingcircus.encServices = [
         { service = "nfs_rg_share-server";
-          address = "127.0.0.1";
+          address = config.networking.hostName;
         }
       ];
 
       flyingcircus.encServiceClients = [
         { service = "nfs_rg_share-server";
-          node = "127.0.0.1";
+          node = config.networking.hostName;
         }
       ];
 


### PR DESCRIPTION
nfs seems to get confused with mixed 127.0.0.1/$hostname exports and
mount

Re FC-21094

@flyingcircusio/release-managers

## Release process

Impact:

none

Changelog:

* Improve NFS mounts for the nfs_rg_share role in devhost containers.(FC-21094)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

no additional requirements, improves reliability on devhost containers

- [x] Security requirements tested? (EVIDENCE)

manual testing in dev containers