### PR TITLE
Update nixpkgs

### DIFF
--- a/pkgs/libmodsecurity/default.nix
+++ b/pkgs/libmodsecurity/default.nix
@@ -1,0 +1,71 @@
+{ lib, stdenv, fetchFromGitHub
+, autoreconfHook, bison, flex, pkg-config
+, curl, geoip, libmaxminddb, libxml2, lua, pcre
+, ssdeep, valgrind, yajl
+, nixosTests
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libmodsecurity";
+  version = "3.0.6";
+
+  src = fetchFromGitHub {
+    owner = "SpiderLabs";
+    repo = "ModSecurity";
+    rev = "v${version}";
+    sha256 = "sha256-V+NBT2YN8qO3Px8zEzSA2ZsjSf1pv8+VlLxYlrpqfGg=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ autoreconfHook bison flex pkg-config ];
+  buildInputs = [ curl geoip libmaxminddb libxml2 lua pcre ssdeep valgrind yajl ];
+
+  outputs = [ "out" "dev" ];
+
+  configureFlags = [
+    "--enable-parser-generation"
+    "--with-curl=${curl.dev}"
+    "--with-libxml=${libxml2.dev}"
+    "--with-maxmind=${libmaxminddb}"
+    "--with-pcre=${pcre.dev}"
+    "--with-ssdeep=${ssdeep}"
+  ];
+
+  postPatch = ''
+    substituteInPlace build/ssdeep.m4 \
+      --replace "/usr/local/libfuzzy" "${ssdeep}/lib" \
+      --replace "\''${path}/include/fuzzy.h" "${ssdeep}/include/fuzzy.h" \
+      --replace "ssdeep_inc_path=\"\''${path}/include\"" "ssdeep_inc_path=\"${ssdeep}/include\""
+    substituteInPlace modsecurity.conf-recommended \
+      --replace "SecUnicodeMapFile unicode.mapping 20127" "SecUnicodeMapFile $out/share/modsecurity/unicode.mapping 20127"
+  '';
+
+  postInstall = ''
+    mkdir -p $out/share/modsecurity
+    cp ${src}/{AUTHORS,CHANGES,LICENSE,README.md,modsecurity.conf-recommended,unicode.mapping} $out/share/modsecurity
+  '';
+
+  enableParallelBuilding = true;
+
+  passthru.tests = {
+    nginx-modsecurity = nixosTests.nginx-modsecurity;
+  };
+
+  meta = with lib; {
+    homepage = "https://github.com/SpiderLabs/ModSecurity";
+    description = ''
+      ModSecurity v3 library component.
+    '';
+    longDescription = ''
+      Libmodsecurity is one component of the ModSecurity v3 project. The
+      library codebase serves as an interface to ModSecurity Connectors taking
+      in web traffic and applying traditional ModSecurity processing. In
+      general, it provides the capability to load/interpret rules written in
+      the ModSecurity SecRules format and apply them to HTTP content provided
+      by your application via Connectors.
+    '';
+    license = licenses.asl20;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ izorkin ];
+  };
+}

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -67,6 +67,10 @@ in {
 
   innotop = super.callPackage ./percona/innotop.nix { };
 
+
+  libmodsecurity = super.callPackage ./libmodsecurity { };
+
+
   jibri = super.callPackage ./jibri { jre_headless = super.jre8_headless; };
 
   jicofo = super.jicofo.overrideAttrs(oldAttrs: rec {
@@ -152,19 +156,6 @@ in {
               ]);
 
   mc = super.callPackage ./mc.nix { };
-
-  libmodsecurity = super.libmodsecurity.overrideAttrs(_: rec {
-      version = "3.0.4";
-
-      src = super.fetchFromGitHub {
-        owner = "SpiderLabs";
-        repo = "ModSecurity";
-        fetchSubmodules = true;
-        rev = "v3.0.4";
-        sha256 = "07vry10cdll94sp652hwapn0ppjv3mb7n2s781yhy7hssap6f2vp";
-      };
-
-    });
 
   mysql = super.mariadb;
 

--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "463fc427206afafb58ae4e06d00515f928a69d10",
-    "sha256": "yFfCSH+PrumYmQGZpYpvCXsmoCJkkCOWQe0emm1FJRc="
+    "rev": "91e4e59bfa3a1778d12a4f611789f6c0bb00b0ce",
+    "sha256": "RqlEqg8lR1TZ3hi0P31UloRMYyKITKoJoigBY62kkGw="
   },
   "nixos-mailserver": {
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/",


### PR DESCRIPTION
Notable security updates and version changes:

* element-web: 1.10.1 -> 1.10.4
* gitlab: 14.7.1 -> 14.7.4
* grafana: 8.3.6 -> 8.4.2
* imagemagick: 7.1.0-24 -> 7.1.0-26
* linux: 5.10.99 -> 5.10.102
* matrix-synapse: 1.52.0 -> 1.53.0
* nginxModules.modsecurity-nginx: 1.0.1 -> 1.0.2
* php74: 7.4.27 -> 7.4.28
* php80: 8.0.14 -> 8.0.16
* postfix: 3.6.4 -> 3.6.5

#PL-130446

@flyingcircusio/release-managers

## Release process

Impact:

* [NixOS 21.11] Matrix, Postfix, Gitlab and Grafana will be restarted. Machines will schedule a reboot to activate the changed kernel.

Changelog: (include changes from commit msg here)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - pull in upstream security fixes regularly
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still run, works on test VM
  - checked commit log for fixed CVEs and possible problems with updates, looked at changelog of grafana