### PR TITLE
adjust disk check limits to elasticsearch watermark defaults if elast…

### DIFF
--- a/nixos/roles/elasticsearch.nix
+++ b/nixos/roles/elasticsearch.nix
@@ -172,6 +172,14 @@ in
       '');
     };
 
+    flyingcircus.services.sensu-client = {
+      expectedDiskCapacity = {
+        # same as https://www.elastic.co/guide/en/elasticsearch/reference/7.17/modules-cluster.html#disk-based-shard-allocation
+        warning = 85;
+        critical = 90;
+      };
+    };
+
     systemd.services.elasticsearch = {
       startLimitIntervalSec = 480;
       startLimitBurst = 3;


### PR DESCRIPTION
adjust disk check limits to elasticsearch watermark defaults if elasticsearch is enabled

This is the most minimal way to do adjust this afaik

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - no new code sources added, just adjusted check-limits with pre-built config options
- [x] Security requirements tested? (EVIDENCE)
  - Ran tests/elasticsearch.nix
