### PR TITLE
PL-129940 Activate jicofo health endpoint, add sensu check

### DIFF
--- a/nixos/roles/jitsi/default.nix
+++ b/nixos/roles/jitsi/default.nix
@@ -200,7 +200,7 @@ in {
 
       flyingcircus.services.sensu-client.checks = {
         jitsi-videobridge-alive = {
-          notification = "Jitsi videobridge alive";
+          notification = "Jitsi videobridge not healthy";
           command = "check_http -v -j HEAD -H localhost -p 8080 -u /about/health";
         };
       };

--- a/nixos/roles/jitsi/default.nix
+++ b/nixos/roles/jitsi/default.nix
@@ -201,7 +201,7 @@ in {
       flyingcircus.services.sensu-client.checks = {
         jitsi-videobridge-alive = {
           notification = "Jitsi videobridge not healthy";
-          command = "check_http -v -j HEAD -H localhost -p 8080 -u /about/health";
+          command = "check_http -v -H localhost -p 8080 -u /about/health";
         };
       };
 

--- a/nixos/services/jitsi/jicofo.nix
+++ b/nixos/services/jitsi/jicofo.nix
@@ -150,7 +150,7 @@ in
     flyingcircus.services.sensu-client.checks = {
       jitsi-jicofo-alive = {
         notification = "Jitsi jicofo not healthy";
-        command = "check_http -v -j HEAD -H localhost -p 8888 -u /about/health";
+        command = "check_http -v -H localhost -p 8888 -u /about/health";
       };
     };
 

--- a/nixos/services/jitsi/jicofo.nix
+++ b/nixos/services/jitsi/jicofo.nix
@@ -86,6 +86,7 @@ in
         "-Dnet.java.sip.communicator.SC_HOME_DIR_NAME" = "jicofo";
         "-Djava.util.logging.config.file" = "/etc/jitsi/jicofo/logging.properties";
         "-Dconfig.file" = "/etc/jitsi/jicofo/jicofo.conf";
+        "-Dorg.jitsi.jicofo.health.ENABLE_HEALTH_CHECKS" = "true";
       };
     in
     {
@@ -143,6 +144,13 @@ in
         }
       }
       '';
+
+    flyingcircus.services.sensu-client.checks = {
+      jitsi-jicofo-alive = {
+        notification = "Jicofo healthy";
+        command = "check_http -v -j HEAD -H localhost -p 8888 -u /about/health";
+      };
+    };
 
     environment.etc."jitsi/jicofo/sip-communicator.properties".source =
       pkgs.writeText "sip-communicator.properties" (

--- a/nixos/services/jitsi/jicofo.nix
+++ b/nixos/services/jitsi/jicofo.nix
@@ -86,7 +86,6 @@ in
         "-Dnet.java.sip.communicator.SC_HOME_DIR_NAME" = "jicofo";
         "-Djava.util.logging.config.file" = "/etc/jitsi/jicofo/logging.properties";
         "-Dconfig.file" = "/etc/jitsi/jicofo/jicofo.conf";
-        "-Dorg.jitsi.jicofo.health.ENABLE_HEALTH_CHECKS" = "true";
       };
     in
     {
@@ -137,6 +136,9 @@ in
     environment.etc."jitsi/jicofo/jicofo.conf".source =
       pkgs.writeText "jicofo.conf" ''
       jicofo {
+        health {
+          enabled = true
+        }
         xmpp {
           client {
             client-proxy: focus.${cfg.xmppDomain}

--- a/nixos/services/jitsi/jicofo.nix
+++ b/nixos/services/jitsi/jicofo.nix
@@ -149,7 +149,7 @@ in
 
     flyingcircus.services.sensu-client.checks = {
       jitsi-jicofo-alive = {
-        notification = "Jicofo healthy";
+        notification = "Jitsi jicofo not healthy";
         command = "check_http -v -j HEAD -H localhost -p 8888 -u /about/health";
       };
     };


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Activates built in health check features to platform, doesn't add new code
- [x] Security requirements tested? (EVIDENCE)
  - Tested on Test VM, shows up green if OK, shows up red if Videobridge is down