### PR TITLE
Update nixpkgs

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "7336576854f45032a04636b1d8fa86db5c6ba7a0",
-    "sha256": "vdbFifme34pCCOaFSdK/47thDE9cpvJVawFCGN0MhcY="
+    "rev": "45595e44034670ebfd06c9a62f63170be974f354",
+    "sha256": "t6niQHCGIpsfbdsWgfhou6q32BDn63zLDGmbB2wWcSk="
   },
   "nixos-mailserver": {
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/",


### PR DESCRIPTION
Update nixpkgs

Notable security updates and version changes:

* cacert: 3.74 -> 3.77
* curl: backport security patches from 7.83.0 (CVE-2022-22576,
  CVE-2022-27774, CVE-2022-27775, CVE-27776)
* element-web: 1.10.11 -> 1.10.12
* ghostscript: add patches for CVE-2021-45944 & CVE-2021-45949
* haproxy: 2.3.14 -> 2.3.18
* imagemagick: 7.1.0-31 -> 7.1.0-33
* libxml2: Backport CVE fixes from v2.9.13 and v2.9.14 (CVE-2022-29824,
  CVE-2022-23308)
* linux: 5.10.113 -> 5.10.115
* openssl_3_0: 3.0.2 -> 3.0.3 (CVE-2022-1292, CVE-2022-1434,
  CVE-2022-1473, CVE-2022-1343)
* openssl_1_1: 1.1.1n -> 1.1.1o (CVE-2022-1292)
* redis: 6.2.6 -> 6.2.7
* runc: fix CVE-2022-29162
* zsh: 5.8 -> 5.8.1 (CVE-2021-45444)

 #PL-130636




@flyingcircusio/release-managers

## Release process

Impact:

* [NixOS 21.11] Most services will be restarted because of a core dependency change. Machines will schedule a reboot to activate the changed kernel.

Changelog: (include changes from commit msg here)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - pull in upstream security fixes regularly
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still run, works on test VM
  - checked commit log for fixed CVEs and possible problems with updates, especially haproxy and redis