### PR TITLE
mailserver: auto-upgrade roundcube DB, require explicit postgresql version setting

### DIFF
--- a/doc/src/mailserver.md
+++ b/doc/src/mailserver.md
@@ -2,7 +2,7 @@
 
 # Mail server
 
-This role installs a complete mail server for incoming and outgoing mail.
+The role `mailserver` installs a complete mail server for incoming and outgoing mail.
 Incoming mail is either delivered to IMAP mailboxes via dovecot, or forwarded to
 an application via alias/transport configs. Outgoing mail is accepted on the
 submission port or via a *sendmail* executable.
@@ -19,15 +19,25 @@ mechanism for user management besides text files.
 ## Which components are included?
 
 The main ingredients of this role are [Postfix] for mail delivery, [Dovecot] as
-IMAP access server, and [Roundcube] as web frontend. We rely mainly on [rspamd]
-for spam protection. To get outgoing mails delivered, they are signed with
-[OpenDKIM] and a basic [SPF] and [SRS] setup is included. Additionally, a
-Thunderbird-compatible client [autoconfiguration] XML file is provided which
-helps many clients to configure themselves properly.
+IMAP access server, and [Roundcube] as web frontend.
+{ref}`nixos-postgresql-server` is used as database for Roundcube settings.
+
+We rely mainly on [rspamd] for spam protection. To get outgoing mails
+delivered, they are signed with[OpenDKIM] and a basic [SPF] and [SRS] setup
+is included.
+
+Additionally, a Thunderbird-compatible client[autoconfiguration] XML file is
+provided which helps many clients to configure themselves properly.
 
 (nixos-mailserver-basic-setup)=
 
 ## How do I perform a basic setup?
+
+:::{warning}
+We strongly recommend putting the `mailserver` role on a separate
+VM without other roles (`postgresql` being the only exception). The role
+has many moving parts which could interfere with roles and applications.
+:::
 
 First, you need public IPv4 and IPv6 addresses for your mail server's frontend
 interface. Contact {ref}`support` if you don't have. Then, pick a mail host name
@@ -35,18 +45,26 @@ which will be advertised as MX name on your mail domain. This host name (called
 **mailHost** from here on) must resolve to the FE addresses with both forward
 and reverse lookups.
 
-Additionally, some mail providers (namely \[Telekom/T-Online\](<https://postmaster.t-online.de/#t4.1>))
-may require that your mailserver has an imprint served at its hostname.
+Additionally, some mail providers (namely \[Telekom/T-Online\]
+(<https://postmaster.t-online.de/#t4.1>)) may require that your mailserver
+has an imprint served at its hostname.
 
-For this you can either set imprintUrl to the location of your existing imprint,
-or use imprintText to specify an imprint in HTML format
+For this you can either set `imprintUrl` to the location of your existing
+imprint, or use `imprintText` to specify an imprint in HTML format
 
-Note that it is not possible to set both imprintUrl and imprintText and imprint cannot be used if you serve webmail under the mailHost (meaning mailHost and webmailHost cannot be the same)
+Note that it is not possible to set both `imprintUrl` and `imprintText` at the
+same time and imprint cannot be used if you serve webmail under the
+`mailHost` (meaning `mailHost` and `webmailHost` cannot be the same).
 
 :::{warning}
 Incorrect DNS setup is the most frequent source of delivery problems. Let our
 {ref}`support` check your setup if in doubt.
 :::
+
+If you choose to use the Roundcube webmail UI by adding the `webmailHost`
+setting, like in the example, make sure to enable a `postgresql` role on the
+machine because Roundcube needs it to store settings. Just use the newest
+version that is available at the moment.
 
 Create a configuration file {file}`/etc/local/mail/config.json` which contains
 all the basic pieces. In the following example, the server's mailHost is
@@ -293,7 +311,8 @@ webmailHost
 
 : Virtual server name for the Roundcube web mail service. Appropriate DNS
   entries are expected to point to the VM's frontend address. If this option is
-  set, the Roundcube service will be enabled.
+  set, the Roundcube service will be enabled. Make sure that a `postgresql`
+  role is enabled when adding this option.
 
 rootAlias
 

--- a/nixos/services/mail/roundcube.nix
+++ b/nixos/services/mail/roundcube.nix
@@ -7,7 +7,19 @@ let
 
 in lib.mkMerge [
   (lib.mkIf (role.enable && role.webmailHost != null) {
-    services.postgresql.enable = true;
+
+    assertions = [ {
+      assertion = config.flyingcircus.services.postgresql.majorVersion != "not set";
+      message = ''
+        PostgreSQL version must be set explicitly!
+        Must be defined either by using a postgresql role or by setting it via custom config like:
+
+        flyingcircus.services.postgresql.majorVersion = "13";
+      '';
+    }];
+
+    flyingcircus.services.postgresql.enable = true;
+    flyingcircus.services.postgresql.majorVersion = fclib.mkPlatform "not set";
 
     flyingcircus.passwordlessSudoRules = [{
       commands = [ chpasswd ];

--- a/nixos/services/mail/roundcube.nix
+++ b/nixos/services/mail/roundcube.nix
@@ -18,8 +18,14 @@ in lib.mkMerge [
       '';
     }];
 
-    flyingcircus.services.postgresql.enable = true;
-    flyingcircus.services.postgresql.majorVersion = fclib.mkPlatform "not set";
+    flyingcircus.services.postgresql = {
+      enable = true;
+      majorVersion = fclib.mkPlatform "not set";
+      autoUpgrade = {
+        enable = true;
+        expectedDatabases = [ "roundcube" ];
+      };
+    };
 
     flyingcircus.passwordlessSudoRules = [{
       commands = [ chpasswd ];

--- a/tests/mail/default.nix
+++ b/tests/mail/default.nix
@@ -12,6 +12,7 @@ let
       server=/net/
       server=/org/
       server=/com/
+      address=/webmail.example.local/192.168.1.3
     '';
     services.haveged.enable = true;
   };
@@ -38,6 +39,8 @@ in
               };
               rootAlias = "user2@example.local";
             };
+
+            flyingcircus.roles.postgresql14.enable = true;
 
             virtualisation.vlans = [ 1 3 ];
 
@@ -199,6 +202,12 @@ in
       mail.succeed("grep -v :placeholder ${passwdFile}")
 
     mail.wait_for_unit('network-online.target')
+
+    with subtest("roundcube webmailer should work"):
+      mail.wait_for_unit("phpfpm-roundcube.service")
+      mail.succeed("sudo -u roundcube psql -c 'select from users;'")
+      mail.succeed("curl webmail.example.local")
+
     client.wait_for_unit('network-online.target')
     ext.wait_for_unit('network-online.target')
 


### PR DESCRIPTION
mailserver/roundcube: require explicit setting for PostgreSQL version

An assertion now checks if the default version of PostgreSQL has been
explicitly overridden to avoid unwanted database upgrades which could
lead to data loss when roundcube writes to an empty database creating a
data split between old and new database cluster.

mailserver/roundcube: enable autoupgrades for postgresgl

Automatically upgrade postgresql database cluster which is enabled
for roundcube by our roundcube module.

Auto-upgrade fails if unexpected databases besides `roundcube`
are present in the old cluster. If other databases are expected,
add them to `flyingcircus.postgresql.autoUpgrade.expectedDatabases`.

 #PL-130600

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

- mailserver: require explicit PostgreSQL version setting if Roundcube web mailer is enabled and enable PostgreSQL auto-upgrades: changing to a higher major PostgreSQL version will automatically upgrade and migrate existing data. Note that it will only work by default when no other databases than `roundcube` are present in the database cluster. If there are more databases, add them to the list of expected databases, like: `flyingcircus.postgresql.autoUpgrade.expectedDatabases = [ "anotherdb"  ];`  (#PL-130600).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - just more automation for database upgrades and a assertion to avoid data loss by accidental postgresql data dir changes.
- [x] Security requirements tested? (EVIDENCE)
  - checked manually on test mail server if auto-upgrading works and explicit postgresql version assertion is triggered when no postgresql role is enabled. 
