### PR TITLE
[21.05] fc-ceph: allow specifying the parent LVM VG for mon vols

### DIFF
--- a/pkgs/fc/ceph/fc/ceph/main.py
+++ b/pkgs/fc/ceph/fc/ceph/main.py
@@ -126,6 +126,11 @@ def main(args=sys.argv[1:]):
         action="store_true",
         help="Create first mon to bootstrap cluster.",
     )
+    parser_create.add_argument(
+        "--lvm-vg",
+        help="Volume Group where the MON volume is created. "
+        "Defaults to using the journal VGs.",
+    )
     parser_create.set_defaults(action="create")
 
     parser_activate = mon_sub.add_parser(


### PR DESCRIPTION
In some setups, mons are run on hosts without the necessary extra disks
for having an own PV and VG housing the mon logical volume.

The logic for using an externally specified VG for mon volume creation
already existed in the code, this commit just adds the CLI argument.

@flyingcircusio/release-managers

Done as part of PL-130865

## Release process

Impact: internal tooling only

Changelog:

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined?
  add possibility of specifying the VG when creating a mon
- [x] Security requirements tested? 
  - successfully used on kyle22
  - just adds the necessary argparse plumbing for an already existing function arg, no code changes in management code
