### PR TITLE
Update nixpkgs

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "1f05f61bc9cb8b49b86780749d9cca46308688a5",
-    "sha256": "02nQpf+ryHwjWv+KYNw9rgO8umzF2KTMHKF3OjSJWlY="
+    "rev": "d3e12dc2e63ea7a0c3724e7b7031e56e5ed553f7",
+    "sha256": "kv2KmdfaKhC11uxJNuLp3H/xQiI8Dg15yJp/AnYIPd0="
   },
   "nixos-mailserver": {
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/",


### PR DESCRIPTION
Update nixpkgs and fix gitlab-registry-cert service

Includes a fix to avoid recreating the Gitlab registry cert.

Notable security updates and version changes:

* cifs-utils: fix information disclosure in logger (CVE-2022-29869)
* cifs-utils: patch buffer-overflow in ip param handling (CVE-2022-27239)
* docker: 20.10.13 -> 20.10.14
* element-web: 1.10.10 -> 1.10.11
* git: 2.33.1 -> 2.33.3 (CVE-2022-24765)
* gitlab: 14.9.2 -> 14.9.3
* grafana: 8.4.6 -> 8.4.7
* gzip: 1.11 -> 1.12 (CVE-2022-1271)
* imagemagick: 7.1.0-26 -> 7.1.0-31
* libarchive: add patches for CVE-2022-26280, OSS Fuzz issue 38764
* libtiff: add patches for multiple CVEs (CVE-2022-0891, CVE-2022-0865, CVE-2022-0924, CVE-2022-0907, CVE-2022-0909, CVE-2022-0908)
* linux: 5.10.111 -> 5.10.113
* matrix-synapse: 1.56.0 -> 1.57.0
* nginxStable: add patch for CVE-2021-3618
* openjdk: 11.0.12+7 -> 11.0.15.+10
* openjdk: 17.0.1+12 -> 17.0.3.+7
* python310: 3.10.3 -> 3.10.4
* python39: 3.9.11 -> 3.9.12
* ruby_2_7: 2.7.5 -> 2.7.6 (CVE-2022-28739)
* ruby_3_0: 3.0.3 -> 3.0.4 (CVE-2022-28738, CVE-2022-28739)

 #PL-130595



@flyingcircusio/release-managers

## Release process

Impact:

* [NixOS 21.11] Most services will be restarted because of a core dependency change. Machines will schedule a reboot to activate the changed kernel.

Changelog: (include changes from commit msg here)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - pull in upstream security fixes regularly
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still run, works on test VM
  - checked commit log for fixed CVEs and possible problems with updates, checked matrix-synapse release notes
  - checked on gitlab staging VM that Gitlab registry cert service doesn't regenerate all the time anymore