### PR TITLE
matomo: fix potential Nginx path traversal, home dir permissions

### DIFF
--- a/nixos/services/matomo.nix
+++ b/nixos/services/matomo.nix
@@ -135,7 +135,6 @@ in {
 
     users.users.${user} = {
       isSystemUser = true;
-      createHome = true;
       home = dataDir;
       group  = user;
     };
@@ -333,7 +332,7 @@ in {
         locations."= /piwik.js".extraConfig = ''
           expires 1M;
         '';
-        locations."/js/tagmanager".alias = dataDir + "/tagmanager";
+        locations."/js/tagmanager/".alias = dataDir + "/tagmanager/";
       }];
     };
   };


### PR DESCRIPTION
The state dir is also the home dir for the matomo user and has
createUser set. This setting changes permissions from the
setup script when system activation runs and the
wrong permissions remain when the setup script does not run after that.
createHome can be disabled, the setup script takes care of everything.

The /js/tagmanager location was missing the trailing slash which makes
path traversal possible.

 #PL-130561

@flyingcircusio/release-managers

## Release process

Follow-up fix for #526

Impact: -

Changelog: -

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - same as #526
  - fixes a path traversal vulnerability introduced by #526 
- [x] Security requirements tested? (EVIDENCE)
  - looked at permissions of affected directories: they don't change anymore when system activation is ran
  - looked at nginx-check-config to see that no potential problems are left