### PR TITLE
Update nixpkgs

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "56c15c8fcab1c92039fc962e3c5d1613858c9e10",
-    "sha256": "jOROKY0iVGs7abSlB1vFx3E/MGRaZckmI1Clwq+GtCA="
+    "rev": "4831ae4a5287019ec3e0cdc4b65f2c5f83e08460",
+    "sha256": "MN0dktebCH1Fo4RJlyARaf6FUTLxz7cLWnOH3lzA77I="
   },
   "nixos-mailserver": {
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/",


### PR DESCRIPTION
Update nixpkgs

Notable security updates and version changes:

* discourse: 2.9.0.beta4 -> 2.9.0.beta9
* github-runner: 2.294.0 -> 2.295.0
* gitlab: 15.1.4 -> 15.2.2
* gnutls: patch CVE-2022-2509
* imagemagick: 7.1.0-44 -> 7.1.0-46
* libtiff: add patch for CVE-2022-34526
* linux: 5.10.134 -> 5.10.136
* matrix-synapse: 1.64.0 -> 1.65.0
* nodejs-16_x: 16.15.0 -> 16.16.0
* nodejs-18_x: 18.2.0 -> 18.7.0
* nspr: 4.34 -> 4.34.1
* php80: 8.0.21 -> 8.0.22
* php81: 8.1.8 -> 8.1.9
* strace: 5.18 -> 5.19
* varnish71: 7.1.0 -> 7.1.1
* zlib: add fixed patch for CVE-2022-37434

 #PL-130858
   
   
   @flyingcircusio/release-managers

## Release process

Impact:

* [NixOS 22.05] Machines will schedule a reboot to activate the changed kernel.

Changelog: (include changes from commit msg here)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - pull in upstream security fixes regularly
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still run, works on test VM
  - checked commit log for fixed CVEs and possible problems with updates, checked matrix-synapse and varnish changelog
