### PR TITLE
beats: add opensource-only packages and use them

### DIFF
--- a/nixos/platform/auditbeat.nix
+++ b/nixos/platform/auditbeat.nix
@@ -11,8 +11,8 @@ in
   options.flyingcircus.auditbeat = with lib; {
     package = mkOption {
       type = types.package;
-      default = pkgs.auditbeat7;
-      defaultText = "pkgs.auditbeat7";
+      default = pkgs.auditbeat7-oss;
+      defaultText = "pkgs.auditbeat7-oss";
       example = literalExample "pkgs.auditbeat7";
       description = ''
         The auditbeat package to use.

--- a/nixos/platform/filebeat.nix
+++ b/nixos/platform/filebeat.nix
@@ -116,8 +116,8 @@ in
 
       package = mkOption {
         type = types.package;
-        default = pkgs."filebeat7";
-        defaultText = "pkgs.filebeat7";
+        default = pkgs.filebeat7-oss;
+        defaultText = "pkgs.filebeat7-oss";
         example = literalExample "pkgs.filebeat7";
         description = ''
           The filebeat package to use.

--- a/nixos/platform/journalbeat.nix
+++ b/nixos/platform/journalbeat.nix
@@ -121,8 +121,8 @@ in
 
         package = mkOption {
           type = types.package;
-          default = pkgs.filebeat7;
-          defaultText = "pkgs.filebeat7";
+          default = pkgs.filebeat7-oss;
+          defaultText = "pkgs.filebeat7-oss";
           example = literalExample "pkgs.filebeat7";
           description = ''
             The filebeat package to use.

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -163,6 +163,16 @@ in {
     ];
   });
 
+  auditbeat7-oss = self.auditbeat7.overrideAttrs(a: a // {
+    name = "auditbeat-oss-${a.version}";
+    preBuild = "rm -rf x-pack";
+  });
+
+  filebeat7-oss = super.filebeat7.overrideAttrs(a: a // {
+    name = "filebeat-oss-${a.version}";
+    preBuild = "rm -rf x-pack";
+  });
+
   # Import old php versions from nix-phps
   inherit (phps) php72 php73;
 


### PR DESCRIPTION
Before building, the x-pack folder is removed from the beats repository
to make sure that the end result is unaffected by proprietary code.
It seems to have no effect on the binary at the moment but this might
change in the future.

 #PL-130528

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Add auditbeat7-oss and filebeat7-oss packages and use them in platform code. They remove unfree code before building the packages to make sure that the result can be used freely without being affected by the Elastic license (#PL-130528).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - no operational impact
  - we have to make sure that we don't include unfree Elastic-licensed code as platform defaults
- [x] Security requirements tested? (EVIDENCE)
  - checked on a test VM that auditbeat and filebeat still run, automated tests work