### PR TITLE
Add setuptools to global python3 env

### DIFF
--- a/nixos/platform/packages.nix
+++ b/nixos/platform/packages.nix
@@ -60,7 +60,7 @@
         psmisc
         pwgen
         python2Full
-        python3
+        (python3.withPackages (ps: with ps; [ setuptools ]))
         python3Packages.virtualenv
         ripgrep
         screen


### PR DESCRIPTION
This avoids breakage after upgrading from 21.05 where setuptools still
was part of the default python3 env.

 #PL-130510

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Add setuptools to global Python 3 which was dropped in the transition from 21.05 to 21.11. This avoid errors like `ModuleNotFoundError: No module named 'pkg_resources'`. In general, applications should not depend on the globally installed python3 interpreter but we re-add this to make upgrades to 21.11 easier (#PL-130510).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - nothing, just adding a Python package that was installed on earlier versions  
- [x] Security requirements tested? (EVIDENCE)
  - checked if global python3 has setuptools available and that the change fixes the supervisor problem on a customer staging VM 