### PR TITLE
polkit: add patch for CVE-2021-4034

### DIFF
--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -9,7 +9,7 @@ let
   phps = (import ../nix-phps/pkgs/phps.nix) (../nix-phps)
     {} super;
 
-  inherit (super) fetchurl lib;
+  inherit (super) fetchpatch fetchurl lib;
 
 in {
   #
@@ -338,6 +338,31 @@ in {
   percona-xtrabackup_8_0 = super.callPackage ./percona/xtrabackup.nix {
     boost = self.boost173;
   };
+
+
+  polkit = super.polkit.overrideAttrs(_: {
+
+    patches = [
+      # Don't use etc/dbus-1/system.d
+      # Upstream MR: https://gitlab.freedesktop.org/polkit/polkit/merge_requests/11
+      (fetchpatch {
+        url = "https://gitlab.freedesktop.org/polkit/polkit/commit/5dd4e22efd05d55833c4634b56e473812b5acbf2.patch";
+        sha256 = "17lv7xj5ksa27iv4zpm4zwd4iy8zbwjj4ximslfq3sasiz9kxhlp";
+      })
+      (fetchpatch {
+        # https://www.openwall.com/lists/oss-security/2021/06/03/1
+        # https://gitlab.freedesktop.org/polkit/polkit/-/merge_requests/79
+        name = "CVE-2021-3560.patch";
+        url = "https://gitlab.freedesktop.org/polkit/polkit/-/commit/a04d13affe0fa53ff618e07aa8f57f4c0e3b9b81.patch";
+        sha256 = "157ddsizgr290jsb8fpafrc37gc1qw5pdvl351vnn3pzhqs7n6f4";
+      })
+      # pkexec: local privilege escalation (CVE-2021-4034)
+      (fetchpatch {
+        url = "https://gitlab.freedesktop.org/polkit/polkit/-/commit/a2bf5c9c83b6ae46cbd5c779d3055bff81ded683.patch";
+        sha256 = "162jkpg2myq0rb0s5k3nfr4pqwv9im13jf6vzj8p5l39nazg5i4s";
+      })
+    ];
+  });
 
   postgis_2_5 = super.postgis.overrideAttrs(_: rec {
     version = "2.5.5";


### PR DESCRIPTION
Allows a privilege escalation from normal users to root using pkexec.
Patch is the same as upstream NixOS 21.11, pulling in a commit from
the polkit project.

 #PL-130363

@flyingcircusio/release-managers

## Release process

Impact:

* Some services that depend on polkit will be restarted

Changelog:

* Fix CVE-2022-4034 that allows local privilege escalation through pkexec (#PL-130363).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - patch critical security problems
- [x] Security requirements tested? (EVIDENCE)
  - we trust that the patch does the right thing, it's from the polkit project itself 
  - all automated tests still work
