### PR TITLE
lamp: update tideways module to 5.5.3 as recommended by Tideways support

### DIFF
--- a/nixos/roles/lamp.nix
+++ b/nixos/roles/lamp.nix
@@ -261,11 +261,6 @@ in {
 
       (lib.mkIf (role.tideways_api_key != "") {
 
-        assertions = [ {
-            assertion = (lib.toInt phpMajor) < 8;
-            message = "Tideways is currently not supported on PHP 8 due to stability issues. (PL-130612)";
-        }];
-
         # tideways daemon
         users.groups.tideways.gid = config.ids.gids.tideways;
 

--- a/pkgs/tideways/module.nix
+++ b/pkgs/tideways/module.nix
@@ -2,7 +2,7 @@
 
 assert stdenv.hostPlatform.system == "x86_64-linux";
 
-let version = "5.4.42"; in
+let version = "5.5.6"; in
 
 stdenv.mkDerivation {
   name = "tideways-php-module-${version}";
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "https://s3-eu-west-1.amazonaws.com/tideways/extension/${version}/tideways-php-${version}-x86_64.tar.gz";
-    sha256 = "sha256-3o6jaH4AlHqa7/HEjKToVyTTFOffntYI8dy5QUXcYus";
+    sha256 = "sha256-7i5EkprZL9TCPfgTdOrdmOeT8zX4awxmPN9GfrpgRtM";
   };
 
   meta = {

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -56,7 +56,9 @@ in {
   lampVm74 = callTest ./lamp/vm-test.nix { version = "lamp_php74"; };
   lampVm74_tideways = callTest ./lamp/vm-test.nix { version = "lamp_php74"; tideways = "1234"; };
   lampVm80 = callTest ./lamp/vm-test.nix { version = "lamp_php80"; };
+  lampVm80_tideways = callTest ./lamp/vm-test.nix { version = "lamp_php80"; tideways = "1234"; };
   lampVm81 = callTest ./lamp/vm-test.nix { version = "lamp_php81"; };
+  lampVm81_tideways = callTest ./lamp/vm-test.nix { version = "lamp_php81"; tideways = "1234"; };
 
   # lampPackage = callTest ./lamp/package-test.nix { };
   # lampPackage72 = callTest ./lamp/package-test.nix { version = "lamp_php72"; };
@@ -66,9 +68,6 @@ in {
   lampPackage80 = callTest ./lamp/package-test.nix { version = "lamp_php80"; };
   lampPackage81 = callTest ./lamp/package-test.nix { version = "lamp_php81"; };
 
-
-  # currently not supported: PL-130612
-  # lamp80_tideways = callTest ./lamp/vmTest.nix { version = "lamp_php80"; tideways = "1234"; };
 
   locale = callTest ./locale.nix {};
   login = callTest ./login.nix {};


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

None

Changelog:

* Unblock use of PHP 8 with Tideways after fixing a known repeatable crash (PL-130612)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

Availability is the security objective here and we used to disable PHP8 + Tideways. With the fixed version we can reenable it.

- [x] Security requirements tested? (EVIDENCE)

Re-enabled automated test proves stability.