### PR TITLE
[21.05] Clean up special group handling, improve journal ACL setup

### DIFF
--- a/nixos/infrastructure/container.nix
+++ b/nixos/infrastructure/container.nix
@@ -171,9 +171,6 @@ in
           id = 2272;
           name = "manager"; } ];
 
-      flyingcircus.users.adminsGroup = {
-         gid = 2003; name = "admins"; technical_contacts = []; };
-
       users.users.developer = {
         # Make the human user a service user, too so that we can place stuff in
         # /etc/local/nixos for provisioning.

--- a/nixos/platform/static.nix
+++ b/nixos/platform/static.nix
@@ -162,6 +162,9 @@ with lib;
       sudo-srv = 503;
       manager = 504;
 
+      # Global permissions granted by user membership in a special resource group.
+      admins = 2003;
+
       # Our custom services
       sensuserver = 31001;
       sensuapi = 31002;

--- a/pkgs/fc/agent/fc/manage/manage.py
+++ b/pkgs/fc/agent/fc/manage/manage.py
@@ -419,7 +419,6 @@ def update_inventory(log):
             (lambda: directory.list_service_clients(), "service_clients.json"),
             (lambda: directory.list_services(), "services.json"),
             (lambda: directory.list_users(), "users.json"),
-            (lambda: directory.lookup_resourcegroup("admins"), "admins.json"),
         ],
     )
 

--- a/tests/sudo.nix
+++ b/tests/sudo.nix
@@ -55,10 +55,6 @@ in
             name = "sudo-srv";
           }
         ];
-        adminsGroup = {
-          gid = 2003;
-          name = "admins";
-        };
       };
 
       flyingcircus.enc.parameters.resource_group = "test";

--- a/tests/users.nix
+++ b/tests/users.nix
@@ -47,7 +47,7 @@ import ./make-test-python.nix ({ lib, testlib, ... }:
         ];
 
         flyingcircus.users = {
-          userData = userData;
+          inherit userData;
         };
 
       };
@@ -92,5 +92,8 @@ import ./make-test-python.nix ({ lib, testlib, ... }:
     with subtest("Home dirs should exist and have correct permissions"):
       assert_permissions("755:u1000:users", "/home/u1000")
       assert_permissions("755:s-service:service", "/srv/s-service")
+
+    with subtest("Activation scripts should run without errors"):
+      machine.succeed("bash -e /run/current-system/activate 2>&1")
   '';
 })


### PR DESCRIPTION
cherry-picked and adapted from fd0d40b6576fbcc7c443c8d2e08e062117177254 supersedes 3e7b8765159dd28d0f2933e8aed11b8e8bbb1839

- Remove option `flyingcircus.users.adminGroup`/`adminGroupPath` and fetching of admins.json from the directory which defines the adminGroup option. We haven't had a use case for this option in years and changing the name of the admins group or gid is a bad idea anyway which will break things.The technical contacts which were also part of admins.json are unused in platform code.
- Add option `flyingcircus.users.requiredPlatformGroups` for group names we rely upon in the platform code.
- Fix journal-acl activation script error in tests by adding the admins group to the set of required groups. This also removes the need for tests to explicitly add the admins group.
- Make activation script tolerant to missing groups and print them.  The error message of setfacl is not helpful so we have to catch it ourselves.
- Test that activation script runs without errors in journal.nix and users.nix.

 #PL-130885

@flyingcircusio/release-managers

## Release process

Impact: internal only

Changelog:

## Security implications

Backports #596, thus the same security implications apply.

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - proper error reporting
- [ ] Security requirements tested? (EVIDENCE)
  - [ ] wait for automated test checks that activation script can be executed without errors to run through
  - [x] looked at the activation script on a test VM

