### PR TITLE
antivirus: make database updates and monitoring more reliable

### DIFF
--- a/nixos/platform/default.nix
+++ b/nixos/platform/default.nix
@@ -267,6 +267,7 @@ in {
         # TODO: replace this when on 22.05.
         "mongodb"
       ];
+      services.sensu-client.mutedSystemdUnits = [ "logrotate.service" ];
     };
 
     # implementation for flyingcircus.passwordlessSudoRules

--- a/nixos/platform/garbagecollect/default.nix
+++ b/nixos/platform/garbagecollect/default.nix
@@ -30,12 +30,14 @@ in {
 
     (mkIf cfg.agent.collect-garbage {
 
-      flyingcircus.services.sensu-client.checks.fc-collect-garbage = {
-        notification = "nix-collect-garbage stamp recent";
-        command = ''
-          ${pkgs.monitoring-plugins}/bin/check_file_age \
-            -f ${log} -w 216000 -c 432000
-        '';
+      flyingcircus.services.sensu-client = {
+        mutedSystemdUnits = [ "fc-collect-garbage.service" ];
+        checks.fc-collect-garbage = {
+          notification = "nix-collect-garbage stamp recent";
+          command =
+            "${pkgs.monitoring-plugins}/bin/check_file_age"
+            + " -f ${log} -w 216000 -c 432000";
+        };
       };
 
       systemd.services.fc-collect-garbage = {

--- a/nixos/services/sensu/client.nix
+++ b/nixos/services/sensu/client.nix
@@ -285,6 +285,12 @@ in {
           description = "Limit of swap usage in MiB before reaching critical.";
         };
       };
+      mutedSystemdUnits = mkOption {
+        type = types.listOf types.str;
+        description = "Units that may fail without triggering the check for failed systemd unit.";
+        example = [ "failing-testunit.service" ];
+
+      };
     };
   };
 
@@ -468,11 +474,9 @@ in {
         };
         systemd_units = {
           notification = "systemd has failed units";
-          command = ''
-            ${pkgs.sensu-plugins-systemd}/bin/check-failed-units.rb \
-              -m logrotate.service \
-              -m fc-collect-garbage.service
-          '';
+          command =
+            "${pkgs.sensu-plugins-systemd}/bin/check-failed-units.rb"
+            + (lib.concatMapStrings (u: " -m ${u}") cfg.mutedSystemdUnits);
         };
         disk = {
           notification = "Disk usage too high";

--- a/pkgs/fc/sensuplugins/fc/sensuplugins/clamav_database.py
+++ b/pkgs/fc/sensuplugins/fc/sensuplugins/clamav_database.py
@@ -1,0 +1,77 @@
+import sys
+from pathlib import Path
+from subprocess import run
+
+
+def main():
+    database_dir = Path("/var/lib/clamav")
+    cld_daily = database_dir / "daily.cld"
+    cvd_daily = database_dir / "daily.cvd"
+
+    warnings = []
+    errors = []
+    other_output = []
+
+    if not cld_daily.exists() and not cvd_daily.exists():
+        print("clamav database CRITICAL: daily.c?d file missing!")
+        sys.exit(2)
+
+    if cld_daily.exists() and cvd_daily.exists():
+        warnings.append(
+            "clamav database WARNING: both daily.cld and daily.cvd exist. "
+            "This is unexpected for normal operations, please check."
+        )
+
+    check_age_cmd = [
+        "check_file_age",
+        "-w",
+        "86400",
+        "-c",
+        "172800",
+    ]
+
+    max_returncode = 0
+
+    if cld_daily.exists():
+        proc = run(check_age_cmd + [cld_daily], capture_output=True, text=True)
+
+        max_returncode = max(max_returncode, proc.returncode)
+        out = proc.stdout.strip()
+
+        if proc.returncode == 2:
+            errors.append(out)
+        elif proc.returncode == 1:
+            warnings.append(out)
+        else:
+            other_output.append(out)
+
+    if cvd_daily.exists():
+        proc = run(check_age_cmd + [cvd_daily], capture_output=True, text=True)
+
+        max_returncode = max(max_returncode, proc.returncode)
+        out = proc.stdout.strip()
+
+        if proc.returncode == 2:
+            errors.append(out)
+        elif proc.returncode == 1:
+            warnings.append(out)
+        else:
+            other_output.append(out)
+
+    if errors:
+        print(" | ".join(errors + warnings))
+        sys.exit(2)
+
+    if warnings:
+        print(" | ".join(warnings))
+        sys.exit(1)
+
+    # Can be:
+    # * Normal (0, OK) exit when only one of the files exists and is recent.
+    # * At least one unexpected error code > 2 when checking the files.
+    print(" | ".join(other_output))
+    sys.exit(max_returncode)
+
+
+if __name__ == "__main__":
+    main()

--- a/pkgs/fc/sensuplugins/setup.py
+++ b/pkgs/fc/sensuplugins/setup.py
@@ -15,6 +15,7 @@ setup(
     install_requires=["PyYAML", "nagiosplugin", "psutil", "requests"],
     entry_points={
         "console_scripts": [
+            "check_clamav_database=fc.sensuplugins.clamav_database:main",
             "check_disk=fc.sensuplugins.disk:main",
             "check_cpu_steal=fc.sensuplugins.cpu:main",
             "check_journal_file=fc.sensuplugins.journalfile:main",


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* antivirus: make database updates and monitoring more reliable. We now use our own clamav mirror now to avoid issues with rate-limiting by the official mirrors. For new installations, the initial database fetch is done immediately now so clamav should work right from the start (#PL-130648).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - make sure that the clamav signature database is updated at least every day
  - database updates should be fetched via SSL
- [x] Security requirements tested? (EVIDENCE)
  - manually checked on a test VM that the private mirror works for inital database downloads and updates 
  - ran the sensu database check script on a test VM with simulated cases (both files exist => warning, one or two files outdated but still within one day => warning, one or two files older than 2 days => error, one file exists => ok)
  - we use a https URL to connect to the private mirror