### PR TITLE
[21.05] Pl 130798: add host utilities `fc-ledtool` and `fc-vm-migration-watch`

### DIFF
--- a/nixos/infrastructure/flyingcircus-physical.nix
+++ b/nixos/infrastructure/flyingcircus-physical.nix
@@ -34,6 +34,7 @@ mkIf (cfg.infrastructureModule == "flyingcircus-physical") {
     };
 
     environment.systemPackages = with pkgs; [
+      fc.ledtool
       fc.secure-erase
       fc.util-physical
       mstflint

--- a/nixos/roles/kvm.nix
+++ b/nixos/roles/kvm.nix
@@ -40,6 +40,11 @@ in
       bridge-utils
     ];
 
+    environment.shellAliases = {
+      # alias for observing both running VMs as well as the migration logs at once
+      fc-vm-migration-watch = "watch '${pkgs.fc.qemu}/bin/fc-qemu ls; echo; grep migration-status /var/log/fc-qemu.log | tail'";
+    };
+
     environment.etc."qemu/fc-qemu.conf".text = let
       hostname = config.networking.hostName;
       migration_address = fclib.fqdn { vlan = "sto"; domain = "gocept.net"; };

--- a/pkgs/fc/default.nix
+++ b/pkgs/fc/default.nix
@@ -17,6 +17,8 @@ rec {
   collectdproxy = callPackage ./collectdproxy {};
   roundcube-chpasswd = callPackage ./roundcube-chpasswd {};
   fix-so-rpath = callPackage ./fix-so-rpath {};
+  ledtool = pkgs.writers.writePython3Bin "fc-ledtool"
+    {} (builtins.readFile ./ledtool/led.py);
   logcheckhelper = callPackage ./logcheckhelper { };
   megacli = callPackage ./megacli { };
   multiping = callPackage ./multiping.nix {};

--- a/pkgs/fc/ledtool/led.py
+++ b/pkgs/fc/ledtool/led.py
@@ -1,0 +1,63 @@
+import argparse
+import glob
+
+ACTION_ENABLE = "enable"
+ACTION_DISABLE = "disable"
+ACTION_STATUS = "status"
+
+
+class Slot(object):
+    def __init__(self, device):
+        self.device = device
+
+        for candidate in glob.glob(
+            "/sys/class/enclosure/*/Slot*/device/block/*"
+        ):
+            _, _, _, _, enclosure, slot, _, _, device = candidate.split("/")
+            if self.device == device:
+                self.enclosure = enclosure
+                self.slot = slot
+                break
+        else:
+            raise KeyError(
+                f"Could not find enclosure slot for device {self.device}"
+            )
+
+    @property
+    def locate_path(self):
+        return f"/sys/class/enclosure/{self.enclosure}/{self.slot}/locate"
+
+    @property
+    def locate_led(self):
+        with open(self.locate_path) as f:
+            return bool(int(f.read().strip()))
+
+    @locate_led.setter
+    def locate_led(self, status):
+        with open(self.locate_path, "w") as f:
+            return f.write(str(int(bool(status))))
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("device")
+    parser.add_argument(
+        "action",
+        default=ACTION_STATUS,
+        choices=[ACTION_STATUS, ACTION_ENABLE, ACTION_DISABLE],
+    )
+    args = parser.parse_args()
+
+    slot = Slot(args.device)
+
+    if args.action == ACTION_ENABLE:
+        slot.locate_led = True
+    elif args.action == ACTION_DISABLE:
+        slot.locate_led = False
+
+    print(f"Device {slot.device} is located in {slot.enclosure}/{slot.slot}.")
+    print(f"  Locate LED enabled: {slot.locate_led}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This adds two small useful utilities to our physical hosts:

- All hosts get `fc-ledtool`, a small helper script for finding and controlling the enclosure locate LEDs of physical disks.
- KVM hosts get `fc-vm-migration-watch`, a watch command displaying  both running VMs and their migration log at the same time

@flyingcircusio/release-managers

## Release process

Impact: just 2 comfort tools for internal use

Changelog: There is no public documentation on KVM and other physical hosts, no changelog necessary.
It might make sense to present on this internally. 

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined?
  These are just 2 added administration helper utilities. One of them only combines existing tools for reading system state, the other exclusively writes to `/sys/class/enclosure/`. Manual functionality test is sufficient.

- [x] Security requirements tested?
  Manually tested on test KVM host kyle09. Both new commands can be executed. Further functionality of `fc-ledtool` has **not** been checked as kyle09's hardware does not support enclosure LEDs. But @ctheune has successfully tested the tool on several other machines.