### PR TITLE
Update nixpkgs for openssl 1.1.1n

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "0f5fbc131671be14b6e76daa8125284b5111b33b",
-    "sha256": "mL+pG1NIg8kKthDRz3zWgo+lzinSauslAxgxLZZmxX8="
+    "rev": "a662ea66f41b8baea9946c00a2ea65a8c4aaef39",
+    "sha256": "5TpyrgBUO9fROdEl973A6bLLKhFtQc12Dt9f061qRr0="
   },
   "nixos-mailserver": {
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/",


### PR DESCRIPTION
Fixes a DOS vulnerability (CVE-2022-0778) that can be exploited with forged certificates.

 #PL-130500

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

## Security implications

- [ ] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [ ] Security requirements tested? (EVIDENCE)
