### PR TITLE
loghost: fix config problems, make config more robust

### DIFF
--- a/nixos/roles/loghost/location.nix
+++ b/nixos/roles/loghost/location.nix
@@ -26,9 +26,9 @@ in
 
   config = lib.mkIf (cfg.enable) {
 
-    flyingcircus.roles.loghost = fclib.mkPlatform { enable = true; };
+    flyingcircus.roles.loghost = { enable = true; };
     flyingcircus.roles.graylog = {
-      serviceTypes = fclib.mkPlatform [ "loghost-location-graylog" ];
+      serviceTypes = lib.mkOverride 90 [ "loghost-location-graylog" ];
     };
 
   };


### PR DESCRIPTION
89cd639e1e8856179bcaee69c556696ecfb7ae82 accidentally changed the
data dir of existing loghosts to the default of /srv/elasticsearch.
This change removes the now ineffective data dir override for loghosts.
Other important options are set with normal priority 100 now instead
of mkPlatform (900) to make similar mistakes less likely.

Set ES auto_create_index to false to avoid creating graylog_deflector
as index. It has to be an alias instead or graylog index rotation will
not work.

 #PL-130815

@flyingcircusio/release-managers

## Release process

Impact:

*

Changelog:

* loghost: fixed various config problems which were discovered after the latest elasticsearch role changes (#PL-130815).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - ensure availability of Graylog and we don't want to lose data 
- [x] Security requirements tested? (EVIDENCE)
  - manually checked on dev loghost-location and test loghost that ES config is correct and Graylog works
  - automated test checks basic functionality of loghost and now checks if data dir and other config is set up correctly