### PR TITLE
All Ceph nodes need client keys.

### DIFF
--- a/pkgs/fc/ceph/fc/ceph/keys.py
+++ b/pkgs/fc/ceph/fc/ceph/keys.py
@@ -226,7 +226,8 @@ ROLE_KEYS = {
     'backyserver': {ClientKey},
     'kvm_host': {ClientKey},
     'ceph_mon': {ClientKey},
-    'ceph_rgw': {RGWKey}}
+    'ceph_osd': {ClientKey},
+    'ceph_rgw': {ClientKey, RGWKey}}
 
 
 class KeyManager(object):


### PR DESCRIPTION
@flyingcircusio/release-managers

fixes [PL-130431](https://yt.flyingcircus.io/issue/PL-130431) ceph nixos: maintenance defect due to missing keyring

## Release process

Impact:

n/a

Changelog:

n/a

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

we already assume that all nodes have a client key, this was missing for non-mon hosts

- [x] Security requirements tested? (EVIDENCE)

manually tested, added corresponding configs for DEV environment