### PR TITLE
matomo: 4.10.0 -> 4.11.0

### DIFF
--- a/pkgs/matomo/default.nix
+++ b/pkgs/matomo/default.nix
@@ -3,16 +3,16 @@
 let
   versions = {
     matomo = {
-      version = "4.10.0";
-      sha256 = "sha256-APS88xeFAeFBMtsuNU5iM7+FUlHLa9HcaXUNkhVwuCQ=";
+      version = "4.11.0";
+      sha256 = "sha256-qjpSzF/icSi03zCjWHAU69CNK5iNVMbfFxX9flqB+3Y=";
     };
 
     matomo-beta = {
-      version = "4.10.0";
+      version = "4.11.0";
       # `beta` examples: "b1", "rc1", null
       # when updating: use null if stable version is >= latest beta or release candidate
       beta = null;
-      sha256 = "sha256-APS88xeFAeFBMtsuNU5iM7+FUlHLa9HcaXUNkhVwuCQ=";
+      sha256 = "sha256-qjpSzF/icSi03zCjWHAU69CNK5iNVMbfFxX9flqB+3Y=";
     };
   };
   common = pname: { version, sha256, beta ? null }:


### PR DESCRIPTION
@flyingcircusio/release-managers

https://matomo.org/changelog/matomo-4-11-0/

## Release process

Impact:

* Matomo will be restarted.

Changelog:

* matomo: update to 4.11.0 (#PL-130689).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - same as before, check that update does not introduce new risks  
- [x] Security requirements tested? (EVIDENCE)
  - checked matomo changelog for breaking and security-related changes: none
  - checked on a test VM that upgrading and setting up new matomo instances works
  - looked at matomo system check: no critical warnings