### PR TITLE
[21.05] Elastic: Make sure we don't use elastic-licensed code

### DIFF
--- a/nixos/roles/elasticsearch.nix
+++ b/nixos/roles/elasticsearch.nix
@@ -19,11 +19,11 @@ let
 
   versionConfiguration = {
     "6" = {
-      package = pkgs.elasticsearch6;
+      package = pkgs.elasticsearch6-oss;
       serviceName = "elasticsearch6-node";
     };
     "7" = {
-      package = pkgs.elasticsearch7;
+      package = pkgs.elasticsearch7-oss;
       serviceName = "elasticsearch7-node";
     };
     null = {
@@ -139,9 +139,6 @@ in
     environment.systemPackages = [
       esShowConfig
     ];
-
-    # The 'elastic' license is considered unfree.
-    nixpkgs.config.allowUnfree = true;
 
     services.elasticsearch = {
       enable = true;

--- a/nixos/roles/kibana.nix
+++ b/nixos/roles/kibana.nix
@@ -75,14 +75,11 @@ in
 
       services.kibana = {
         enable = true;
-        extraConf = lib.optionalAttrs (kibanaVersion == "7") {
-          xpack.reporting.enabled = false;
-        };
 
         # Unlike elasticsearch, kibana cannot listen to both IPv4 and IPv6.
         # We choose to use IPv4 here.
         listenAddress = head fclib.network.srv.v4.addresses;
-        package = pkgs."kibana${kibanaVersion}";
+        package = pkgs."kibana${kibanaVersion}-oss";
       } // lib.optionalAttrs (kibanaVersion == "6") {
           elasticsearch.url = elasticSearchUrl;
       } // lib.optionalAttrs (kibanaVersion == "7") {


### PR DESCRIPTION
NixOS 21.05 allows to select the OSS versions of Elasticsearch and
Kibana which are distributed under the free Apache 2.0 license, without
the proprietary x-pack folder.

 #PL-130528

@flyingcircusio/release-managers

## Release process

Impact:

* [NixOS 21.05] Elasticsearch and Kibana will be restarted.

Changelog:

* Elasticsearch/Kibana: use OSS packages by default to make sure we don't provide unfree functionality covered by the Elastic license (#PL-130528).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- known log4j exploits are mitigated
- we just want to avoid licensing issues
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still run, manually checked on a test VM that ES/Kibana 6 and 7 work
  - 6.8.21 has a fixed log4j version, 7.10.2 doesn't have it but ES is still considered relatively safe because of other measures taken in ES and our `Dlog4j2.formatMsgNoLookups=true` setting
