### PR TITLE
Pl 130880 backy ceph dependency missing

### DIFF
--- a/nixos/roles/backyserver.nix
+++ b/nixos/roles/backyserver.nix
@@ -94,7 +94,7 @@ in
     systemd.services.backy = {
         description = "Backy backup server";
         wantedBy = [ "multi-user.target" ];
-        path = [ backy pkgs.fc.agent ];
+        path = [ backy pkgs.ceph pkgs.fc.agent ];
 
         environment = {
           CEPH_ARGS = "--id ${enc.name}";


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

none

Changelog:

nothing to not as this was never customer-visibly released

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

working software ;)

- [x] Security requirements tested? (EVIDENCE)

no specific checks necessary, saw that the change caused backy to properly work again
