### PR TITLE
java: use crc32-patched zlib for more openjdk variants

### DIFF
--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -158,8 +158,10 @@ in {
     '';
   });
 
-  jdk8_headless = super.jdk8_headless.override { zlib = self.zlibCrcInputFix; };
-  jdk11_headless = super.jdk11_headless.override { zlib = self.zlibCrcInputFix; };
+  # This also propagates to the jre* and *_headless variants.
+  openjdk8 = super.openjdk8.override { zlib = self.zlibCrcInputFix; };
+  openjdk11 = super.openjdk11.override { zlib = self.zlibCrcInputFix; };
+  openjdk17 = super.openjdk17.override { zlib = self.zlibCrcInputFix; };
 
   inherit (super.callPackages ./matomo {})
     matomo
@@ -349,6 +351,6 @@ in {
   xtrabackup = self.percona-xtrabackup_8_0;
 
   zlibCrcInputFix = super.zlib.overrideAttrs(a: {
-    patches = [ ./zlib-1.12.12-incorrect-crc-inputs-fix.patch  ];
+    patches = a.patches ++ [ ./zlib-1.12.12-incorrect-crc-inputs-fix.patch ];
   });
 }

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -43,6 +43,7 @@ in {
 
   graylog = callTest ./graylog.nix {};
   haproxy = callTest ./haproxy.nix {};
+  java = callTest ./java.nix {};
   journal = callTest ./journal.nix {};
   kernelconfig = callTest ./kernelconfig.nix {};
   kibana6 = callTest ./kibana.nix { version = "6"; };

--- a/tests/java.nix
+++ b/tests/java.nix
@@ -1,0 +1,81 @@
+import ./make-test-python.nix ({ pkgs, testlib, ... }:
+{
+  name = "java";
+
+  nodes = {
+    machine =
+      { pkgs, config, ... }:
+      {
+        imports = [
+          (testlib.fcConfig { })
+        ];
+      };
+    };
+
+  testScript = ''
+    start_all()
+
+    patched_zlib = "${pkgs.zlibCrcInputFix}"
+
+    jdk = "${pkgs.jdk}"
+    jdk11 = "${pkgs.jdk11}"
+    jdk11_headless = "${pkgs.jdk11_headless}"
+    jdk17 = "${pkgs.jdk17}"
+    jdk17_headless = "${pkgs.jdk17_headless}"
+    jdk8 = "${pkgs.jdk8}"
+    jdk8_headless = "${pkgs.jdk8_headless}"
+    jre = "${pkgs.jre}"
+    jre8 = "${pkgs.jre8}"
+    jre8_headless = "${pkgs.jre8_headless}"
+    jre_headless = "${pkgs.jre_headless}"
+    openjdk = "${pkgs.openjdk}"
+    openjdk11 = "${pkgs.openjdk11}"
+    openjdk11_headless = "${pkgs.openjdk11_headless}"
+    openjdk17 = "${pkgs.openjdk17}"
+    openjdk17_headless = "${pkgs.openjdk17_headless}"
+    openjdk8 = "${pkgs.openjdk8}"
+    openjdk8_headless = "${pkgs.openjdk8_headless}"
+
+    with subtest("Package aliases for Java 8 should point to the same package"):
+      assert openjdk8 == jdk8
+
+    with subtest("Package aliases for Java 8 headless should point to the same package"):
+      assert openjdk8_headless == jdk8_headless
+
+    with subtest("Package aliases for Java 11 should point to the same package"):
+      assert openjdk11 == jdk11
+
+    with subtest("Package aliases for Java 11 headless should point to the same package"):
+      assert openjdk11_headless == jdk11_headless
+
+    with subtest("Package aliases for Java 17 should point to the same package"):
+      assert jre == jdk
+      assert jdk == openjdk
+      assert openjdk == jdk17
+      assert jdk17 == openjdk17
+
+    with subtest("Package aliases for Java 17 headless should point to the same package"):
+      assert jre_headless == jdk17_headless
+      assert jdk17_headless == openjdk17_headless
+
+    package_versions = {
+      jdk8: "1.8",
+      jdk8_headless: "1.8",
+      jre8: "1.8",
+      jre8_headless: "1.8",
+      jdk11: "11",
+      jdk11_headless: "11",
+      openjdk17: "17",
+    }
+
+    print(f"Patched zlib: {patched_zlib}")
+
+    for package, version in package_versions.items():
+      with subtest(f"Checking java version in {package}"):
+        out = machine.succeed(f"{package}/bin/java -version 2>&1")
+        assert f"openjdk version \"{version}." in out
+
+      with subtest(f"{package} should use patched zlib"):
+        machine.succeed(f"grep {patched_zlib} {package}/bin/java")
+  '';
+})


### PR DESCRIPTION
We only used the zlib patch for some of the headless versions before and
missed the aliases, so for example jdk11_headless used the patch while
openjdk11_headless war not despite being they the same package upstream.
We now have a test that makes sure that we don't break the aliases and
patch all openjdk versions and their headless variants.

Java 17 wouldn't build with our patched zlib which was due to a missing
zlib patch from upstream. Our crc32 patch is now added to the list
instead of replacing it.

 #PL-130760


@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* java: apply patched zlib to all commonly used openjdk variants and aliases. Since [release 2022_011](https://doc.flyingcircus.io/platform/changes/2022/r011.html?highlight=zlib#nixos-21-11-platform) only jdk8_headless and jdk11_headless used the patched zlib. It's recommended to use the openjdk17_headless package for applications. openjdk11, openjdk8 and their headless variants can also be used. (#PL-130760).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  -  make sure that java can use the crc32 code from zlib 1.2.12 properly without breaking
- [x] Security requirements tested? (EVIDENCE)
  - automated test checks if java versions are callable and use the patched zlib version