### PR TITLE
devhost: fix memcached dualstack localhost binding

### DIFF
--- a/nixos/infrastructure/container.nix
+++ b/nixos/infrastructure/container.nix
@@ -66,7 +66,7 @@ in
       flyingcircus.roles.coturn.hostName = config.networking.hostName;
       flyingcircus.roles.coturn.config.listening-ips =  [ "[::]" ];
 
-      flyingcircus.roles.memcached.listenAddresses = [ "[::]" ];
+      flyingcircus.roles.memcached.listenAddresses = [ "0.0.0.0" "[::]" ];
 
       flyingcircus.roles.mailserver.smtpBind4 = [ "127.0.0.1" ];
       flyingcircus.roles.mailserver.smtpBind6 = [ "::1" ];


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Fix memcached's localhost dualstack binding when running in a devhost container. (FC-21094)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

no specific requirements

- [x] Security requirements tested? (EVIDENCE)

manually tested in dev container