### PR TITLE
[21.11] agent: set state version

### DIFF
--- a/pkgs/fc/agent/fc/util/enc.py
+++ b/pkgs/fc/agent/fc/util/enc.py
@@ -6,11 +6,14 @@ import os
 import shutil
 import socket
 import tempfile
+from pathlib import Path
 
 import structlog
 from fc.util.directory import connect
 
 structlog = structlog.get_logger()
+
+STATE_VERSION_FILE = Path("/etc/local/nixos/state_version")
 
 
 def load_enc(log, enc_path):
@@ -67,6 +70,34 @@ def initialize_enc(log, tmpdir, enc_path):
             enc_path=str(enc_path),
             initial_enc_path=str(initial_enc_path),
         )
+
+
+def initialize_state_version(
+    log, os_release_file: Path, state_version_file: Path
+):
+
+    if not state_version_file.exists():
+
+        with open(os_release_file) as f:
+            for line in f.readlines():
+                if line.startswith("VERSION_ID="):
+                    _, state_version_quoted = line.strip().split("=")
+                    break
+
+        state_version = state_version_quoted.strip('"')
+
+        log.info(
+            "initialize-state-version",
+            _replace_msg=(
+                f"No state version found, setting {state_version} from running "
+                "system."
+            ),
+            state_version=state_version,
+        )
+
+        state_version_file.write_text(state_version)
+        state_version_file.chmod(0o664)
+        shutil.chown(state_version_file, "root", "service")
 
 
 def update_enc_nixos_config(log, enc, enc_path):
@@ -232,6 +263,11 @@ def update_enc(log, tmpdir, enc_path):
     and writes the current system state.
     """
     initialize_enc(log, tmpdir, enc_path)
+    initialize_state_version(
+        log,
+        os_release_file=Path("/etc/os-release"),
+        state_version_file=STATE_VERSION_FILE,
+    )
     enc = load_enc(log, enc_path)
     update_inventory(log, enc)
     update_enc_nixos_config(log, enc, enc_path)

--- a/pkgs/fc/agent/fc/util/tests/test_enc.py
+++ b/pkgs/fc/agent/fc/util/tests/test_enc.py
@@ -47,7 +47,9 @@ def test_initialize_enc_should_not_crash_when_initial_data_missing(
 @unittest.mock.patch("fc.util.enc.write_system_state")
 @unittest.mock.patch("fc.util.enc.update_enc_nixos_config")
 @unittest.mock.patch("fc.util.enc.update_inventory")
+@unittest.mock.patch("fc.util.enc.initialize_state_version")
 def test_update_enc(
+    initialize_state_version,
     update_inventory,
     update_enc_nixos_config,
     write_system_state,
@@ -63,6 +65,7 @@ def test_update_enc(
 
     update_enc(logger, tmpdir_path, enc_path)
 
+    initialize_state_version.assert_called_once()
     update_inventory.assert_called_with(logger, enc_data)
     update_enc_nixos_config.assert_called_with(logger, enc_data, enc_path)
     write_system_state.assert_called_with(logger)


### PR DESCRIPTION
Partial backport of #PL-130893: only sets the state version to the current system version but it's unused while still on 21.11. After upgrading to 22.05, the state version will be read from the file and thus stay at 21.11.

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

- Write state version (currently equal to the platform version: 21.11) to `/etc/local/nixos/state_version`. This has no effect for now but allows us to manage platform upgrades better in the future (#PL-130893).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - nothing, just record current state version for future use 
- [x] Security requirements tested? (EVIDENCE)
  - checked manually that state version is written correctly
