### PR TITLE
Update nixpkgs

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "4831ae4a5287019ec3e0cdc4b65f2c5f83e08460",
-    "sha256": "MN0dktebCH1Fo4RJlyARaf6FUTLxz7cLWnOH3lzA77I="
+    "rev": "f31aacb0e776ec6d8a6b3936caf1ad6ea1cbf09b",
+    "sha256": "mI/HuxpruH980JMgyzP+a7EzwR38WLwp4fD8lZqr+10="
   },
   "nixos-mailserver": {
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/",


### PR DESCRIPTION
Update nixpkgs

Notable security updates and version changes:

* element-web: 1.11.4 -> 1.11.5
* gcc12: 12.1.0 -> 12.2.0
* git: 2.36.0 -> 2.36.2, fix CVE-2022-29187
* github-runner: 2.295.0 -> 2.296.2
* gitlab: 15.2.2 -> 15.3.3
* go_1_17: 1.17.10 -> 1.17.13
* go_1_18: 1.18.2 -> 1.18.6
* grafana: 8.5.9 -> 8.5.11 (CVE-2022-31176)
* imagemagick: 7.1.0-46 -> 7.1.0-48
* inetutils: add patch for CVE-2022-39028
* k3s: 1.23.6+k3s1 -> 1.23.10+k3s1
* libtiff: patch CVE-2022-{2867,2868,2869}
* linux: 5.10.136 -> 5.10.143
* matrix-synapse: 1.65.0 -> 1.67.0
* nextcloud24: 24.0.4 -> 24.0.5
* nss_latest: 3.81 -> 3.82
* podman: 4.1.1 -> 4.2.0
* postgresql_10: 10.21 -> 10.22
* postgresql_11: 11.16 -> 11.17
* postgresql_12: 12.11 -> 12.12
* postgresql_13: 13.7 -> 13.8
* postgresql_14: 14.4 -> 14.5
* qemu: add patch for CVE-2020-14394
* qemu: add patches for CVE-2022-0216
* rsync: 3.2.3 -> 3.2.5
* samba: 4.15.5 -> 4.15.9
* vim: 8.2.5172 -> 9.0.0244, fix CVE-2022-25{22,71,8{0,1},98}

 #PL-130892


@flyingcircusio/release-managers

## Release process

Impact:

* [NixOS 22.05] PostgreSQL, matrix-synapse, nextcloud and Gitlab will be restarted. Machines will schedule a reboot to activate the changed kernel.

Changelog: (include changes from commit msg here)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - pull in upstream security fixes regularly
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still run, works on test VM
  - checked commit log for fixed CVEs and possible problems with updates, checked synapse and k3s changelog