### PR TITLE
lamp: fix apache/php reload bug

### DIFF
--- a/nixos/roles/lamp.nix
+++ b/nixos/roles/lamp.nix
@@ -121,6 +121,11 @@ in {
 
           services.httpd.enable = true;
           services.httpd.adminAddr = "admin@flyingcircus.io";
+
+          # PL-130372 workaround for glibc TLS issue when loading
+          # many modules.
+          systemd.services.httpd.serviceConfig.ExecReload = lib.mkForce "";
+
           # We always provide the PHP cli environment but we need to ensure
           # to choose the right one in case someone uses the LAMP role.
           environment.systemPackages = [


### PR DESCRIPTION
work around for PL-130372

@flyingcircusio/release-managers

## Release process

Impact:

* Apache on LAMP servers will be restarted.

Changelog:

* Work around a suspected Apache/PHP bug regarding dynamic library loading and static thread local storage by restarting Apache instead of reloading gracefully. (PL-130372)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

availability/stability matters

- [x] Security requirements tested? (EVIDENCE)

added automated test to the lamp test suite
