### PR TITLE
[20.09] add MIT license to whole repo

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,0 +1,7 @@
+Copyright 2018-2022 Flying Circus Internet Operations GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -85,3 +85,9 @@ Update nixpkgs version
 1. Update rev id in versions.json and zero out sha256
 2. Run `nix-build versions.nix` to get the correct checkout
 3. Fix checksum and run `eval $(./dev-setup)` to activate.
+
+
+License
+-------
+
+Unless explicitly stated otherwise, content in this repository is licensed under the [MIT License](COPYING).


### PR DESCRIPTION
Add information about code licensing for repo content. Time frame has
been chosen starting at the year of the first commit 2018, as upstream
nixpkgs compatibility was always implicitly assumed from the start.

@flyingcircusio/release-managers

## Release process

Impact: none, except for clarifying the legal situation

Changelog:

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [x] Security requirements tested? There is nothing to be tested.
