### PR TITLE
solr: fix by using zlib-patched Java version

### DIFF
--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -308,7 +308,10 @@ in {
   sensu-plugins-redis = super.callPackage ./sensuplugins-rb/sensu-plugins-redis { };
   sensu-plugins-systemd = super.callPackage ./sensuplugins-rb/sensu-plugins-systemd { };
 
+  solr = super.solr.override { jre = self.jdk11_headless; };
+
   temporal_tables = super.callPackage ./postgresql/temporal_tables { };
+
   tideways_daemon = super.callPackage ./tideways/daemon.nix {};
   tideways_module = super.callPackage ./tideways/module.nix {};
 


### PR DESCRIPTION
We already saw similar breakage with ES and Graylog using zlib 1.2.12.
Using our jre11_headless with the zlib patch for the problem also helps
here.

 #PL-130547

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* (add to nixpkgs update block) solr: use patched Java package to fix zlib issue)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
 - fix known zlib problem  
- [x] Security requirements tested? (EVIDENCE)
  - built solr package and ran executable 
