### PR TITLE
Remediate the partial/broken fix for Apache reloads with mod_php

### DIFF
--- a/doc/src/lamp.rst
+++ b/doc/src/lamp.rst
@@ -3,7 +3,7 @@
 LAMP (Apache/mod_php)
 =====================
 
-The LAMP role starts a managed instance of Apache with ``mod_php`` that can be
+The LAMP role starts a managed instance of Apache with ``php-fpm`` that can be
 used to easily run a production-ready PHP application server.
 
 .. note::
@@ -45,6 +45,8 @@ A complete configuration might looks something like this:
 	      MaxRequestWorkers 5
 	    '';
 
+	    fpmMaxChildren = 100;
+
 	    php_ini = ''
 	      ; max filesize
 	      upload_max_filesize = 200M
@@ -85,9 +87,16 @@ this to adjust global settings like workers:
 
 	MaxRequestWorkers 5
 
-Note that if you distribute your configuration over multiple files then you
+Note, that if you distribute your configuration over multiple files then you
 can repeat this option and the values will be concatenated to a single big
 Apache config file. They will also always apply to all vhosts.
+
+
+``flyingcircus.roles.lamp.fpmMaxChildren`` (optional)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+
+Set the maximum number of worker processes any vhost is allowed to spawn.
 
 
 ``flyingcircus.roles.lamp.php`` (optional)
@@ -98,7 +107,6 @@ CLI.
 
 Supported packages:
 
-* ``pkgs.lamp_php56`` (outdated but provided for legacy applications)
 * ``pkgs.lamp_php72`` (outdated but provided for legacy applications)
 * ``pkgs.lamp_php73``
 * ``pkgs.lamp_php74``

--- a/nixos/roles/lamp.nix
+++ b/nixos/roles/lamp.nix
@@ -8,6 +8,11 @@ in {
       enable = mkEnableOption "Flying Circus LAMP stack";
       supportsContainers = fclib.mkEnableContainerSupport;
 
+      fpmMaxChildren = mkOption {
+        type = types.int;
+        default = 25;
+      };
+
       apache_conf = mkOption {
         type = types.lines;
         default = "";
@@ -111,134 +116,155 @@ in {
       lib.mkMerge [
 
       (lib.mkIf (!role.enable) {
-          # Install the default upstream PHP when the LAMP role is not activated.
-          environment.systemPackages = [
-            pkgs.php
-          ];
+        # Install the default upstream PHP when the LAMP role is not activated.
+        environment.systemPackages = [
+          pkgs.php
+        ];
       })
 
+      # General config if the role is enabled but not specific to the
+      # selection of mod_php or FPM
       (lib.mkIf role.enable {
+        services.httpd.enable = true;
+        services.httpd.adminAddr = "admin@flyingcircus.io";
+        services.httpd.mpm = "event";
 
-          services.httpd.enable = true;
-          services.httpd.adminAddr = "admin@flyingcircus.io";
+        # We always provide the PHP cli environment but we need to ensure
+        # to choose the right one in case someone uses the LAMP role.
+        environment.systemPackages = [
+          role.php
+          role.php.packages.composer
+        ];
 
-          # PL-130372 workaround for glibc TLS issue when loading
-          # many modules.
-          systemd.services.httpd.serviceConfig.ExecReload = lib.mkForce "";
+        # Provide a similar PHP config for the PHP CLI as for Apache (httpd).
+        # The file referenced by PHPRC is loaded together with the php.ini
+        # from the global PHP package which only specifies the extensions.
+        environment.variables.PHPRC = "${pkgs.writeText "php.ini" phpOptions}";
+        services.httpd.logPerVirtualHost = true;
+        services.httpd.group = "service";
+        services.httpd.user = "nobody";
+        services.httpd.extraModules = [ "rewrite" "version" "status" "proxy_fcgi" ];
+        services.httpd.extraConfig = ''
+          # Those options are chosen for prefork
+          # StartServers 2 (default)
+          # MinSpareServers 5 (default)
+          # MaxSpareServers 10 (Default)
 
-          # We always provide the PHP cli environment but we need to ensure
-          # to choose the right one in case someone uses the LAMP role.
-          environment.systemPackages = [
-            role.php
-            role.php.packages.composer
-          ];
+          # MaxRequestWorkers default: 256, limit to lower number
+          # to avoid starvation/thrashing
+          MaxRequestWorkers 150
 
-          # Provide a similar PHP config for the PHP CLI as for Apache (httpd).
-          # The file referenced by PHPRC is loaded together with the php.ini
-          # from the global PHP package which only specifies the extensions.
-          environment.variables.PHPRC = "${pkgs.writeText "php.ini" config.services.httpd.phpOptions}";
-          services.httpd.logPerVirtualHost = true;
-          services.httpd.group = "service";
-          services.httpd.user = "nobody";
-          services.httpd.extraModules = [ "rewrite" "version" "status" ];
-          services.httpd.mpm = "prefork";
-          services.httpd.extraConfig = ''
-            # Those options are chosen for prefork
-            # StartServers 2 (default)
-            # MinSpareServers 5 (default)
-            # MaxSpareServers 10 (Default)
+          # Determine lifetime of processes
+          # MaxConnectionsPerChild default: 0, set limit to
+          # avoid potential memory leaks
+          MaxConnectionsPerChild     10000
 
-            # MaxRequestWorkers default: 256, limit to lower number
-            # to avoid starvation/thrashing
-            MaxRequestWorkers 150
+          Listen localhost:7999
+          <VirtualHost localhost:7999>
+          <Location "/server-status">
+              SetHandler server-status
+          </Location>
+          </VirtualHost>
 
-            # Determine lifetime of processes
-            # MaxConnectionsPerChild default: 0, set limit to
-            # avoid potential memory leaks
-            MaxConnectionsPerChild     10000
+          <Proxy "fcgi://localhost/" enablereuse=on max=10>
+          </Proxy>
+          '' +
+          # * vhost configs
+          (lib.concatMapStrings (vhost:
+            let port=toString vhost.port;
+            in
+            ''
 
-            Listen localhost:7999
-            <VirtualHost localhost:7999>
-            <Location "/server-status">
-                SetHandler server-status
-            </Location>
+            Listen *:${port}
+            <VirtualHost *:${port}>
+                ServerName "${config.networking.hostName}"
+                DocumentRoot "${vhost.docroot}"
+                <Directory "${vhost.docroot}">
+                    AllowOverride all
+                    Require all granted
+                    Options FollowSymlinks
+                    DirectoryIndex index.html index.php
+                </Directory>
+                <FilesMatch "\.php$">
+                    SetHandler "proxy:unix:${config.services.phpfpm.pools."lamp-${port}".socket}|fcgi://localhost/"
+                </FilesMatch>
             </VirtualHost>
-            '' +
-            # * vhost configs
-            (lib.concatMapStrings (vhost:
-              ''
+            ''
+          ) role.vhosts) +
+          role.apache_conf;
 
-              Listen *:${toString vhost.port}
-              <VirtualHost *:${toString vhost.port}>
-                  ServerName "${config.networking.hostName}"
-                  DocumentRoot "${vhost.docroot}"
-                  <Directory "${vhost.docroot}">
-                      AllowOverride all
-                      Require all granted
-                      Options FollowSymlinks
-                      DirectoryIndex index.html index.php
-                  </Directory>
-              </VirtualHost>
-              ''
-            ) role.vhosts) +
-            role.apache_conf;
+        # The upstream module has a default that makes Apache listen on port 80
+        # which conflicts with our webgateway role.
+        services.httpd.virtualHosts = {};
 
-          services.httpd.enablePHP = true;
-          services.httpd.phpOptions = phpOptions;
-          services.httpd.phpPackage = role.php;
-
-          # The upstream module has a default that makes Apache listen on port 80
-          # which conflicts with our webgateway role.
-          services.httpd.virtualHosts = {};
-
-          flyingcircus.services.sensu-client.checks = {
-            httpd_status = {
-              notification = "Apache status page";
-              command = "check_http -H localhost -p 7999 -u /server-status?auto -v";
-              timeout = 30;
+        services.phpfpm.pools = builtins.listToAttrs (map
+          (vhost: {
+             name = "lamp-${toString vhost.port}";
+             value = {
+               user = config.services.httpd.user;
+               group = config.services.httpd.group;
+               phpPackage = role.php;
+               phpOptions = phpOptions;
+               settings = {
+                 "listen.owner" = config.services.httpd.user;
+                 "listen.group" = config.services.httpd.group;
+                 "pm" = "dynamic";
+                 "pm.max_children" = (toString role.fpmMaxChildren);
+                 "pm.start_servers" = "5";
+                 "pm.min_spare_servers" = "5";
+                 "pm.max_spare_servers" = "10";
+               };
             };
+          }) role.vhosts);
+
+        flyingcircus.services.sensu-client.checks = {
+          httpd_status = {
+            notification = "Apache status page";
+            command = "check_http -H localhost -p 7999 -u /server-status?auto -v";
+            timeout = 30;
           };
+        };
 
-          flyingcircus.services.telegraf.inputs = {
-            apache  = [{
-              urls = [ "http://localhost:7999/server-status?auto" ];
-            }];
+        flyingcircus.services.telegraf.inputs = {
+          apache  = [{
+            urls = [ "http://localhost:7999/server-status?auto" ];
+          }];
+        };
+
+        systemd.tmpfiles.rules = [
+          "d /var/log/httpd 0750 root service"
+          "a+ /var/log/httpd - - - - group:sudo-srv:r-x"
+        ];
+
+      })
+
+      (lib.mkIf (role.tideways_api_key != "") {
+        # tideways daemon
+        users.groups.tideways.gid = config.ids.gids.tideways;
+
+        users.users.tideways = {
+          description = "tideways daemon user";
+          uid = config.ids.uids.tideways;
+          isSystemUser = true;
+          group = "tideways";
+          extraGroups = [ "service" ];
+        };
+
+        systemd.services.tideways-daemon = rec {
+          description = "tideways daemon";
+          wantedBy = [ "multi-user.target" ];
+          wants = [ "network.target" ];
+          after = wants;
+          serviceConfig = {
+            ExecStart = ''
+              ${pkgs.tideways_daemon}/tideways-daemon --address=127.0.0.1:9135
+            '';
+            Restart = "always";
+            RestartSec = "60s";
+            User = "tideways";
+            Type = "simple";
           };
-
-          systemd.tmpfiles.rules = [
-            "d /var/log/httpd 0750 root service"
-            "a+ /var/log/httpd - - - - group:sudo-srv:r-x"
-          ];
-
-    })
-
-    (lib.mkIf (role.tideways_api_key != "") {
-          # tideways daemon
-          users.groups.tideways.gid = config.ids.gids.tideways;
-
-          users.users.tideways = {
-            description = "tideways daemon user";
-            uid = config.ids.uids.tideways;
-            isSystemUser = true;
-            group = "tideways";
-            extraGroups = [ "service" ];
-          };
-
-          systemd.services.tideways-daemon = rec {
-            description = "tideways daemon";
-            wantedBy = [ "multi-user.target" ];
-            wants = [ "network.target" ];
-            after = wants;
-            serviceConfig = {
-              ExecStart = ''
-                ${pkgs.tideways_daemon}/tideways-daemon --address=127.0.0.1:9135
-              '';
-              Restart = "always";
-              RestartSec = "60s";
-              User = "tideways";
-              Type = "simple";
-            };
-          };
-    }) ];
-
+        };
+      })
+      ];
 }

--- a/tests/lamp.nix
+++ b/tests/lamp.nix
@@ -1,4 +1,4 @@
-import ./make-test-python.nix ({ version ? "" , tideways ? "", ... }:
+import ./make-test-python.nix ({ version ? "" , tideways ? "", lib, ... }:
 {
   name = "lamp";
   nodes = {
@@ -68,10 +68,6 @@ import ./make-test-python.nix ({ version ? "" , tideways ? "", ... }:
     with subtest("apache (httpd) opens expected ports"):
       assert_listen(lamp, "httpd", {"127.0.0.1:7999", "::1:7999", ":::8000"})
 
-    with subtest("our changes for config files should be there"):
-      lamp.succeed("grep 'custom-apache-conf' ${nodes.lamp.config.services.httpd.configFile}")
-      lamp.succeed("grep 'custom-php-ini' ${nodes.lamp.config.systemd.services.httpd.environment.PHPRC}")
-
     lamp.succeed('mkdir -p /srv/docroot')
     lamp.succeed('echo "<? phpinfo(); ?>" > /srv/docroot/test.php')
 
@@ -80,7 +76,7 @@ import ./make-test-python.nix ({ version ? "" , tideways ? "", ... }:
       for x in range(300):
         print("="*80)
         print(f"Reload try {x}")
-        lamp.execute("systemctl reload httpd")
+        lamp.succeed("systemctl reload httpd")
         lamp.sleep(0.1)
         code, output = lamp.execute("grep 'TLS block' /var/log/httpd/error.log")
         if not code:


### PR DESCRIPTION
After we switched to an optional FPM on 21.05 we are now switching to
a pure FPM environment in 21.11.

Fixes PL-130496

@flyingcircusio/release-managers

## Release process

Impact:

* All LAMP servers will be restarted and switched from mod_php to FPM.

Changelog:

* LAMP: switch from mod_php to FPM due to stability reasons and for future flexibility. (PL-130496)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

fpm user/group is identical to apache and they share a socket with 0660 permissions.

- [x] Security requirements tested? (EVIDENCE)

checked manually, tests still work
