### PR TITLE
Clean up special group handling, improve journal ACL setup

### DIFF
--- a/nixos/infrastructure/container.nix
+++ b/nixos/infrastructure/container.nix
@@ -171,9 +171,6 @@ in
           id = 2272;
           name = "manager"; } ];
 
-      flyingcircus.users.adminsGroup = {
-         gid = 2003; name = "admins"; technical_contacts = []; };
-
       users.users.developer = {
         # Make the human user a service user, too so that we can place stuff in
         # /etc/local/nixos for provisioning.

--- a/nixos/platform/static.nix
+++ b/nixos/platform/static.nix
@@ -160,6 +160,9 @@ with lib;
       sudo-srv = 503;
       manager = 504;
 
+      # Global permissions granted by user membership in a special resource group.
+      admins = 2003;
+
       # Our custom services
       sensuclient = 31004;
       powerdns = 31005;

--- a/nixos/platform/systemd.nix
+++ b/nixos/platform/systemd.nix
@@ -5,9 +5,27 @@ with lib;
 
 let
   fclib = config.fclib;
+  cfg = config.flyingcircus.systemd;
 in
 {
+  options = with lib; {
+    flyingcircus.systemd = {
+
+      journalReadGroups = mkOption {
+        description = "Groups that are allowed to read the system journal.";
+        type = types.listOf types.string;
+      };
+
+    };
+  };
+
   config = {
+
+    flyingcircus.systemd.journalReadGroups = [
+      "sudo-srv"
+      "service"
+      "admins"
+    ];
 
     services.journald.extraConfig = ''
       SystemMaxUse=2G
@@ -20,24 +38,23 @@ in
     flyingcircus.activationScripts = {
 
       systemd-journal-acl = let
-        journalReadGroups = [
-          "sudo-srv"
-          "service"
-          "admins"
-        ];
-        acls =
-          lib.concatMapStrings
-            (group: "-m g:${group}:rX -m d:g:${group}:rX ")
-            journalReadGroups;
-
-      in ''
-        # Note: journald seems to change some permissions and the group if they
-        # differ from its expectations for /var/log/journal.
-        # Changing permissions via ACL like here is supported by journald.
-        install -d -g systemd-journal /var/log/journal
-        ${pkgs.acl}/bin/setfacl -R ${acls} /var/log/journal
+      mkSetfaclCmd = group: ''
+        if [ $(getent group ${group}) ]; then
+          ${pkgs.acl}/bin/setfacl -R -m g:${group}:rX -m d:g:${group}:rX /var/log/journal
+        else
+          echo "Warning: expected group '${group}' not found, skipping ACL."
+        fi
       '';
 
+      in {
+        deps = [ "users" ];
+        text = ''
+          # Note: journald seems to change some permissions and the group if they
+          # differ from its expectations for /var/log/journal.
+          # Changing permissions via ACL like here is supported by journald.
+          install -d -g systemd-journal /var/log/journal
+        '' + lib.concatMapStringsSep "\n" mkSetfaclCmd cfg.journalReadGroups;
+      };
     };
 
     flyingcircus.localConfigDirs.systemd = {

--- a/pkgs/fc/agent/fc/util/enc.py
+++ b/pkgs/fc/agent/fc/util/enc.py
@@ -221,7 +221,6 @@ def update_inventory(log, enc):
             (lambda: directory.list_service_clients(), "service_clients.json"),
             (lambda: directory.list_services(), "services.json"),
             (lambda: directory.list_users(), "users.json"),
-            (lambda: directory.lookup_resourcegroup("admins"), "admins.json"),
         ],
     )
 

--- a/tests/sudo.nix
+++ b/tests/sudo.nix
@@ -55,10 +55,6 @@ in
             name = "sudo-srv";
           }
         ];
-        adminsGroup = {
-          gid = 2003;
-          name = "admins";
-        };
       };
 
       flyingcircus.enc.parameters.resource_group = "test";

--- a/tests/users.nix
+++ b/tests/users.nix
@@ -47,7 +47,7 @@ import ./make-test-python.nix ({ lib, testlib, ... }:
         ];
 
         flyingcircus.users = {
-          userData = userData;
+          inherit userData;
         };
 
       };
@@ -92,5 +92,8 @@ import ./make-test-python.nix ({ lib, testlib, ... }:
     with subtest("Home dirs should exist and have correct permissions"):
       assert_permissions("755:u1000:users", "/home/u1000")
       assert_permissions("755:s-service:service", "/srv/s-service")
+
+    with subtest("Activation scripts should run without errors"):
+      machine.succeed("bash -e /run/current-system/activate 2>&1")
   '';
 })


### PR DESCRIPTION
- Remove option `flyingcircus.users.adminGroup`/`adminGroupPath` and
  fetching of admins.json from the directory which defines the
  adminGroup option. We haven't had a use case for this option in years
  and changing the name of the admins group or gid is a bad idea anyway
  which will break things.The technical contacts which were also part of
  admins.json are unused in platform code.
- Add option `flyingcircus.users.requiredPlatformGroups` for group names
  we rely upon in the platform code.
- Fix journal-acl activation script error in tests by adding the admins
  group to the set of required groups. This also removes the need for
  tests to explicitly add the admins group.
- Make activation script tolerant to missing groups and print them.  The
  error message of setfacl is not helpful so we have to catch it
  ourselves.
- Test that activation script runs without errors in journal.nix and
  users.nix.

 #PL-130885


@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - proper error reporting 
- [x] Security requirements tested? (EVIDENCE)
  - automated test checks that activation script can be executed without errors
  - looked at the activation script on a test VM