### PR TITLE
[21.05] Elastic: 7.10.2 for all flavours of ES/Kibana, use JDK 11

### DIFF
--- a/nixos/roles/elasticsearch.nix
+++ b/nixos/roles/elasticsearch.nix
@@ -177,6 +177,9 @@ in
         Restart = "always";
       };
       preStart = lib.mkAfter ''
+        # redirect jvm logs to the data directory
+        mkdir -m 0700 -p ${cfg_service.dataDir}/logs
+        ${pkgs.sd}/bin/sd 'logs/gc.log' '${cfg_service.dataDir}/logs/gc.log' ${cfg_service.dataDir}/config/jvm.options
         # Install scripts
         mkdir -p ${cfg_service.dataDir}/scripts
       '';

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -54,7 +54,9 @@ in {
 
   docsplit = super.callPackage ./docsplit { };
 
-  elasticsearch7 = super.elasticsearch7.overrideAttrs(_: rec {
+  elasticsearch7 = (super.elasticsearch7.override {
+    jre_headless = self.jdk11_headless;
+  }).overrideAttrs(_: rec {
     version = elk7Version;
     name = "elasticsearch-${version}";
 
@@ -64,7 +66,9 @@ in {
     };
   });
 
-  elasticsearch7-oss = super.elasticsearch7-oss.overrideAttrs(_: rec {
+  elasticsearch7-oss = (super.elasticsearch7-oss.override {
+    jre_headless = self.jdk11_headless;
+  }).overrideAttrs(_: rec {
     version = elk7Version;
     name = "elasticsearch-oss-${version}";
 

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -54,6 +54,16 @@ in {
 
   docsplit = super.callPackage ./docsplit { };
 
+  elasticsearch7 = super.elasticsearch7.overrideAttrs(_: rec {
+    version = elk7Version;
+    name = "elasticsearch-${version}";
+
+    src = super.fetchurl {
+      url = "https://artifacts.elastic.co/downloads/elasticsearch/${name}-linux-x86_64.tar.gz";
+      sha256 = "07p16n53fg513l4f04zq10hh5j9q6rjwz8hs8jj8y97jynvf6yiv";
+    };
+  });
+
   elasticsearch7-oss = super.elasticsearch7-oss.overrideAttrs(_: rec {
     version = elk7Version;
     name = "elasticsearch-oss-${version}";
@@ -62,7 +72,6 @@ in {
       url = "https://artifacts.elastic.co/downloads/elasticsearch/${name}-linux-x86_64.tar.gz";
       sha256 = "1m6wpxs56qb6n473hawfw2n8nny8gj3dy8glq4x05005aa8dv6kh";
     };
-    meta.license = null;
   });
 
   flannel = super.flannel.overrideAttrs(_: rec {
@@ -131,6 +140,16 @@ in {
     };
   });
 
+  kibana7 = super.kibana7.overrideAttrs(_: rec {
+    version = elk7Version;
+    name = "kibana-${version}";
+
+    src = super.fetchurl {
+      url = "https://artifacts.elastic.co/downloads/kibana/${name}-linux-x86_64.tar.gz";
+      sha256 = "06p0v39ih606mdq2nsdgi5m7y1iynk9ljb9457h5rrx6jakc2cwm";
+    };
+  });
+
   kibana7-oss = super.kibana7-oss.overrideAttrs(_: rec {
     version = elk7Version;
     name = "kibana-oss-${version}";
@@ -139,7 +158,6 @@ in {
       url = "https://artifacts.elastic.co/downloads/kibana/${name}-linux-x86_64.tar.gz";
       sha256 = "050rhx82rqpgqssp1rdflz1ska3f179kd2k2xznb39614nk0m6gs";
     };
-    meta.license = null;
   });
 
   inherit (super.callPackages ./matomo {})

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -248,6 +248,9 @@ in {
   mc = super.callPackage ./mc.nix { };
 
   mongodb-3_6 = super.mongodb-3_6.overrideAttrs(_: rec {
+    # We have set the license to null to avoid that Hydra complains about unfree
+    # licenses (here: SSPL). We should explicitly allow SSPL in the future and
+    # remove this override here.
     meta.license = null;
     version = "3.6.19";
     name = "mongodb-${version}";
@@ -257,6 +260,9 @@ in {
     };
   });
   mongodb-4_0 = super.mongodb-4_0.overrideAttrs(_: rec {
+    # We have set the license to null to avoid that Hydra complains about unfree
+    # licenses (here: SSPL). We should explicitly allow SSPL in the future and
+    # remove this override here.
     meta.license = null;
     version = "4.0.19";
     name = "mongodb-${version}";
@@ -266,6 +272,9 @@ in {
     };
   });
   mongodb-4_2 = super.mongodb-4_2.overrideAttrs(_: rec {
+    # We have set the license to null to avoid that Hydra complains about unfree
+    # licenses (here: SSPL). We should explicitly allow SSPL in the future and
+    # remove this override here.
     meta.license = null;
     version = "4.2.18";
     name = "mongodb-${version}";


### PR DESCRIPTION
Tthis is a follow-up to PR #521

 #PL-130528

@flyingcircusio/release-managers

## Release process

Impact:

* ElasticSearch will be restarted

Changelog:

* Elasticsearch: use Java 11 which is recommended for the used ES version and provides additional protection against log4shell exploits (#PL-130528).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - make sure ES is protected from the log4shell vulnerability
- [x] Security requirements tested? (EVIDENCE)
  - ES now uses the recommended Java 11 which adds more protection against log4shell exploits (https://xeraa.net/blog/2021_mitigate-log4j2-log4shell-elasticsearch).
