### PR TITLE
Update jitsi, add watchdogs, systemd notify

### DIFF
--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -115,29 +115,29 @@ in {
 
   jicofo = super.jicofo.overrideAttrs(oldAttrs: rec {
     pname = "jicofo";
-    version = "1.0-877";
+    version = "1.0-900";
     src = fetchurl {
       url = "https://download.jitsi.org/stable/${pname}_${version}-1_all.deb";
-      sha256 = "sha256-p2HTKgEkCo5mW+pFSsbAgqeNDTrrYNtwfzgDXqE2PzU=";
+      hash = "sha256-tAuWhu1DdasOuLIz9/Ox1n1XcFWm5qnTVr6FpdKpwbE=";
     };
   });
 
   jitsi-meet = super.jitsi-meet.overrideAttrs(oldAttrs: rec {
     pname = "jitsi-meet";
-    version = "1.0.6155";
+    version = "1.0.6260";
     src = fetchurl {
       url = "https://download.jitsi.org/jitsi-meet/src/jitsi-meet-${version}.tar.bz2";
-      sha256 = "sha256-baCRVYe1z2uH3vSb5KbWs0y4KyQYO3JpTyoGFZIZQqo=";
+      hash = "sha256-Y1ELKdFdbnq20yUt4XoXmstJm8uI8EBGIFOvFWf+5Uw=";
     };
 
   });
 
   jitsi-videobridge = super.jitsi-videobridge.overrideAttrs(oldAttrs: rec {
     pname = "jitsi-videobridge2";
-    version = "2.1-681-g3544ed05";
+    version = "2.2-9-g8cded16e";
     src = fetchurl {
       url = "https://download.jitsi.org/stable/${pname}_${version}-1_all.deb";
-      sha256 = "sha256-86lzt9SnZ6lpo7z6PQvVMZRdNJ0zeDUP92wrbnR0FbE=";
+      hash = "sha256-L9h+qYV/W2wPzycfDGC4AXpTl7wlulyt2KryA+Tb/YU=";
     };
     # jvb complained about missing libcrypto.so.3, add openssl 3 here.
     installPhase = ''


### PR DESCRIPTION
@flyingcircusio/release-managers

Update packages to latest stable

Jicofo and jitsi-videobridge2 services now have "watchdogs" in their
start scripts that restart the service when timing out after 40 seconds
by using WatchdogSignal=SIGTERM and Restart=Always.

Both use the Jicofo health API but they check for different things: The
videobridge watchdog checks if the videobridge is unusable for Jicofo
while Jicofo itself checks for everything else (like 5xx codes from the
API or connection timeout).

Both services now use the "notify" service type, signalling their
readyness only when the Jicofo API health check is ok (from their
perspective).

Because of that, the separate service for delaying the videobridge
start should not be needed anymore and is removed.

The videobridge also uses "Wants" for the relation to Jicofo now
so it doesn't die immediately when Jicofo exits but still starts
Jicofo if it's not active when videobridge wants to start.

Other changes:

* don't stop Jicofo when the unit changes
* fix shellcheck warnings for unquoted vars and `export var=$(...)`

## Release process

Impact:

* [NixOS 21.11] Jitsi services will be restarted. Conferences will be interrupted for a short amount of time.

Changelog:

* Jitsi: update packages to latest stable and add watchdog checks to restart Jitsi services if they are running but don't work properly. This usually happens after a reboot or large system update, making Jitsi conferences unavailable until a manual service restart (#PL-130720). 

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - use up-to-date Jitsi versions  
  - have proper availabilty checks for Jitsi conferencing components
- [x] Security requirements tested? (EVIDENCE)
  -checked if automatic restarts work and basic conferencing features are ok on a test VM  
  - looked at [Jitsi changelog](https://github.com/jitsi/jitsi-meet-release-notes/blob/master/CHANGELOG-WEB.md)  
