### PR TITLE
devhost: make container cleanup optional, make nginx more robust

### DIFF
--- a/doc/src/devhost.rst
+++ b/doc/src/devhost.rst
@@ -293,7 +293,7 @@ by using a tool that responds to changes in your filesystem (like )
 In the future there will be optimized support for this behaviour in batou.
 
 To sync code that is currently being developed on (and assuming you are using
-an editor / IDE on your local mcine)
+an editor / IDE on your local machine)
 
 
 Maintenance
@@ -307,6 +307,16 @@ an automatic cleanup policy:
 
 * Containers are deleted 30 days after their last deployment, thus reducing
   storage requirements.
+
+The automatic cleanup policy can be disabled using the
+``flyingcircus.roles.devhost.cleanupContainers`` option.
+
+To manually delete a container you can use the build script's ``destroy`` action:
+
+.. code-block:: sh
+
+   $ fc-build-dev-container destroy <mycontainer>
+
 
 
 Known issues


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

none

Changelog:

* Improve our container `devhost` role: automatic cleanup is optional now and nginx configs are more robust regarding container DNS lookups.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

no specific requirements afaict

- [x] Security requirements tested? (EVIDENCE)

tested manually on our internal devhost

