### PR TITLE
nixos-mailserver: pull in upstream, fix for cert reload deadlock

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -7,8 +7,8 @@
   },
   "nixos-mailserver": {
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/",
-    "rev": "32c90985be7ae42736716044f00c28435492a462",
-    "sha256": "0cvpvq13ballwfi0qcq82dc977j5qmgqmwvhrja950wsfkh68dwm",
+    "rev": "001b3caa1a26aaf99cfbc3fd86e883e9d7c8af58",
+    "sha256": "7f99ce7f42164781b02056ed491188c27da200ed1d66571cd365e1b34722efe1",
     "fetchSubmodules": false,
     "deepClone": false,
     "leaveDotGit": false


### PR DESCRIPTION
Use the new security.acme.certs.*.serviceReload option for the
mail cert to avoid deadlocks when postfix is restarting because
of config changes at the same time. This problem sometimes prevented
postfix from starting at all. Reload uses --no-block now so this
shouldn't happen anymore. This change is taken from
https://gitlab.com/simple-nixos-mailserver/nixos-mailserver/-/merge_requests/265

Another upstream change also removed the reload for nginx. This reload
is unneccessary and has probably also contributed to the deadlock problem.

 #PL-130204

@flyingcircusio/release-managers

## Release process

Impact:

* [NixOS 21.11] mailserver: Postfix and dovecot will be restarted. 

Changelog:

* mailserver: fix possible reload deadlock when SSL certificate and mail server configuration change at the same time. We have seen cases where postfix was down because of that problem (#PL-130204). 
* mailserver: use relaxed/relaxed DKIM canonicalization algorithms to avoid invalid signatures when mail providers change whitespace in messages, for example.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
 - postfix has to be available after config changes and cert renewals
 - use recent upstream code for nixos-mailserver and make sure that no problematic changes are introduced by that
- [x] Security requirements tested? (EVIDENCE)
  - looked at upstream changes 
  - checked logs on our test mail server, sent mail from/to web mailer there and test Discourse.