### PR TITLE
[21.05] ceph/radosgw: bind to port 80 and provide iptables port redirection

### DIFF
--- a/nixos/roles/ceph/rgw.nix
+++ b/nixos/roles/ceph/rgw.nix
@@ -41,6 +41,7 @@ in
           admin socket = /run/ceph/radosgw.asok
           rgw data = /srv/ceph/radosgw/ceph-$id
           rgw enable ops log = false
+          rgw frontends = "civetweb port=80"
           debug rgw = 0 5
           debug civetweb = 1 5
           debug rados = 1 5
@@ -86,18 +87,37 @@ in
         };
       };
 
+      networking.firewall.extraStopCommands = ''
+        ip46tables -w -t nat -D PREROUTING -j fc-nat-pre 2>/dev/null|| true
+        ip46tables -w -t nat -F fc-nat-pre 2>/dev/null || true
+        ip46tables -w -t nat -X fc-nat-pre 2>/dev/null || true
+      '';
+
       networking.firewall.extraCommands = let
         srv = fclib.network.srv;
       in ''
+        set -x
         # Accept traffic from S3 gateways from within the SRV network.
+        ip46tables -w -t nat -N fc-nat-pre
 
       '' + (lib.concatMapStringsSep "\n"
-              (net: "iptables -A nixos-fw -i ${srv.device} -s ${net} -p tcp --dport 7480 -j ACCEPT")
+              (net: ''
+                iptables -A nixos-fw -i ${srv.device} -s ${net} -p tcp --dport 80 -j ACCEPT
+                # PL-130368 Fix S3 presigned URLs
+                iptables -t nat -A fc-nat-pre -p tcp --dport 7480 -j REDIRECT --to-port 80
+              '')
               srv.v4.networks
       ) + "\n" +
       (lib.concatMapStringsSep "\n"
-              (net: "ip6tables -A nixos-fw -i ${srv.device} -s ${net} -p tcp --dport 7480 -j ACCEPT")
-              srv.v6.networks);
+              (net: ''
+                ip6tables -A nixos-fw -i ${srv.device} -s ${net} -p tcp --dport 80 -j ACCEPT
+                # PL-130368 Fix S3 presigned URLs
+                ip6tables -t nat -A fc-nat-pre -p tcp --dport 7480 -j REDIRECT --to-port 80
+              '')
+              srv.v6.networks) +
+      ''
+          ip46tables -t nat -A PREROUTING -j fc-nat-pre
+      '';
 
       systemd.services.fc-ceph-rgw-update-stats = {
         description = "Update RGW stats";


### PR DESCRIPTION
This fixes pre-signed URLs where Ceph does not understand that
the process is running on 7480 but virtual hosted on 80.

PL-130368 Fix S3 presigned URLs

@flyingcircusio/release-managers

## Release process

Impact:

* Our internal Rados Gateways will be restarted but frontends will fail over between multiple gateways transparently.

Changelog:

* This fixes pre-signed URLs where Ceph does not understand that the process is running on 7480 but virtual hosted on 80.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

no relevant changes

- [x] Security requirements tested? (EVIDENCE)

functionality tested manually in dev with zagy
