### PR TITLE
[21.05] nginx: remove duplicate/broken ssl cert checks 

### DIFF
--- a/nixos/services/nginx/default.nix
+++ b/nixos/services/nginx/default.nix
@@ -343,17 +343,11 @@ in
           interval = 60;
         };
 
-      } //
-      (lib.mapAttrs' (name: _: (lib.nameValuePair "nginx_cert_${name}" {
-        notification = "HTTPS cert for ${name} (Let's encrypt)";
-        command = "${pkgs.monitoring-plugins}/bin/check_http -H ${name} -p 443 -S -C 5";
-        interval = 600;
-      })) acmeVhosts);
+      };
 
       networking.firewall.allowedTCPPorts = [ 80 443 ];
 
       security.acme.certs = acmeSettings;
-
 
       flyingcircus.passwordlessSudoRules = [
         {


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

none

Changelog:

* Remove duplicate, broken SSL certificate checks. (PL-130379)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

none

- [x] Security requirements tested? (EVIDENCE)

none