### PR TITLE
matomo: make tag manager plugin work

### DIFF
--- a/nixos/services/matomo.nix
+++ b/nixos/services/matomo.nix
@@ -155,6 +155,7 @@ in {
       environment.PIWIK_USER_PATH = dataDir;
       serviceConfig = {
         Type = "oneshot";
+        RemainAfterExit = true;
         User = user;
         # hide especially config.ini.php from other
         UMask = "0007";
@@ -191,6 +192,10 @@ in {
         '';
       script = ''
             # Use User-Private Group scheme to protect Matomo data, but allow administration / backup via 'matomo' group
+            mkdir -p ${dataDir}/tagmanager
+            ${pkgs.acl}/bin/setfacl -m u:nginx:x ${dataDir}/
+            ${pkgs.acl}/bin/setfacl -Rm u:nginx:rX ${dataDir}/tagmanager/
+            ${pkgs.acl}/bin/setfacl -dm u:nginx:r ${dataDir}/tagmanager/
             # Copy config folder
             chmod g+s "${dataDir}"
             cp -r "${cfg.package}/share/config" "${dataDir}/"
@@ -328,6 +333,7 @@ in {
         locations."= /piwik.js".extraConfig = ''
           expires 1M;
         '';
+        locations."/js/tagmanager".alias = dataDir + "/tagmanager";
       }];
     };
   };

--- a/pkgs/matomo/default.nix
+++ b/pkgs/matomo/default.nix
@@ -43,6 +43,7 @@ let
           # This changes the default config for path.geoip2 so that it doesn't point
           # to the nix store.
           ./change-path-geoip2.patch
+          ./tag-manager-writable-container-js-location.patch
         ];
 
         # this bootstrap.php adds support for getting PIWIK_USER_PATH
@@ -78,6 +79,7 @@ let
           "misc/composer/clean-xhprof.sh"
           "misc/cron/archive.sh"
           "plugins/GeoIp2/config/config.php"
+          "plugins/TagManager/config/config.php"
           "plugins/Installation/FormDatabaseSetup.php"
           "vendor/pear/archive_tar/sync-php4"
           "vendor/szymach/c-pchart/coverage.sh"

--- a/pkgs/matomo/tag-manager-writable-container-js-location.patch
+++ b/pkgs/matomo/tag-manager-writable-container-js-location.patch
@@ -1,0 +1,19 @@
+diff --git a/plugins/TagManager/config/config.php b/plugins/TagManager/config/config.php
+index 676c3d0..69289f4 100644
+--- a/plugins/TagManager/config/config.php
++++ b/plugins/TagManager/config/config.php
+@@ -3,12 +3,12 @@
+ return array(
+     'TagManagerContainerStorageDir' => function () {
+         // the location where we store the generated javascript or json container files
+-        return '/js';
++        return '/../../../../var/lib/matomo/tagmanager';
+     },
+     'TagManagerContainerWebDir' => function (\Psr\Container\ContainerInterface $c) {
+         // the path under which the containers are available through the web. this may be different to the storage
+         // path if using eg htaccess rewrites
+-        return $c->get('TagManagerContainerStorageDir');
++        return '/js/tagmanager';
+     },
+     'TagManagerContainerFilesPrefix' => function () {
+         // the prefix for any container file


### PR DESCRIPTION
Tag manager needs a writable location to store JS files for containers
to work. Writing to the main JS directory is bad, so tag manager gets
its own directory in /var/lib/matomo delivered via the path /js/tagmanager.

 #PL-130561

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Matomo: make tag manager plugin work. The plugin needs a writable directory to store JS files for containers created via the Admin UI (#PL-130561).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - tag manager should be able to write to a separate directory for its JS files, not to other dirs
  - nginx should be able to read but not write the tag manager JS files 
  - should not break existing installations 
- [x] Security requirements tested? (EVIDENCE)
  - checked on a test VM that updating an existing installation works as well as starting from scratch
  - looked at file permissions of the matomo state directory contents on the test VM
