### PR TITLE
fixup: ceph/mon: keep pg max object skew warning for jewel

### DIFF
--- a/nixos/services/ceph/client.nix
+++ b/nixos/services/ceph/client.nix
@@ -56,6 +56,7 @@ in
 
           mon data = /srv/ceph/mon/$cluster-$id
           mon osd allow primary affinity = true
+          ${lib.optionalString (cfg.client.cephRelease == "jewel") "mon pg warn max object skew = 20"}
 
           mgr data = /srv/ceph/mgr/$cluster-$id
         '';


### PR DESCRIPTION
Fixup for e803041c837d1b71143df5b1d9dd97505e652d59

Without this warning value being altered, Ceph false-positively warns about skewed object numbers in pgs of different pools. In Luminous, the whole check is dropped, in Jewel we still have to adjust the limit to avoid a false warning.

Tested on a dev host

@flyingcircusio/release-managers

## Release process

Impact: internal, restores a missing previous setting

Changelog:

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE) reintroduces a wrongly removed config option again to fix a false positive warning
- [x] Security requirements tested? (EVIDENCE) built on a host in dev, with the restriction that this host was already running on Luminous, while this fix is for Jewel.
