### PR TITLE
fc-collect-garbage: ignore errors in systemd unit

### DIFF
--- a/nixos/platform/garbagecollect/fc-collect-garbage.py
+++ b/nixos/platform/garbagecollect/fc-collect-garbage.py
@@ -1,0 +1,65 @@
+import datetime
+import os
+import pwd
+import subprocess
+import sys
+
+
+def main():
+    exclude_file = sys.argv[1]
+    rc = []
+    users_to_scan = [
+        user
+        for user in pwd.getpwall()
+        if user.pw_uid >= 1000 and user.pw_dir != "/var/empty"
+    ]
+    print(f"Running fc-userscan for {len(users_to_scan)} users")
+    for user in users_to_scan:
+        print(f"Scanning {user.pw_dir} as {user.pw_name}")
+        p = subprocess.Popen(
+            [
+                "fc-userscan",
+                "-r",
+                "-c",
+                user.pw_dir + "/.cache/fc-userscan.cache",
+                "-L10000000",
+                "--unzip=*.egg",
+                "-E",
+                exclude_file,
+                user.pw_dir,
+            ],
+            stdin=subprocess.DEVNULL,
+            preexec_fn=lambda: os.setresuid(user.pw_uid, 0, 0),
+        )
+        rc.append(p.wait())
+
+    status = max(rc)
+    print("Overall status of fc-userscan calls:", status)
+
+    if status >= 2:
+        print("Aborting garbagecollect. See above for fc-userscan errors")
+        sys.exit(2)
+    if status >= 1:
+        print("Aborting garbagecollect. See above for fc-userscan warnings")
+        sys.exit(1)
+
+    print("Running nix-collect-garbage")
+    rc = subprocess.run(
+        ["nix-collect-garbage", "--delete-older-than", "3d"],
+        check=True,
+        stdin=subprocess.DEVNULL,
+    ).returncode
+
+    if rc > 0:
+        print(
+            f"nix-collect-garbage failed with status {rc}. "
+            "See above for command output."
+        )
+        sys.exit(3)
+
+    open("${log}", "w").write(str(datetime.datetime.now()) + "\n")
+    print("fc-collect-garbage finished without problems.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

It's a common problem that fc-userscan dies when files are deleted while
it is running. This failure now marks the fc-collect-garbage unit as failed
which may break a system rebuild. The reason is that the
switch-to-configuration script is looking for units that failed during
the system switch and that it aborts if it finds one.
This doesn't mean that the failure has been caused by the switch, it may
be just a coincidence. We have seen this problem when automated deployments
delete files and also start a system rebuild while the
fc-collect-garbage unit is running concurrently, activated by its timer.

The unit now accepts exit codes 0, 1, 2, 3 as "successful" exit codes
so it doesn't trigger the problem anymore. We can tolerate errors in the
garbage collect unit because it will be run on the next day again.

There's a Sensu check that warns us when garbage collection
doesn't work for longer time periods.

Changelog:

* Common errors in the daily Nix store garbage collection job don't mark the systemd unit as failed anymore. These failures were sometimes propagated to automated deployments which shouldn't fail in that case (#PL-130101).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - garbage collection should not create unneccessary failures, for example in automated deployments
  - make sure that garbage collection errors don't go unnoticed for too long
- [x] Security requirements tested? (EVIDENCE)
  - checked manually on test VM if the unit reacts properly to fc-userscan failures and that system switches don't fail then
  - looked at the sensu check that warns us if garbage collection is broken for multiple days, we also have the disk full check
