### PR TITLE
Update nixpkgs for gitlab 14.8.5

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "8f01bce4e03fc8021bb76110afcc4df52242924a",
-    "sha256": "v96uFBE0I/+j+bZFfrVaz2Z8wG7rAeVpftYlzbw3SNo="
+    "rev": "77c561e6add6108ca4ec6c6ac230a15e0d08ac54",
+    "sha256": "iUacnEzuWdnVRwQ0EdO34Osam0e5PFE69lVTVEfdYXE="
   },
   "nixos-mailserver": {
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/",


### PR DESCRIPTION
Important security update for users of LDAP authentication.

 #PL-130540

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Gitlab: 14.8.4 -> 14.8.5 (#PL-130540).

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - use a current Gitlab version with the latest security fixes
- [x] Security requirements tested? (EVIDENCE)
  - 14.8.5 is the most recent patch release and fixes a critical LDAP issue (already rolled out to affected systems as hotfix)
  - manually tested on staging Gitlab instance
  - automated test still runs
