### PR TITLE
Elasticsearch: prevent cluster splits, rolling upgrades, multi-node bootstrap

### DIFF
--- a/doc/src/elasticsearch.rst
+++ b/doc/src/elasticsearch.rst
@@ -20,19 +20,114 @@ Elastic doesn't provide updates to the 7.x line anymore so 7.10.2
 will be the last available version. We are planning to move to OpenSearch
 instead which is a fork of Elasticsearch 7.10.2.
 
+Interaction
+-----------
+
+The Elasticsearch API is listening on the SRV interface. You can access
+the API of nodes in the same project via HTTP without authentication.
+Some examples:
+
+Show active nodes:
+
+.. code-block:: shell
+
+   curl test66:9200/_cat/nodes
+
+Show cluster health:
+
+.. code-block:: shell
+
+   curl test66:9200/_cat/health
+
+Show indices:
+
+.. code-block:: shell
+
+   curl test66:9200/_cat/indices
+
 Configuration
 -------------
 
-Upon activating the role, Elasticsearch forms a cluster with the same name as
-the VM. To change the cluster name, add a file
-:file:`/etc/local/elasticsearch/clusterName`, with the cluster name as its sole
-contents. To activate, run :command:`sudo fc-manage --build` (see
-:ref:`nixos-local` for details).
+The role works without additional config for single-node setups.
+By default, the cluster name is the host name of the machine.
 
-Elasticsearch instances are configured with a reasonable memory configuration,
-depending on the VMs configured memory.
+Custom config can be set via NixOS options which is required for multi-node
+setups. Plain config in :file:`/etc/local/elasticsearch` is still supported, too.
+See :file:`/etc/local/elasticsearch/elasticsearch/elasticsearch.nix.example` for an example.
+Copy the file to :file:`/etc/local/nixos/elasticsearch.nix`, for example, to
+include it in the system config.
 
-To add additional configuration options, add a file
+To see the final rendered config for Elasticsearch, use the
+:command:`elasticsearch-show-config` command as service or sudo-srv user.
+
+To activate config changes, run :command:`sudo fc-manage --build`
+(see :ref:`nixos-local` for details).
+
+NixOS Options
+~~~~~~~~~~~~~
+
+**flyingcircus.roles.elasticsearch.clusterName**
+
+The cluster name ES will use. By default, the string from
+:file:`/etc/local/elasticsearch/clusterName` is used. If the file doesn’t exist,
+the host name is used as fallback. Because of this, you have to set the
+cluster name explicitly if you want to set up a multi-node cluster.
+
+**flyingcircus.roles.elasticsearch.heapPercentage**
+
+Percentage of memory to use for ES heap. Defaults to 50 % of available
+RAM: ``systemMemory * heapPercentage / 100``
+
+**flyingcircus.roles.elasticsearch.esNodes**
+
+Names of the nodes that join this cluster and are eligible as masters.
+By default, all ES nodes in a resource group are part of this cluster
+and master-eligible. Note that all of them have to use the same
+clusterName which must be set explicitly when you want to set up a
+multi-node cluster.
+
+If only one esNode is given here, the node will start in single-node
+mode which means that it won’t try to find other ES nodes before
+initializing the cluster.
+
+Having both ES6 and ES7 nodes in a cluster is possible. This allows
+rolling upgrades. Note that new nodes that are added to a cluster have
+to use the newest version.
+
+ES7: Values must use the same format as nodeName (just the hostname by
+default) or cluster initialization will fail.
+
+**flyingcircus.roles.elasticsearch.initialMasterNodes**
+
+*(ES7 only, has no effect for ES6)*
+
+Name of the nodes that should take a part in the initial master
+election.
+
+.. warning::
+
+   This should only be set when initializing a cluster
+   with multiple nodes from scratch and removed after the cluster has
+   formed!
+
+By default, this is empty which means that the node will join an
+existing cluster or run in single-node mode when esNodes has only one
+entry. You can set this to
+``config.flyingcircus.roles.elasticsearch.esNodes`` to include all
+automatically discovered nodes.
+
+**flyingcircus.roles.elasticsearch.extraConfig**
+
+Additional YAML lines which are appended to the main
+:file:`elasticsearch.yml` config file.
+
+Legacy Custom Config
+--------------------
+
+You can add a file named :file:`/etc/local/elasticsearch/clusterName`, with
+the cluster name as its sole contents.
+
+To add additional configuration options, create a file
 :file:`/etc/local/elasticsearch/elasticsearch.yml`. Its contents will be
 appended to the base configuration.
 
@@ -40,7 +135,7 @@ appended to the base configuration.
 Monitoring
 ----------
 
-The following checks are provided by the elasticsearch role:
+The following checks are provided by the elasticsearch roles:
 
 * Circuit Breakers active
 * Cluster Health

--- a/nixos/roles/default.nix
+++ b/nixos/roles/default.nix
@@ -43,6 +43,7 @@ in {
     ./webproxy.nix
 
     (mkRemovedOptionModule [ "flyingcircus" "roles" "mysql" "rootPassword" ] "Change the root password via MySQL and modify secret files")
+    (mkRenamedOptionModule [ "flyingcircus" "roles" "elasticsearch" "dataDir" ] [ "services" "elasticsearch" "dataDir" ])
     (mkRenamedOptionModule [ "flyingcircus" "roles" "rabbitmq38" ] [ "flyingcircus" "roles" "rabbitmq" ])
     (mkRenamedOptionModule [ "flyingcircus" "roles" "redis4" ] [ "flyingcircus" "roles" "redis" ])
     (mkRenamedOptionModule [ "flyingcircus" "roles" "statshost" "enable" ] [ "flyingcircus" "roles" "statshost-global" "enable" ])

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -33,8 +33,8 @@ in {
   coturn = callTest ./coturn.nix {};
   devhost = callTest ./devhost.nix {};
   docker = callTest (nixpkgs + /nixos/tests/docker.nix) {};
-  elasticsearch6 = callTest ./elasticsearch.nix { version = "6"; };
-  elasticsearch7 = callTest ./elasticsearch.nix { version = "7"; };
+  elasticsearch6 = callSubTests ./elasticsearch.nix { version = "6"; };
+  elasticsearch7 = callSubTests ./elasticsearch.nix { version = "7"; };
   fcagent = callSubTests ./fcagent.nix {};
   ffmpeg = callTest ./ffmpeg.nix {};
   filebeat = callTest ./filebeat.nix {};

--- a/tests/elasticsearch.nix
+++ b/tests/elasticsearch.nix
@@ -1,86 +1,155 @@
-import ./make-test-python.nix ({ version ? "7", pkgs, testlib, ... }:
-let
-  ipv4 = testlib.fcIP.srv4 1;
-  ipv6 = testlib.fcIP.srv6 1;
-in
+import ./make-test-python.nix ({ version ? "7", pkgs, testlib, lib, ... }:
 {
-  name = "elasticsearch";
 
-  machine =
-    { pkgs, config, ... }:
+  name = "elasticsearch${version}";
+  testCases = {
+
+    single = let
+      ipv4 = testlib.fcIP.srv4 1;
+      ipv6 = testlib.fcIP.srv6 1;
+    in
     {
-      imports = [
-        (testlib.fcConfig { net.fe = false; })
-      ];
+      nodes = {
+        machine = { pkgs, config, ... }: {
+          imports = [
+            (testlib.fcConfig { net.fe = false; })
+          ];
 
-      networking.domain = "test";
-      networking.extraHosts = ''
-        ${ipv6} machine.test
+          networking.domain = "test";
+          networking.extraHosts = ''
+            ${ipv6} machine.test
+          '';
+          virtualisation.memorySize = 3072;
+          virtualisation.qemu.options = [ "-smp 2" ];
+          flyingcircus.roles."elasticsearch${version}".enable = true;
+          flyingcircus.roles.elasticsearch.esNodes = [ "machine" ];
+        };
+      };
+
+      testScript = { nodes, ... }:
+      let
+        sensuCheck = testlib.sensuCheckCmd nodes.machine;
+      in ''
+        import json
+
+        expected_major_version = ${version}
+
+        checks = [
+          "${sensuCheck "es_node_status"}",
+          "${sensuCheck "es_circuit_breakers"}",
+          "${sensuCheck "es_cluster_health"}",
+          "${sensuCheck "es_file_descriptor"}",
+          "${sensuCheck "es_heap"}",
+          "${sensuCheck "es_shard_allocation_status"}",
+        ]
+
+        expected_sockets = [
+          "${ipv4}:9200",
+          "${ipv6}:9200",
+          "${ipv4}:9300",
+          "${ipv6}:9300",
+        ]
+
+        def assert_listen(machine, process_name, expected_sockets):
+          result = machine.succeed(f"netstat -tlpn | grep {process_name} | awk '{{ print $4 }}'")
+          actual = set(result.splitlines())
+          assert set(expected_sockets) == actual, f"expected sockets: {expected_sockets}, found: {actual}"
+
+        machine.wait_for_unit("elasticsearch")
+
+        with subtest("Elasticsearch API should respond"):
+            api_result = json.loads(machine.wait_until_succeeds("curl ${ipv4}:9200"))
+
+        with subtest(f"version should be {expected_major_version}.x in the OSS flavor"):
+          version_info = api_result["version"]
+          major_version = int(version_info["number"][0])
+          assert major_version == expected_major_version, f"expected major version {expected_major_version}, got {major_version}"
+          build_flavor = version_info["build_flavor"]
+          assert build_flavor == "oss", f"expected oss flavor, got {build_flavor}"
+
+        with subtest("service user should be able to write to local config dir"):
+          machine.succeed('sudo -u elasticsearch touch /etc/local/elasticsearch/clusterName')
+
+        with subtest("elasticsearch (java) opens expected ports"):
+          assert_listen(machine, "java", expected_sockets)
+
+        with subtest("all sensu checks should be green"):
+          for check_cmd in checks:
+            machine.succeed(check_cmd)
+
+        with subtest("killing the elasticsearch process should trigger an automatic restart"):
+          machine.succeed("systemctl kill -s KILL elasticsearch")
+          machine.sleep(0.5)
+          machine.wait_until_succeeds("${sensuCheck "es_node_status"}")
+
+        with subtest("status check should be red after shutting down nginx"):
+          machine.systemctl('stop elasticsearch')
+          machine.wait_until_fails("${sensuCheck "es_node_status"}")
       '';
-      virtualisation.memorySize = 3072;
-      virtualisation.qemu.options = [ "-smp 2" ];
-      flyingcircus.roles."elasticsearch${version}".enable = true;
-      flyingcircus.roles.elasticsearch.esNodes = [ "machine" ];
     };
 
-  testScript = { nodes, ... }:
-  let
-    sensuCheck = testlib.sensuCheckCmd nodes.machine;
-  in ''
-    import json
+    multi = {
+      nodes = let
+        mkESNode = { id, conf ? {}}:
+          { pkgs, config, nodes, lib, ... }: {
+            imports = [
+              (testlib.fcConfig { net.fe = false; inherit id; })
+            ];
 
-    expected_major_version = ${version}
+            networking.domain = "test";
+            virtualisation.memorySize = 3072;
+            virtualisation.qemu.options = [ "-smp 2" ];
+            flyingcircus.roles."elasticsearch${version}".enable = true;
+            flyingcircus.roles.elasticsearch = {
+              clusterName = "test";
+              initialMasterNodes = lib.optionals (version != "6")
+                config.flyingcircus.roles.elasticsearch.esNodes;
+            };
+            flyingcircus.encServices = [
+              {
+                address = "node1.test";
+                service = "elasticsearch${version}-node";
+              }
+              {
+                address = "node2.test";
+                service = "elasticsearch${version}-node";
+              }
+              {
+                address = "node3.test";
+                service = "elasticsearch${version}-node";
+              }
+            ];
+            networking.firewall.trustedInterfaces = [ "ethsrv" ];
+          };
+      in
+      {
+        node1 = mkESNode { id = 1; };
+        node2 = mkESNode { id = 2; };
+        node3 = mkESNode { id = 3; };
+      };
 
-    checks = [
-      "${sensuCheck "es_node_status"}",
-      "${sensuCheck "es_circuit_breakers"}",
-      "${sensuCheck "es_cluster_health"}",
-      "${sensuCheck "es_file_descriptor"}",
-      "${sensuCheck "es_heap"}",
-      "${sensuCheck "es_shard_allocation_status"}",
-    ]
+      testScript = ''
+        print()
+        node1.start()
 
-    expected_sockets = [
-      "${ipv4}:9200",
-      "${ipv6}:9200",
-      "${ipv4}:9300",
-      "${ipv6}:9300",
-    ]
+        ${lib.optionalString (version == "7") ''
+          with subtest("ES on node1 should start, waiting for a second node"):
+            node1.wait_for_unit("elasticsearch")
+            out = node1.wait_until_succeeds("curl node1:9200/_cat/nodes")
+            print(out)
+            assert "master_not_discovered_exception" in out, "Could not find master_not_discovered_exception in output"
+        ''}
+        with subtest("starting node2 should form a cluster"):
+          node2.wait_for_unit("elasticsearch")
+          node2.sleep(2)
+          print(node2.succeed("curl node1:9200/_cat/nodes"))
+          print(node2.wait_until_succeeds("curl --fail-with-body node2:9200/_cat/nodes"))
 
-    def assert_listen(machine, process_name, expected_sockets):
-      result = machine.succeed(f"netstat -tlpn | grep {process_name} | awk '{{ print $4 }}'")
-      actual = set(result.splitlines())
-      assert set(expected_sockets) == actual, f"expected sockets: {expected_sockets}, found: {actual}"
-
-    machine.wait_for_unit("elasticsearch")
-
-    with subtest("Elasticsearch API should respond"):
-        api_result = json.loads(machine.wait_until_succeeds("curl ${ipv4}:9200"))
-
-    with subtest(f"version should be {expected_major_version}.x in the OSS flavor"):
-      version_info = api_result["version"]
-      major_version = int(version_info["number"][0])
-      assert major_version == expected_major_version, f"expected major version {expected_major_version}, got {major_version}"
-      build_flavor = version_info["build_flavor"]
-      assert build_flavor == "oss", f"expected oss flavor, got {build_flavor}"
-
-    with subtest("service user should be able to write to local config dir"):
-      machine.succeed('sudo -u elasticsearch touch /etc/local/elasticsearch/clusterName')
-
-    with subtest("elasticsearch (java) opens expected ports"):
-      assert_listen(machine, "java", expected_sockets)
-
-    with subtest("all sensu checks should be green"):
-      for check_cmd in checks:
-        machine.succeed(check_cmd)
-
-    with subtest("killing the elasticsearch process should trigger an automatic restart"):
-      machine.succeed("systemctl kill -s KILL elasticsearch")
-      machine.sleep(0.5)
-      machine.wait_until_succeeds("${sensuCheck "es_node_status"}")
-
-    with subtest("status check should be red after shutting down nginx"):
-      machine.systemctl('stop elasticsearch')
-      machine.wait_until_fails("${sensuCheck "es_node_status"}")
-  '';
+        with subtest("node3 should join the existing cluster"):
+          node3.wait_for_unit("elasticsearch")
+          node3.sleep(2)
+          print(node3.wait_until_succeeds("curl --fail-with-body node3:9200/_cat/nodes"))
+      '';
+    };
+  };
 })


### PR DESCRIPTION
* Support mixed-version clusters for rolling upgrades by including
  all ES node versions for the esNodes option default. Before,
  upgrading single nodes without proper config could break a cluster.
* The single_node option is now set automatically depending on the number
  of nodes in esNodes.
* Remove custom postStart loop which waited only 120s for ES to appear.
  We now use the upstream default of waiting forever.
* Set master quorum to make ES6 multi-node safer.
* Add initialMasterNodes option to allow initialization of multi-
  node clusters with ES7. By default, the list is empty now which
  is the upstream default and strongly recommended for running clusters.
  The option is only meant for initialization of clusters. Before, we
  just set it always to esNodes and the value couldn't be changed
  easily.
* Remove dataDir option and point to upstream option.
* Replace deprecated string option type with proper types to avoid
  dangerous string concatenation when merging definitions.
* Add extraConfig option for plain YML config.
* Use discovery.seed_hosts for ES7 to fix deprecation warning
* Allow service/sudo-srv users to run elasticsearch-show-config.
* README.txt moves to README.md, now includes more dynamic info about
  the ES node/cluster and generated option descriptions.
* Add a test which initializes a cluster with three nodes.

 #PL-130608
@flyingcircusio/release-managers

## Release process

Impact:

* [NixOS 21.11] Elasticsearch nodes will be restarted.

Changelog:

* Elasticsearch role improvements: 
  * Make default config safer to prevent accidental cluster splits.
  * Add initialMasterNodes option for multi-node cluster initialization.
  * Change config defaults to support mixed-version clusters for rolling upgrades.
  * Allow service/sudo-srv users to run elasticsearch-show-config.
  * Extend README and role documentation (#PL-130608).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - sane default config to reduce risk of data loss/split in multi-node clusters  
- [x] Security requirements tested? (EVIDENCE)
  - automated test checks basic functionality and that multi-node initialization works
  - checked behaviour when adding/removing nodes with multiple test VMs, mixed versions