### PR TITLE
Add flyingcircus.allowedUnfreePackageNames as no-op

### DIFF
--- a/nixos/platform/default.nix
+++ b/nixos/platform/default.nix
@@ -60,6 +60,23 @@ in {
       type = types.attrsOf types.unspecified;
     };
 
+    flyingcircus.allowedUnfreePackageNames = mkOption {
+      type = listOf str;
+      description = ''
+        *Has no effect on this platform version but is needed for 21.11*
+        *Add unfree package names here before upgrading to 21.11*
+
+        Names of packages that are allowed to be used regardless of their
+        license. Nix by default denies using packages with licenses considered
+        "unfree" by nixpkgs. Note that unfree packages are not pre-built by
+        cache.nixos.org and have to be pre-built by our hydra.flyingcircus.io
+        (triggered by a NixOS test, defined in pkgs/overlay.nix or listed in
+        release/default.nix includedPkgNames). Otherwise, it will be built
+        directly on the machine using the package.
+      '';
+      default = [];
+    };
+
     flyingcircus.enc_services = mkOption {
       default = [];
       type = listOf attrs;


### PR DESCRIPTION
Has no effect on 21.05 but makes upgrading to 21.11
easier if unfree packages are present. 21.11 requires
this setting.

 #PL-130528

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Add flyingcircus.allowedUnfreePackageNames to make upgrades to 21.11 easier if unfree packages are used. Has no effect on 21.05. (#PL-130528).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - nothing 
- [x] Security requirements tested? (EVIDENCE)
  - checked on a test VM that the option can be defined 
