### PR TITLE
[21.05] ceph: fix cleanup of old image versions

### DIFF
--- a/pkgs/fc/ceph/fc/ceph/images.py
+++ b/pkgs/fc/ceph/fc/ceph/images.py
@@ -341,12 +341,11 @@ class BaseImage:
         snaps = run_rbd("snap", "ls", self.volume)
         snaps.sort(key=lambda x: x["id"])
         for snap in snaps[:-3]:
-            logger.info(
-                "\tPurging snapshot {}@{}".format(self.volume, snap["name"])
-            )
+            snap_spec = self.volume + "@" + snap["name"]
+            logger.info("\tPurging snapshot " + snap_spec)
             try:
-                run(["rbd", "snap", "unprotect", self.volume + snap["name"]])
-                run(["rbd", "snap", "rm", self.volume + snap["name"]])
+                run(["rbd", "snap", "unprotect", snap_spec])
+                run(["rbd", "snap", "rm", snap_spec])
             except Exception:
                 logger.exception("Error trying to purge snapshot:")
 


### PR DESCRIPTION
While rewriting the code from using Ceph API to CLI calls,
the "@" between image and snapshot name was forgotten so cleaning
up old image snapshots didn't work at all.

 #PL-130633

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* (internal change)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - clean up old images so that our ceph cluster doesn't run full  
- [x] Security requirements tested? (EVIDENCE)
  - trivial change, wil check later in dev when it's merged (checked now)