### PR TITLE
PL-130179 Add longterm backy schedule

### DIFF
--- a/nixos/infrastructure/flyingcircus-physical.nix
+++ b/nixos/infrastructure/flyingcircus-physical.nix
@@ -27,6 +27,10 @@ mkIf (cfg.infrastructureModule == "flyingcircus-physical") {
         fsIdentifier = "provided";
         gfxmodeBios = "text";
       };
+
+      # Wanted by backy and Ceph servers
+      kernel.sysctl."vm.vfs_cache_pressure" = 10;
+
     };
 
     environment.systemPackages = with pkgs; [

--- a/nixos/roles/backyserver.nix
+++ b/nixos/roles/backyserver.nix
@@ -80,6 +80,9 @@ in
           daily: {interval: 1d, keep: 8}
           monthly: {interval: 30d, keep: 2}
           weekly: {interval: 7d, keep: 3}
+        longterm:
+          daily: {interval: 1d, keep: 30}
+          monthly: {interval: 30d, keep: 12}
     '';
 
     flyingcircus.agent.extraCommands = ''

--- a/nixos/roles/backyserver.nix
+++ b/nixos/roles/backyserver.nix
@@ -13,6 +13,7 @@ let
     src = pkgs.fetchFromGitHub {
       owner = "flyingcircusio";
       repo = "backy-extract";
+      # 1.1.0
       rev = "5fd4c02e757918e22b634b16ae86927b82eb9f2a";
       sha256 = "1msg4p4h6ksj3vrsshhh5msfwgllai42jczyvd4nvrsqpncg12ik";
     };
@@ -58,8 +59,9 @@ in
     };
 
     boot = {
-      kernel.sysctl."vm.vfs_cache_pressure" = 10;
-      kernelModules = [ "mq_deadline" ];
+      # Extracted to flyingcircus-physical.nix
+      # kernel.sysctl."vm.vfs_cache_pressure" = 10;
+      kernelModules = [ "mq_deadline" ]; 
     };
 
     environment.etc."backy.global.conf".text = ''
@@ -92,7 +94,7 @@ in
     systemd.services.backy = {
         description = "Backy backup server";
         wantedBy = [ "multi-user.target" ];
-        path = [ pkgs.backy pkgs.fc.agent ];
+        path = [ backy pkgs.fc.agent ];
 
         environment = {
           CEPH_ARGS = "--id ${enc.name}";
@@ -102,33 +104,16 @@ in
           ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
         };
 
-        # Theory of operation: raising write_expire timeouts means that
-        # requests are much more unlikely to get into 'expired' state which effectively
-        # means FIFO which means thrashing under high load.
         script = ''
             set -e
 
             # Delete old logs from pre-journal days.
             rm -f /var/log/backy.log*
 
-            for device in /sys/block/*; do
-                if ! [[ -d ''${device} ]]; then
-                    continue
-                fi
-
-                case ''${device##*/} in
-                    sd?)
-                        echo "mq-deadline" > "''${device}/queue/scheduler"
-                        sleep 0.1
-                        echo 50000 > "''${device}/queue/iosched/write_expire"  # default: 5000
-                    ;;
-                esac
-            done
-
             if ! [[ -f /etc/backy.conf ]]; then
               fc-backy
             fi
-            exec ${pkgs.backy}/bin/backy scheduler
+            exec ${backy}/bin/backy scheduler
         '';
 
     };
@@ -142,13 +127,13 @@ in
 
       backy_sla = {
         notification = "Backy SLA conformance";
-        command = "sudo ${pkgs.backy}/bin/backy check";
+        command = "sudo ${backy}/bin/backy check";
       };
 
     };
 
     flyingcircus.passwordlessSudoRules = [
-      { commands = [ "${pkgs.backy}/bin/backy check" ];
+      { commands = [ "${backy}/bin/backy check" ];
         groups = [ "sensuclient" ];
       }
     ];

--- a/nixos/services/ceph/server.nix
+++ b/nixos/services/ceph/server.nix
@@ -102,7 +102,8 @@ in
       "vm.dirty_background_ratio" = "10";
       "vm.dirty_ratio" = "40";
       "vm.max_map_count" = "524288";
-      "vm.vfs_cache_pressure" = "10";
+      # Extracted to flyingcircus-physical.nix
+      # kernel.sysctl."vm.vfs_cache_pressure" = 10;
 
       # 10G tuning for OSDs
       "vm.min_free_kbytes" = "513690";

--- a/pkgs/fc/agent/fc/manage/backy.py
+++ b/pkgs/fc/agent/fc/manage/backy.py
@@ -1,11 +1,9 @@
 """Generates /etc/backy.conf from directory data."""
 
 import argparse
-import copy
 import json
 import logging
 import logging.handlers
-import os
 import os.path as p
 import shutil
 import socket

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -26,6 +26,7 @@ in {
 
   antivirus = callTest ./antivirus.nix {};
   audit = callTest ./audit.nix {};
+  backyserver = callTest ./backyserver.nix {};
   channel = callTest ./channel.nix {};
   coturn = callTest ./coturn.nix {};
   devhost = callTest ./devhost.nix {};


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

none

Changelog:

* Add new 'longterm' schedule option for backy that covers a 30 day daily and 12 months monthly rhythm. (PL-130179)
## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

not relevant

- [x] Security requirements tested? (EVIDENCE)

nothing to test