### PR TITLE
Update nixpkgs for gitlab 14.9.4

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "d3e12dc2e63ea7a0c3724e7b7031e56e5ed553f7",
-    "sha256": "kv2KmdfaKhC11uxJNuLp3H/xQiI8Dg15yJp/AnYIPd0="
+    "rev": "7336576854f45032a04636b1d8fa86db5c6ba7a0",
+    "sha256": "vdbFifme34pCCOaFSdK/47thDE9cpvJVawFCGN0MhcY="
   },
   "nixos-mailserver": {
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/",


### PR DESCRIPTION
Security update with medium severity

Taken from an upstream nixpkgs PR.

[nixpkgs changes](https://github.com/flyingcircusio/nixpkgs/compare/d3e12dc2e63ea7a0c3724e7b7031e56e5ed553f7...7336576854f45032a04636b1d8fa86db5c6ba7a0) 

 #PL-130610

@flyingcircusio/release-managers

## Release process

Impact:

* [NixOS 21.11] Gitlab will be restarted and unavailable for a short period of time.

Changelog:

* Gitlab: 14.9.3 -> 14.9.4 (#PL-130610).

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - use a current Gitlab version with the latest security fixes
- [x] Security requirements tested? (EVIDENCE)
  - 14.9.4 is the most recent patch release and fixes security issue with medium severity
  - manually tested on staging Gitlab instance
  - automated test still runs