### PR TITLE
K3s frontend improvements

### DIFF
--- a/doc/src/kubernetes.rst
+++ b/doc/src/kubernetes.rst
@@ -352,6 +352,14 @@ on your requirements there are a few more options available:
           # generate. The default is 10 and you can adjust this as needed.
           maxExpectedPods = 5;
 
+          # If the proxy should talk to the backend using SSL.
+          # Certificates are not verified to speed up things and make things work with self-signed certificates.
+          sslBackend = false;
+
+          # haproxy options for the server-template directive used for the pod backends,
+          # added verbatim to the end of the generated line.
+          extraPodTemplateOptions = "";
+
         };
 
     }

--- a/nixos/services/k3s/frontend.nix
+++ b/nixos/services/k3s/frontend.nix
@@ -47,6 +47,7 @@ let
     {
       inherit binds;
       inherit (conf) mode;
+      options = if conf.mode == "http" then [ "httplog" ] else [ "tcplog" ];
       servers =
         lib.optionals (conf.lbServicePort != null)
           (map

--- a/nixos/services/k3s/frontend.nix
+++ b/nixos/services/k3s/frontend.nix
@@ -31,6 +31,15 @@ let
           let
             port = if conf.lbServicePort != null then conf.lbServicePort else conf.podPort;
           in [ "127.0.0.1:${toString port}" ];
+
+      podOptions = lib.concatStringsSep " " [
+        "check resolvers cluster init-addr none"
+        (lib.optionalString conf.sslBackend "ssl verify none")
+        (lib.optionalString (conf.extraPodTemplateOptions != "") conf.extraPodTemplateOptions)
+      ];
+      podDns = "*.${serviceFqdn}:${toString conf.podPort}";
+      podInstances = toString conf.maxExpectedPods;
+      podTemplate = "server-template pod ${podInstances} ${podDns} ${podOptions}";
     in
     assert
       lib.assertMsg (conf.lbServicePort != null || conf.podPort != null)
@@ -42,17 +51,16 @@ let
         lib.optionals (conf.lbServicePort != null)
           (map
             (n: "${lib.replaceStrings [".gocept.net"] [""] n.address} ${head n.ips}:${toString conf.lbServicePort} check"
-                + (lib.optionalString (conf.podPort != null) " backup"))
+                + (lib.optionalString (conf.podPort != null) " backup")
+                + (lib.optionalString conf.sslBackend " ssl verify none"))
             agents);
 
-      extraConfig = ''
-        balance leastconn
-      '' + lib.optionalString (conf.podPort != null) ''
-        server-template pod ${toString conf.maxExpectedPods} *.${serviceFqdn}:${toString conf.podPort} check resolvers cluster init-addr none
-      '' + lib.optionalString (conf.haproxyExtraConfig != "") ''
-        # frontend haproxyExtraConfig
-        ${conf.haproxyExtraConfig}
-      '';
+      extraConfig = lib.concatStringsSep "\n" [
+        "balance leastconn"
+        (lib.optionalString (conf.podPort != null) podTemplate)
+        (lib.optionalString (conf.haproxyExtraConfig != "") "# From haproxyExtraConfig option")
+        (lib.optionalString (conf.haproxyExtraConfig != "") conf.haproxyExtraConfig)
+      ];
   }) frontendCfg;
 in
 {
@@ -96,6 +104,12 @@ in
             type = lines;
             default = "";
             description = "haproxy config lines added verbatim to the end of the listen block configured for this service.";
+          };
+
+          extraPodTemplateOptions = mkOption {
+            type = string;
+            default = "";
+            description = "haproxy options for the server-template directive used for the pod backends, added verbatim to the end of the generated line.";
           };
 
           maxExpectedPods = mkOption {
@@ -144,6 +158,15 @@ in
               A typical case would be an ingress service which is handling both HTTP and HTTPS
               where you would have `frontend.kubernetes.frontend.ingress-http` and
               `ingress-https`, both pointing at the same serviceName `ingress`.
+            '';
+          };
+
+          sslBackend = mkOption {
+            type = bool;
+            default = false;
+            description = ''
+              If the proxy should talk to the backend using SSL.
+              Certificates are not verified to speed up things and make things work with self-signed certificates.
             '';
           };
 

--- a/nixos/services/k3s/frontend.nix
+++ b/nixos/services/k3s/frontend.nix
@@ -231,7 +231,7 @@ in
         '';
       };
 
-      networking.nameservers = lib.mkOverride 90 (server.ips ++ fcNameservers);
+      networking.nameservers = lib.mkOverride 90 (lib.take 3 ([netCfg.clusterDns] ++ fcNameservers));
 
       services.k3s = let
         nodeAddress = head fclib.network.srv.v4.addresses;


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* K3s/Kubernetes frontend improvements (#PL-130265): 
  * VM now adds cluster DNS to resolv.conf so names like `web-service.namespace.svc.cluster.local` can be resolved now. Before, only haproxy could resolve internal DNS names.
  *  Added option `sslBackend` to use SSL for the backend pod connection from haproxy to the backend pod.
  * Added new option `extraPodTemplateOptions` to add options to the generated `server-template` line.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - optionally protect connections from the frontend to backend pods with SSL 
- [x] Security requirements tested? (EVIDENCE)
  - automated test still runs, manually checked in our test k3s cluster
