### PR TITLE
Add LAMP PHP 7.2 package

### DIFF
--- a/doc/src/lamp.rst
+++ b/doc/src/lamp.rst
@@ -99,6 +99,7 @@ CLI.
 Supported packages:
 
 * ``pkgs.lamp_php56`` (outdated but provided for legacy applications)
+* ``pkgs.lamp_php72`` (outdated but provided for legacy applications)
 * ``pkgs.lamp_php73``
 * ``pkgs.lamp_php74``
 * ``pkgs.lamp_php80``

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -167,10 +167,19 @@ in {
   # Import old php versions from nix-phps
   # NOTE: php7.3 is already removed on unstable
   inherit (phps) php56;
+  inherit (phps) php72;
 
   # Those are specialised packages for "direct consumption" use in our LAMP roles.
 
   lamp_php56 = self.php56.withExtensions ({ enabled, all }:
+              enabled ++ [
+                all.bcmath
+                all.imagick
+                all.memcached
+                all.redis
+              ]);
+
+  lamp_php72 = self.php72.withExtensions ({ enabled, all }:
               enabled ++ [
                 all.bcmath
                 all.imagick

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -50,6 +50,7 @@ in {
 
   lamp = callTest ./lamp.nix { };
   lamp56 = callTest ./lamp.nix { version = "lamp_php56"; };
+  lamp72 = callTest ./lamp.nix { version = "lamp_php72"; };
   lamp73 = callTest ./lamp.nix { version = "lamp_php73"; };
   lamp73_tideways = callTest ./lamp.nix { version = "lamp_php73"; tideways = "1234"; };
   lamp74 = callTest ./lamp.nix { version = "lamp_php74"; };

--- a/tests/lamp.nix
+++ b/tests/lamp.nix
@@ -95,7 +95,7 @@ import ./make-test-python.nix ({ version ? "" , tideways ? "", ... }:
       lamp.succeed("egrep 'short_open_tag.*On' result")
       lamp.succeed("egrep 'output_buffering => 0 => 0' result")
 
-      if php_version.major > 5:
+      if php_version >= packaging.version.parse("7.3"):
         lamp.succeed("egrep 'curl.cainfo.*/etc/ssl/certs/ca-certificates.crt' result")
 
       if tideways_api_key:
@@ -134,7 +134,7 @@ import ./make-test-python.nix ({ version ? "" , tideways ? "", ... }:
       lamp.succeed("egrep 'output_buffering +1 +1' result")
       lamp.succeed("egrep 'BCMath support.*enabled' result")
 
-      if php_version.major > 5:
+      if php_version >= packaging.version.parse("7.3"):
         lamp.succeed("egrep 'curl.cainfo.*/etc/ssl/certs/ca-certificates.crt' result")
 
       if tideways_api_key:


### PR DESCRIPTION
bugs id: PL-130410

@flyingcircusio/release-managers

## Release process

Impact:
- Expect no impact on existing installations

Changelog:
* Enable PHP 7.2 in for usage in our LAMP role for legacy reasons

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [x] Security requirements tested? (EVIDENCE)
  - [x] Testet on a target VM with an application needing 7.2 from dev checkout

