### PR TITLE
mailserver: handle missing FE properly, fix on devhost

### DIFF
--- a/nixos/infrastructure/container.nix
+++ b/nixos/infrastructure/container.nix
@@ -68,8 +68,8 @@ in
 
       flyingcircus.roles.memcached.listenAddresses = [ "0.0.0.0" "[::]" ];
 
-      flyingcircus.roles.mailserver.smtpBind4 = [ "127.0.0.1" ];
-      flyingcircus.roles.mailserver.smtpBind6 = [ "::1" ];
+      flyingcircus.roles.mailserver.smtpBind4 = "127.0.0.1";
+      flyingcircus.roles.mailserver.smtpBind6 = "::1";
       flyingcircus.roles.mailserver.explicitSmtpBind = false;
 
       flyingcircus.roles.mysql.listenAddresses = [ "::" ];
@@ -139,6 +139,9 @@ in
           ssh_pubkey = [
            "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGc7V2c2zFPRMl8/gmBv1/MEldEuJau8jHjhx+2qziYs root@ct-dir-dev2"
           ];
+          email_addresses = [
+            "developer@example.com"
+          ];
           uid = "developer";}
         { class = "service";
           gid = 100;
@@ -148,6 +151,9 @@ in
           password = "*";
           name = "s-dev";
           ssh_pubkey = [] ;
+          email_addresses = [
+            "technicalcontact@example.com"
+          ];
           permissions = { container = []; };
           uid = "s-dev"; } ];
 

--- a/nixos/roles/mailserver.nix
+++ b/nixos/roles/mailserver.nix
@@ -32,6 +32,17 @@ let
       example = "mail.example.com";
     };
 
+    policydSPFExtraSkipAddresses = mkOption {
+      type = with types; listOf str;
+      description = ''
+        Extra addresses policyd should skip in SPF checks.
+        Local addresses are always skipped.
+        This extends the `skip_addresses` setting in policyd-spf.conf.
+      '';
+      default = if hasFE then listenFe else
+                if listenSrv != [] then listenSrv else [];
+    };
+
     rootAlias = mkOption {
       type = types.str;
       description = "Address to receive all mail to root@localhost.";


### PR DESCRIPTION
mailserver: handle missing FE properly, fix on devhost

The role had multiple issues which prevented it from being used in
devhost containers because they don't have a ethfe interface.

- Add a new option `flyingcircus.roles.policydSPFExtraSkipAddresses` which
  works similar to `smtpBind4` which already had a proper fallback to SRV or
  none at all.
- Fix type for `smtpBind*` settings and missing mail addresses for default
  users in container.nix.
- Use flyingcircus.nginx.virtualHosts which is already correctly set up
  for the devhost environment and remove explicit FE listen addresses.

 #PL-130785

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

- `mailserver` role now works in devhost environments and in other situations where the machine has no FE interface (#PL-130785).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - doesn't affect existing mailserver instances which all have a FE interface; role should also work when no FE interface is present for example in a devhost environment
- [x] Security requirements tested? (EVIDENCE)
  - deployed a container with mailserver role on devhost and checked that postfix and nginx services are running, checked on test mailserver that policyd config is still the same