### PR TITLE
Jitsi: update all packages to the latest stable versions

### DIFF
--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -111,29 +111,29 @@ in {
 
   jicofo = super.jicofo.overrideAttrs(oldAttrs: rec {
     pname = "jicofo";
-    version = "1.0-846";
+    version = "1.0-862";
     src = super.fetchurl {
       url = "https://download.jitsi.org/stable/${pname}_${version}-1_all.deb";
-      sha256 = "1gsij3mv1rbcx6wvxf5a2cb58py7ak56z2sajdpjv4w3ihxi9h5a";
+      sha256 = "11rq6kqcvmjj5589bpi8v31gx287vkixxjycimbi4fqwfg57f1s1";
     };
   });
 
   jitsi-meet = super.jitsi-meet.overrideAttrs(oldAttrs: rec {
     pname = "jitsi-meet";
-    version = "1.0.5818";
+    version = "1.0.5913";
     src = super.fetchurl {
       url = "https://download.jitsi.org/jitsi-meet/src/jitsi-meet-${version}.tar.bz2";
-      sha256 = "1il9c6q8aa86k9br1g59320kz15qpxcgpd2rrcfxyh8q95h6hmm1";
+      sha256 = "0m58gyj5qvihk2lvg9raqjlq6m4znm3bd48zj2mv77ia069lc31m";
     };
 
   });
 
   jitsi-videobridge = super.jitsi-videobridge.overrideAttrs(oldAttrs: rec {
     pname = "jitsi-videobridge2";
-    version = "2.1-617-ga8b39c3f";
+    version = "2.1-634-gff8609ad";
     src = super.fetchurl {
       url = "https://download.jitsi.org/stable/${pname}_${version}-1_all.deb";
-      sha256 = "0pnzf5nj1i47rkaf8ayvl6jdkizg9i126ljrzvrxasvkjqf7xd0b";
+      sha256 = "10f4542nn5dkabkmv7zykbq4wj39w9i6z0avpgwb6n527c15myyc";
     };
   });
 


### PR DESCRIPTION
 #PL-130541

@flyingcircusio/release-managers

## Release process

Impact:

* [NixOS 21.11] Jitsi will be restarted and conferences will be interrupted for a short period of time.

Changelog:

* Jitsi: update jitsi-videobridge, jicofo and jitsi-meet to latest stable versions (#PL-130541).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - use recent Jitsi package versions 
- [x] Security requirements tested? (EVIDENCE)
  - we have the latest stable version now
  - Checked on the test machine that Jitsi conferences and authentication still work.