### PR TITLE
LAMP: accept flyingcircus.roles.lamp.useFPM as obsolete option

### DIFF
--- a/nixos/lib/default.nix
+++ b/nixos/lib/default.nix
@@ -4,6 +4,7 @@ let
   attrsets = import ./attrsets.nix { inherit config lib; };
   files = import ./files.nix { inherit config pkgs lib; };
   math = import ./math.nix { inherit pkgs lib; };
+  modules = import ./modules.nix { inherit pkgs lib; };
   network = import ./network.nix { inherit config pkgs lib; };
   system = import ./system.nix { inherit config pkgs lib; };
   utils = import ./utils.nix { inherit config pkgs lib; };
@@ -21,7 +22,7 @@ in
 
   config = {
     fclib =
-      { inherit attrsets files math network system utils; }
-      // attrsets // files // math // network // system // utils // lists;
+      { inherit attrsets files math modules network system utils; }
+      // attrsets // files // math // modules // network // system // utils // lists;
   };
 }

--- a/nixos/lib/modules.nix
+++ b/nixos/lib/modules.nix
@@ -1,0 +1,27 @@
+# Helpers for NixOS modules and options.
+
+{ lib, ... }:
+{
+  #
+  # Should be used together with obsoleteOptionWarning for an option
+  # that doesn't have an effect anymore but should not fail if still used.
+  mkObsoleteOption = replacementInstructions:
+    lib.mkOption {
+      description = "Obsolete option: ${replacementInstructions}";
+    };
+
+
+  # Warns that an option should not be used anymore and has no effect.
+  # Returns a warning (a list of strings) to be added to config.warnings.
+  # Should be used together with mkObsoleteOption to declare the option.
+  # Example:
+  #  warnings =
+  #   fclib.obsoleteOptionWarning options ["flyingcircus" "x"] "Use y instead."
+  obsoleteOptionWarning = options: optionName: replacementInstructions:
+    with lib.options;
+    let opt = lib.getAttrFromPath optionName options; in
+    lib.mkIf (opt.isDefined) [
+      ("The option definition `${showOption optionName}' in ${showFiles opt.files} "
+        + "no longer has any effect; please remove it. ${replacementInstructions}")
+    ];
+}

--- a/nixos/roles/lamp.nix
+++ b/nixos/roles/lamp.nix
@@ -1,12 +1,15 @@
-{ config, pkgs, lib, ... }:
+{ config, options, pkgs, lib, ... }:
 let
   role = config.flyingcircus.roles.lamp;
   fclib = config.fclib;
 in {
+
   options = with lib; {
     flyingcircus.roles.lamp = {
       enable = mkEnableOption "Flying Circus LAMP stack";
       supportsContainers = fclib.mkEnableContainerSupport;
+
+      useFPM = fclib.mkObsoleteOption "FPM is always used now.";
 
       fpmMaxChildren = mkOption {
         type = types.int;
@@ -114,6 +117,13 @@ in {
     in
 
       lib.mkMerge [
+      {
+        warnings =
+          fclib.obsoleteOptionWarning
+            options
+            [ "flyingcircus" "roles" "lamp" "useFPM" ]
+            "FPM is always used now.";
+      }
 
       (lib.mkIf (!role.enable) {
         # Install the default upstream PHP when the LAMP role is not activated.


### PR DESCRIPTION
This option is only present on 21.05, so 21.11 upgrades break when
it is set. Produce a warning a warning instead that it can be removed.

Add two helpers for obsolete options, mkObsoleteOption to declare
the option and obsoleteOptionWarning to generate a list that can be
added to config.warnings.

 #PL-130565

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* LAMP: accept the obsolete useFPM option instead of failing to make upgrading from 21.05 easier. FPM is always used on 21.11. (#PL-130565). 

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - has no effect on security, we just want to avoid failing upgrades 
- [x] Security requirements tested? (EVIDENCE)
  - checked on a test VM that nothing breaks and the warning is displayed properly when the option is defined. 
