### PR TITLE
Update nixpkgs

### DIFF
--- a/nixos/services/graylog/default.nix
+++ b/nixos/services/graylog/default.nix
@@ -259,12 +259,12 @@ in {
         ];
 
       in {
-        JAVA_HOME = pkgs.jre8_headless;
+        JAVA_HOME = pkgs.jdk8_headless;
         GRAYLOG_CONF = graylogConfPath;
         JAVA_OPTS = lib.concatStringsSep " " javaOpts;
       };
 
-      path = [ pkgs.jre8_headless pkgs.which pkgs.procps ];
+      path = [ pkgs.jdk8_headless pkgs.which pkgs.procps ];
 
       preStart = ''
         rm -rf /var/lib/graylog/plugins || true

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -99,6 +99,10 @@ in {
     };
   });
 
+  graylog = (super.graylog.override {
+    openjdk11_headless = self.jdk8_headless;
+  });
+
   kibana7 = super.callPackage ./kibana/7.x.nix { inherit elasticKibana7Version; unfree = true; };
   kibana7-oss = super.callPackage ./kibana/7.x.nix { inherit elasticKibana7Version; };
 
@@ -136,6 +140,9 @@ in {
       sha256 = "10f4542nn5dkabkmv7zykbq4wj39w9i6z0avpgwb6n527c15myyc";
     };
   });
+
+  jdk8_headless = super.jdk8_headless.override { zlib = self.zlibCrcInputFix; };
+  jdk11_headless = super.jdk11_headless.override { zlib = self.zlibCrcInputFix; };
 
   inherit (super.callPackages ./matomo {})
     matomo
@@ -310,4 +317,8 @@ in {
   wkhtmltopdf = self.wkhtmltopdf_0_12_6;
 
   xtrabackup = self.percona-xtrabackup_8_0;
+
+  zlibCrcInputFix = super.zlib.overrideAttrs(a: {
+    patches = [ ./zlib-1.12.12-incorrect-crc-inputs-fix.patch  ];
+  });
 }

--- a/pkgs/zlib-1.12.12-incorrect-crc-inputs-fix.patch
+++ b/pkgs/zlib-1.12.12-incorrect-crc-inputs-fix.patch
@@ -1,0 +1,38 @@
+diff --git a/crc32.c b/crc32.c
+index a1bdce5c2..451887bc7 100644
+--- a/crc32.c
++++ b/crc32.c
+@@ -630,7 +630,7 @@ unsigned long ZEXPORT crc32_z(crc, buf, len)
+ #endif /* DYNAMIC_CRC_TABLE */
+
+     /* Pre-condition the CRC */
+-    crc ^= 0xffffffff;
++    crc = (~crc) & 0xffffffff;
+
+     /* Compute the CRC up to a word boundary. */
+     while (len && ((z_size_t)buf & 7) != 0) {
+@@ -749,7 +749,7 @@ unsigned long ZEXPORT crc32_z(crc, buf, len)
+ #endif /* DYNAMIC_CRC_TABLE */
+
+     /* Pre-condition the CRC */
+-    crc ^= 0xffffffff;
++    crc = (~crc) & 0xffffffff;
+
+ #ifdef W
+
+@@ -1077,7 +1077,7 @@ uLong ZEXPORT crc32_combine64(crc1, crc2, len2)
+ #ifdef DYNAMIC_CRC_TABLE
+     once(&made, make_crc_table);
+ #endif /* DYNAMIC_CRC_TABLE */
+-    return multmodp(x2nmodp(len2, 3), crc1) ^ crc2;
++    return multmodp(x2nmodp(len2, 3), crc1) ^ (crc2 & 0xffffffff);
+ }
+
+ /* ========================================================================= */
+@@ -1112,5 +1112,5 @@ uLong crc32_combine_op(crc1, crc2, op)
+     uLong crc2;
+     uLong op;
+ {
+-    return multmodp(op, crc1) ^ crc2;
++    return multmodp(op, crc1) ^ (crc2 & 0xffffffff);
+ }

--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "77c561e6add6108ca4ec6c6ac230a15e0d08ac54",
-    "sha256": "iUacnEzuWdnVRwQ0EdO34Osam0e5PFE69lVTVEfdYXE="
+    "rev": "1f05f61bc9cb8b49b86780749d9cca46308688a5",
+    "sha256": "02nQpf+ryHwjWv+KYNw9rgO8umzF2KTMHKF3OjSJWlY="
   },
   "nixos-mailserver": {
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/",


### PR DESCRIPTION
Update nixpkgs

Notable security updates and version changes:

* apacheHttpd: 2.4.52 -> 2.4.53
* discourse: 2.9.0.beta1 -> 2.9.0.beta4
* element-web: 1.10.6 -> 1.10.10
* gitlab: 14.8.5 -> 14.9.2
* grafana: 8.4.4 -> 8.4.6
* keycloak: 16.1.0 -> 17.0.1
* libarchive: 3.5.2 -> 3.5.3
* libressl: 3.4.1 -> 3.4.3
* libressl_3_2: add patch for CVE-2022-0778
* linux: 5.10.106 -> 5.10.111
* matrix-synapse: 1.54.0 -> 1.56.0
* mediawiki: 1.36.3 -> 1.36.4
* openvpn: 2.5.2 -> 2.5.6, 2.4.11 -> 2.4.12 (CVE-2022-0547)
* php74: 7.4.28 -> 7.4.29
* php.packages.composer: 2.1.9 -> 2.3.5 (CVE-2022-24828)
* php80: 8.0.16 -> 8.0.18
* powerdns: apply patch for ixfr validation issue
* python310: 3.10.0 -> 3.10.3
* python38: 3.8.12 -> 3.8.13
* python39: 3.9.6 -> 3.9.11
* strace: 5.16 -> 5.17
* subversion: 1.14.1 -> 1.14.2
* subversion_1_10: 1.10.7 -> 1.10.8
* zlib: 1.2.11 -> 1.2.12 (CVE-2018-25032)

ES: fix index corruption problem due to zlib update

Lucene reports corrupted indices on older CPU generations with zlib
1.12.12. Use a patched zlib for jre11_headless to fix the problem.

Patch is taken from upstream zlib commit
https://github.com/madler/zlib/commit/ec3df00224d4b396e2ac6586ab5d25f673caa4c2

Graylog: Web UI was broken after the zlib update. Using jdk8_headless
with the patched zlib helps.
  
#PL-130547

@flyingcircusio/release-managers

## Release process

Impact:

* [NixOS 21.11] Most services will be restarted because of a core dependency change. Machines will schedule a reboot to activate the changed kernel.

Changelog: XXX please include warning/hint about zlib compatibility issues (include changes from commit msg here)



## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - pull in upstream security fixes regularly
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still run, works on test VM
  - checked commit log for fixed CVEs and possible problems with updates, looked at changelogs of PHP, matrix-synapse, apache and grafana
