### PR TITLE
Update nixpkgs

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "f4cf82996be177196cb28d234b28ba111bae98fc",
-    "sha256": "ituvQrk0Il9OnudqN6CH40qfqI5bMP4AB2RPYum3Dr8="
+    "rev": "51f03c41bdf023e305f7a48205b191cceb67ead7",
+    "sha256": "sKTF4cjt8BOKuypJVpUKRQdsSdWO6qY4hgEiZB4ZPF4="
   },
   "nixos-mailserver": {
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/",


### PR DESCRIPTION
Update nixpkgs

Notable security updates and version changes:

* linux: 5.10.124 -> 5.10.126

 #PL-130744


@flyingcircusio/release-managers

## Release process

Impact:

* [NixOS 21.11] Machines will schedule a reboot to activate the changed kernel.

Changelog: (include changes from commit msg here)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - pull in upstream security fixes regularly
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still run, works on test VM
  - checked commit log for fixed CVEs and possible problems with updates