### PR TITLE
fix incorrect unit, leading to 10p vm images

### DIFF
--- a/pkgs/fc/ceph/fc/ceph/images.py
+++ b/pkgs/fc/ceph/fc/ceph/images.py
@@ -225,7 +225,15 @@ class BaseImage:
     def store_in_ceph(self, img):
         """Updates image data from uncompressed image file."""
         logger.info(f"\tStoring in volume {self.volume}")
-        run(["rbd", "resize", "-s", str(os.stat(img).st_size), self.volume])
+        run(
+            [
+                "rbd",
+                "resize",
+                "-s",
+                str(os.stat(img).st_size) + "B",
+                self.volume,
+            ]
+        )
         with self.mapped() as blockdev:
             delta_update(img, blockdev)
 


### PR DESCRIPTION
no unit on CLI means MiB as the unit. the former API uses integers
representing bytes without units so this caused us to create 10P volumes
accidentally.

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - nothing new, we just don't want to break our ceph with large images 
- [x] Security requirements tested? (EVIDENCE)
  - manually ran rbd resize command to check if we use the right unit suffix now