### PR TITLE
[21.05] elasticsearch: add dummy option single_node

### DIFF
--- a/nixos/roles/elasticsearch.nix
+++ b/nixos/roles/elasticsearch.nix
@@ -130,6 +130,16 @@ in
       enable = mkEnableOption "Enable the Flying Circus elasticsearch7 role.";
       supportsContainers = fclib.mkEnableContainerSupport;
     };
+
+    # Dummy option that does nothing on 21.05 to make upgrades to 21.11
+    # easier.
+    # Set it to false before upgrading multi-node clusters!
+    # On 21.11, the option is required and has `true` as default which splits
+    # multi-node clusters.
+    # This behaviour breaks indices that have replicas and they cannot be
+    # recovered.
+    services.elasticsearch.single_node = mkOption {};
+
   };
 
   config = lib.mkMerge [


### PR DESCRIPTION
Add a dummy option that does nothing on 21.05 to make upgrades to 21.11
easier.  Set it to false before upgrading multi-node clusters! On
21.11, the option is required and has `true` as default which splits
multi-node clusters.  This behaviour breaks indices that have replicas
and they cannot be recovered.

 #PL-130608

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Elasticsearch: add dummy option `services.elasticsearch.single_node` which does nothing on 21.05 but is required on 21.11 to make upgrades easier. On 21.11, the option has `true` as default which breaks multi-node clusters on upgrade. Make sure to set the option to `false` on 21.05 before upgrading such clusters!

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - option does nothing here, only relevant on 21.11 
- [x] Security requirements tested? (EVIDENCE)
  - checked on a test VM that defining the option works