### PR TITLE
Update nixpkgs

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "NixOS",
     "repo": "nixpkgs",
-    "rev": "932ec35ff8ac0fef5667ad2b0db4a009440255a9",
-    "sha256": "0q1gidyk8ncpas0gq08x0n2hcwhjz7m4bx8sln060cbf10pcdj95"
+    "rev": "0fd9ee1aa36ce865ad273f4f07fdc093adeb5c00",
+    "sha256": "vWpUEqQdVP4srj+/YLJRTN9vjpTs4je0cdWKXPbDItc="
   },
   "nixos-mailserver": {
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/",


### PR DESCRIPTION
Notable security updates and version changes:

* binutils: 2.35.1 -> 2.35.2 (CVE-2020-35448, CVE-2021-20284,
  CVE-2021-20294)
* gegl_0_4: patch https://github.com/advisories/GHSA-g9gv-9646-jvp8
* unicorn: add patch for https://github.com/advisories/GHSA-rmvm-v6m6-87vr


@flyingcircusio/release-managers

## Release process

Impact:

[NixOS 21.05]: Many services will be restarted because of a core dependency change. 

Changelog:

(include changes from commit msg)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - pull in upstream security fixes regularly
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still run, works on test VM
  - checked commit log for fixed CVEs and possible problems with updates