### PR TITLE
webgateway: update Nginx proxy timeouts and HTTP version

### DIFF
--- a/nixos/services/nginx/base-module.nix
+++ b/nixos/services/nginx/base-module.nix
@@ -162,10 +162,10 @@ let
 
       ${optionalString (cfg.recommendedProxySettings) ''
         proxy_redirect          off;
-        proxy_connect_timeout   90;
-        proxy_send_timeout      90;
-        proxy_read_timeout      90;
-        proxy_http_version      1.0;
+        proxy_connect_timeout   ${cfg.proxyTimeout};
+        proxy_send_timeout      ${cfg.proxyTimeout};
+        proxy_read_timeout      ${cfg.proxyTimeout};
+        proxy_http_version      1.1;
         include ${recommendedProxyConfig};
       ''}
 
@@ -517,9 +517,18 @@ in
         ";
       };
 
+      proxyTimeout = mkOption {
+        type = types.str;
+        default = "60s";
+        example = "20s";
+        description = "
+          Change the proxy related timeouts in recommendedProxySettings.
+        ";
+      };
+
       package = mkOption {
         default = pkgs.nginxStable;
-        defaultText = "pkgs.nginxStable";
+        defaultText = literalExpression "pkgs.nginxStable";
         type = types.package;
         apply = p: p.override {
           modules = p.modules ++ cfg.additionalModules;
@@ -534,7 +543,7 @@ in
       additionalModules = mkOption {
         default = [];
         type = types.listOf (types.attrsOf types.anything);
-        example = literalExample "[ pkgs.nginxModules.brotli ]";
+        example = literalExpression "[ pkgs.nginxModules.brotli ]";
         description = ''
           Additional <link xlink:href="https://www.nginx.com/resources/wiki/modules/">third-party nginx modules</link>
           to install. Packaged modules are available in
@@ -767,7 +776,7 @@ in
             addresses = mkOption {
               type = types.listOf types.str;
               default = [];
-              example = literalExample ''[ "[::1]" "127.0.0.1:5353" ]'';
+              example = literalExpression ''[ "[::1]" "127.0.0.1:5353" ]'';
               description = "List of resolvers to use";
             };
             valid = mkOption {
@@ -831,7 +840,7 @@ in
           Defines a group of servers to use as proxy target.
         '';
         default = {};
-        example = literalExample ''
+        example = literalExpression ''
           "backend_server" = {
             servers = { "127.0.0.1:8000" = {}; };
             extraConfig = ''''
@@ -848,7 +857,7 @@ in
         default = {
           localhost = {};
         };
-        example = literalExample ''
+        example = literalExpression ''
           {
             "hydra.example.com" = {
               forceSSL = true;


### PR DESCRIPTION
Use HTTP/1.1 to communicate with upstream servers. This fixes HTTP 413
responses from haproxy when Nginx passes a GET request with a
request body. haproxy stopped to accept these requests via HTTP/1.0
starting with version 2.5 because they could be a security risk.

Add the `proxyTimeout` option from upstream and use its default of 60s
instead of 90s which is also more in line with the recommendations from
the Nginx project.

Also adds some uses of literalExpression from the upstream module for
option examples and default texts.

 #PL-130875

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

- webgateway/nginx: set HTTP version to 1.1 (before: 1.0) and timeouts to 60s (before: 90s) in `recommendedProxySettings` which are enabled by default. The timeout can be changed via the new `services.nginx.proxyTimeout` option. The switch to HTTP/1.1 fixes HTTP 413 responses from haproxy when Nginx passes a GET request with a request body. haproxy stopped to accept these requests via HTTP/1.0
starting with version 2.5 because they could be a security risk. You may want to check plain nginx config in `/etc/local/nginx` and change these settings accordingly or remove them to use the defaults (#PL-130875).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - use recommendations from upstream (NixOS/nginx). HTTP/1.1 by default should also be more secure.  
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still run
  - checked on a test VM that the new settings are effective and communication between nginx and haproxy works for GET requests with body 
