### PR TITLE
PL-129904 remove check_load from sensu checks since its alerts are not useful

### DIFF
--- a/nixos/services/sensu/client.nix
+++ b/nixos/services/sensu/client.nix
@@ -428,13 +428,13 @@ in {
         #     "io";
         #   interval = 10;
         # };
-        load = {
-          notification = "Load is too high";
-          command =
-            "check_load -r -w ${cfg.expectedLoad.warning} " +
-            "-c ${cfg.expectedLoad.critical}";
-          interval = 10;
-        };
+        # load = {
+        #   notification = "Load is too high";
+        #   command =
+        #     "check_load -r -w ${cfg.expectedLoad.warning} " +
+        #     "-c ${cfg.expectedLoad.critical}";
+        #   interval = 10;
+        # };
         swap = {
           notification = "Swap usage is too high";
           command =


### PR DESCRIPTION
@flyingcircusio/release-managers
PL-129904

Commented out the sensu check since we decided that its alerts are not useful

Could also be stripped out, together with a provisional psi check that was also decided to be non-useful

might be useful for documentating the history though or having a snippet avaliable for customer specific deployments

## Release process

Impact:

none

Changelog:

* Stop checking `load` from Sensu: it has proven to not be a good predictor for problems. (PL-129904)
  We recently added pressure stall information (PSI) to our VM dashboards which are more fine-grained and can be used combined with traditional load for analysing issues but neither is qualified to be used for alerting.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - sensu check for load was decided to be non-useful -> commented out
  - no new code or logic introduced 
- [x] Security requirements tested? (EVIDENCE)
  - built test vm with commented out test, no problems noticed 
