### PR TITLE
Percona: 8.0.22-13 -> 8.0.26-17

### DIFF
--- a/pkgs/percona/8.0.nix
+++ b/pkgs/percona/8.0.nix
@@ -2,16 +2,16 @@
 , lzo, lz4, bzip2, snappy
 , libiconv, openssl, pcre, boost, judy, bison, libxml2
 , libaio, jemalloc, cracklib, systemd, numactl
-, asio, buildEnv, check, scons, curl, perl, openldap, libtirpc, rpcsvc-proto
+, asio, buildEnv, check, scons, curl, perl, cyrus_sasl, openldap, libtirpc, rpcsvc-proto
 }:
 
 stdenv.mkDerivation rec {
   pname = "percona";
-  version = "8.0.22-13";
+  version = "8.0.26-17";
 
   src = fetchurl {
     url = "https://www.percona.com/downloads/Percona-Server-8.0/Percona-Server-${version}/source/tarball/percona-server-${version}.tar.gz";
-    sha256 = "16ncjy3hwzm10hi6c3smk275pv775d4j1nrgyamjrs4hfzf4jhk1";
+    sha256 = "0r1pw4s5hcplgqld6xd30jrc7h76wg1h9z2ms8rs5lryr12blqdq";
   };
 
   preConfigure = lib.optional stdenv.isDarwin ''
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     ncurses openssl zlib pcre jemalloc libiconv libaio systemd boost
-    curl perl openldap.dev libtirpc
+    curl perl cyrus_sasl openldap.dev libtirpc
   ];
 
   enableParallelBuilding = true;


### PR DESCRIPTION
Fixes a bug in 8.0.22 that hit one of our customers. Others were not
affected but they may run into the same problem when using certain
queries.

https://jira.percona.com/browse/PS-7485?page=com.atlassian.jira.plugin.system.issuetabpanels%3Aworklog-tabpanel

 #PL-130362

@flyingcircusio/release-managers

## Release process

Impact:

* [NixOS 21.05] MySQL/Percona 8 will be restarted.

Changelog:

* Percona: 8.0.22-13 -> 8.0.26-17. Fixes a known bug (https://jira.percona.com/browse/PS-7485?page=com.atlassian.jira.plugin.system.issuetabpanels%3Aworklog-tabpanel) that affects some queries and crashes the server process. (#PL-130362).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  -  nothing new, use the newest bugfix release
- [x] Security requirements tested? (EVIDENCE)
  - automated test still runs, checked on a test VM that mysql is working
  - checked percona release notes for security-relevant changes or other things affecting updates
