### PR TITLE
multiple fixes for improved graylog performance

### DIFF
--- a/nixos/platform/network.nix
+++ b/nixos/platform/network.nix
@@ -268,6 +268,14 @@ in
       # neighbour discovery. Seen on #denog on 2020-11-19
       "net.ipv6.route.max_size" = 2147483647;
 
+      # Ensure we can work in larger vLANs with hundreds of nodes.
+      "net.ipv4.neigh.default.gc_thresh1" = 1024;
+      "net.ipv4.neigh.default.gc_thresh2" = 4096;
+      "net.ipv4.neigh.default.gc_thresh3" = 8192;
+      "net.ipv6.neigh.default.gc_thresh1" = 1024;
+      "net.ipv6.neigh.default.gc_thresh2" = 4096;
+      "net.ipv6.neigh.default.gc_thresh3" = 8192;
+
       # See PL-130189
       # conntrack entries are created (for v4/v6) if any rules
       # for related/established and/or NATing are used in the

--- a/nixos/roles/graylog.nix
+++ b/nixos/roles/graylog.nix
@@ -325,7 +325,7 @@ in
             servers = map
               ( node:
                   "${node.address} ${head (filter fclib.isIp6 node.ips)}:${toString glAPIPort}"
-                  + " check fall 1 rise 2 inter 10s maxconn 20"
+                  + " check fall 1 rise 2 inter 10s maxconn 500"
               )
               clusterNodes;
             balance = "roundrobin";

--- a/nixos/roles/sensuserver.nix
+++ b/nixos/roles/sensuserver.nix
@@ -29,17 +29,6 @@ in
 
   config = lib.mkIf config.flyingcircus.roles.sensuserver.enable {
 
-      # Sensu talks to all VMs in a location permanently, so there are
-      # a lot of entries in the neighbour table. Increase numbers
-      # to avoid unneccessary garbage collecting and table overflows.
-      boot.kernel.sysctl = {
-        "net.ipv4.neigh.default.gc_thresh1" = 1024;
-        "net.ipv4.neigh.default.gc_thresh2" = 4096;
-        "net.ipv4.neigh.default.gc_thresh3" = 8192;
-        "net.ipv6.neigh.default.gc_thresh1" = 1024;
-        "net.ipv6.neigh.default.gc_thresh2" = 4096;
-        "net.ipv6.neigh.default.gc_thresh3" = 8192;
-      };
       flyingcircus.roles.rabbitmq.enable = true;
       flyingcircus.services.nginx.enable = true;
       flyingcircus.services.rabbitmq.listenAddress = lib.mkOverride 90 "::";


### PR DESCRIPTION
* increase gc_thresh* for all nodes to ensure working in large vLANs
  and talking with hundreds of nodes is reliable.

* increase maxconn for the graylog UI to ensure ability to work with
  many users and open tabs at once.

@flyingcircusio/release-managers

## Release process

Impact:

none

Changelog:

* Increase neighbour discovery tables for IPv4 and IPv6 on all nodes to ensure services that talk to a lot of neighbours on a single LAN work properly with at least multiple hundreds of neighbours. (PL-130380)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

balanced resource usage, larger tables need a bit more ram but are necessary for properly working networking in our growing locations

- [x] Security requirements tested? (EVIDENCE)

we already used this and know it works, tried it on the affected machine in the ticket (graylog server) and did not see negative effects, but had kernel error messages subside. moved the code from sensu-servers only to all nodes now.