### PR TITLE
k3s: 1.22.3+k3s1 -> 1.23.3+k3s1

### DIFF
--- a/pkgs/k3s/default.nix
+++ b/pkgs/k3s/default.nix
@@ -1,0 +1,315 @@
+{ stdenv
+, lib
+, makeWrapper
+, socat
+, iptables
+, iproute2
+, bridge-utils
+, btrfs-progs
+, conntrack-tools
+, runc
+, rsync
+, kmod
+, libseccomp
+, buildGoModule
+, pkg-config
+, ethtool
+, util-linux
+, fetchFromGitHub
+, fetchurl
+, fetchzip
+, fetchgit
+, zstd
+, yq-go
+, nixosTests
+}:
+
+with lib;
+
+# k3s is a kinda weird derivation. One of the main points of k3s is the
+# simplicity of it being one binary that can perform several tasks.
+# However, when you have a good package manager (like nix), that doesn't
+# actually make much of a difference; you don't really care if it's one binary
+# or 10 since with a good package manager, installing and running it is
+# identical.
+# Since upstream k3s packages itself as one large binary with several
+# "personalities" (in the form of subcommands like 'k3s agent' and 'k3s
+# kubectl'), it ends up being easiest to mostly mimic upstream packaging, with
+# some exceptions.
+# K3s also carries patches to some packages (such as containerd and cni
+# plugins), so we intentionally use the k3s versions of those binaries for k3s,
+# even if the upstream version of those binaries exist in nixpkgs already. In
+# the end, that means we have a thick k3s binary that behaves like the upstream
+# one for the most part.
+# However, k3s also bundles several pieces of unpatched software, from the
+# strongswan vpn software, to iptables, to socat, conntrack, busybox, etc.
+# Those pieces of software we entirely ignore upstream's handling of, and just
+# make sure they're in the path if desired.
+let
+  k3sVersion = "1.23.3+k3s1";     # k3s git tag
+  k3sCommit = "6f4217a3405d16a1a51bbb40872d7dcb87207bb9"; # k3s git commit at the above version
+  k3sRepoSha256 = "sha256-0dRusG1vL+1KbmViIUNCZK1b+FEgV6otcVUyFonHmm4=";
+
+  # taken from ./manifests/traefik.yaml, extracted from '.spec.chart' https://github.com/k3s-io/k3s/blob/v1.23.3%2Bk3s1/scripts/download#L9
+  # The 'patch' and 'minor' versions are currently hardcoded as single digits only, so ignore the trailing two digits. Weird, I know.
+  traefikChartVersion = "10.9.1";
+  traefikChartSha256 = "sha256-XM1DLofU1zEEFeB5bNQ7cgv102gXsToPP7SFh87QuGQ=";
+
+  # taken from ./scripts/version.sh VERSION_ROOT https://github.com/k3s-io/k3s/blob/v1.23.3%2Bk3s1/scripts/version.sh#L47
+  k3sRootVersion = "0.9.1";
+  k3sRootSha256 = "0r2cj4l50cxkrvszpzxfk36lvbjf9vcmp6d5lvxg8qsah8lki3x8";
+
+  # taken from ./scripts/version.sh VERSION_CNIPLUGINS https://github.com/k3s-io/k3s/blob/v1.23.3%2Bk3s1/scripts/version.sh#L45
+  k3sCNIVersion = "0.9.1-k3s1";
+  k3sCNISha256 = "1327vmfph7b8i14q05c2xdfzk60caflg1zhycx0mrf3d59f4zsz5";
+
+  # taken from go.mod, the 'github.com/containerd/containerd' line
+  # run `grep github.com/containerd/containerd go.mod | head -n1 | awk '{print $4}'`
+  containerdVersion = "v1.5.9-k3s1";
+  containerdSha256 = "sha256-7xlhBA6KuwFlw+jyThygv4Ow9F3xjjIUtS6x8YHwjic=";
+
+  # run `grep github.com/kubernetes-sigs/cri-tools go.mod | head -n1 | awk '{print $4}'` in the k3s repo at the tag
+  criCtlVersion = "v1.22.0-k3s1";
+
+  baseMeta = {
+    description = "A lightweight Kubernetes distribution";
+    license = licenses.asl20;
+    homepage = "https://k3s.io";
+    maintainers = with maintainers; [ euank mic92 ];
+    platforms = platforms.linux;
+  };
+
+  # https://github.com/k3s-io/k3s/blob/5fb370e53e0014dc96183b8ecb2c25a61e891e76/scripts/build#L19-L40
+  versionldflags = [
+    "-X github.com/rancher/k3s/pkg/version.Version=v${k3sVersion}"
+    "-X github.com/rancher/k3s/pkg/version.GitCommit=${lib.substring 0 8 k3sCommit}"
+    "-X k8s.io/client-go/pkg/version.gitVersion=v${k3sVersion}"
+    "-X k8s.io/client-go/pkg/version.gitCommit=${k3sCommit}"
+    "-X k8s.io/client-go/pkg/version.gitTreeState=clean"
+    "-X k8s.io/client-go/pkg/version.buildDate=1970-01-01T01:01:01Z"
+    "-X k8s.io/component-base/version.gitVersion=v${k3sVersion}"
+    "-X k8s.io/component-base/version.gitCommit=${k3sCommit}"
+    "-X k8s.io/component-base/version.gitTreeState=clean"
+    "-X k8s.io/component-base/version.buildDate=1970-01-01T01:01:01Z"
+    "-X github.com/kubernetes-sigs/cri-tools/pkg/version.Version=${criCtlVersion}"
+    "-X github.com/containerd/containerd/version.Version=${containerdVersion}"
+    "-X github.com/containerd/containerd/version.Package=github.com/k3s-io/containerd"
+    "-X github.com/containerd/containerd/version.Version=${containerdVersion}"
+    "-X github.com/containerd/containerd/version.Package=github.com/k3s-io/containerd"
+  ];
+
+  # bundled into the k3s binary
+  traefikChart = fetchurl {
+    url = "https://helm.traefik.io/traefik/traefik-${traefikChartVersion}.tgz";
+    sha256 = traefikChartSha256;
+  };
+  # so, k3s is a complicated thing to package
+  # This derivation attempts to avoid including any random binaries from the
+  # internet. k3s-root is _mostly_ binaries built to be bundled in k3s (which
+  # we don't care about doing, we can add those as build or runtime
+  # dependencies using a real package manager).
+  # In addition to those binaries, it's also configuration though (right now
+  # mostly strongswan configuration), and k3s does use those files.
+  # As such, we download it in order to grab 'etc' and bundle it into the final
+  # k3s binary.
+  k3sRoot = fetchzip {
+    # Note: marked as apache 2.0 license
+    url = "https://github.com/k3s-io/k3s-root/releases/download/v${k3sRootVersion}/k3s-root-amd64.tar";
+    sha256 = k3sRootSha256;
+    stripRoot = false;
+  };
+  k3sCNIPlugins = buildGoModule rec {
+    pname = "k3s-cni-plugins";
+    version = k3sCNIVersion;
+    vendorSha256 = null;
+
+    subPackages = [ "." ];
+
+    src = fetchFromGitHub {
+      owner = "rancher";
+      repo = "plugins";
+      rev = "v${version}";
+      sha256 = k3sCNISha256;
+    };
+
+    postInstall = ''
+      mv $out/bin/plugins $out/bin/cni
+    '';
+
+    meta = baseMeta // {
+      description = "CNI plugins, as patched by rancher for k3s";
+    };
+  };
+  # Grab this separately from a build because it's used by both stages of the
+  # k3s build.
+  k3sRepo = fetchgit {
+    url = "https://github.com/k3s-io/k3s";
+    rev = "v${k3sVersion}";
+    sha256 = k3sRepoSha256;
+  };
+  # Stage 1 of the k3s build:
+  # Let's talk about how k3s is structured.
+  # One of the ideas of k3s is that there's the single "k3s" binary which can
+  # do everything you need, from running a k3s server, to being a worker node,
+  # to running kubectl.
+  # The way that actually works is that k3s is a single go binary that contains
+  # a bunch of bindata that it unpacks at runtime into directories (either the
+  # user's home directory or /var/lib/rancher if run as root).
+  # This bindata includes both binaries and configuration.
+  # In order to let nixpkgs do all its autostripping/patching/etc, we split this into two derivations.
+  # First, we build all the binaries that get packed into the thick k3s binary
+  # (and output them from one derivation so they'll all be suitably patched up).
+  # Then, we bundle those binaries into our thick k3s binary and use that as
+  # the final single output.
+  # This approach was chosen because it ensures the bundled binaries all are
+  # correctly built to run with nix (we can lean on the existing buildGoModule
+  # stuff), and we can again lean on that tooling for the final k3s binary too.
+  # Other alternatives would be to manually run the
+  # strip/patchelf/remove-references step ourselves in the installPhase of the
+  # derivation when we've built all the binaries, but haven't bundled them in
+  # with generated bindata yet.
+  k3sServer = buildGoModule rec {
+    pname = "k3s-server";
+    version = k3sVersion;
+
+    src = k3sRepo;
+    vendorSha256 = "sha256-9+2k/ipAOhc8JJU+L2dwaM01Dkw+0xyrF5kt6mL19G0=";
+
+    nativeBuildInputs = [ pkg-config ];
+    buildInputs = [ libseccomp ];
+
+    subPackages = [ "cmd/server" ];
+    ldflags = versionldflags;
+
+    # create the multicall symlinks for k3s
+    postInstall = ''
+      mv $out/bin/server $out/bin/k3s
+      pushd $out
+      # taken verbatim from https://github.com/k3s-io/k3s/blob/v1.23.3%2Bk3s1/scripts/build#L105-L113
+      ln -s k3s ./bin/k3s-agent
+      ln -s k3s ./bin/k3s-server
+      ln -s k3s ./bin/k3s-etcd-snapshot
+      ln -s k3s ./bin/k3s-secrets-encrypt
+      ln -s k3s ./bin/k3s-certificate
+      ln -s k3s ./bin/kubectl
+      ln -s k3s ./bin/crictl
+      ln -s k3s ./bin/ctr
+      popd
+    '';
+
+    meta = baseMeta // {
+      description = "The various binaries that get packaged into the final k3s binary";
+    };
+  };
+  k3sContainerd = buildGoModule {
+    pname = "k3s-containerd";
+    version = k3sVersion;
+    src = fetchFromGitHub {
+      owner = "k3s-io";
+      repo = "containerd";
+      rev = containerdVersion;
+      sha256 = containerdSha256;
+    };
+    vendorSha256 = null;
+    buildInputs = [ btrfs-progs ];
+    subPackages = [ "cmd/containerd" "cmd/containerd-shim-runc-v2" ];
+    ldflags = versionldflags;
+  };
+in
+buildGoModule rec {
+  pname = "k3s";
+  version = k3sVersion;
+
+  src = k3sRepo;
+  proxyVendor = true;
+  vendorSha256 = "sha256-8Yp9csyRNSYi9wo8E8mF8cu92wG1t3l18wJ8Y4L7HEA=";
+
+  patches = [
+    ./patches/0001-scrips-download-strip-downloading-just-package-CRD.patch
+    ./patches/0002-Don-t-build-a-static-binary-in-package-cli.patch
+  ];
+
+  # Important utilities used by the kubelet, see
+  # https://github.com/kubernetes/kubernetes/issues/26093#issuecomment-237202494
+  # Note the list in that issue is stale and some aren't relevant for k3s.
+  k3sRuntimeDeps = [
+    kmod
+    socat
+    iptables
+    iproute2
+    bridge-utils
+    ethtool
+    util-linux # kubelet wants 'nsenter' from util-linux: https://github.com/kubernetes/kubernetes/issues/26093#issuecomment-705994388
+    conntrack-tools
+  ];
+
+  buildInputs = k3sRuntimeDeps;
+
+  nativeBuildInputs = [
+    makeWrapper
+    rsync
+    yq-go
+    zstd
+  ];
+
+  # embedded in the final k3s cli
+  propagatedBuildInputs = [
+    k3sCNIPlugins
+    k3sContainerd
+    k3sServer
+    runc
+  ];
+
+  # We override most of buildPhase due to peculiarities in k3s's build.
+  # Specifically, it has a 'go generate' which runs part of the package. See
+  # this comment:
+  # https://github.com/NixOS/nixpkgs/pull/158089#discussion_r799965694
+  # So, why do we use buildGoModule at all? For the `vendorSha256` / `go mod download` stuff primarily.
+  buildPhase = ''
+    patchShebangs ./scripts/package-cli ./scripts/download ./scripts/build-upload
+
+    # copy needed 'go generate' inputs into place
+    mkdir -p ./bin/aux
+    rsync -a --no-perms ${k3sServer}/bin/ ./bin/
+    ln -vsf ${runc}/bin/runc ./bin/runc
+    ln -vsf ${k3sCNIPlugins}/bin/cni ./bin/cni
+    ln -vsf ${k3sContainerd}/bin/* ./bin/
+    rsync -a --no-perms --chmod u=rwX ${k3sRoot}/etc/ ./etc/
+    mkdir -p ./build/static/charts
+    # Note, upstream's chart has a 00 suffix. This seems to not matter though, so we're ignoring that naming detail.
+    export TRAEFIK_CHART_FILE=${traefikChart}
+    # place the traefik chart using their code since it's complicated
+    # We trim the actual download, see patches
+    ./scripts/download
+
+    export ARCH=$GOARCH
+    export DRONE_TAG="v${k3sVersion}"
+    export DRONE_COMMIT="${k3sCommit}"
+    # use ./scripts/package-cli to run 'go generate' + 'go build'
+
+    ./scripts/package-cli
+    mkdir -p $out/bin
+  '';
+
+  # Otherwise it depends on 'getGoDirs', which is normally set in buildPhase
+  doCheck = false;
+
+  installPhase = ''
+    # wildcard to match the arm64 build too
+    install -m 0755 dist/artifacts/k3s* -D $out/bin/k3s
+    wrapProgram $out/bin/k3s \
+      --prefix PATH : ${lib.makeBinPath k3sRuntimeDeps} \
+      --prefix PATH : "$out/bin"
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    $out/bin/k3s --version | grep -F "v${k3sVersion}" >/dev/null
+  '';
+
+  passthru.updateScript = ./update.sh;
+
+  passthru.tests = { inherit (nixosTests) k3s-single-node k3s-single-node-docker; };
+
+  meta = baseMeta;
+}

--- a/pkgs/k3s/patches/0001-scrips-download-strip-downloading-just-package-CRD.patch
+++ b/pkgs/k3s/patches/0001-scrips-download-strip-downloading-just-package-CRD.patch
@@ -1,0 +1,40 @@
+From 6f53bd36a40da4c71486e3b79f6e32d53d6eea5d Mon Sep 17 00:00:00 2001
+From: Euan Kemp <euank@euank.com>
+Date: Thu, 3 Feb 2022 23:50:40 -0800
+Subject: [PATCH 2/2] scrips/download: strip downloading, just package CRD
+
+The CRD packaging is a complicated set of commands, so let's reuse it.
+---
+ scripts/download | 10 ++--------
+ 1 file changed, 2 insertions(+), 8 deletions(-)
+
+diff --git a/scripts/download b/scripts/download
+index 5effc0562a..82361803ee 100755
+--- a/scripts/download
++++ b/scripts/download
+@@ -24,12 +24,6 @@ rm -rf ${CONTAINERD_DIR}
+ mkdir -p ${CHARTS_DIR}
+ mkdir -p ${DATA_DIR}
+
+-curl --compressed -sfL https://github.com/k3s-io/k3s-root/releases/download/${VERSION_ROOT}/k3s-root-${ARCH}.tar | tar xf - --exclude=bin/socat
+-
+-git clone --single-branch --branch=${VERSION_RUNC} --depth=1 https://github.com/opencontainers/runc ${RUNC_DIR}
+-
+-git clone --single-branch --branch=${VERSION_CONTAINERD} --depth=1 https://github.com/k3s-io/containerd ${CONTAINERD_DIR}
+-
+ setup_tmp() {
+     TMP_DIR=$(mktemp -d --tmpdir=${CHARTS_DIR})
+     cleanup() {
+@@ -44,8 +38,8 @@ setup_tmp() {
+
+ download_and_package_traefik () {
+   echo "Downloading Traefik Helm chart from ${TRAEFIK_URL}"
+-  curl -sfL ${TRAEFIK_URL} -o ${TMP_DIR}/${TRAEFIK_FILE}
+-  code=$?
++  # nixpkgs: copy in our known traefik chart instead
++  cp $TRAEFIK_CHART_FILE ${TMP_DIR}/${TRAEFIK_FILE}
+
+   if [ $code -ne 0 ]; then
+     echo "Error: Failed to download Traefik Helm chart!"
+--
+2.34.1

--- a/pkgs/k3s/patches/0002-Don-t-build-a-static-binary-in-package-cli.patch
+++ b/pkgs/k3s/patches/0002-Don-t-build-a-static-binary-in-package-cli.patch
@@ -1,0 +1,36 @@
+From 49c000c7c5dd7a502a2be4c638d2c32b65673c00 Mon Sep 17 00:00:00 2001
+From: Euan Kemp <euank@euank.com>
+Date: Sun, 6 Feb 2022 23:13:00 -0800
+Subject: [PATCH] Don't build a static binary in package-cli
+
+since nixpkgs prefers dynamically linked binaries.
+
+Also remove "trimpath" for the 'go generate' step because the codegen
+they use doesn't work with trimpath set.
+---
+ scripts/package-cli | 5 ++---
+ 1 file changed, 2 insertions(+), 3 deletions(-)
+
+diff --git a/scripts/package-cli b/scripts/package-cli
+index 28927327b7..95dbb469f1 100755
+--- a/scripts/package-cli
++++ b/scripts/package-cli
+@@ -48,14 +48,13 @@ fi
+
+ CMD_NAME=dist/artifacts/k3s${BIN_SUFFIX}
+
+-"${GO}" generate
++GOFLAGS="" "${GO}" generate
+ LDFLAGS="
+     -X github.com/rancher/k3s/pkg/version.Version=$VERSION
+     -X github.com/rancher/k3s/pkg/version.GitCommit=${COMMIT:0:8}
+     -w -s
+ "
+-STATIC="-extldflags '-static'"
+-CGO_ENABLED=0 "${GO}" build -ldflags "$LDFLAGS $STATIC" -o ${CMD_NAME} ./cmd/k3s/main.go
++CGO_ENABLED=0 "${GO}" build -ldflags "$LDFLAGS" -o ${CMD_NAME} ./cmd/k3s/main.go
+
+ stat ${CMD_NAME}
+
+--
+2.34.1

--- a/pkgs/k3s/update.sh
+++ b/pkgs/k3s/update.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl gnugrep gnused jq
+
+set -x -eu -o pipefail
+
+WORKDIR=$(mktemp -d)
+trap "rm -rf ${WORKDIR}" EXIT
+
+cd $(dirname "${BASH_SOURCE[0]}")
+
+LATEST_TAG_RAWFILE=${WORKDIR}/latest_tag.json
+curl --silent ${GITHUB_TOKEN:+"-u \":$GITHUB_TOKEN\""} \
+    https://api.github.com/repos/k3s-io/k3s/releases > ${LATEST_TAG_RAWFILE}
+
+LATEST_TAG_NAME=$(jq 'map(.tag_name)' ${LATEST_TAG_RAWFILE} | \
+    grep -v -e rc -e engine | tail -n +2 | head -n -1 | sed 's|[", ]||g' | sort -rV | head -n1)
+
+K3S_VERSION=$(echo ${LATEST_TAG_NAME} | sed 's/^v//')
+
+K3S_COMMIT=$(curl --silent ${GITHUB_TOKEN:+"-u \":$GITHUB_TOKEN\""} \
+    https://api.github.com/repos/k3s-io/k3s/tags \
+    | jq -r "map(select(.name == \"${LATEST_TAG_NAME}\")) | .[0] | .commit.sha")
+
+K3S_REPO_SHA256=$(nix-prefetch-url --quiet --unpack https://github.com/k3s-io/k3s/archive/refs/tags/${LATEST_TAG_NAME}.tar.gz)
+
+FILE_SCRIPTS_DOWNLOAD=${WORKDIR}/scripts-download
+curl --silent https://raw.githubusercontent.com/k3s-io/k3s/${K3S_COMMIT}/scripts/download > $FILE_SCRIPTS_DOWNLOAD
+
+FILE_SCRIPTS_VERSION=${WORKDIR}/scripts-version.sh
+curl --silent https://raw.githubusercontent.com/k3s-io/k3s/${K3S_COMMIT}/scripts/version.sh > $FILE_SCRIPTS_VERSION
+
+FILE_MANIFESTS_TRAEFIK=${WORKDIR}/manifests-traefik.yaml
+curl --silent https://raw.githubusercontent.com/k3s-io/k3s/${K3S_COMMIT}/manifests/traefik.yaml > $FILE_MANIFESTS_TRAEFIK
+
+TRAEFIK_CHART_VERSION=$(awk -F/ '/traefik-([[:digit:]]+\.)/ {sub(/traefik-/, "", $6) ; sub(/\.tgz/, "", $6); print $6}' $FILE_MANIFESTS_TRAEFIK)
+
+TRAEFIK_CHART_SHA256=$(nix-prefetch-url --quiet "https://helm.traefik.io/traefik/traefik-${TRAEFIK_CHART_VERSION}.tgz")
+
+K3S_ROOT_VERSION=$(grep 'ROOT_VERSION=' ${FILE_SCRIPTS_DOWNLOAD} \
+    | cut -d'=' -f2 | cut -d' ' -f1 | sed 's/^v//')
+K3S_ROOT_SHA256=$(nix-prefetch-url --quiet --unpack \
+    "https://github.com/k3s-io/k3s-root/releases/download/v${K3S_ROOT_VERSION}/k3s-root-amd64.tar")
+
+CNIPLUGINS_VERSION=$(grep 'VERSION_CNIPLUGINS=' ${FILE_SCRIPTS_VERSION} \
+    | cut -d'=' -f2 | cut -d' ' -f1 | sed -e 's/"//g' -e 's/^v//')
+CNIPLUGINS_SHA256=$(nix-prefetch-url --quiet --unpack \
+    "https://github.com/rancher/plugins/archive/refs/tags/v${CNIPLUGINS_VERSION}.tar.gz")
+
+setKV () {
+    sed -i "s|$1 = \".*\"|$1 = \"${2:-}\"|" ./default.nix
+}
+
+setKV k3sVersion ${K3S_VERSION}
+setKV k3sCommit ${K3S_COMMIT}
+setKV k3sRepoSha256 ${K3S_REPO_SHA256}
+
+setKV traefikChartVersion ${TRAEFIK_CHART_VERSION}
+setKV traefikChartSha256 ${TRAEFIK_CHART_SHA256}
+
+setKV k3sRootVersion ${K3S_ROOT_VERSION}
+setKV k3sRootSha256 ${K3S_ROOT_SHA256}
+
+setKV k3sCNIVersion ${CNIPLUGINS_VERSION}
+setKV k3sCNISha256 ${CNIPLUGINS_SHA256}

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -101,6 +101,8 @@ in {
     matomo
     matomo-beta;
 
+
+  k3s = super.callPackage ./k3s { buildGoModule = super.buildGo117Module; };
   kubernetes-dashboard = super.callPackage ./kubernetes-dashboard.nix { };
   kubernetes-dashboard-metrics-scraper = super.callPackage ./kubernetes-dashboard-metrics-scraper.nix { };
 

--- a/tests/k3s/airgapped-k3s-images.nix
+++ b/tests/k3s/airgapped-k3s-images.nix
@@ -17,44 +17,44 @@
 }
 {
   imageName = "docker.io/rancher/local-path-provisioner";
-  imageDigest = "sha256:d5999b20a1b180940061677db3bdb48dd7eb432cd48147c4ff15469fb74ade80";
-  sha256 = "01q9cfiw2r3lb35hmjr5qbc8g5chrjl894bvdf3w0jysb029x2y2";
+  imageDigest = "sha256:1da612c913ce0b4ab82e20844baa9dce1f7065e39412d6a0bb4de99c413f21bf";
+  sha256 = "1j38hsal1rvl9201nszlhwwmafgk7mnr3zg7ln9crnazxh7bpq0a";
   finalImageName = "docker.io/rancher/local-path-provisioner";
-  finalImageTag = "v0.0.20";
+  finalImageTag = "v0.0.21";
 }
 {
   imageName = "docker.io/rancher/mirrored-coredns-coredns";
-  imageDigest = "sha256:1113439e909a4b03b85f080d63df48734520356bd34da890bc2b5583467ba43b";
-  sha256 = "0xgzx1j6lzqwzrwcgq6hhbdxqx49ssv2wciixsqamfc97i7sd465";
+  imageDigest = "sha256:d4aec4c63c47a553b334dbf079578cd9dc8616866a467d87e3e6b94e26ea9ed7";
+  sha256 = "0xwggdl6mf9nhfcf96lz4lj3z16inv2ixmp59anj5sp2na0rjqig";
   finalImageName = "docker.io/rancher/mirrored-coredns-coredns";
-  finalImageTag = "1.8.4";
+  finalImageTag = "1.8.6";
 }
 {
   imageName = "docker.io/rancher/mirrored-library-busybox";
-  imageDigest = "sha256:6216b36ad2a781614fa5f2850b70e318c7a4c4384730072a9a35fa946acb14e8";
-  sha256 = "0g3w9ks10f1v8hspwg7pfj7bjad9y52n4nyvk9c0vnzs9q90ag7a";
+  imageDigest = "sha256:3a893a88f682cc604c70d2e7df5690b037d78e2d859f3d9f638cb93d40aaaf20";
+  sha256 = "1yqf4g5h1ag4whypi1hdv6yghwh3fdzsr7g6bd85cn2c6c0z2n75";
   finalImageName = "docker.io/rancher/mirrored-library-busybox";
-  finalImageTag = "1.32.1";
+  finalImageTag = "1.34.1";
 }
 {
   imageName = "docker.io/rancher/mirrored-library-traefik";
-  imageDigest = "sha256:7523a6c0ff383450739451e3cbf9206c149f14c51bbf2bb469486653bea1e337";
-  sha256 = "0jn2j0bk5i5qlwayw5syhvi890bgc7qlphqw5yw28q8diaxlz6l1";
+  imageDigest = "sha256:b02bfc3350c6d343e42bfab5f3ae5dad4674e49b81b093b00b0e09be8d120525";
+  sha256 = "0djfgmrpxlj8jya9kqxdlii6i4zgskd7ji0mqy1hi032pjak5zid";
   finalImageName = "docker.io/rancher/mirrored-library-traefik";
-  finalImageTag = "2.5.0";
+  finalImageTag = "2.5.6";
 }
 {
   imageName = "docker.io/rancher/mirrored-metrics-server";
-  imageDigest = "sha256:37e86275eb9821e933925640bc05fd1403eee34f214f5ed5716a44f26502e510";
-  sha256 = "1435w1jfjk1g2ykw4v5s474rmb27iv38vz0b2bmgxc4iifwvqz0r";
+  imageDigest = "sha256:48ecad4fe641a09fa4459f93c7ad29d4916f6b9cf7e934d548f1d8eff96e2f35";
+  sha256 = "0msyrcmlcx3yy7xwpay8nlry77lfxl0kmbg2zxfnl7qslms9yyyd";
   finalImageName = "docker.io/rancher/mirrored-metrics-server";
-  finalImageTag = "v0.5.0";
+  finalImageTag = "v0.5.2";
 }
 {
   imageName = "docker.io/rancher/mirrored-pause";
-  imageDigest = "sha256:82f4f58a1877a3a819de055a111b33fc63127b896b928b0bd7419da549f88d65";
-  sha256 = "11wp0msgizai32r5g0ny071psdjj0pv37v7g7xa0711hqh5ndxfm";
+  imageDigest = "sha256:74c4244427b7312c5b901fe0f67cbc53683d06f4f24c6faee65d4182bf0fa893";
+  sha256 = "0qm3q199bzj5z73fs2h6ivkbmqcifgjbb34i145chmx5hrg8zfr1";
   finalImageName = "docker.io/rancher/mirrored-pause";
-  finalImageTag = "3.1";
+  finalImageTag = "3.6";
 }
 ]


### PR DESCRIPTION
 #PL-130456

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* k3s: 1.22.3 -> 1.23.3

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - nothing new 
- [x] Security requirements tested? (EVIDENCE)
  - automated test still works
  - read the urgent upgrade notes if there's something interesting. Reviewing all kubernetes changes is not feasible for us so we have to trust upstream NixOS/k3s/Kubernetes with this. 
