### PR TITLE
k3s: fix apiserver sensu check

### DIFF
--- a/nixos/roles/k3s/server.nix
+++ b/nixos/roles/k3s/server.nix
@@ -116,7 +116,7 @@ in {
       kube-apiserver = {
         notification = "Kubernetes API server is not working";
         command = ''
-          ${pkgs.monitoring-plugins}/bin/check_http -j HEAD -H localhost -p 10251 -u /metrics
+          ${pkgs.monitoring-plugins}/bin/check_http -j HEAD -H localhost -p 6443 --ssl -e HTTP/1.1
         '';
       };
 


### PR DESCRIPTION
Check apiserver availability by trying to connect to the API endpoint at
port 6443.

The metrics endpoint at port 10251 that was previously used for that has
been removed since k3s 1.21.

 #PL-130641

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* k3s: fix apiserver availability check (#PL-130641).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  -  only monitoring: we want to see if the k3s apiserver is available  
- [x] Security requirements tested? (EVIDENCE)
  - Verified on the k3s test cluster that the check works 
