### PR TITLE
Update nixpkgs & gitlab

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "72016e3b3fffeb5e76bb106f3a05007597186a29",
-    "sha256": "NFFuYh4lKMfZHTlLQp9auFx0i1mUeAe9dzr97XG7vh0="
+    "rev": "f4cf82996be177196cb28d234b28ba111bae98fc",
+    "sha256": "ituvQrk0Il9OnudqN6CH40qfqI5bMP4AB2RPYum3Dr8="
   },
   "nixos-mailserver": {
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/",


### PR DESCRIPTION
Update nixpkgs, update gitlab

Pull upstream NixOS changes that include security fixes and other
updates, update Gitlab (#PL-130706, #PL-130730):

* gitlab: 14.9.5 -> 14.10.5
* imagemagick: 7.1.0-37 -> 7.1.0-39
* linux: 5.10.121 -> 5.10.124
* matrix-synapse: 1.59.1 -> 1.61.1
* nspr: 4.32 -> 4.34
* nss_latest: 3.78 -> 3.80


@flyingcircusio/release-managers

## Release process

Impact:

Changelog: (include changes from commit msg here)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - pull in upstream security fixes regularly
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still run, works on test VM
  - checked commit log for fixed CVEs and possible problems with updates, checked [matrix-synapse update notes](https://github.com/matrix-org/synapse/blob/develop/docs/upgrade.md)
