### PR TITLE
lamp: disable proxy reuse to avoid apache confusing the fpm pools

### DIFF
--- a/pkgs/tideways/daemon.nix
+++ b/pkgs/tideways/daemon.nix
@@ -2,7 +2,7 @@
 
 assert stdenv.hostPlatform.system == "x86_64-linux";
 
-let version = "1.6.32"; in
+let version = "1.7.28"; in
 
 stdenv.mkDerivation {
   name = "tideways-daemon-${version}";
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "https://s3-eu-west-1.amazonaws.com/tideways/daemon/${version}/tideways-daemon_linux_amd64-${version}.tar.gz";
-    sha256 = "0ksnq6z89n9y8qyd46slia5ykqiwz7qvw53c9f9cyjbfbkqkzzzc";
+    sha256 = "sha256-9FezE7/yYiZmYC3PjPNMR6Lt0sqa5PMB2q3GK0H+1bY";
   };
 
   meta = {

--- a/pkgs/tideways/module.nix
+++ b/pkgs/tideways/module.nix
@@ -2,7 +2,7 @@
 
 assert stdenv.hostPlatform.system == "x86_64-linux";
 
-let version = "5.3.20"; in
+let version = "5.4.42"; in
 
 stdenv.mkDerivation {
   name = "tideways-php-module-${version}";
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "https://s3-eu-west-1.amazonaws.com/tideways/extension/${version}/tideways-php-${version}-x86_64.tar.gz";
-    sha256 = "00l8vn37kn8qp742rhcs7pq6cwkqijllg5m68ajxx9gh9j5h08nk";
+    sha256 = "sha256-3o6jaH4AlHqa7/HEjKToVyTTFOffntYI8dy5QUXcYus";
   };
 
   meta = {

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -56,7 +56,9 @@ in {
   lamp74 = callTest ./lamp.nix { version = "lamp_php74"; };
   lamp74_tideways = callTest ./lamp.nix { version = "lamp_php74"; tideways = "1234"; };
   lamp80 = callTest ./lamp.nix { version = "lamp_php80"; };
-  lamp80_tideways = callTest ./lamp.nix { version = "lamp_php80"; tideways = "1234"; };
+
+  # currently not supported: PL-130612
+  # lamp80_tideways = callTest ./lamp.nix { version = "lamp_php80"; tideways = "1234"; };
 
   locale = callTest ./locale.nix {};
   login = callTest ./login.nix {};


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Fix an Apache FPM configuration issue: FPM pools would get confused and keepalive connections could  block workers indefinitely. Disable FPM proxy connection reuse. (PL-130609)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

no specific requirements

- [x] Security requirements tested? (EVIDENCE)

covered by existing and new integration tests