### PR TITLE
mailserver: fix password change via roundcube

### DIFF
--- a/nixos/services/mail/roundcube.nix
+++ b/nixos/services/mail/roundcube.nix
@@ -2,20 +2,18 @@
 
 let
   role = config.flyingcircus.roles.mailserver;
-  chpasswd = "/run/wrappers/bin/roundcube-chpasswd";
+  chpasswd = "${pkgs.fc.roundcube-chpasswd}/bin/roundcube-chpasswd";
   fclib = config.fclib;
 
 in lib.mkMerge [
   (lib.mkIf (role.enable && role.webmailHost != null) {
     services.postgresql.enable = true;
 
-    security.wrappers = {
-      roundcube-chpasswd = {
-        source = "${pkgs.fc.roundcube-chpasswd}/bin/roundcube-chpasswd";
-        owner = "vmail";
-        group = "vmail";
-      };
-    };
+    flyingcircus.passwordlessSudoRules = [{
+      commands = [ chpasswd ];
+      users = [ "roundcube" ];
+      runAs = "vmail";
+    }];
 
     services.nginx.virtualHosts.${role.webmailHost} = {
       forceSSL = true;
@@ -29,14 +27,13 @@ in lib.mkMerge [
         $config['archive_type'] = 'year';
         $config['managesieve_vacation'] = 1;
         $config['mime_types'] = '${pkgs.mime-types}/etc/mime.types';
-        $config['password_chpasswd_cmd'] = '${chpasswd} ${role.passwdFile}';
+        $config['password_chpasswd_cmd'] = '/run/wrappers/bin/sudo -u vmail ${chpasswd} ${role.passwdFile}';
         $config['password_confirm_current'] = true;
         $config['password_driver'] = 'chpasswd';
         $config['password_minimum_length'] = 10;
         $config['smtp_server'] = 'tls://${role.mailHost}';
         $config['smtp_user'] = '%u';
         $config['smtp_pass'] = '%p';
-
       '';
       database = {
         username = "roundcube";


### PR DESCRIPTION
Users couldn't change their passwords on 21.11 via the roundcube UI.
The wrapper for roundcube-chpasswd didn't work because 21.11
doesn't set setuid by default anymore for security.wrappers.
We now use sudo instead to give roundcube the permission to run
roundcube-chpasswd as vmail user who owns the mail passwd file.

 #PL-130674

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* mailserver: fix changing the password via web mailer (roundcube) settings (#PL-130674).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  -  logged-in mail users should be able to change their own password via the UI
  - the roundcube-chpasswd command must be restricted by the roundcube user
- [x] Security requirements tested? (EVIDENCE)
  - tested changing the password via roundcube manually
  - automated test checks that changing the password works and sudo rules are correct
  - checked sudo rules on a test VM