### PR TITLE
Add fc-postgresql command and autoupgrade options

### DIFF
--- a/doc/src/postgresql.md
+++ b/doc/src/postgresql.md
@@ -63,6 +63,70 @@ The default monitoring setup checks that the PostgreSQL server process is
 running and that it responds to connection attempts to the standard PostgreSQL
 port.
 
+## Major Version Upgrades
+
+Upgrading to a new major version, for example from 13.x to 14.x, requires a
+migration of the old database cluster living in {file}`/srv/postgresql/13` to
+the new data directory at {file}`/srv/postgresql/14`. A common way to do this
+is to use {command}`pg_upgrade` bundled with PostgreSQL. This works on our
+platform but finding the right arguments for the command is not trivial.
+
+To make it easy, we have a `fc-postgresql` command which can show the
+current state of data directories for the available major versions, prepare
+and run upgrade migrations.
+
+:::{note}
+{command}`fc-postgresql` has to be run as `postgres` user. Prefix the
+commands with `sudo -u postgres` or use `sudo -iu postgres` to change
+to the `postgres` user. This is allowed for `service` and `sudo-srv`
+users.
+:::
+
+To show which data directories exists, their migration status and which
+service version is running, use {command}`fc-postgresql list-versions`.
+
+:::{note}
+Please look at the output of {command}`fc-postgresql list-versions`
+before performing an upgrade and make sure that your assumptions about
+the current state (which version is active, which data dirs are there, ...)
+are correct.
+:::
+
+To prepare an upgrade, for example, when you use the `postgresql13` role at
+the moment and you want to change to `postgresql14`, run
+{command}`fc-postgresql upgrade --new-version 14` while the old role is
+still active. It's safe to run the command while PostgreSQL is running as it
+does not have an impact on the current cluster and downtime is not required.
+
+The command should automatically find the old data directory for 13, set up
+the new data directory and succeed if no problems with the old cluster were
+found. Problems may occur if the old cluster has been created with
+non-standard settings which are not compatible with the new cluster, the old
+directory has an invalid structure or multiple old data directories which
+need migration are found.
+
+:::{warning}
+Depending on the machine and the amount of data, the next step may take
+some time. PostgreSQL will not be available during the upgrade!
+:::
+
+To actually run the upgrade, use {command}`fc-postgresql upgrade --new-version
+14 --upgrade-now`. This will stop the postgresql service, migrate data and
+mark the old data directory as migrated. It cannot be used by the postgresql
+service anymore after this point.
+
+Run {command}`fc-postgresql list-versions` to see how the status of the old
+and new data dir has changed.
+
+After the migration, postgresql is still stopped and you have to change your
+configuration to the new major version, for example by disabling the
+`postgresql13` role and activating the `postgresql14` role, in one step.
+
+If you really need to go back to the old version, delete the new data directory
+as `postgres` user, remove the {file}`fcio_migrated_to*` files in the old data
+directory and switch back to the old postgresql role.
+
+
 ## Miscellaneous
 
 Our PostgreSQL installations have the autoexplain feature enabled by default.

--- a/nixos/platform/agent.nix
+++ b/nixos/platform/agent.nix
@@ -95,9 +95,14 @@ in
           ];
           groups = [ "sudo-srv" "service" ];
         }
-
-        { commands = [ "${pkgs.fc.agent}/bin/fc-manage check" ];
+        {
+          commands = [ "${pkgs.fc.agent}/bin/fc-manage check" ];
           groups = [ "sensuclient" ];
+        }
+        {
+          commands = [ "${pkgs.fc.agent}/bin/fc-postgresql check-autoupgrade-unexpected-dbs" ];
+          users = [ "sensuclient" ];
+          runAs = "postgres";
         }
       ];
 

--- a/nixos/services/postgresql.nix
+++ b/nixos/services/postgresql.nix
@@ -4,6 +4,7 @@ with builtins;
 
 let
   cfg = config.flyingcircus.services.postgresql;
+  upstreamCfg = config.services.postgresql;
   fclib = config.fclib;
   packages = {
     "10" = pkgs.postgresql_10;
@@ -12,6 +13,8 @@ let
     "13" = pkgs.postgresql_13;
     "14" = pkgs.postgresql_14;
   };
+
+  oldestMajorVersion = head (lib.attrNames packages);
 
   listenAddresses =
     fclib.network.lo.dualstack.addresses ++
@@ -53,6 +56,37 @@ in {
 
     flyingcircus.services.postgresql = {
       enable = mkEnableOption "Enable preconfigured PostgreSQL";
+
+      autoUpgrade = {
+        enable = mkEnableOption ''
+          Automatically migrate old data dir when major version of PostgreSQL
+          changes, using fc-postgresql/pg_upgrade.
+          The old data dir will be kept and has to be removed manually later.
+          You can run `sudo -u postgres fc-postgresql prepare-autoupgrade` to
+          create the new data dir before upgrading PostgreSQL to reduce downtime
+          and the risk of failure. You have to add databases to `expectedDatabases`
+          or disable `checkExpectedDatabases` to make this work.
+        '';
+        checkExpectedDatabases = mkOption {
+          type = types.bool;
+          default = true;
+          description = ''
+            Check that only the databases specified by `expectedDatabases`
+            (and the standard internal databases) are present.
+            This is enabled by default and prevents auto-upgrades affecting
+            unexpected databases.
+          '';
+        };
+        expectedDatabases = mkOption {
+          type = types.listOf types.str;
+          default = [];
+          description = ''
+            List of databases that are expected to be present before upgrading.
+            If more databases are found, the upgrade will not run.
+          '';
+        };
+      };
+
       majorVersion = mkOption {
           type = types.str;
           description = ''
@@ -63,205 +97,304 @@ in {
 
   };
 
-  config =
-  (lib.mkIf cfg.enable (
-  let
-    postgresqlPkg = getAttr cfg.majorVersion packages;
-
-    extensions = lib.optionals (lib.versionOlder cfg.majorVersion "12") [
-      (pkgs.postgis_2_5.override { postgresql = postgresqlPkg; })
-      (pkgs.temporal_tables.override { postgresql = postgresqlPkg; })
-      (pkgs.rum.override { postgresql = postgresqlPkg; })
-    ] ++ lib.optionals (lib.versionAtLeast cfg.majorVersion "12") [
-      postgresqlPkg.pkgs.periods
-      postgresqlPkg.pkgs.postgis
-      (pkgs.rum.override { postgresql = postgresqlPkg; })
-    ];
-
-  in {
-
-    systemd.services.postgresql.bindsTo = [ "network-addresses-ethsrv.service" ];
-
-    systemd.services.postgresql.postStart =
+  config = lib.mkMerge [
+    (lib.mkIf cfg.enable (
     let
-      psql = "${postgresqlPkg}/bin/psql --port=${toString config.services.postgresql.port}";
-    in ''
-      if ! ${psql} -c '\du' template1 | grep -q '^ *nagios *|'; then
-        ${psql} -c 'CREATE ROLE nagios NOSUPERUSER NOCREATEDB NOCREATEROLE NOINHERIT LOGIN' template1
-      fi
-      if ! ${psql} -l | grep -q '^ *nagios *|'; then
-        ${postgresqlPkg}/bin/createdb --port ${toString config.services.postgresql.port} nagios
-      fi
-      ${psql} -q -d nagios -c 'REVOKE ALL ON SCHEMA public FROM PUBLIC CASCADE;'
-    '';
+      postgresqlPkg = getAttr cfg.majorVersion packages;
 
-    systemd.services.postgresql.serviceConfig =
-      lib.optionalAttrs (lib.versionAtLeast cfg.majorVersion "12") {
-        RuntimeDirectory = "postgresql";
-      };
+      extensions = lib.optionals (lib.versionOlder cfg.majorVersion "12") [
+        (pkgs.postgis_2_5.override { postgresql = postgresqlPkg; })
+        (pkgs.temporal_tables.override { postgresql = postgresqlPkg; })
+        (pkgs.rum.override { postgresql = postgresqlPkg; })
+      ] ++ lib.optionals (lib.versionAtLeast cfg.majorVersion "12") [
+        postgresqlPkg.pkgs.periods
+        postgresqlPkg.pkgs.postgis
+        (pkgs.rum.override { postgresql = postgresqlPkg; })
+      ];
 
-    users.users.postgres = {
-      shell = "/run/current-system/sw/bin/bash";
-      home = lib.mkForce "/srv/postgresql";
-    };
+    in {
 
-    environment.etc."local/postgresql/${cfg.majorVersion}/README.txt".text = ''
-        Put your local postgresql configuration here. This directory
-        is being included with include_dir.
-        '';
-
-    flyingcircus.infrastructure.preferNoneSchedulerOnSsd = true;
-
-    flyingcircus.activationScripts = {
-      postgresql-srv = lib.stringAfter [ "users" "groups" ] ''
-        install -d -o postgres /srv/postgresql
-      '';
-    };
-
-    flyingcircus.localConfigDirs.postgresql = {
-      dir = (toString localConfigPath);
-      user = "postgres";
-    };
-
-    flyingcircus.passwordlessSudoRules = [
-      # Service users may switch to the postgres system user
-      {
-        commands = [ "ALL" ];
-        groups = [ "sudo-srv" "service" ];
-        runAs = "postgres";
-      }
-    ];
-
-    # System tweaks
-    boot.kernel.sysctl = {
-      "kernel.shmmax" = toString sharedMemoryMax;
-      "kernel.shmall" = toString (sharedMemoryMax / 4096);
-    };
-
-    services.udev.extraRules = ''
-      # increase readahead for postgresql
-      SUBSYSTEM=="block", ACTION=="add|change", KERNEL=="vd[a-z]", ATTR{bdi/read_ahead_kb}="1024", ATTR{queue/read_ahead_kb}="1024"
-    '';
-
-    services.postgresql = {
-
-      enable = true;
-      # The config check is too strict for now because it doesn't build
-      # when there's an error and fails even for our default config.
-      # May happen when files are not accessible from the Nix sandbox.
-      # Looks like that locale files cannot be found.
-      # XXX: Switching it to a warning and filtering out locale issues
-      # would be interesting.
-      checkConfig = false;
-      dataDir = "/srv/postgresql/${cfg.majorVersion}";
-      extraPlugins = extensions;
-      initialScript = ./postgresql-init.sql;
-      logLinePrefix = "user=%u,db=%d ";
-      package = postgresqlPkg;
-
-      authentication = ''
-        local postgres root       trust
-        # trusted access for Nagios
-        host    nagios          nagios          0.0.0.0/0               trust
-        host    nagios          nagios          ::/0                    trust
-        # authenticated access for others
-        host all  all  0.0.0.0/0  md5
-        host all  all  ::/0       md5
-      '';
-
-      settings = {
-        #------------------------------------------------------------------------------
-        # CONNECTIONS AND AUTHENTICATION
-        #------------------------------------------------------------------------------
-        listen_addresses = lib.mkOverride 50 (concatStringsSep "," listenAddresses);
-        max_connections = 400;
-        #------------------------------------------------------------------------------
-        # RESOURCE USAGE (except WAL)
-        #------------------------------------------------------------------------------
-        # available memory: ${toString currentMemory}MB
-        shared_buffers = "${toString sharedBuffers}MB"; # starting point is 25% RAM
-        temp_buffers = "16MB";
-        work_mem = "${toString workMem}MB";
-        maintenance_work_mem = "${toString maintenanceWorkMem}MB";
-        #------------------------------------------------------------------------------
-        # QUERY TUNING
-        #------------------------------------------------------------------------------
-        effective_cache_size = "${toString (sharedBuffers * 2)}MB";
-
-        random_page_cost = randomPageCost;
-        # version-specific resource settings for >=9.3
-        effective_io_concurrency = 100;
-
-        #------------------------------------------------------------------------------
-        # WRITE AHEAD LOG
-        #------------------------------------------------------------------------------
-        wal_level = "hot_standby";
-        wal_buffers = "${toString walBuffers}MB";
-        checkpoint_completion_target = 0.9;
-        archive_mode = false;
-
-        #------------------------------------------------------------------------------
-        # ERROR REPORTING AND LOGGING
-        #------------------------------------------------------------------------------
-        log_min_duration_statement = 100;
-        log_checkpoints = true;
-        log_connections = true;
-        log_lock_waits = true;
-        log_autovacuum_min_duration = 5000;
-        log_temp_files = "1kB";
-        shared_preload_libraries = "auto_explain, pg_stat_statements";
-        "auto_explain.log_min_duration" = "3s";
-
-        #------------------------------------------------------------------------------
-        # CLIENT CONNECTION DEFAULTS
-        #------------------------------------------------------------------------------
-        datestyle = "iso, mdy";
-        lc_messages = "en_US.utf8";
-        lc_monetary = "en_US.utf8";
-        lc_numeric = "en_US.utf8";
-        lc_time = "en_US.utf8";
-      } // localConfig;
-
-    };
-
-    # PostgreSQL used /tmp as socket location in earlier NixOS versions.
-    # That has been changed to /run/postgresql but users may still expect the old location.
-    systemd.tmpfiles.rules = [
-      "L /tmp/.s.PGSQL.5432 - - - - /run/postgresql/.s.PGSQL.5432"
-    ];
-
-    flyingcircus.services = {
-
-      sensu-client.checks =
-        lib.listToAttrs (
-        map (host:
-            let saneHost = replaceStrings [":"] ["_"] host;
-            in
-            { name = "postgresql-listen-${saneHost}-5432";
-              value = {
-                notification = "PostgreSQL listening on ${host}:5432";
-                command = ''
-                  ${pkgs.sensu-plugins-postgres}/bin/check-postgres-alive.rb \
-                    -h ${host} -u nagios -d nagios -P 5432 -T 10
-                '';
-                interval = 120;
-              };
-            })
-          listenAddresses);
-
-      telegraf.inputs = {
-        postgresql = [
-          (if (lib.versionOlder cfg.majorVersion "12") then {
-            address = "host=/tmp user=root sslmode=disable dbname=postgres";
-          }
-          else {
-            address = "host=/run/postgresql user=root sslmode=disable dbname=postgres";
-            # Workaround for a telegraf bug: https://github.com/influxdata/telegraf/issues/6712
-            ignored_databases = [ "postgres" "template0" "template1" ];
-          })
+      systemd.services.postgresql.unitConfig = {
+        ConditionPathExists = [
+          # There is an upgrade running currently, postgresql must not start now.
+          "!${upstreamCfg.dataDir}/fcio_stopper"
         ];
       };
-    };
 
-  }));
+      systemd.services.postgresql.bindsTo = [ "network-addresses-ethsrv.service" ];
+
+      systemd.services.postgresql.preStart = lib.mkBefore ''
+        if [[ -e ${upstreamCfg.dataDir}/fcio_migrated_to ]]; then
+          echo "Error: cannot start because the migration marker ${upstreamCfg.dataDir}/fcio_migrated_to is present."
+          echo "This data dir must not be used anymore if there is a newer data dir."
+          echo "Maybe the wrong postgresql role version is selected?"
+          echo "See 'sudo -u postgres fc-postgresql list-versions'"
+          echo "and 'sudo -u postgres cat ${upstreamCfg.dataDir}/fcio_migrated_to.log'"
+          echo "Only delete the marker if you sure that you want to use this data dir."
+          exit 2
+        fi
+
+        if [[ -e ${upstreamCfg.dataDir}/fcio_upgrade_prepared ]]; then
+          echo "Error: cannot start because the upgrade preparation marker ${upstreamCfg.dataDir}/fcio_upgrade_prepared is present."
+          echo "Is there an unfinished manual upgrade or did you mean to enable autoupgrade?"
+          echo "See 'sudo -u postgres fc-postgresql list-versions'"
+          echo "and 'sudo -u postgres cat ${upstreamCfg.dataDir}/fcio_upgrade_prepared'"
+          echo "Only delete the marker if you sure that you want to use this data dir."
+          exit 2
+        fi
+      '';
+
+      systemd.services.postgresql.postStart =
+      let
+        psql = "${postgresqlPkg}/bin/psql --port=${toString upstreamCfg.port}";
+      in ''
+        if ! ${psql} -c '\du' template1 | grep -q '^ *nagios *|'; then
+          ${psql} -c 'CREATE ROLE nagios NOSUPERUSER NOCREATEDB NOCREATEROLE NOINHERIT LOGIN' template1
+        fi
+        if ! ${psql} -l | grep -q '^ *nagios *|'; then
+          ${postgresqlPkg}/bin/createdb --port ${toString upstreamCfg.port} nagios
+        fi
+        ${psql} -q -d nagios -c 'REVOKE ALL ON SCHEMA public FROM PUBLIC CASCADE;'
+
+        ln -sfT ${postgresqlPkg} ${upstreamCfg.dataDir}/package
+        ln -sfT ${upstreamCfg.dataDir}/package /nix/var/nix/gcroots/per-user/postgres/package_${cfg.majorVersion}
+      '';
+
+      systemd.services.postgresql.serviceConfig =
+        lib.optionalAttrs (lib.versionAtLeast cfg.majorVersion "12") {
+          RuntimeDirectory = "postgresql";
+        };
+
+      users.users.postgres = {
+        shell = "/run/current-system/sw/bin/bash";
+        home = lib.mkForce "/srv/postgresql";
+      };
+
+      environment.etc."local/postgresql/${cfg.majorVersion}/README.txt".text = ''
+          Put your local postgresql configuration here. This directory
+          is being included with include_dir.
+          '';
+
+      flyingcircus.infrastructure.preferNoneSchedulerOnSsd = true;
+
+      flyingcircus.activationScripts = {
+        postgresql-srv = lib.stringAfter [ "users" "groups" ] ''
+          install -d -o postgres /srv/postgresql
+          install -d -o postgres /nix/var/nix/gcroots/per-user/postgres
+        '';
+      };
+
+      flyingcircus.localConfigDirs.postgresql = {
+        dir = (toString localConfigPath);
+        user = "postgres";
+      };
+
+      flyingcircus.passwordlessSudoRules = [
+        # Service users may switch to the postgres system user
+        {
+          commands = [ "ALL" ];
+          groups = [ "sudo-srv" "service" ];
+          runAs = "postgres";
+        }
+        {
+          commands = [
+            "${pkgs.systemd}/bin/systemctl start postgresql"
+            "${pkgs.systemd}/bin/systemctl stop postgresql"
+          ];
+          users = [ "postgres" ];
+        }
+      ];
+
+      # System tweaks
+      boot.kernel.sysctl = {
+        "kernel.shmmax" = toString sharedMemoryMax;
+        "kernel.shmall" = toString (sharedMemoryMax / 4096);
+      };
+
+      services.udev.extraRules = ''
+        # increase readahead for postgresql
+        SUBSYSTEM=="block", ACTION=="add|change", KERNEL=="vd[a-z]", ATTR{bdi/read_ahead_kb}="1024", ATTR{queue/read_ahead_kb}="1024"
+      '';
+
+      services.postgresql = {
+
+        enable = true;
+        # The config check is too strict for now because it doesn't build
+        # when there's an error and fails even for our default config.
+        # May happen when files are not accessible from the Nix sandbox.
+        # Looks like that locale files cannot be found.
+        # XXX: Switching it to a warning and filtering out locale issues
+        # would be interesting.
+        checkConfig = false;
+        dataDir = "/srv/postgresql/${cfg.majorVersion}";
+        extraPlugins = extensions;
+        initialScript = ./postgresql-init.sql;
+        logLinePrefix = "user=%u,db=%d ";
+        package = postgresqlPkg;
+
+        authentication = ''
+          local postgres root       trust
+          # trusted access for Nagios
+          host    nagios          nagios          0.0.0.0/0               trust
+          host    nagios          nagios          ::/0                    trust
+          # authenticated access for others
+          host all  all  0.0.0.0/0  md5
+          host all  all  ::/0       md5
+        '';
+
+        settings = {
+          #------------------------------------------------------------------------------
+          # CONNECTIONS AND AUTHENTICATION
+          #------------------------------------------------------------------------------
+          listen_addresses = lib.mkOverride 50 (concatStringsSep "," listenAddresses);
+          max_connections = 400;
+          #------------------------------------------------------------------------------
+          # RESOURCE USAGE (except WAL)
+          #------------------------------------------------------------------------------
+          # available memory: ${toString currentMemory}MB
+          shared_buffers = "${toString sharedBuffers}MB"; # starting point is 25% RAM
+          temp_buffers = "16MB";
+          work_mem = "${toString workMem}MB";
+          maintenance_work_mem = "${toString maintenanceWorkMem}MB";
+          #------------------------------------------------------------------------------
+          # QUERY TUNING
+          #------------------------------------------------------------------------------
+          effective_cache_size = "${toString (sharedBuffers * 2)}MB";
+
+          random_page_cost = randomPageCost;
+          # version-specific resource settings for >=9.3
+          effective_io_concurrency = 100;
+
+          #------------------------------------------------------------------------------
+          # WRITE AHEAD LOG
+          #------------------------------------------------------------------------------
+          wal_level = "hot_standby";
+          wal_buffers = "${toString walBuffers}MB";
+          checkpoint_completion_target = 0.9;
+          archive_mode = false;
+
+          #------------------------------------------------------------------------------
+          # ERROR REPORTING AND LOGGING
+          #------------------------------------------------------------------------------
+          log_min_duration_statement = 100;
+          log_checkpoints = true;
+          log_connections = true;
+          log_lock_waits = true;
+          log_autovacuum_min_duration = 5000;
+          log_temp_files = "1kB";
+          shared_preload_libraries = "auto_explain, pg_stat_statements";
+          "auto_explain.log_min_duration" = "3s";
+
+          #------------------------------------------------------------------------------
+          # CLIENT CONNECTION DEFAULTS
+          #------------------------------------------------------------------------------
+          datestyle = "iso, mdy";
+          lc_messages = "en_US.utf8";
+          lc_monetary = "en_US.utf8";
+          lc_numeric = "en_US.utf8";
+          lc_time = "en_US.utf8";
+        } // localConfig;
+
+      };
+
+      # PostgreSQL used /tmp as socket location in earlier NixOS versions.
+      # That has been changed to /run/postgresql but users may still expect the old location.
+      systemd.tmpfiles.rules = [
+        "d /var/log/fc-agent/postgresql - postgres service"
+        "L /tmp/.s.PGSQL.5432 - - - - /run/postgresql/.s.PGSQL.5432"
+      ];
+
+      flyingcircus.services = {
+
+        sensu-client.checkEnvPackages = [
+          postgresqlPkg
+        ];
+
+        sensu-client.checks =
+          lib.optionalAttrs (cfg.autoUpgrade.enable && cfg.autoUpgrade.checkExpectedDatabases) {
+            postgresql-autoupgrade-possible = {
+              notification = "Unexpected PostgreSQL databases present, autoupgrade will fail!";
+              command = "sudo -u postgres ${pkgs.fc.agent}/bin/fc-postgresql check-autoupgrade-unexpected-dbs";
+              interval = 600;
+            };
+          } // (lib.listToAttrs (
+          map (host:
+              let saneHost = replaceStrings [":"] ["_"] host;
+              in
+              { name = "postgresql-listen-${saneHost}-5432";
+                value = {
+                  notification = "PostgreSQL listening on ${host}:5432";
+                  command = ''
+                    ${pkgs.sensu-plugins-postgres}/bin/check-postgres-alive.rb \
+                      -h ${host} -u nagios -d nagios -P 5432 -T 10
+                  '';
+                  interval = 120;
+                };
+              })
+            listenAddresses));
+
+        telegraf.inputs = {
+          postgresql = [
+            (if (lib.versionOlder cfg.majorVersion "12") then {
+              address = "host=/tmp user=root sslmode=disable dbname=postgres";
+            }
+            else {
+              address = "host=/run/postgresql user=root sslmode=disable dbname=postgres";
+              # Workaround for a telegraf bug: https://github.com/influxdata/telegraf/issues/6712
+              ignored_databases = [ "postgres" "template0" "template1" ];
+            })
+          ];
+        };
+      };
+
+    }))
+
+    (lib.mkIf cfg.autoUpgrade.enable {
+      environment.etc."local/postgresql/autoupgrade.json".text = toJSON {
+        expected_databases = cfg.autoUpgrade.expectedDatabases;
+      };
+
+      systemd.services.fc-postgresql-autoupgrade = {
+        path = with pkgs; [
+          sudo
+        ];
+
+        before = [ "postgresql.service" ];
+        requiredBy = [ "postgresql.service" ];
+
+        script = let
+          expectedDatabaseStr = lib.concatMapStringsSep " " (d: "--expected ${d}") cfg.autoUpgrade.expectedDatabases;
+          upgradeCmd = [
+            "${pkgs.fc.agent}/bin/fc-postgresql upgrade"
+            "--new-version ${cfg.majorVersion}"
+            "--new-data-dir ${upstreamCfg.dataDir}"
+            "--new-bin-dir ${upstreamCfg.package}/bin"
+            "--no-stop"
+            "--nothing-to-do-is-ok"
+            "--upgrade-now"
+          ] ++ lib.optional cfg.autoUpgrade.checkExpectedDatabases
+            "--existing-db-check ${expectedDatabaseStr}";
+        in
+          concatStringsSep " \\\n  " upgradeCmd;
+
+        serviceConfig = {
+          Type = "oneshot";
+          RemainAfterExit = true;
+          User = "postgres";
+          Group = "postgres";
+          ProtectHome = true;
+          ProtectSystem = true;
+        };
+        unitConfig = {
+          ConditionPathExists = [
+            # Don't try to autoupgrade if the new data dir has markers that
+            # show that a migration already has happenend (fcio_migrated_from)
+            # or that the postgresql.service already has used this directory (package).
+            "!${upstreamCfg.dataDir}/fcio_migrated_from"
+            "!${upstreamCfg.dataDir}/package"
+          ];
+        };
+      };
+    })
+  ];
 }

--- a/pkgs/fc/agent/conftest.py
+++ b/pkgs/fc/agent/conftest.py
@@ -1,0 +1,24 @@
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--with-nix-build",
+        action="store_true",
+        default=False,
+        dest="with_nix_build",
+        help=(
+            "Run tests that need a working Nix environment which can "
+            "download and build things. Does not work in isolated environments"
+        ),
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("with_nix_build"):
+        return
+
+    skip_nix = pytest.mark.skip(reason="needs --with-nix-build option to run")
+    for item in items:
+        if "needs_nix" in item.keywords:
+            item.add_marker(skip_nix)

--- a/pkgs/fc/agent/fc/manage/postgresql.py
+++ b/pkgs/fc/agent/fc/manage/postgresql.py
@@ -1,0 +1,489 @@
+import json
+import os
+import shutil
+import traceback
+from pathlib import Path
+from typing import List, NamedTuple, Optional
+
+import fc.util.postgresql
+import rich
+import structlog
+from fc.util.logging import init_logging
+from fc.util.postgresql import PGVersion
+from rich.table import Table
+from typer import Exit, Option, Typer, confirm, echo
+
+STOPPER_TEMPLATE = """\
+A fc-postgresql upgrade command is running with PID {pid}, postgresql service
+won't start with this file present. Remove this if you really want to start
+the service with this data dir.
+"""
+
+
+class Context(NamedTuple):
+    logdir: Path
+    verbose: bool
+    pg_data_root: Path
+
+
+app = Typer()
+context: Context
+
+
+def stop_pg(log, old_data_dir: Path, stop: bool):
+    postgres_running = fc.util.postgresql.is_service_running()
+    if postgres_running and stop is None:
+        stop = confirm("Postgresql is running, should I stop it?")
+    if postgres_running and not stop:
+        log.error(
+            "upgrade-postgresql-running",
+            _replace_msg=(
+                "PostgreSQL is running! Please make sure that it doesn't "
+                "run during the migration."
+            ),
+        )
+        raise Exit(2)
+    elif postgres_running:
+        fc.util.postgresql.run(
+            ["sudo", "systemctl", "stop", "postgresql"],
+            text=True,
+            check=True,
+        )
+        postgres_running = False
+    old_dir_stopper = old_data_dir / "fcio_stopper"
+    old_dir_stopper.write_text(STOPPER_TEMPLATE.format(pid=os.getpid()))
+    shutil.chown(old_dir_stopper, user="postgres")
+    return postgres_running
+
+
+@app.callback(no_args_is_help=True)
+def fc_postgresql(
+    verbose: bool = Option(
+        False, "--verbose", "-v", help="Show debug messages and code locations."
+    ),
+    logdir: Path = Option(
+        exists=True,
+        file_okay=False,
+        writable=True,
+        default="/var/log/fc-agent/postgresql",
+        help="Directory for log files.",
+    ),
+    pg_data_root: Path = Option(
+        exists=True,
+        file_okay=False,
+        writable=True,
+        default="/srv/postgresql",
+        help=(
+            "Directory where PG data dirs are stored. subdirectories are "
+            "expected to have the PostgreSQL major version as name"
+        ),
+    ),
+):
+    global context
+
+    context = Context(
+        logdir=logdir,
+        verbose=verbose,
+        pg_data_root=pg_data_root,
+    )
+
+    init_logging(verbose, syslog_identifier="fc-postgresql")
+
+
+@app.command(
+    no_args_is_help=True,
+    help="Major version upgrade using pg_upgrade.",
+)
+def upgrade(
+    new_version: PGVersion = Option(
+        show_choices=True,
+        default=None,
+        help=(
+            "PostgreSQL version to upgrade to. Should usually be specified. "
+            "Upgrading by passing the new data dir and new binary dir "
+            "instead is also supported but not recommended."
+        ),
+    ),
+    upgrade_now: bool = Option(
+        default=False,
+        help="Actually do the upgrade now. If not given, "
+        "just create the new data dir and do pre-checks",
+    ),
+    existing_db_check: bool = Option(
+        default=True,
+        help="Stop upgrade if unexpected databases are present.",
+    ),
+    expected: Optional[List[str]] = Option(
+        default=[],
+        help=(
+            "Database name that is expected to be present before the "
+            "migration. "
+            "Databases created by FCIO automation are automatically added to "
+            "the expected databases."
+            "Option can be specified multiple times."
+        ),
+    ),
+    new_data_dir: Optional[Path] = Option(
+        file_okay=False,
+        help=(
+            "New PostgreSQL data directory. Will be determined automatically "
+            "if --new-version is specified"
+        ),
+        default=None,
+    ),
+    new_bin_dir: Optional[Path] = Option(
+        file_okay=False,
+        exists=True,
+        help=(
+            "Directory where the new PostgreSQL binaries are. Will be "
+            "determined automatically if --new-version is specified"
+        ),
+        default=None,
+    ),
+    stop: Optional[bool] = Option(default=None),
+    nothing_to_do_is_ok: Optional[bool] = False,
+):
+    log = structlog.get_logger()
+
+    log.debug("upgrade-start")
+
+    if not (new_data_dir and new_bin_dir):
+        if new_version is None:
+            echo(
+                "If PG version is not specified, both new-data-dir and "
+                "new-bin-dir must be specified instead!"
+            )
+            raise Exit(2)
+
+        new_bin_dir = fc.util.postgresql.build_new_bin_dir(
+            log, context.pg_data_root, new_version
+        )
+        new_data_dir = context.pg_data_root / new_version.value
+
+    old_data_dir = fc.util.postgresql.find_old_data_dir(
+        log, context.pg_data_root, new_version
+    )
+
+    exit_on_no_old_data_dir(log, old_data_dir, nothing_to_do_is_ok)
+
+    fc.util.postgresql.prepare_upgrade(
+        log,
+        old_data_dir,
+        new_version,
+        new_bin_dir,
+        new_data_dir,
+        expected_databases=expected if existing_db_check else None,
+    )
+
+    if upgrade_now:
+
+        stop_pg(log, old_data_dir, stop)
+
+        fc.util.postgresql.run_pg_upgrade(
+            log,
+            new_bin_dir,
+            new_data_dir,
+            old_data_dir,
+        )
+
+        current_pgdata = fc.util.postgresql.get_current_pgdata_from_service()
+
+        if new_data_dir == current_pgdata:
+            log.info(
+                "upgrade-finished-service-ready",
+                _replace_msg=(
+                    "Upgrade is finished. You can start the postgresql "
+                    "service now."
+                ),
+            )
+        else:
+            log.info(
+                "upgrade-finished-service-not-ready",
+                _replace_msg=(
+                    "Upgrade is finished. The postgresql service still refers "
+                    "to another data dir: {current_pgdata} and should not be "
+                    "started. Switch to the postgresql{new_version} role now, "
+                    "if applicable."
+                ),
+                current_pgdata=current_pgdata,
+                new_version=new_version.value,
+            )
+    else:
+        fc.util.postgresql.run_pg_upgrade_check(
+            log,
+            new_bin_dir,
+            new_data_dir,
+            old_data_dir,
+        )
+
+        log.info(
+            "upgrade-prepare-finished",
+            _replace_msg=(
+                "Upgrade preparation finished. If everything looks correct, "
+                "run the upgrade by adding --upgrade-now to the command line."
+            ),
+        )
+
+
+def exit_on_no_old_data_dir(log, old_data_dir, nothing_to_do_is_ok):
+    if old_data_dir is None:
+        if nothing_to_do_is_ok:
+            log.info(
+                "upgrade-nothing-to-do",
+                _replace_msg=(
+                    "No old data directory found that could be migrated."
+                ),
+            )
+            raise Exit()
+        else:
+            log.error(
+                "upgrade-no-old-dirs-found",
+                _replace_msg=(
+                    "Couldn't find an eligible data dir for upgrading in "
+                    f"{context.pg_data_root}. Data dirs must have a symlink "
+                    "called 'package' pointing to the corresponding postgresql "
+                    "package."
+                ),
+            )
+            raise Exit(2)
+
+
+@app.command()
+def check_autoupgrade_unexpected_dbs(
+    config: Path = Option(
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+        default="/etc/local/postgresql/autoupgrade.json",
+    ),
+):
+    with open(config) as f:
+        autoupgrade_config = json.load(f)
+        expected_databases = set(autoupgrade_config["expected_databases"])
+
+    log = structlog.get_logger()
+
+    data_dir = fc.util.postgresql.get_current_pgdata_from_service()
+    try:
+        fc.util.postgresql.get_existing_dbs(
+            log,
+            data_dir,
+            postgres_running=True,
+            expected_dbs=expected_databases,
+        )
+    except fc.util.postgresql.UnexpectedDatabasesFound as e:
+        print(
+            f"WARNING: autoupgrade will not work, unexpected databases found:"
+            f" {e.unexpected_dbs}, "
+            f"expected only: {expected_databases}"
+        )
+        raise Exit(1)
+    except Exception:
+        print("UNKNOWN: getting existing databases failed with an exception:")
+        traceback.print_exc()
+        raise Exit(3)
+
+    print(f"OK: no unexpected databases found that would block autoupgrade.")
+
+
+@app.command(help="Prep data dir for autoupgrade")
+def prepare_autoupgrade(
+    config: Path = Option(
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+        default="/etc/local/postgresql/autoupgrade.json",
+    ),
+    new_version: PGVersion = Option(
+        ...,
+        prompt=True,
+        show_choices=True,
+        help="PostgreSQL version to upgrade to.",
+    ),
+    nothing_to_do_is_ok: Optional[bool] = False,
+):
+    with open(config) as f:
+        autoupgrade_config = json.load(f)
+        expected_databases = autoupgrade_config["expected_databases"]
+
+    log = structlog.get_logger()
+
+    new_bin_dir = fc.util.postgresql.build_new_bin_dir(
+        log, context.pg_data_root, new_version
+    )
+    new_data_dir = context.pg_data_root / new_version.value
+
+    if fc.util.postgresql.is_service_running():
+        current_data_dir = fc.util.postgresql.get_current_pgdata_from_service()
+        current_service_version = (
+            fc.util.postgresql.get_pg_version_from_data_dir(
+                log, current_data_dir
+            )
+        )
+
+        if new_version == current_service_version:
+            log.info(
+                "prepare-autoupgrade-requested-version-current",
+                version=new_version,
+                _replace_msg=(
+                    "No upgrade needed: the currently running postgresql "
+                    "service already uses the requested version {version}"
+                ),
+            )
+            raise Exit()
+    else:
+        log.warn(
+            "prepare-autoupgrade-pg-not-running",
+            _replace_msg=(
+                "The postgresql service is not running. You might want "
+                "to check its status. This can happen when autoupgrade "
+                "refused to do an upgrade. Continuing."
+            ),
+        )
+
+    try:
+        old_data_dir = fc.util.postgresql.find_old_data_dir(
+            log, context.pg_data_root, new_version
+        )
+    except fc.util.postgresql.MultipleOldDirsFound as e:
+        log.error(
+            "upgrade-multiple-old-dirs-found",
+            old_data_dirs=[str(d) for d in e.found_dirs],
+            _replace_msg=(
+                "Found multiple old data dirs which could be upgraded: "
+                "{eligible_old_data_dirs}"
+            ),
+        )
+        raise Exit(2)
+
+    exit_on_no_old_data_dir(log, old_data_dir, nothing_to_do_is_ok)
+
+    try:
+        fc.util.postgresql.prepare_upgrade(
+            log,
+            old_data_dir=old_data_dir,
+            new_version=new_version,
+            new_bin_dir=new_bin_dir,
+            new_data_dir=new_data_dir,
+            expected_databases=expected_databases,
+        )
+    except fc.util.postgresql.NewDataDirUnusable as e:
+        log.error(
+            "prepare-autoupgrade-new-data-dir-unusable",
+            _replace_msg=(
+                "New data dir already exists at {new_data_dir} and it "
+                "doesn't have the fcio_upgrade_prepare marker file. "
+                "Refusing to use this directory."
+            ),
+            new_data_dir=e.data_dir,
+        )
+        raise Exit(2)
+    except fc.util.postgresql.UnexpectedDatabasesFound as e:
+        log.error(
+            "prepare-autoupgrade-unexpected-dbs",
+            _replace_msg=(
+                "Found unexpected databases {unexpected_dbs}, "
+                "autoupgrade will refuse to run the upgrade."
+            ),
+            unexpected_dbs=e.unexpected_dbs,
+        )
+        raise Exit(2)
+
+    fc.util.postgresql.run_pg_upgrade_check(
+        log,
+        new_bin_dir=new_bin_dir,
+        new_data_dir=new_data_dir,
+        old_data_dir=old_data_dir,
+    )
+
+    log.info(
+        "prepare-autoupgrade-finished",
+        _replace_msg="Preparation completed, autoupgrade should run fine.",
+    )
+
+
+LIST_VERSION_HELP = """\
+Data dirs and migration state.
+
+## Fields
+
+*Version*
+
+Major version of PostgreSQL. All versions available on the current platform
+version are shown.
+
+*Data Dir*
+
+Path to data dir if it exists for this version.
+
+*Service Running?*
+
+`Yes` if postgresql.service is running and is using this version.
+
+*Migrated To*
+
+Target data dir where data has been migrated to. Data dirs with which have
+been migrated must not be used anymore.
+
+*Migrated From*
+
+Source data dir where data has been migrated from.
+
+*Package Known?*
+
+`Yes` if package link in data dir is valid. The link points to the PostgreSQL
+version that is or has been used for this data dir. The link is needed to
+upgrade to a newer version as pg_upgrade needs the old binaries to work.
+fc-postgresql upgrade and auto-upgrades will fail if this is missing.
+
+*Prepared For Upgrade?*
+
+`Yes` if data dir is prepared to be used as target for an upgrade migration.
+This means that `fc-postgresql prepare-autoupgrade` or `fc-postgresql
+upgrade` without `--upgrade-now` has created this data dir.
+
+"""
+
+
+@app.command(help=LIST_VERSION_HELP)
+def list_versions():
+
+    current_pgdata = fc.util.postgresql.get_current_pgdata_from_service()
+    service_running = fc.util.postgresql.is_service_running()
+
+    table = Table(
+        show_header=True,
+        title="Postgresql versions",
+        show_lines=True,
+        title_style="bold",
+    )
+
+    table.add_column("Version")
+    table.add_column("Data Dir")
+    table.add_column("Service Running?")
+    table.add_column("Migrated To")
+    table.add_column("Migrated From")
+    table.add_column("Package Known?")
+    table.add_column("Prepared For Upgrade?")
+    for version in [v.value for v in PGVersion]:
+        data_dir = context.pg_data_root / version
+
+        from_link = data_dir / "fcio_migrated_from"
+        to_link = data_dir / "fcio_migrated_to"
+        prepared_marker = data_dir / "fcio_upgrade_prepared"
+
+        table.add_row(
+            version,
+            str(data_dir) if data_dir.exists() else "-",
+            "Yes" if current_pgdata == data_dir and service_running else "-",
+            str(to_link.readlink()) if to_link.is_symlink() else "-",
+            str(from_link.readlink()) if from_link.is_symlink() else "-",
+            "Yes" if (data_dir / "package").exists() else "-",
+            "Yes" if prepared_marker.exists() else "-",
+        )
+
+    rich.print(table)
+
+
+if __name__ == "__main__":
+    app()

--- a/pkgs/fc/agent/fc/manage/tests/test_postgresql.py
+++ b/pkgs/fc/agent/fc/manage/tests/test_postgresql.py
@@ -1,0 +1,128 @@
+import json
+import traceback
+from unittest.mock import Mock, patch
+
+import fc.manage.postgresql
+import pytest
+import typer.testing
+
+
+@pytest.fixture
+def old_data_dir(tmp_path, monkeypatch):
+    old_data_dir = tmp_path / "postgresql/10/package"
+    old_data_dir.mkdir(parents=True)
+
+    monkeypatch.setattr(
+        "fc.util.postgresql.find_old_data_dir", Mock(return_value=old_data_dir)
+    )
+
+    return old_data_dir
+
+
+@pytest.fixture
+def invoke_app(log, tmp_path, old_data_dir):
+    runner = typer.testing.CliRunner()
+    main_args = (
+        "--verbose",
+        "--logdir",
+        tmp_path / "log",
+        "--pg-data-root",
+        tmp_path / "postgresql",
+    )
+
+    (tmp_path / "postgresql/11").mkdir()
+    (tmp_path / "log").mkdir()
+
+    def _invoke_app(*args):
+        result = runner.invoke(fc.manage.postgresql.app, main_args + args)
+        if result.exc_info:
+            traceback.print_tb(result.exc_info[2])
+        assert result.exit_code == 0, (
+            f"unexpected exit code, output:" f" {result.output}"
+        )
+
+        return result
+
+    return _invoke_app
+
+
+def test_invoke_main_help(invoke_app):
+    result = invoke_app("--help")
+    assert "Usage: fc-postgresql" in result.output
+
+
+def test_invoke_list_versions(invoke_app, monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "fc.util.postgresql.get_current_pgdata_from_service",
+        (lambda: tmp_path / "postgresql/10"),
+    )
+    monkeypatch.setattr("fc.util.postgresql.is_service_running", (lambda: True))
+    result = invoke_app("list-versions")
+    print(result.output)
+
+
+@patch("fc.util.postgresql.run_pg_upgrade")
+@patch("fc.util.postgresql.run_pg_upgrade_check")
+@patch("fc.util.postgresql.prepare_upgrade")
+@patch("fc.util.postgresql.build_new_bin_dir")
+def test_invoke_upgrade(
+    build_new_bin_dir: Mock,
+    prepare_upgrade: Mock,
+    run_pg_upgrade_check: Mock,
+    run_pg_upgrade: Mock,
+    invoke_app,
+):
+    invoke_app("upgrade", "--new-version", "12")
+    build_new_bin_dir.assert_called()
+    prepare_upgrade.assert_called()
+    run_pg_upgrade_check.assert_called()
+    # Make sure we don't run destructive things by default.
+    run_pg_upgrade.assert_not_called()
+
+
+@patch("fc.util.postgresql.get_current_pgdata_from_service")
+@patch("fc.util.postgresql.run_pg_upgrade")
+@patch("fc.manage.postgresql.stop_pg")
+@patch("fc.util.postgresql.prepare_upgrade")
+@patch("fc.util.postgresql.build_new_bin_dir")
+def test_invoke_upgrade_now(
+    build_new_bin_dir: Mock,
+    prepare_upgrade: Mock,
+    stop_pg,
+    run_pg_upgrade: Mock,
+    get_current_pg_data_from_service,
+    invoke_app,
+):
+    invoke_app("upgrade", "--new-version", "12", "--upgrade-now")
+    build_new_bin_dir.assert_called()
+    prepare_upgrade.assert_called()
+    run_pg_upgrade.assert_called()
+
+
+@patch("fc.util.postgresql.run_pg_upgrade")
+@patch("fc.util.postgresql.run_pg_upgrade_check")
+@patch("fc.util.postgresql.prepare_upgrade")
+@patch("fc.util.postgresql.get_current_pgdata_from_service")
+@patch("fc.util.postgresql.get_pg_version_from_data_dir")
+@patch("fc.util.postgresql.build_new_bin_dir")
+def test_invoke_prepare_autoupgrade(
+    build_new_bin_dir: Mock,
+    get_pg_version_from_data_dir: Mock,
+    get_current_pgdata_from_service: Mock,
+    prepare_upgrade: Mock,
+    run_pg_upgrade_check: Mock,
+    run_pg_upgrade: Mock,
+    invoke_app,
+    tmp_path,
+    monkeypatch,
+):
+    config = tmp_path / "autoupgrade.json"
+    conf = {"expected_databases": ["test"]}
+    config.write_text(json.dumps(conf), encoding="utf8")
+    monkeypatch.setattr("fc.util.postgresql.is_service_running", (lambda: True))
+    invoke_app("prepare-autoupgrade", "--config", config, "--new-version", "11")
+    build_new_bin_dir.assert_called()
+    prepare_upgrade.assert_called()
+    run_pg_upgrade_check.assert_called()
+    # Make sure we don't run destructive things by default.
+    run_pg_upgrade.assert_not_called()

--- a/pkgs/fc/agent/fc/util/postgresql.py
+++ b/pkgs/fc/agent/fc/util/postgresql.py
@@ -1,0 +1,471 @@
+import getpass
+import os
+import re
+import shutil
+from datetime import datetime
+from enum import Enum
+from pathlib import Path
+from subprocess import CalledProcessError, run
+
+from typer import confirm
+
+MIGRATED_TO_TEMPLATE = """\
+WARNING: This data directory should not be used anymore!
+
+Migrated to {new_data_dir} at {dt} by `fc-postgresql` with command:
+
+{upgrade_cmd}
+"""
+
+
+MIGRATED_FROM_TEMPLATE = """\
+Migrated from {old_data_dir} at {dt} by `fc-postgresql` with command:
+
+{upgrade_cmd}
+"""
+
+
+PREPARED_TEMPLATE = """\
+Prepared as new data directory for a migration from {old_data_dir} by
+`fc-postgresql` with command:
+
+{initdb_cmd}
+"""
+
+
+class PGVersion(str, Enum):
+    PG10 = "10"
+    PG11 = "11"
+    PG12 = "12"
+    PG13 = "13"
+    PG14 = "14"
+
+
+def run_as_postgres(cmd, **kwargs):
+    if getpass.getuser() != "postgres":
+        cmd = ["sudo", "-u", "postgres"] + cmd
+
+    return run(cmd, text=True, **kwargs)
+
+
+def get_current_pgdata_from_service():
+    current_pgdata_cmd = [
+        "systemctl",
+        "show",
+        "postgresql",
+        "--property",
+        "Environment",
+        "--value",
+    ]
+
+    proc = run(
+        current_pgdata_cmd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    current_pgdata = [
+        Path(p.removeprefix("PGDATA="))
+        for p in proc.stdout.split()
+        if p.startswith("PGDATA")
+    ]
+
+    if current_pgdata:
+        return current_pgdata[0]
+
+
+def is_service_running():
+    proc = run(["systemctl", "is-active", "--quiet", "postgresql.service"])
+    return proc.returncode == 0
+
+
+def build_new_bin_dir(log, pg_data_root: Path, new_version: PGVersion):
+    nix_build_new_pg_cmd = [
+        "nix-build",
+        "<nixpkgs>",
+        "-A",
+        "postgresql_" + new_version.value,
+        "--out-link",
+        pg_data_root / "pg_upgrade-package",
+    ]
+    try:
+        proc = run(
+            nix_build_new_pg_cmd, check=True, text=True, capture_output=True
+        )
+    except CalledProcessError as e:
+        log.error(
+            "upgrade-build-postgresql-failed",
+            stdout=e.stdout,
+            stderr=e.stderr,
+        )
+        raise
+    new_bin_dir = Path(proc.stdout.strip()) / "bin"
+    return new_bin_dir
+
+
+class MultipleOldDirsFound(Exception):
+    def __int__(self, found_dirs):
+        self.found_dirs = found_dirs
+
+
+def find_old_data_dir(log, pg_data_root: Path, new_version: PGVersion):
+    old_data_dirs = list(sorted(pg_data_root.glob("1[0-5]")))
+    log.debug(
+        "upgrade-old-data-dir-candidates",
+        old_data_dirs=[str(d) for d in old_data_dirs],
+    )
+    eligible_old_data_dirs = [
+        p
+        for p in old_data_dirs
+        if (p / "package").is_symlink() and p.name < new_version
+    ]
+    log.debug(
+        "upgrade-eligible-old-data-dirs",
+        eligible_old_data_dirs=[str(d) for d in eligible_old_data_dirs],
+    )
+    if not eligible_old_data_dirs:
+        return None
+
+    if len(eligible_old_data_dirs) > 1:
+        raise MultipleOldDirsFound(eligible_old_data_dirs)
+
+    return eligible_old_data_dirs[0]
+
+
+def get_pg_version_from_data_dir(log, data_dir: Path):
+    try:
+        version_str = (data_dir / "PG_VERSION").read_text().strip()
+    except OSError:
+        log.error(
+            "cannot-read-pg-version",
+            _replace_msg="Unable to read PG_VERSION from {data_dir}",
+            data_dir=data_dir,
+        ),
+        raise
+    try:
+        version = PGVersion(version_str)
+    except ValueError:
+        log.error(
+            "unsupported-old-pg-version",
+            _replace_msg="Postgres version {version} is not supported",
+            version=version_str,
+        )
+        raise
+    log.debug("get-pg-version-from-data-dir", version=version.value)
+
+    return version
+
+
+def create_new_data_dir(
+    log,
+    collate,
+    ctype,
+    new_bin_dir,
+    new_data_dir,
+    old_data_dir,
+):
+    log.info(
+        "upgrade-init-new-data-dir",
+        _replace_msg=("Initializing new data dir in {new_data_dir}."),
+        new_data_dir=new_data_dir,
+        collate=collate,
+        ctype=ctype,
+    )
+    new_data_dir.mkdir(mode=0o0700)
+    shutil.chown(new_data_dir, "postgres", "postgres")
+    initdb_cmd = [
+        new_bin_dir / "initdb",
+        "-D",
+        new_data_dir,
+        "--lc-collate",
+        collate,
+        "--lc-ctype",
+        ctype,
+    ]
+    initdb_cmd_str = " ".join(str(e) for e in initdb_cmd)
+    log.debug("upgrade-initdb-cmd", cmd=initdb_cmd_str)
+    try:
+        run_as_postgres(initdb_cmd, check=True)
+    except CalledProcessError as e:
+        log.error(
+            "upgrade-initdb-failed",
+            stdout=e.stdout,
+            stderr=e.stderr,
+        )
+        raise
+    (new_data_dir / "fcio_upgrade_prepared").write_text(
+        PREPARED_TEMPLATE.format(
+            initdb_cmd=initdb_cmd_str, old_data_dir=old_data_dir
+        )
+    )
+    shutil.chown(new_data_dir / "fcio_upgrade_prepared", "postgres", "postgres")
+
+
+class UnexpectedDatabasesFound(Exception):
+    def __init__(self, unexpected_dbs):
+        self.unexpected_dbs = unexpected_dbs
+
+
+def get_existing_dbs(log, data_dir, postgres_running, expected_dbs=None):
+    if postgres_running:
+        get_dbs_cmd = [
+            "psql",
+            "-qAt",
+        ]
+    else:
+        get_dbs_cmd = [
+            data_dir / "package/bin/postgres",
+            "--single",
+            "-r",
+            "/dev/null",
+            "-D",
+            data_dir,
+            "postgres",
+        ]
+    get_db_sql = "select datname,datcollate,datctype from pg_database"
+    try:
+        proc = run_as_postgres(
+            get_dbs_cmd,
+            check=True,
+            capture_output=True,
+            input=get_db_sql,
+        )
+    except CalledProcessError as e:
+        log.error(
+            "upgrade-get-existing-dbs-failed",
+            stdout=e.stdout,
+            stderr=e.stderr,
+        )
+        raise
+    log.trace("upgrade-existing-dbs-out", stdout=proc.stdout)
+    if postgres_running:
+        existing_dbs = {}
+
+        for line in proc.stdout.strip().splitlines():
+            datname, datcollate, datctype = line.split("|")
+            existing_dbs[datname] = {
+                "datname": datname,
+                "datcollate": datcollate,
+                "datctype": datctype,
+            }
+
+    else:
+        existing_dbs = {}
+        current_db = None
+        for line in proc.stdout.splitlines():
+            line = line.strip()
+            if match := re.search(': (.+) = "(.+)"', line):
+                column, value = match.groups()
+                current_db[column] = value
+            elif line.startswith("----"):
+                if current_db:
+                    existing_dbs[current_db["datname"]] = current_db
+                current_db = {}
+
+    expected_existing_dbs = {
+        "nagios",
+        "postgres",
+        "root",
+        "template0",
+        "template1",
+        *expected_dbs,
+    }
+    if expected_dbs is None:
+        log.debug("get-existing-dbs", existing_dbs=existing_dbs)
+    else:
+        unexpected_dbs = set(existing_dbs) - expected_existing_dbs
+        log.debug(
+            "get-existing-dbs-unexpected-db-check",
+            expected_dbs=expected_dbs,
+            existing_dbs=existing_dbs,
+            unexpected_dbs=unexpected_dbs,
+        )
+        if unexpected_dbs:
+            raise UnexpectedDatabasesFound(unexpected_dbs)
+
+    return existing_dbs
+
+
+class NewDataDirUnusable(Exception):
+    def __init__(self, data_dir):
+        self.data_dir = data_dir
+
+
+def check_new_data_dir(log, new_data_dir):
+    if (new_data_dir / "fcio_upgrade_prepared").exists():
+        new_data_dir_mode = new_data_dir.stat().st_mode
+
+        log.debug(
+            "upgrade-use-existing-new-data-dir",
+            new_data_dir=str(new_data_dir),
+            owner=new_data_dir.owner(),
+            group=new_data_dir.group(),
+            mode=oct(new_data_dir_mode)[3:],
+        )
+        if new_data_dir_mode != 0o040700:
+            log.error("upgrade-existing-data-dir-wrong-mode")
+    else:
+
+        raise NewDataDirUnusable(new_data_dir)
+
+
+def prepare_upgrade(
+    log,
+    old_data_dir: Path,
+    new_version: PGVersion,
+    new_bin_dir: Path,
+    new_data_dir: Path,
+    expected_databases: list[str],
+):
+    fcio_migrated_to_link = old_data_dir / "fcio_migrated_to"
+    if fcio_migrated_to_link.is_symlink():
+        log.error(
+            "upgrade-old-data-dir-has-migrated-to",
+            _replace_msg=(
+                "{migrated_to_link} already exists, "
+                "looks like the old data dir has been migrated before. "
+                "Remove the file if you know what you are doing and try again."
+            ),
+            migrated_to_link=str(fcio_migrated_to_link),
+        )
+        raise RuntimeError("upgrade-old-data-dir-has-migrated-to")
+
+    old_version = get_pg_version_from_data_dir(log, old_data_dir)
+    postgres_running = is_service_running()
+    log.debug(
+        "upgrade-from-status",
+        old_data_dir=str(old_data_dir),
+        postgres_running=postgres_running,
+    )
+    existing_db_info = get_existing_dbs(
+        log,
+        old_data_dir,
+        postgres_running,
+        expected_databases,
+    )
+    postgres_db = existing_db_info["postgres"]
+    collate = postgres_db["datcollate"]
+    ctype = postgres_db["datctype"]
+    log.info(
+        "prepare-upgrade-postgres-db",
+        _replace_msg=(
+            f"Prepare upgrade from {old_version} -> {new_version}, "
+            "using collation {collate} and ctype {ctype}."
+        ),
+        old_version=old_version.value,
+        new_version=new_version.value,
+        collate=collate,
+        ctype=ctype,
+    )
+    if new_data_dir.exists():
+        check_new_data_dir(
+            log,
+            new_data_dir,
+        )
+    else:
+        create_new_data_dir(
+            log,
+            collate,
+            ctype,
+            new_bin_dir,
+            new_data_dir,
+            old_data_dir,
+        )
+
+
+def run_pg_upgrade_check(
+    log,
+    new_bin_dir,
+    new_data_dir,
+    old_data_dir,
+):
+    upgrade_cmd = [
+        new_bin_dir / "pg_upgrade",
+        "--old-datadir",
+        old_data_dir,
+        "--new-datadir",
+        new_data_dir,
+        "--old-bindir",
+        old_data_dir / "package/bin",
+        "--new-bindir",
+        new_bin_dir,
+        "--check",
+    ]
+
+    log.debug("upgrade-pg_upgrade-cmd", cmd=upgrade_cmd)
+    # pg_upgrade wants to write log files to the current work dir.
+    os.chdir(new_data_dir)
+    try:
+        run_as_postgres(
+            upgrade_cmd,
+            check=True,
+        )
+    except CalledProcessError as e:
+        log.error(
+            "pg-upgrade-check-failed",
+            stdout=e.stdout,
+            stderr=e.stderr,
+        )
+        raise
+
+
+def run_pg_upgrade(
+    log,
+    new_bin_dir: Path,
+    new_data_dir: Path,
+    old_data_dir: Path,
+):
+    upgrade_cmd = [
+        new_bin_dir / "pg_upgrade",
+        "--old-datadir",
+        old_data_dir,
+        "--new-datadir",
+        new_data_dir,
+        "--old-bindir",
+        old_data_dir / "package/bin",
+        "--new-bindir",
+        new_bin_dir,
+    ]
+    log.debug("upgrade-pg_upgrade-cmd", cmd=upgrade_cmd)
+    # pg_upgrade wants to write log files to the current work dir.
+    os.chdir(new_data_dir)
+    try:
+        run_as_postgres(
+            upgrade_cmd,
+            check=True,
+        )
+    except CalledProcessError as e:
+        log.error(
+            "upgrade-pg-upgrade-failed",
+            stdout=e.stdout,
+            stderr=e.stderr,
+        )
+        raise
+    migration_finished_dt = datetime.now()
+    upgrade_cmd_str = " ".join(str(e) for e in upgrade_cmd)
+    (new_data_dir / "fcio_migrated_from").symlink_to(old_data_dir)
+    (old_data_dir / "fcio_migrated_to").symlink_to(new_data_dir)
+    (new_data_dir / "fcio_migrated_from.log").write_text(
+        MIGRATED_FROM_TEMPLATE.format(
+            old_data_dir=old_data_dir,
+            dt=migration_finished_dt.isoformat(),
+            upgrade_cmd=upgrade_cmd_str,
+        )
+    )
+    (old_data_dir / "fcio_migrated_to.log").write_text(
+        MIGRATED_TO_TEMPLATE.format(
+            new_data_dir=new_data_dir,
+            dt=migration_finished_dt.isoformat(),
+            upgrade_cmd=upgrade_cmd_str,
+        )
+    )
+    (new_data_dir / "fcio_upgrade_prepared").unlink(missing_ok=True)
+    (old_data_dir / "package").unlink(missing_ok=True)
+    (old_data_dir / "fcio_stopper").unlink(missing_ok=True)
+    old_version = (old_data_dir / "PG_VERSION").read_text().strip()
+    nix_gc_root = (
+        Path("/nix/var/nix/gcroots/per-user/postgres")
+        / f"package_{old_version}"
+    )
+    nix_gc_root.unlink(missing_ok=True)

--- a/pkgs/fc/agent/fc/util/subprocess_helper.py
+++ b/pkgs/fc/agent/fc/util/subprocess_helper.py
@@ -1,7 +1,7 @@
 """Helpers for dealing with subprocesses"""
 
 
-def get_popen_stdout_lines(popen, log, log_event):
+def get_popen_stdout_lines(popen, log=None, log_event=None):
     """Reads stdout line-by-line from a Popen object until the stream ends
     and returns a list of all received lines.
     Every line logged at trace level as it appears.
@@ -16,7 +16,10 @@ def get_popen_stdout_lines(popen, log, log_event):
     stdout_lines = []
     line = popen.stdout.readline()
     while line:
-        log.trace(log_event, cmd_output_line=line.strip("\n"))
+        if log is None:
+            print(line, end="")
+        else:
+            log.trace(log_event, cmd_output_line=line.strip("\n"))
         stdout_lines.append(line)
         line = popen.stdout.readline()
 

--- a/pkgs/fc/agent/fc/util/tests/test_postgresql.py
+++ b/pkgs/fc/agent/fc/util/tests/test_postgresql.py
@@ -1,0 +1,87 @@
+import json
+import traceback
+import unittest.mock
+from unittest.mock import Mock, patch
+
+import fc.manage.postgresql
+import fc.util.postgresql
+import pytest
+import typer.testing
+from fc.util.postgresql import (
+    PGVersion,
+    build_new_bin_dir,
+    prepare_upgrade,
+    run_pg_upgrade,
+    run_pg_upgrade_check,
+)
+
+
+@pytest.fixture
+def pg10_data_dir(log, tmp_path, monkeypatch):
+    data_dir = tmp_path / "postgresql/10"
+    data_dir.mkdir(parents=True)
+    (data_dir / "package")
+    (data_dir / "PG_VERSION").write_text("10")
+    (data_dir / "fcio_stopper").touch()
+    monkeypatch.setattr(
+        "fc.util.postgresql.get_current_pgdata_from_service",
+        (lambda: data_dir),
+    )
+    return data_dir
+
+
+@pytest.mark.needs_nix
+def test_build_new_bin_dir(logger, tmp_path):
+    new_bin_dir = build_new_bin_dir(logger, tmp_path, PGVersion.PG11)
+    assert (new_bin_dir / "pg_upgrade").exists()
+
+
+def test_prepare_upgrade(logger, pg10_data_dir, monkeypatch, tmp_path):
+    monkeypatch.setattr("shutil.chown", Mock())
+    monkeypatch.setattr(
+        "fc.util.postgresql.get_existing_dbs",
+        (
+            lambda *a: {
+                "postgres": {
+                    "datname": "postgres",
+                    "datcollate": "C",
+                    "datctype": "C",
+                }
+            }
+        ),
+    )
+    monkeypatch.setattr("fc.util.postgresql.is_service_running", (lambda: True))
+    new_data_dir = tmp_path / "postgresql/11"
+    new_data_dir.mkdir()
+    (new_data_dir / "fcio_upgrade_prepared").touch()
+    new_bin_dir = new_data_dir
+    fc.util.postgresql.prepare_upgrade(
+        logger,
+        old_data_dir=pg10_data_dir,
+        new_version=PGVersion.PG11,
+        new_bin_dir=new_bin_dir,
+        new_data_dir=new_data_dir,
+        expected_databases=[],
+    )
+
+
+def test_run_pg_upgrade(logger, tmp_path, pg10_data_dir, monkeypatch):
+    monkeypatch.setattr("fc.util.postgresql.run_as_postgres", Mock())
+    new_data_dir = tmp_path / "postgresql/11"
+    new_data_dir.mkdir()
+    new_bin_dir = new_data_dir
+    (new_data_dir / "fcio_upgrade_prepared").touch()
+    run_pg_upgrade(
+        logger,
+        old_data_dir=pg10_data_dir,
+        new_bin_dir=new_bin_dir,
+        new_data_dir=new_data_dir,
+    )
+
+    assert (new_data_dir / "fcio_migrated_from").exists()
+    assert (new_data_dir / "fcio_migrated_from.log").exists()
+    assert not (new_data_dir / "fcio_upgrade_prepared").exists()
+    assert (pg10_data_dir / "fcio_migrated_to").exists()
+    assert (pg10_data_dir / "fcio_migrated_to.log").exists()
+    assert not (pg10_data_dir / "package").exists()
+    assert not (pg10_data_dir / "fcio_stopper").exists()

--- a/pkgs/fc/agent/setup.cfg
+++ b/pkgs/fc/agent/setup.cfg
@@ -5,5 +5,7 @@ universal=1
 test=pytest
 
 [tool:pytest]
-addopts = -v --showlocals --ignore=lib --ignore=lib64
+addopts = -v --showlocals --ignore=lib --ignore=lib64 --strict-markers
+markers =
+  needs_nix: marks test that need a working Nix environment to download and build things
 testpaths = fc

--- a/pkgs/fc/agent/setup.py
+++ b/pkgs/fc/agent/setup.py
@@ -69,6 +69,7 @@ setup(
             "fc-manage=fc.manage.cli:main",
             "fc-monitor=fc.manage.monitor:main",
             "fc-resize-disk=fc.manage.resize_disk:app",
+            "fc-postgresql=fc.manage.postgresql:app",
             "fctl=fc.util.fctl:app",
         ],
     },

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -85,11 +85,12 @@ in {
   openvpn = callTest ./openvpn.nix {};
   percona80 = callTest ./mysql.nix { rolename = "percona80"; };
   physical-installer = callTest ./physical-installer.nix { inherit nixpkgs; };
-  postgresql10 = callTest ./postgresql.nix { version = "10"; };
-  postgresql11 = callTest ./postgresql.nix { version = "11"; };
-  postgresql12 = callTest ./postgresql.nix { version = "12"; };
-  postgresql13 = callTest ./postgresql.nix { version = "13"; };
-  postgresql14 = callTest ./postgresql.nix { version = "14"; };
+  postgresql10 = callTest ./postgresql { version = "10"; };
+  postgresql11 = callTest ./postgresql { version = "11"; };
+  postgresql12 = callTest ./postgresql { version = "12"; };
+  postgresql13 = callTest ./postgresql { version = "13"; };
+  postgresql14 = callTest ./postgresql { version = "14"; };
+  postgresql-autoupgrade = callSubTests ./postgresql/upgrade.nix {};
   prometheus = callTest ./prometheus.nix {};
   rabbitmq = callTest ./rabbitmq.nix {};
   redis = callTest ./redis.nix {};

--- a/tests/postgresql/default.nix
+++ b/tests/postgresql/default.nix
@@ -1,28 +1,18 @@
-import ./make-test-python.nix ({ version ? "14", lib, pkgs, ... }:
+import ../make-test-python.nix ({ version ? "14", lib, testlib, pkgs, ... }:
 let
-  ipv4 = "192.168.101.1";
-  ipv6 = "2001:db8:f030:1c3::1";
+  ipv4 = testlib.fcIP.srv4 1;
+  ipv6 = testlib.fcIP.srv6 1;
 in {
   name = "postgresql${version}";
-  machine =
-    { ... }:
-    {
-      imports = [ ../nixos ../nixos/roles ];
-      flyingcircus.roles."postgresql${version}".enable = true;
+  nodes = {
+    machine = { ... }: {
+      imports = [
+        (testlib.fcConfig { net.fe = false; })
+      ];
 
-      flyingcircus.enc.parameters = {
-        resource_group = "test";
-        interfaces.srv = {
-          mac = "52:54:00:12:34:56";
-          bridged = false;
-          networks = {
-            "192.168.101.0/24" = [ ipv4 ];
-            "2001:db8:f030:1c3::/64" = [ ipv6 ];
-          };
-          gateways = {};
-        };
-      };
+      flyingcircus.roles."postgresql${version}".enable = true;
     };
+  };
 
   testScript =
     let

--- a/tests/postgresql/upgrade.nix
+++ b/tests/postgresql/upgrade.nix
@@ -1,0 +1,248 @@
+import ../make-test-python.nix ({lib, testlib, pkgs, ... }:
+let
+  release = import ../../release {};
+  channel = release.release.src;
+
+  insertSql = pkgs.writeText "insert.sql" ''
+    CREATE TABLE employee (
+      id INT PRIMARY KEY,
+      name TEXT
+    );
+    INSERT INTO employee VALUES (1, 'John Doe');
+  '';
+
+  dataTest = pkgs.writeScript "postgresql-tests" ''
+    set -e
+    createdb employees
+    psql --echo-all -d employees < ${insertSql}
+  '';
+
+  psql = "sudo -u postgres -- psql";
+  fc-postgresql = "sudo -u postgres -- fc-postgresql";
+
+  testSetup = ''
+    # Make nix-build work inside the VM
+    machine.execute("ln -s ${channel} /nix/var/nix/profiles/per-user/root/channels")
+
+    # Taken from upstream acme.nix
+    def switch_to(node, name, expect="succeed"):
+        # On first switch, this will create a symlink to the current system so that we can
+        # quickly switch between derivations
+        root_specs = "/tmp/specialisation"
+        node.execute(
+          f"test -e {root_specs}"
+          f" || ln -s $(readlink /run/current-system)/specialisation {root_specs}"
+        )
+
+        switcher_path = f"/run/current-system/specialisation/{name}/bin/switch-to-configuration"
+        rc, _ = node.execute(f"test -e '{switcher_path}'")
+        if rc > 0:
+            switcher_path = f"/tmp/specialisation/{name}/bin/switch-to-configuration"
+
+        if expect == "fail":
+          node.fail(f"{switcher_path} test")
+        else:
+          node.succeed(f"{switcher_path} test")
+
+    machine.wait_for_unit("postgresql.service")
+    machine.wait_for_open_port(5432)
+
+    machine.succeed('sudo -u postgres -- sh ${dataTest}')
+  '';
+
+in {
+  name = "postgresql-upgrade";
+  testCases = {
+    manual = {
+      name = "manual";
+      nodes = {
+        machine = { ... }: {
+          imports = [
+            (testlib.fcConfig { net.fe = false; })
+          ];
+
+          flyingcircus.roles.postgresql10.enable = lib.mkDefault true;
+
+          specialisation = {
+            pg12.configuration = {
+              flyingcircus.roles.postgresql10.enable = false;
+              flyingcircus.roles.postgresql12.enable = true;
+            };
+            pg13.configuration = {
+              flyingcircus.roles.postgresql10.enable = false;
+              flyingcircus.roles.postgresql13.enable = true;
+            };
+            pg14.configuration = {
+              flyingcircus.roles.postgresql10.enable = false;
+              flyingcircus.roles.postgresql14.enable = true;
+            };
+          };
+
+          system.extraDependencies = with pkgs; [
+            postgresql_11
+            postgresql_12
+            postgresql_13
+            postgresql_14
+          ];
+        };
+      };
+
+      testScript = ''
+        ${testSetup}
+        with subtest("prepare-autoupgrade should fail when the option is not enabled"):
+          machine.fail("${fc-postgresql} prepare-autoupgrade --new-version 11")
+
+        with subtest("prepare should fail with unexpected database employees"):
+          machine.fail('${fc-postgresql} upgrade --new-version 11')
+
+        print(machine.succeed("${fc-postgresql} list-versions"))
+
+        with subtest("prepare upgrade 10 -> 11"):
+          machine.succeed('${fc-postgresql} upgrade --new-version 11 --expected employees')
+          machine.succeed("stat /srv/postgresql/11/fcio_upgrade_prepared")
+          # postgresql should still run
+          machine.succeed("systemctl status postgresql")
+          print(machine.succeed("${fc-postgresql} list-versions"))
+
+        with subtest("upgrade 10 -> 11"):
+          machine.succeed('${fc-postgresql} upgrade --expected employees --new-version 11 --stop --upgrade-now')
+          machine.succeed("stat /srv/postgresql/10/fcio_migrated_to")
+          machine.succeed("stat /srv/postgresql/11/fcio_migrated_from")
+          # postgresql should be stopped
+          machine.fail("systemctl status postgresql")
+          print(machine.succeed("${fc-postgresql} list-versions"))
+
+        machine.execute("rm -rf /srv/postgresql/11")
+        machine.execute("rm -rf /srv/postgresql/10/fcio_migrated_to")
+        machine.systemctl("start postgresql")
+
+        with subtest("upgrade 10 -> 12 in one step"):
+          machine.succeed('${fc-postgresql} upgrade --expected employees --new-version 12 --stop --upgrade-now')
+          machine.succeed("stat /srv/postgresql/10/fcio_migrated_to")
+          machine.succeed("stat /srv/postgresql/12/fcio_migrated_from")
+          # postgresql should be stopped
+          machine.fail("systemctl status postgresql")
+          # move to pg12 role and wait for postgresql to start
+          switch_to(machine, "pg12")
+          machine.wait_for_unit("postgresql")
+          print(machine.succeed("${fc-postgresql} list-versions"))
+
+        with subtest("upgrade 12 -> 13 in one step"):
+          machine.succeed('${fc-postgresql} upgrade --expected employees --new-version 13 --stop --upgrade-now')
+          machine.succeed("stat /srv/postgresql/12/fcio_migrated_to")
+          machine.succeed("stat /srv/postgresql/13/fcio_migrated_from")
+          switch_to(machine, "pg13")
+          machine.wait_for_unit("postgresql")
+          print(machine.succeed("${fc-postgresql} list-versions"))
+
+        with subtest("upgrade 13 -> 14 in one step"):
+          machine.succeed('${fc-postgresql} upgrade --expected employees --new-version 14 --stop --upgrade-now')
+          machine.succeed("stat /srv/postgresql/13/fcio_migrated_to")
+          machine.succeed("stat /srv/postgresql/14/fcio_migrated_from")
+          switch_to(machine, "pg14")
+          machine.wait_for_unit("postgresql")
+          print(machine.succeed("${fc-postgresql} list-versions"))
+      '';
+    };
+    automatic = {
+      name = "automatic";
+      nodes = {
+        machine = { ... }: {
+          imports = [
+            (testlib.fcConfig { net.fe = false; })
+          ];
+
+          flyingcircus.roles.postgresql10.enable = lib.mkDefault true;
+          flyingcircus.services.postgresql.autoUpgrade = {
+            enable = true;
+            expectedDatabases = [ "employees" ];
+          };
+
+          specialisation = {
+            pg11UnexpectedDb.configuration = {
+              flyingcircus.services.postgresql.autoUpgrade.expectedDatabases = lib.mkForce [];
+              flyingcircus.roles.postgresql10.enable = false;
+              flyingcircus.roles.postgresql11.enable = true;
+            };
+            pg11.configuration = {
+              flyingcircus.roles.postgresql10.enable = false;
+              flyingcircus.roles.postgresql11.enable = true;
+            };
+            pg12.configuration = {
+              flyingcircus.roles.postgresql10.enable = false;
+              flyingcircus.roles.postgresql12.enable = true;
+            };
+            pg13.configuration = {
+              flyingcircus.roles.postgresql10.enable = false;
+              flyingcircus.roles.postgresql13.enable = true;
+            };
+            pg14.configuration = {
+              flyingcircus.roles.postgresql10.enable = false;
+              flyingcircus.roles.postgresql14.enable = true;
+            };
+          };
+
+          system.extraDependencies = with pkgs; [
+            postgresql_11
+            postgresql_12
+            postgresql_13
+            postgresql_14
+          ];
+        };
+      };
+
+      testScript = ''
+        ${testSetup}
+        print(machine.succeed("${fc-postgresql} list-versions"))
+
+        with subtest("autoupgrade should refuse when unexpected DB is present"):
+          switch_to(machine, "pg11UnexpectedDb", expect="fail")
+          machine.fail("systemctl status postgresql")
+          print(machine.succeed("${fc-postgresql} list-versions"))
+
+        with subtest("prepare autoupgrade should fail when unexpected DB is present"):
+          machine.fail('${fc-postgresql} prepare-autoupgrade --new-version 12')
+          print(machine.succeed("${fc-postgresql} list-versions"))
+
+        with subtest("autoupgrade 10 -> 11"):
+          # add the expectedDatabases setting and wait for postgresql to start
+          switch_to(machine, "pg11")
+          machine.wait_for_unit("postgresql")
+          machine.succeed("stat /srv/postgresql/10/fcio_migrated_to")
+          machine.succeed("stat /srv/postgresql/11/fcio_migrated_from")
+          print(machine.succeed("${fc-postgresql} list-versions"))
+
+        with subtest("prepare autoupgrade 11 -> 12"):
+          machine.succeed('${fc-postgresql} prepare-autoupgrade --new-version 12')
+          machine.succeed("stat /srv/postgresql/12/fcio_upgrade_prepared")
+          # postgresql should still run
+          machine.succeed("systemctl status postgresql")
+          print(machine.succeed("${fc-postgresql} list-versions"))
+
+        with subtest("autoupgrade 11 -> 12"):
+          # move to pg12 role and wait for postgresql to start
+          switch_to(machine, "pg12")
+          machine.wait_for_unit("postgresql")
+          machine.succeed("stat /srv/postgresql/11/fcio_migrated_to")
+          machine.succeed("stat /srv/postgresql/12/fcio_migrated_from")
+          print(machine.succeed("${fc-postgresql} list-versions"))
+
+        with subtest("autoupgrade 12 -> 13"):
+          # move to pg13 role and wait for postgresql to start
+          switch_to(machine, "pg13")
+          machine.wait_for_unit("postgresql")
+          machine.succeed("stat /srv/postgresql/12/fcio_migrated_to")
+          machine.succeed("stat /srv/postgresql/13/fcio_migrated_from")
+          print(machine.succeed("${fc-postgresql} list-versions"))
+
+        with subtest("autoupgrade 13 -> 14"):
+          # move to pg14 role and wait for postgresql to start
+          switch_to(machine, "pg14")
+          machine.wait_for_unit("postgresql")
+          machine.succeed("stat /srv/postgresql/13/fcio_migrated_to")
+          machine.succeed("stat /srv/postgresql/14/fcio_migrated_from")
+          print(machine.succeed("${fc-postgresql} list-versions"))
+      '';
+    };
+  };
+})


### PR DESCRIPTION
Add fc-postgresql command and autoupgrade options

The new command `fc-postgresql` (to be run as postgres user) can show
the current state of data directories for the available major versions,
prepare and run upgrade migrations.

Documentation now shows how to prepare and run manual upgrades using
`fc-postgresql upgrade`.

This also adds the `flyingcircus.services.postgresql.autoUpgrade`
submodule which is at the moment intended to be used internally in
platform code for roles that need postgresql and want to manage upgrades
without user intervention. The options are not in the user documentation
but we may add them later when we want to recommend using auto-upgrades
to users.

Documented fc-postgresql commands are:

- list-versions
- upgrade

Undocumented in customer docs:

- check-autoupgrade-unexpected-dbs (to be used as Sensu check if
  autoupgrade is enabled)
- prepare-autoupgrade (to be used manually to prepare automated
  upgrades)

 #PL-130197


@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

- postgresql: Add `fc-postgresql` with various subcommands for listing data directories for all major versions of PostgreSQL and upgrading database clusters (a wrapper around `pg_upgrade`). The command has to be run as `postgres` user. We also add options for automated database upgrades which are experimental and are meant for internal use only in platform code at the moment. (#PL-130197).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - No new permissions are required: we automate steps that would be done manually with the same permissions (as postgres user, limited to sudo-srv and service users) otherwise. Activating autoupgrade will reduce the need to use elevated privileges a bit.
- [x] Security requirements tested? (EVIDENCE)
  - new automated tests which tests various upgrade scenarios, with manual commands, mixed and fully automatic 