### PR TITLE
Elastic: 7.10.2 for all flavours of ES/Kibana, use JDK 11

### DIFF
--- a/pkgs/kibana/7.x.nix
+++ b/pkgs/kibana/7.x.nix
@@ -1,10 +1,11 @@
-{ elasticKibanaOSS7Version
+{ elasticKibana7Version
 , lib, stdenv
 , makeWrapper
 , fetchurl
 , nodejs-10_x
 , coreutils
 , which
+, unfree ? false
 }:
 
 with lib;
@@ -12,12 +13,16 @@ let
   nodejs = nodejs-10_x;
 
 in stdenv.mkDerivation rec {
-  name = "kibana-oss-${version}";
-  version = elasticKibanaOSS7Version;
+  flavour = if unfree then "" else "-oss";
+  name = "kibana${flavour}-${version}";
+  version = elasticKibana7Version;
 
   src = fetchurl {
     url = "https://artifacts.elastic.co/downloads/kibana/${name}-linux-x86_64.tar.gz";
-    sha256 = "050rhx82rqpgqssp1rdflz1ska3f179kd2k2xznb39614nk0m6gs";
+    sha256 =
+      if unfree
+      then "06p0v39ih606mdq2nsdgi5m7y1iynk9ljb9457h5rrx6jakc2cwm"
+      else "050rhx82rqpgqssp1rdflz1ska3f179kd2k2xznb39614nk0m6gs";
   };
 
   patches = [
@@ -39,7 +44,7 @@ in stdenv.mkDerivation rec {
   meta = {
     description = "Visualize logs and time-stamped data";
     homepage = "http://www.elasticsearch.org/overview/kibana";
-    license = licenses.asl20;
+    license = if unfree then licenses.elastic else licenses.asl20;
     platforms = with platforms; linux;
   };
 }

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -5,7 +5,7 @@ let
   # We want to have the last available OSS version for Kibana and Elasticsearch.
   # We don't override the global elk7Version because it's ok to use newer versions
   # for the (free) beats and unfree Elasticsearch/Kibana.
-  elasticKibanaOSS7Version = "7.10.2";
+  elasticKibana7Version = "7.10.2";
 
   # import fossar/nix-phps overlay with nixpkgs-unstable's generic.nix copied in
   # then use release-set as pkgs
@@ -54,8 +54,18 @@ in {
 
   docsplit = super.callPackage ./docsplit { };
 
+  elasticsearch7 = super.elasticsearch7.overrideAttrs(_: rec {
+    version = elasticKibana7Version;
+    name = "elasticsearch-${version}";
+
+    src = super.fetchurl {
+      url = "https://artifacts.elastic.co/downloads/elasticsearch/${name}-linux-x86_64.tar.gz";
+      sha256 = "07p16n53fg513l4f04zq10hh5j9q6rjwz8hs8jj8y97jynvf6yiv";
+    };
+  });
+
   elasticsearch7-oss = super.elasticsearch7.overrideAttrs(_: rec {
-    version = elasticKibanaOSS7Version;
+    version = elasticKibana7Version;
     name = "elasticsearch-oss-${version}";
 
     src = super.fetchurl {
@@ -77,7 +87,8 @@ in {
     };
   });
 
-  kibana7-oss = super.callPackage ./kibana/7.x.nix { inherit elasticKibanaOSS7Version; };
+  kibana7 = super.callPackage ./kibana/7.x.nix { inherit elasticKibana7Version; unfree = true; };
+  kibana7-oss = super.callPackage ./kibana/7.x.nix { inherit elasticKibana7Version; };
 
   # From nixos-unstable 1f5891a700b11ee9afa07074395e1e30799bf392
   kubernetes-helm = super.callPackage ./helm { };

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -54,7 +54,17 @@ in {
 
   docsplit = super.callPackage ./docsplit { };
 
-  elasticsearch7 = super.elasticsearch7.overrideAttrs(_: rec {
+  elasticsearch6 = (super.elasticsearch6.override {
+    jre_headless = self.jdk11_headless;
+  });
+
+  elasticsearch6-oss = (super.elasticsearch6-oss.override {
+    jre_headless = self.jdk11_headless;
+  });
+
+  elasticsearch7 = (super.elasticsearch7.override {
+    jre_headless = self.jdk11_headless;
+  }).overrideAttrs(_: rec {
     version = elasticKibana7Version;
     name = "elasticsearch-${version}";
 
@@ -64,7 +74,9 @@ in {
     };
   });
 
-  elasticsearch7-oss = super.elasticsearch7.overrideAttrs(_: rec {
+  elasticsearch7-oss = (super.elasticsearch7.override {
+    jre_headless = self.jdk11_headless;
+  }).overrideAttrs(_: rec {
     version = elasticKibana7Version;
     name = "elasticsearch-oss-${version}";
 


### PR DESCRIPTION

 #PL-130528

@flyingcircusio/release-managers

## Release process

Impact/Changelog:

This is a follow-up to #516, already documenting impact and changelog.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - use officially recommended Java version
- [x] Security requirements tested? (EVIDENCE)
  - manually checked on a test VM that switching versions works (Kibana breaking when switching from unfree to oss is expected, .`kibana` indices must be deleted manually) 