### PR TITLE
filebeat-journal: set log level to error

### DIFF
--- a/nixos/platform/journalbeat.nix
+++ b/nixos/platform/journalbeat.nix
@@ -35,7 +35,9 @@ in
 
             # "info" would have some helpful information but also logs every single
             # log shipping (up to once per second) which is too much noise.
-            logging.level = "warning";
+            # "warning" is still annoying because of the error:
+            # "route ip+net: netlinkrib: address family not supported by protocol"
+            logging.level = "error";
           } extra));
       in {
         description = "Ship system journal to ${host}:${toString port}";


### PR DESCRIPTION
warning produces too many log entries that have no diagnostic value.

 #PL-130817

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - keep log spam minimal   
- [x] Security requirements tested? (EVIDENCE)
  - checked on a test VM that the log output of filebeat-journal-* doesn't spam anymore