### PR TITLE
Update nixpkgs

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "397669babd51cebd19b07e3f70fd4b6960f0fb1a",
-    "sha256": "laJBzNX07O8YPEvcJGWGD3pDttOmnG6AqZQFVbsO3Xc="
+    "rev": "72016e3b3fffeb5e76bb106f3a05007597186a29",
+    "sha256": "NFFuYh4lKMfZHTlLQp9auFx0i1mUeAe9dzr97XG7vh0="
   },
   "nixos-mailserver": {
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/",


### PR DESCRIPTION
Update nixpkgs

Notable security updates and version changes:

* apacheHttpd: 2.4.53 -> 2.4.54  (CVE-2022-31813, CVE-2022-30556, 
  CVE-2022-30522, CVE-2022-29404, CVE-2022-28615, CVE-2022-28614, 
  CVE-2022-28330, CVE-2022-26377)
* gitlab: 14.9.4 -> 14.9.5
* imagemagick: 7.1.0-35 -> 7.1.0-37
* libtiff: add patches for CVE-2022-1354 & CVE-2022-1355
* linux: 5.10.118 -> 5.10.121
* python39: 3.9.12 -> 3.9.13
* vim: 8.2.4816 -> 8.2.4975

 #PL-130684


@flyingcircusio/release-managers

## Release process

Impact:

* [NixOS 21.11] Apache and Gitlab will be restarted. Machines will schedule a reboot to activate the changed kernel.

Changelog: (include changes from commit msg here)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - pull in upstream security fixes regularly
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still run, works on test VM
  - checked commit log for fixed CVEs and possible problems with updates, checked Apache changelog
