### PR TITLE
[21.05] fc-ceph/osd: safety checks when destroying OSDs

### DIFF
--- a/pkgs/fc/ceph/src/fc/ceph/main.py
+++ b/pkgs/fc/ceph/src/fc/ceph/main.py
@@ -47,6 +47,12 @@ def main(args=sys.argv[1:]):
         help="Use the destruction process for the specified objectstore type, "
         "instead of autodetecting it.",
     )
+    parser_destroy.add_argument(
+        "--unsafe-destroy",
+        action="store_true",
+        help="Skip the check (Luminous only) whether an OSD is safe to destroy without "
+        "affecting data redundancy. This can result in data loss or cluster failure!!",
+    )
     parser_destroy.set_defaults(action="destroy")
 
     parser_create_fs = osd_sub.add_parser(
@@ -128,6 +134,12 @@ def main(args=sys.argv[1:]):
         choices=fc.ceph.osd.OBJECTSTORE_TYPES,
         help="Type of the OSD after rebuilding, defaults to keeping the current "
         "objectstore type.\nThe current type is detected automatically.",
+    )
+    parser_rebuild.add_argument(
+        "--unsafe-destroy",
+        action="store_true",
+        help="Skip the check (Luminous only) whether an OSD is safe to destroy without "
+        "affecting data redundancy. This can result in data loss or cluster failure!!",
     )
     parser_rebuild.add_argument(
         "ids",

--- a/pkgs/fc/ceph/src/fc/ceph/osd/jewel.py
+++ b/pkgs/fc/ceph/src/fc/ceph/osd/jewel.py
@@ -91,9 +91,9 @@ class OSDManager(object):
             except Exception:
                 traceback.print_exc()
 
-    def destroy(self, ids, force_objectstore_type):
-        # force_objectstore_type is ignored and only there for argument compatibility
-        # to luminous
+    def destroy(self, ids, force_objectstore_type, unsafe_destroy):
+        # force_objectstore_type and unsafe_destroy are ignored and only there for
+        # argument compatibility to luminous
         ids = self._parse_ids(ids, allow_non_local=f"DESTROY {ids}")
 
         for id_ in ids:
@@ -131,8 +131,11 @@ class OSDManager(object):
             except Exception:
                 traceback.print_exc()
 
-    # target_objectstore_type is ignored but required for call compatibility
-    def rebuild(self, ids, journal_size, target_objectstore_type):
+    # target_objectstore_type and unsafde_destroy are ignored but required for
+    # call compatibility
+    def rebuild(
+        self, ids, journal_size, target_objectstore_type, unsafe_destroy
+    ):
         ids = self._parse_ids(ids)
 
         for id_ in ids:


### PR DESCRIPTION
When operating on Luminous OSDs, all operations involving the destruction of an OSD now do a safety check by default whether the operation would cause reduced data redundancy beyond the desired level. The check can be overriden if necessary.
Tests have been adapted to test both safe as well as unsafe destruction and rebuild.

Jewel OSD operations remain unchanged.

closes #PL-130928

@flyingcircusio/release-managers

## Release process

Impact: internal tooling only

Changelog:

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? This implements the *Establish secure defaults* OWASP rule for destructive OSD operations. Apart from that, operability shall remain unchanged.
- [x] Security requirements tested? Extended automated VM tests with both safe and unsafe destroy and rebuild operations; manually tested on a dev machine
