### PR TITLE
[21.05] netboot-installer: make ethtool and tcpdump available

### DIFF
--- a/release/netboot-installer.nix
+++ b/release/netboot-installer.nix
@@ -321,6 +321,8 @@ in
       show_interfaces
       secure_erase
       ipmitool
+      ethtool
+      tcpdump
     ];
   };
 }


### PR DESCRIPTION
ethtool and tcpdump can be useful for identifying network interfaces at system installation phase. Thus it makes sense to have them available right away in the installer image.

@flyingcircusio/release-managers

## Release process

Impact: internal only

Changelog:

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? Two helper utilities are added to the install image. This does not affect installed production images
- [x] Security requirements tested? (EVIDENCE)
  - [x] installer image still needs to build, packages introduce no conflicts
