### PR TITLE
[21.05] netboot-installer: fall back to ATA IDs if no WWN is available

### DIFF
--- a/release/netboot-installer.nix
+++ b/release/netboot-installer.nix
@@ -132,7 +132,9 @@ __EOF__
 
 
 root_disk_wwn=""
-for x in /dev/disk/by-id/wwn-*; do
+# get unique root disk ID to be used in bootloader later
+# not all disks are able to export a WWN ID, fall back to ATA ID
+for x in /dev/disk/by-id/wwn-* /dev/disk/by-id/ata-*; do
   if [ "$(realpath $x)" == "''${root_disk}" ]; then
     root_disk_wwn=$x
     break


### PR DESCRIPTION
`fc-install` relies on extracting the WWN of disks for having a reliable
unique identifier to hand to the bootloader. Unfortunately, some disks
e.g from Transcend do not export their WWN via `/dev/disk/by-id/wwn-*`.

For these cases, this commit adds a fallback of using their `ata-*` IDs.

This issue was found while handling PL-130733.

@flyingcircusio/release-managers

## Release process

Impact:
internal installer tooling fixes, only relevant for our physical machines

Changelog:
none

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? Not a security-relevant change, ata IDs are expected to be uniquely random as well 
- [x] Security requirements tested? Did a successful install on kyle14 which required this fix.
