### PR TITLE
[21.05] docker: fix default access from containers to the host services

### DIFF
--- a/doc/src/docker.rst
+++ b/doc/src/docker.rst
@@ -6,10 +6,6 @@ Docker
 Runs a `Docker <http://docker.com>`_ daemon to use containers for application
 deployment.
 
-.. note:: Docker support is – at the moment – still experimental. Feel free to
-  use it but we suggest contacting our support before putting anything into
-  production.
-
 
 Interaction
 -----------
@@ -19,19 +15,22 @@ All service users can interact with Docker using the :command:`docker` command.
 Network
 -------
 
-The Flying Circus network is already designed to allow customer application
-components to talk to each other securely and reliably. Docker should be
-run with the :command:`--network host` option to ensure proper integration.
+The Flying Circus network is designed to allow customer application components
+to talk to each other securely and reliably. We recommend using the `bridged`
+networking option.
 
-If you want your container to be reachable from the public internet, make sure
-it binds to an address on the :file:`ethfe` interface (or ``0.0.0.0`` or ``::``).
-You then need to :ref:`open up appropriate ports in the firewall <nixos-firewall>`.
+Programs running in a `bridged` container can access the rest of the network
+similar to programs run directly on the host. They can access neighbouring
+`srv` services in the same resource group and talk to the internet either
+directly through the frontend network or masqueraded through the
+server-to-server network.
 
-Other hosts in the same project can automatically connect to all the ports your
-container provides by connecting to ``<$hostname>:<port>`` (which ends up on
-on the :file:`ethsrv` interface).
+.. note::
 
-All other network configurations are not supported at the moment.
+  We used to recommend the `host` networking option as a workaround due to
+  incompatibilities with the NixOS firewall management. This option is now no
+  longer recommended as it breaks fundamental assumptions about how containers
+  work and how they are isolated.
 
 
 .. vim: set spell spelllang=en:

--- a/nixos/roles/docker.nix
+++ b/nixos/roles/docker.nix
@@ -15,6 +15,15 @@ in
     environment.systemPackages = [ pkgs.docker-compose ];
     flyingcircus.users.serviceUsers.extraGroups = [ "docker" ];
     virtualisation.docker.enable = true;
+
+    networking.firewall.extraCommands = ''
+      # allow access to host from docker networks, we consider this identical
+      # to access from locally running processes.
+      # We grant the full RFC1918 172.16.0.0/12 range.
+      iptables -A nixos-fw -i br-+ -s 172.16.0.0/12 -j nixos-fw-accept
+      iptables -A nixos-fw -i docker+ -s 172.16.0.0/12 -j nixos-fw-accept
+    '';
+
   };
 
 }


### PR DESCRIPTION
Fixes PL-130058

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Improve default firewall rules for docker bridged networking: allow access to host service similar to other locally run services. (PL-130058)
* 
## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

network scope needs to be managed properly, in this case expectations are that docker containers can work in our managed network similar to locally run processes on a VM.

this also cleans up the recommendation for using the less secure `host` networking mode.

- [x] Security requirements tested? (EVIDENCE)

manually verified the new config on a test vm