### PR TITLE
[21.05] fix system builds being blocked on hosts with 128 CPUs

### DIFF
--- a/nixos/infrastructure/flyingcircus-physical.nix
+++ b/nixos/infrastructure/flyingcircus-physical.nix
@@ -134,4 +134,10 @@ mkIf (cfg.infrastructureModule == "flyingcircus-physical") {
       };
     };
 
+    # PL-130846 Temporary fix until having Nix >= 2.4:
+    # Ensure there are enough build users available to fulfill `maxJobs`, which is
+    # automatically set to the number of cores. Our largest machines currently have
+    # 128 core-threads.
+    nix.nrBuildUsers = 128;
+
 }

--- a/nixos/platform/systemd.nix
+++ b/nixos/platform/systemd.nix
@@ -5,6 +5,12 @@ with lib;
 
 let
   fclib = config.fclib;
+
+    journalReadGroups = [
+      "sudo-srv"
+      "service"
+      "admins"
+    ];
 in
 {
   config = {
@@ -17,14 +23,11 @@ in
 
     services.journald.forwardToSyslog = lib.mkOverride 90 false;
 
+    # for factl to succeed, all groups referenced have to exist.
+    users.groups = lib.attrsets.genAttrs journalReadGroups (uname: {name = uname;});
     flyingcircus.activationScripts = {
 
       systemd-journal-acl = let
-        journalReadGroups = [
-          "sudo-srv"
-          "service"
-          "admins"
-        ];
           acls =
             lib.concatMapStrings
               (group: "-m g:${group}:rX -m d:g:${group}:rX ")

--- a/nixos/platform/systemd.nix
+++ b/nixos/platform/systemd.nix
@@ -25,18 +25,25 @@ in
           "service"
           "admins"
         ];
-        acls =
-          lib.concatMapStrings
-            (group: "-m g:${group}:rX -m d:g:${group}:rX ")
-            journalReadGroups;
+          acls =
+            lib.concatMapStrings
+              (group: "-m g:${group}:rX -m d:g:${group}:rX ")
+              journalReadGroups;
 
-      in ''
-        # Note: journald seems to change some permissions and the group if they
-        # differ from its expectations for /var/log/journal.
-        # Changing permissions via ACL like here is supported by journald.
-        install -d -g systemd-journal /var/log/journal
-        ${pkgs.acl}/bin/setfacl -R ${acls} /var/log/journal
-      '';
+        # setfacl requires all users and groups specified to exist already. Especially
+        # after a fresh system installation that might not be always the case, so only
+        # execute after succesful user and group creation.
+        in {
+          deps = [ "users" "etc" ];
+          text = ''
+            # Note: journald seems to change some permissions and the group if they
+            # differ from its expectations for /var/log/journal.
+            # Changing permissions via ACL like here is supported by journald.
+            install -d -g systemd-journal /var/log/journal
+
+            ${pkgs.acl}/bin/setfacl -R ${acls} /var/log/journal
+          '';
+        };
 
     };
 


### PR DESCRIPTION
@flyingcircusio/release-managers

Hosts with many CPUs (or CPU hyperthreads) want to create as many
parallel build jobs as they have cores by default. The default of just
32 nixbld users is not enough to fulfill all of them, causing the build
to fail due to a bug in Nix 2.3.
As our largest host right now has 128 CPUs (actually just hyperthreads), this PR just always creates 128 nixbld users on physical hosts.

Temporary fix until Nix 2.4+

Necessary preconditions for that: Fixing the activation scripts.
- ensure all groups referenced by a `factl` command exist
- ensure that this `factl` command is run in the activation script after users and groups have been set up

## Release process

Impact: Internal fix only, just affecting physical hosts and supposed to fix a server bootstrap issue

Changelog: no changelog for internal fixes

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined?
  - availability: `fc-agent -be` must work without any further manual intervention after boot
  - authentication: as this PR modifies user and group management, actual permissions need to remain the same as intended before
- [x] Security requirements tested? (EVIDENCE)
  - automatic NixOS tests still succeed, especially `journal.nix` which tests the intended permissions on the systemd journal
  - manual successful installation with these fixes (semantically equivalent, formatting cleaned up afterwards) on affected host kyle35

Writing a generic test for one of the underlying issues of failing activation script snippets would be useful as well, but where to put such a test still needs to be discussed.