### PR TITLE
Use Linux 5.10 instead of 5.15, fixes qemu fsfreeze problem

### DIFF
--- a/nixos/platform/default.nix
+++ b/nixos/platform/default.nix
@@ -177,6 +177,12 @@ in {
         "bfq"
       ];
 
+      # The default of 5.15 showed problems with hanging fsfreezes
+      # when mysql/mariadb/percona is running on a machine and the
+      # filesystem is being frozen for Ceph snapshots. 5.10 doesn't
+      # seem to have this issue.
+      kernelPackages = pkgs.linuxKernel.packages.linux_5_10;
+
       kernelParams = [
         # Crash management
         "panic=1"


### PR DESCRIPTION
The combination of Linux 5.15 and percona/mariadb sometimes
causes a fsfreeze to hang forever when there's at least some
DB activity going on at the same time. Using a 5.10 kernel
like as we do on NixOS 21.11 fixes the problem.

 #PL-130833 

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - VM availability: fixes an infinite file system freeze error
- [x] Security requirements tested? (EVIDENCE)
  - checked on a test VM that the 5.10 kernel doesn't have the fsfreeze problem 