### PR TITLE
antivirus: quick and reliable database initialization

### DIFF
--- a/nixos/roles/antivirus.nix
+++ b/nixos/roles/antivirus.nix
@@ -39,10 +39,40 @@ in
       };
     };
 
-    systemd.services.clamav-daemon.serviceConfig = {
-      PrivateTmp = lib.mkForce "no";
-      PrivateNetwork = lib.mkForce "no";
-      Restart = "always";
+    systemd.services.clamav-daemon = {
+      serviceConfig = {
+        PrivateTmp = lib.mkForce "no";
+        PrivateNetwork = lib.mkForce "no";
+        Restart = "always";
+      };
+
+      unitConfig = {
+        # Only start clamav when required database files are present.
+        # Taken from the service template from the clamav repo.
+        ConditionPathExistsGlob = [
+          "/var/lib/clamav/main.{c[vl]d,inc}"
+          "/var/lib/clamav/daily.{c[vl]d,inc}"
+        ];
+      };
+    };
+
+    systemd.services.clamav-init-database = {
+      # Shouldn't have a dependency on clamav-freshclam to avoid unneccessary
+      # starts. For example, using `requires would always trigger freshclam
+      # when the daemon (re)starts, causing unwanted startup delays.
+      wantedBy = [ "clamav-daemon.service" ];
+      before = [ "clamav-daemon.service" ];
+      # This is a blocking call so we can be sure that the database
+      # has been created before starting the daemon.
+      serviceConfig.ExecStart = "systemctl start clamav-freshclam";
+      unitConfig = {
+        # Opposite condition of clamav-daemon: only run this service if
+        # database files are not present.
+        ConditionPathExistsGlob = [
+          "!/var/lib/clamav/main.{c[vl]d,inc}"
+          "!/var/lib/clamav/daily.{c[vl]d,inc}"
+        ];
+      };
     };
 
     services.clamav.updater = {
@@ -53,16 +83,23 @@ in
       };
     };
 
-    systemd.services.clamav-freshclam.serviceConfig = {
-      # Ignore various error cases to avoid breaking fc-manage if the
-      # timer fails during the rebuild.
-      # The list is mostly taken from the freshclam manpage.
-      # We added 11 which is used when rate limiting hits.
-      SuccessExitStatus = lib.mkForce [ 11 40 50 51 52 53 54 55 56 57 58 59 60 61 62 ];
+    systemd.services.clamav-freshclam = {
+      # By using `wants` here, the daemon is started after the freshclam run
+      # if the daemon unit is not active yet, probably because of missing
+      # database files.
+      # nixpkgs already sets `after` in clamav-daemon so the startup order
+      # is correct.
+      wants = [ "clamav-daemon.service" ];
+      serviceConfig = {
+        # Ignore various error cases to avoid breaking fc-manage if the
+        # timer fails during the rebuild.
+        # The list is mostly taken from the freshclam manpage.
+        # We added 11 which is used when rate limiting hits.
+        SuccessExitStatus = lib.mkForce [ 11 40 50 51 52 53 54 55 56 57 58 59 60 61 62 ];
+      };
     };
 
     systemd.timers.clamav-freshclam.timerConfig = {
-      OnActiveSec = "10";
       # upstream default is to run the timer hourly but in our case too many VMs
       # try to run at the same time. Randomize the timer to run somewhere in the
       # 1 hour window.


### PR DESCRIPTION
With the previous PR, the clamav daemon still may crash on the first
run because the database is not preset yet.

Setting OnActiveSec to a low value or even 0 for the freshclam timer
doesn't help when randomization is active which delays the
start for up to 60 minutes.

The new solution here introduces a new unit which is only triggered
when the required database files are absent. The opposite condition
prevents the daemon from starting and crashing instantly, until the
database fetch is finished.

 #PL-130648

@flyingcircusio/release-managers

Follow up to PR #548 which didn't fix the initialization problems properly.

## Release process

Impact:

Changelog:

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - same as before, we just want faster and more reliable startup when initializing the role
- [x] Security requirements tested? (EVIDENCE)
  - checked on a test VM that service dependencies do the right thing: it sets up the database before clamav daemon starts and doesn't trigger database updates if not needed
  - automated test now checks that the sensu database check handles basic cases correctly and update timer is present.