### PR TITLE
Update nixpkgs

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "45595e44034670ebfd06c9a62f63170be974f354",
-    "sha256": "t6niQHCGIpsfbdsWgfhou6q32BDn63zLDGmbB2wWcSk="
+    "rev": "397669babd51cebd19b07e3f70fd4b6960f0fb1a",
+    "sha256": "laJBzNX07O8YPEvcJGWGD3pDttOmnG6AqZQFVbsO3Xc="
   },
   "nixos-mailserver": {
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/",


### PR DESCRIPTION
Update nixpkgs

Notable security updates and version changes:

* clamav: 0.103.5 -> 0.103.6
* curl: add patches for CVE-2022-27781 & CVE-2022-27782
* grafana: fix CVE-2022-29170
* imagemagick: 7.1.0-33 -> 7.1.0-35
* linux: 5.10.115 -> 5.10.118
* logrotate: fix CVE-2022-1348
* matrix-synapse: 1.57.0 -> 1.59.1
* podman: add patch for CVE-2022-27649
* postgresql_10: 10.20 -> 10.21 (CVE-2022-1552)
* postgresql_11: 11.15 -> 11.16 (CVE-2022-1552)
* postgresql_12: 12.10 -> 12.11 (CVE-2022-1552)
* postgresql_13: 13.6 -> 13.7 (CVE-2022-1552)
* postgresql_14: 14.2 -> 14.3 (CVE-2022-1552)

 #PL-130662


@flyingcircusio/release-managers

## Release process

## Impact

* [NixOS 21.11] Most services will be restarted because of a core dependency change. Machines will schedule a reboot to activate the changed kernel.

Changelog: (include changes from commit msg here)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - pull in upstream security fixes regularly
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still run, works on test VM
  - checked commit log for fixed CVEs and possible problems with updates, looked at Synapse release notes