### PR TITLE
[21.05] Revert "ceph/mon: drop pg max object skew warning" to fix MANY_OBJECTS_PER_PG warning

### DIFF
--- a/nixos/services/ceph/client.nix
+++ b/nixos/services/ceph/client.nix
@@ -20,7 +20,6 @@ in
 
     flyingcircus.services.ceph = {
       config = lib.mkOption {
-        # TODO for next ceph release upgrade: move to structured config with INI generator
         type = lib.types.lines;
         default = ''
           [global]
@@ -56,6 +55,7 @@ in
 
           mon data = /srv/ceph/mon/$cluster-$id
           mon osd allow primary affinity = true
+          mon pg warn max object skew = 20
 
           mgr data = /srv/ceph/mgr/$cluster-$id
         '';


### PR DESCRIPTION
This reverts commit e803041c837d1b71143df5b1d9dd97505e652d59. The config option was erroneously removed, but is actually still required on our production machines.
Tested on a cluster with `ceph config set mon_pg_warn_max_object_skew 20` to resolve the MANY_OBJECTS_PER_PG warning.

@flyingcircusio/release-managers

## Release process

Impact: internal only

Changelog:

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? Fixes a health warning by bringing back a previously applied config option.
- [x] Security requirements tested? Verified in WHQ that this fixes the regression introduced by temporarily setting `ceph config set mon_pg_warn_max_object_skew 20`. Also rolled this out to a single dev server.
