### PR TITLE
Update nixpkgs

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "91e4e59bfa3a1778d12a4f611789f6c0bb00b0ce",
-    "sha256": "RqlEqg8lR1TZ3hi0P31UloRMYyKITKoJoigBY62kkGw="
+    "rev": "8f01bce4e03fc8021bb76110afcc4df52242924a",
+    "sha256": "v96uFBE0I/+j+bZFfrVaz2Z8wG7rAeVpftYlzbw3SNo="
   },
   "nixos-mailserver": {
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/",


### PR DESCRIPTION
Update nixpkgs

Notable security updates and version changes:

* bind: 9.16.25 -> 9.16.27 (CVE-2021-25220, CVE-2022-0396)
* element-web: 1.10.4 -> 1.10.6
* gitlab: 14.7.4 -> 14.8.4
* glibc: 2.33-117 -> 2.33-123
* grafana: 8.4.2 -> 8.4.4
* linux: 5.10.102 -> 5.10.106
* matrix-synapse: 1.53.0 -> 1.54.0
* mysql57: 5.7.27 -> 5.7.37
* nodejs-12_x: 12.22.9 -> 12.22.11
* nodejs-14_x: 14.18.3 -> 14.19.1
* nodejs-16_x: 16.13.2 -> 16.14.2
* nodejs-17_x: 17.4.0 -> 17.7.2
* openssl_1_1: 1.1.1m -> 1.1.1n (CVE-2022-0778)
* openssl_3_0: 3.0.1 -> 3.0.2 (CVE-2022-0778)
* postgresql_10: 10.19 -> 10.20
* postgresql_11: 11.14 -> 11.15
* postgresql_12: 12.9 -> 12.10
* postgresql_13: 13.5 -> 13.6
* postgresql_14: 14.1 -> 14.2
* util-linux: 2.37.3 -> 2.37.4 (CVE-2022-0563)

Notable Bugfixes:

 * nixos/tomcat: configure default group and fix broken
   default package reference

 #PL-130514


@flyingcircusio/release-managers

## Release process

Impact:

* [NixOS 21.11] Most services will be restarted because of a core dependency change. Machines will schedule a reboot to activate the changed kernel.

Changelog: (include changes from commit msg here)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - pull in upstream security fixes regularly
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still run, works on test VM
  - checked commit log for fixed CVEs and possible problems with updates
