### PR TITLE
Elastic: use OSS versions of 6.x, add OSS versions for 7.x

### DIFF
--- a/nixos/roles/elasticsearch.nix
+++ b/nixos/roles/elasticsearch.nix
@@ -19,11 +19,11 @@ let
 
   versionConfiguration = {
     "6" = {
-      package = pkgs.elasticsearch6;
+      package = pkgs.elasticsearch6-oss;
       serviceName = "elasticsearch6-node";
     };
     "7" = {
-      package = pkgs.elasticsearch7;
+      package = pkgs.elasticsearch7-oss;
       serviceName = "elasticsearch7-node";
     };
     null = {
@@ -139,9 +139,6 @@ in
     environment.systemPackages = [
       esShowConfig
     ];
-
-    # The 'elastic' license is considered unfree.
-    nixpkgs.config.allowUnfree = true;
 
     services.elasticsearch = {
       enable = true;

--- a/nixos/roles/kibana.nix
+++ b/nixos/roles/kibana.nix
@@ -75,14 +75,11 @@ in
 
       services.kibana = {
         enable = true;
-        extraConf = lib.optionalAttrs (kibanaVersion == "7") {
-          xpack.reporting.enabled = false;
-        };
 
         # Unlike elasticsearch, kibana cannot listen to both IPv4 and IPv6.
         # We choose to use IPv4 here.
         listenAddress = head fclib.network.srv.v4.addresses;
-        package = pkgs."kibana${kibanaVersion}";
+        package = pkgs."kibana${kibanaVersion}-oss";
       } // lib.optionalAttrs (kibanaVersion == "6") {
           elasticsearch.url = elasticSearchUrl;
       } // lib.optionalAttrs (kibanaVersion == "7") {

--- a/pkgs/kibana/7.x.nix
+++ b/pkgs/kibana/7.x.nix
@@ -1,0 +1,45 @@
+{ elasticKibanaOSS7Version
+, lib, stdenv
+, makeWrapper
+, fetchurl
+, nodejs-10_x
+, coreutils
+, which
+}:
+
+with lib;
+let
+  nodejs = nodejs-10_x;
+
+in stdenv.mkDerivation rec {
+  name = "kibana-oss-${version}";
+  version = elasticKibanaOSS7Version;
+
+  src = fetchurl {
+    url = "https://artifacts.elastic.co/downloads/kibana/${name}-linux-x86_64.tar.gz";
+    sha256 = "050rhx82rqpgqssp1rdflz1ska3f179kd2k2xznb39614nk0m6gs";
+  };
+
+  patches = [
+    # Kibana specifies it specifically needs nodejs 10.15.2 but nodejs in nixpkgs is at a higher version.
+    ./disable-nodejs-version-check-7.patch
+  ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    mkdir -p $out/libexec/kibana $out/bin
+    mv * $out/libexec/kibana/
+    rm -r $out/libexec/kibana/node
+    makeWrapper $out/libexec/kibana/bin/kibana $out/bin/kibana \
+      --prefix PATH : "${lib.makeBinPath [ nodejs coreutils which ]}"
+    sed -i 's@NODE=.*@NODE=${nodejs}/bin/node@' $out/libexec/kibana/bin/kibana
+  '';
+
+  meta = {
+    description = "Visualize logs and time-stamped data";
+    homepage = "http://www.elasticsearch.org/overview/kibana";
+    license = licenses.asl20;
+    platforms = with platforms; linux;
+  };
+}

--- a/pkgs/kibana/disable-nodejs-version-check-7.patch
+++ b/pkgs/kibana/disable-nodejs-version-check-7.patch
@@ -1,0 +1,19 @@
+diff --git a/src/setup_node_env/node_version_validator.js b/src/setup_node_env/node_version_validator.js
+index 3f611e5a..f5c60c85 100644
+--- a/src/setup_node_env/node_version_validator.js
++++ b/src/setup_node_env/node_version_validator.js
+@@ -25,11 +25,11 @@ var pkg = require('../../package.json'); // Note: This is written in ES5 so we c
+ var currentVersion = process && process.version || null;
+ var rawRequiredVersion = pkg && pkg.engines && pkg.engines.node || null;
+ var requiredVersion = rawRequiredVersion ? 'v' + rawRequiredVersion : rawRequiredVersion;
+-var isVersionValid = !!currentVersion && !!requiredVersion && currentVersion === requiredVersion; // Validates current the NodeJS version compatibility when Kibana starts.
++var isVersionValid = !!currentVersion && !!requiredVersion; // Validates current the NodeJS version compatibility when Kibana starts.
+
+ if (!isVersionValid) {
+   var errorMessage = 'Kibana does not support the current Node.js version ' + currentVersion + '. Please use Node.js ' + requiredVersion + '.'; // Actions to apply when validation fails: error report + exit.
+
+   console.error(errorMessage);
+   process.exit(1);
+-}
+\ No newline at end of file
++}

--- a/tests/kibana.nix
+++ b/tests/kibana.nix
@@ -32,6 +32,7 @@ in
     };
 
   testScript = ''
+    expected_major_version = ${version}
     start_all()
 
     machine.wait_for_unit("elasticsearch")
@@ -50,6 +51,9 @@ in
 
     with subtest("cluster healthy?"):
         machine.succeed(status_check)
+
+    with subtest(f"version should be {expected_major_version}.x in the OSS flavor"):
+      machine.succeed(f"systemctl show kibana -P ExecStart --value | grep kibana-oss-{expected_major_version}")
 
     with subtest("killing the kibana process should trigger an automatic restart"):
         machine.succeed(


### PR DESCRIPTION
Elasticsearch/Kibana6: OSS (Apache 2.0) still present on 21.11 as
elasticsearch6-oss and kibana6-oss, use them by default in the role code.

Elasticsearch/Kibana7: pin to 7.10.2 which is the latest version
available as OSS, use these packages by default in the role code.
Version 7.10.2 is the same as on our 21.05 platform and it's the
newest available OSS version of 7.x.

Beats are not affected by this change, they can follow the upstream
versions independently.

 #PL-130528

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Elasticsearch/Kibana: pin version for the 7.x roles to 7.10.2 which is the last version available with a free license. (#PL-130528).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- known log4j exploits are mitigated 
- we just want to avoid licensing issues
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still run, manually checked on a test VM
  - 6.8.21 has a fixed log4j version, 7.10.2 doesn't have it but ES is still considered relatively safe because of other measures taken in ES and our `Dlog4j2.formatMsgNoLookups=true` setting