### PR TITLE
[21.05] Disable createHome for users

### DIFF
--- a/nixos/platform/users.nix
+++ b/nixos/platform/users.nix
@@ -36,6 +36,7 @@ let
           value = {
             description = user.name;
             group = primaryGroup user;
+            createHome = false;
             extraGroups =
               lib.optionals (user.class == "service") serviceUserExtraGroups;
             hashedPassword = lib.removePrefix "{CRYPT}" user.password;

--- a/tests/testlib.nix
+++ b/tests/testlib.nix
@@ -84,6 +84,7 @@ rec {
     id ? 1,
     net ? {},
     resource_group ? "test", location ? "test", secrets ? {},
+    extraEncParameters ? {},
   }: { config, ... }:
   {
     imports = [
@@ -94,7 +95,7 @@ rec {
     config = {
       virtualisation.vlans = map (vlan: vlans.${vlan}) (attrNames config.flyingcircus.enc.parameters.interfaces);
 
-      flyingcircus.enc.parameters = {
+      flyingcircus.enc.parameters = (lib.recursiveUpdate {
         inherit resource_group location secrets;
 
         interfaces = mapAttrs (name: vid: {
@@ -107,7 +108,7 @@ rec {
           gateways = {};
         })
           (filterAttrs (name: vid: (!(net ? ${name}) && (name == "srv" || name == "fe")) || net ? ${name} && net.${name}) vlans);
-      };
+      } extraEncParameters);
     };
   };
 

--- a/tests/users.nix
+++ b/tests/users.nix
@@ -1,50 +1,56 @@
-import ./make-test-python.nix ({ lib, ... }:
+import ./make-test-python.nix ({ lib, testlib, ... }:
 
 {
   name = "users";
   machine =
     { pkgs, lib, config, ... }:
-    {
-      imports = [ ../nixos ../nixos/roles ];
-
-      users.groups = {
-        login = { members = [ "u1001" ]; };
-        manager = { members = [ "u1002" ]; };
-        sudo-srv = { members = [ "u1003" ]; };
-        wheel = { members = [ "u1004" ]; };
-      };
-
-      flyingcircus.enc.parameters.interfaces.srv = {
-        mac = "52:54:00:12:34:56";
-        bridged = false;
-        networks = {
-          "192.168.101.0/24" = [ "192.168.101.1" ];
-          "2001:db8:f030:1c3::/64" = [ "2001:db8:f030:1c3::1" ];
-        };
-        gateways = {};
-      };
-
-      users.users =
-        lib.mapAttrs'
-          (id: groups:
-            lib.nameValuePair
-              "u${id}"
-              {
-                uid = builtins.fromJSON id;
-                extraGroups = groups;
-                isNormalUser = true;
-                name = "u${id}";
-                hashedPassword = "*";
-              }
-          )
+    let
+      userData =
+        (lib.mapAttrsToList (id: groups: {
+          class = "human";
+          gid = 100;
+          home_directory = "/home/u${id}";
+          id = builtins.fromJSON id;
+          login_shell = "/bin/bash";
+          name = "Human User";
+          password = "*";
+          permissions.test = groups;
+          ssh_pubkey = [];
+          uid = "u${id}";
+        })
+        {
+          "1000" = [ ];
+          "1001" = [ "login" ];
+          "1002" = [ "manager" ];
+          "1003" = [ "sudo-srv" ];
+          "1004" = [ "wheel" ];
+        }) ++ [
           {
-            "1000" = [ ];
-            "1001" = [ "login" ];
-            "1002" = [ "manager" ];
-            "1003" = [ "sudo-srv" ];
-            "1004" = [ "wheel" ];
-          };
-    };
+            class = "service";
+            gid = 101;
+            home_directory = "/srv/s-service";
+            id = 1074;
+            login_shell = "/bin/bash";
+            name = "s-service";
+            password = "*";
+            permissions.test = [];
+            ssh_pubkey = [];
+            uid = "s-service";
+          }
+        ];
+      in
+      {
+        imports = [
+          (testlib.fcConfig {
+            extraEncParameters = { resource_group = "test"; };
+          })
+        ];
+
+        flyingcircus.users = {
+          userData = userData;
+        };
+
+      };
 
   testScript = ''
     machine.wait_for_unit('multi-user.target')
@@ -64,16 +70,27 @@ import ./make-test-python.nix ({ lib, ... }:
       print(b)
       raise AssertionError()
 
-    cmp(set(get("ls /etc/local/htpasswd*").split()), {
-      '/etc/local/htpasswd_fcio_users',
-      '/etc/local/htpasswd_fcio_users.login',
-      '/etc/local/htpasswd_fcio_users.manager',
-      '/etc/local/htpasswd_fcio_users.sudo-srv',
-      '/etc/local/htpasswd_fcio_users.wheel'})
+    def assert_permissions(expected, path):
+      permissions = machine.succeed(f"stat {path} -c %a:%U:%G").strip()
+      print(f"{path}: {permissions}")
+      assert permissions == expected, f"expected: {expected}, got {permissions}"
 
-    assert get("cat /etc/local/htpasswd_fcio_users.login") == "u1001:*"
-    assert get("cat /etc/local/htpasswd_fcio_users.manager")== "u1002:*"
-    assert get("cat /etc/local/htpasswd_fcio_users.sudo-srv") == "u1003:*"
-    assert get("cat /etc/local/htpasswd_fcio_users.wheel")== "u1004:*"
+    with subtest("Common and group-specific htpasswd files should be present"):
+      cmp(set(get("ls /etc/local/htpasswd*").split()), {
+        '/etc/local/htpasswd_fcio_users',
+        '/etc/local/htpasswd_fcio_users.login',
+        '/etc/local/htpasswd_fcio_users.manager',
+        '/etc/local/htpasswd_fcio_users.sudo-srv',
+        '/etc/local/htpasswd_fcio_users.wheel'})
+
+    with subtest("Group-specific htpasswd should contain the right users"):
+      assert get("cat /etc/local/htpasswd_fcio_users.login") == "u1001:*"
+      assert get("cat /etc/local/htpasswd_fcio_users.manager")== "u1002:*"
+      assert get("cat /etc/local/htpasswd_fcio_users.sudo-srv") == "u1003:*"
+      assert get("cat /etc/local/htpasswd_fcio_users.wheel")== "u1004:*"
+
+    with subtest("Home dirs should exist and have correct permissions"):
+      assert_permissions("755:u1000:users", "/home/u1000")
+      assert_permissions("755:s-service:service", "/srv/s-service")
   '';
 })


### PR DESCRIPTION
(Same as #512 for 21.11) 

This avoids setting the permissions for home dirs twice in the
activation script. This led to situations in the past where the
activation script died after the users script and home dir permissions
were set to 700.
Let our activation snippet handle home dir creation and
setting permissions to 755.

 #PL-130524

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Make sure that home dir permissions are always set correctly when activating a new system (#PL-130524). 

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - we n must set home dir permissions reliably to the value we want
- [x] Security requirements tested? (EVIDENCE)
  - manually checked on a test VM that home dirs are created with the right permissions and that wrong permissions are fixed when running the activation script