### PR TITLE
[21.05] ES/Kibana: fix version overrides for 7.10.2

### DIFF
--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -54,13 +54,13 @@ in {
 
   docsplit = super.callPackage ./docsplit { };
 
-  elasticsearch7 = super.elasticsearch7.overrideAttrs(_: rec {
+  elasticsearch7-oss = super.elasticsearch7-oss.overrideAttrs(_: rec {
     version = elk7Version;
-    name = "elasticsearch-${version}";
+    name = "elasticsearch-oss-${version}";
 
     src = super.fetchurl {
       url = "https://artifacts.elastic.co/downloads/elasticsearch/${name}-linux-x86_64.tar.gz";
-      sha256 = "07p16n53fg513l4f04zq10hh5j9q6rjwz8hs8jj8y97jynvf6yiv";
+      sha256 = "1m6wpxs56qb6n473hawfw2n8nny8gj3dy8glq4x05005aa8dv6kh";
     };
     meta.license = null;
   });
@@ -131,13 +131,13 @@ in {
     };
   });
 
-  kibana7 = super.kibana7.overrideAttrs(_: rec {
+  kibana7-oss = super.kibana7-oss.overrideAttrs(_: rec {
     version = elk7Version;
-    name = "kibana-${version}";
+    name = "kibana-oss-${version}";
 
     src = super.fetchurl {
       url = "https://artifacts.elastic.co/downloads/kibana/${name}-linux-x86_64.tar.gz";
-      sha256 = "06p0v39ih606mdq2nsdgi5m7y1iynk9ljb9457h5rrx6jakc2cwm";
+      sha256 = "050rhx82rqpgqssp1rdflz1ska3f179kd2k2xznb39614nk0m6gs";
     };
     meta.license = null;
   });

--- a/tests/elasticsearch.nix
+++ b/tests/elasticsearch.nix
@@ -28,6 +28,7 @@ in
     sensuCheck = testlib.sensuCheckCmd nodes.machine;
   in ''
     import json
+    from pprint import pprint
 
     expected_major_version = ${version}
 
@@ -59,6 +60,7 @@ in
 
     with subtest(f"version should be {expected_major_version}.x in the OSS flavor"):
       version_info = api_result["version"]
+      pprint(version_info)
       major_version = int(version_info["number"][0])
       assert major_version == expected_major_version, f"expected major version {expected_major_version}, got {major_version}"
       build_flavor = version_info["build_flavor"]

--- a/tests/kibana.nix
+++ b/tests/kibana.nix
@@ -32,6 +32,7 @@ in
     };
 
   testScript = ''
+    expected_major_version = ${version}
     start_all()
 
     machine.wait_for_unit("elasticsearch")
@@ -50,6 +51,9 @@ in
 
     with subtest("cluster healthy?"):
         machine.succeed(status_check)
+
+    with subtest(f"version should be {expected_major_version}.x in the OSS flavor"):
+      machine.succeed(f"systemctl show kibana -P ExecStart --value | grep kibana-oss-{expected_major_version}")
 
     with subtest("killing the kibana process should trigger an automatic restart"):
         machine.succeed(


### PR DESCRIPTION
We have switched to the OSS versions with #517 but the overrides still
targeted the unfree packages. We now use 7.10.2-oss as intended.

Also add a version check in the kibana test taken from the 21.11 platform.

 #PL-130528

@flyingcircusio/release-managers

## Release process

Impact:

Changelog: -

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - same as before, just a correction of a previous PR 
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still run, checked on test VM that we use the correct version now