### PR TITLE
[21.05] Remediate the partial/broken fix for Apache reloads with mod_php

### DIFF
--- a/doc/src/lamp.rst
+++ b/doc/src/lamp.rst
@@ -3,8 +3,9 @@
 LAMP (Apache/mod_php)
 =====================
 
-The LAMP role starts a managed instance of Apache with ``mod_php`` that can be
-used to easily run a production-ready PHP application server.
+The LAMP role starts a managed instance of Apache with ``mod_php``(or optionally
+``php-fpm``) that can be used to easily run a production-ready PHP application
+server.
 
 .. note::
 
@@ -32,6 +33,8 @@ A complete configuration might looks something like this:
 	{
 
 	  flyingcircus.roles.lamp = {
+
+	  	useFPM = true;
 
 	    vhosts = [
 	      { port = 8000;
@@ -88,6 +91,15 @@ this to adjust global settings like workers:
 Note that if you distribute your configuration over multiple files then you
 can repeat this option and the values will be concatenated to a single big
 Apache config file. They will also always apply to all vhosts.
+
+``flyingcircus.roles.lamp.useFPM`` (optional)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Whether to use ``mod_php`` (default) or use a separate ``php-fpm`` process per
+virtual host that improves reliability and security. This also switches Apache
+to using the ``event`` worker model.
+
+This is off by default but will become the default in our 21.11 platform.
 
 
 ``flyingcircus.roles.lamp.php`` (optional)

--- a/doc/src/lamp.rst
+++ b/doc/src/lamp.rst
@@ -14,6 +14,11 @@ server.
 	directly to consumers but should be placed behind a :ref:`webgateway
 	<nixos-webgateway>`.
 
+.. note::
+
+	Due to stability issues we only support PHP 8.0 when using FPM instead of
+	mod_php.
+
 Configuration
 -------------
 

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -61,8 +61,6 @@ in {
   lamp74_tideways = callTest ./lamp.nix { version = "lamp_php74"; tideways = "1234"; };
   lamp74_fpm = callTest ./lamp.nix { version = "lamp_php74"; fpm = true; };
   lamp74_tideways_fpm = callTest ./lamp.nix { version = "lamp_php74"; tideways = "1234"; fpm = true; };
-  lamp80 = callTest ./lamp.nix { version = "lamp_php80"; };
-  lamp80_tideways = callTest ./lamp.nix { version = "lamp_php80"; tideways = "1234"; };
   lamp80_fpm = callTest ./lamp.nix { version = "lamp_php80"; fpm = true; };
   lamp80_tideways_fpm = callTest ./lamp.nix { version = "lamp_php80"; tideways = "1234"; fpm = true; };
 

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -50,13 +50,21 @@ in {
 
   lamp = callTest ./lamp.nix { };
   lamp56 = callTest ./lamp.nix { version = "lamp_php56"; };
+  lamp56_fpm = callTest ./lamp.nix { version = "lamp_php56"; fpm = true; };
   lamp72 = callTest ./lamp.nix { version = "lamp_php72"; };
+  lamp72_fpm = callTest ./lamp.nix { version = "lamp_php72"; fpm = true; };
   lamp73 = callTest ./lamp.nix { version = "lamp_php73"; };
   lamp73_tideways = callTest ./lamp.nix { version = "lamp_php73"; tideways = "1234"; };
+  lamp73_fpm = callTest ./lamp.nix { version = "lamp_php73"; fpm = true; };
+  lamp73_tideways_fpm = callTest ./lamp.nix { version = "lamp_php73"; tideways = "1234"; fpm = true; };
   lamp74 = callTest ./lamp.nix { version = "lamp_php74"; };
   lamp74_tideways = callTest ./lamp.nix { version = "lamp_php74"; tideways = "1234"; };
+  lamp74_fpm = callTest ./lamp.nix { version = "lamp_php74"; fpm = true; };
+  lamp74_tideways_fpm = callTest ./lamp.nix { version = "lamp_php74"; tideways = "1234"; fpm = true; };
   lamp80 = callTest ./lamp.nix { version = "lamp_php80"; };
   lamp80_tideways = callTest ./lamp.nix { version = "lamp_php80"; tideways = "1234"; };
+  lamp80_fpm = callTest ./lamp.nix { version = "lamp_php80"; fpm = true; };
+  lamp80_tideways_fpm = callTest ./lamp.nix { version = "lamp_php80"; tideways = "1234"; fpm = true; };
 
   locale = callTest ./locale.nix {};
   login = callTest ./login.nix {};

--- a/tests/lamp.nix
+++ b/tests/lamp.nix
@@ -1,4 +1,4 @@
-import ./make-test-python.nix ({ version ? "" , tideways ? "", ... }:
+import ./make-test-python.nix ({ version ? "" , tideways ? "", fpm ? false, lib, ... }:
 {
   name = "lamp";
   nodes = {
@@ -22,6 +22,8 @@ import ./make-test-python.nix ({ version ? "" , tideways ? "", ... }:
 
         flyingcircus.roles.lamp = {
           enable = true;
+
+          useFPM = fpm;
 
           vhosts = [ { port = 8000; docroot = "/srv/docroot"; } ];
 
@@ -68,10 +70,15 @@ import ./make-test-python.nix ({ version ? "" , tideways ? "", ... }:
     with subtest("apache (httpd) opens expected ports"):
       assert_listen(lamp, "httpd", {"127.0.0.1:7999", "::1:7999", ":::8000"})
 
+    '' +
+
+    (lib.optionalString (!fpm) ''
     with subtest("our changes for config files should be there"):
       lamp.succeed("grep 'custom-apache-conf' ${nodes.lamp.config.services.httpd.configFile}")
       lamp.succeed("grep 'custom-php-ini' ${nodes.lamp.config.systemd.services.httpd.environment.PHPRC}")
+    '') +
 
+    ''
     lamp.succeed('mkdir -p /srv/docroot')
     lamp.succeed('echo "<? phpinfo(); ?>" > /srv/docroot/test.php')
 
@@ -80,7 +87,7 @@ import ./make-test-python.nix ({ version ? "" , tideways ? "", ... }:
       for x in range(300):
         print("="*80)
         print(f"Reload try {x}")
-        lamp.execute("systemctl reload httpd")
+        lamp.succeed("systemctl reload httpd")
         lamp.sleep(0.1)
         code, output = lamp.execute("grep 'TLS block' /var/log/httpd/error.log")
         if not code:


### PR DESCRIPTION
We planned to switch to FPM anyways, so this is what happens here.
On 21.05 we're going to grant a switch to select between FPM and
mod_php (default is mod_php).

Fixes PL-130496

@flyingcircusio/release-managers

## Release process

Impact:

none

Changelog:

* LAMP role: provide FPM as an alternative to the mod_php based environments. This is a drop-in replacement and can be enabled using the `flyingcircus.roles.lamp.useFPM` flag. (PL-130496).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

fpm runs with the same limited user/group as apache (nobody/service), the socket is readable/writable for nobody/service.

- [x] Security requirements tested? (EVIDENCE)

verified on test vm, for everything else the tests still work