### PR TITLE
[21.05] Capacity review backy volumes

### DIFF
--- a/nixos/roles/backyserver.nix
+++ b/nixos/roles/backyserver.nix
@@ -73,6 +73,10 @@ in
       };
     };
 
+    services.telegraf.extraConfig.inputs.disk = [
+      { mount_points = [ "/srv/backy" ]; }
+    ];
+
     boot = {
       # Extracted to flyingcircus-physical.nix
       # kernel.sysctl."vm.vfs_cache_pressure" = 10;


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

n/a

Changelog:

* Add used disk space telemetry for backup server data volumes. (PL-130682)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

No specific requirements for the code here. The change itself is motived to support and improve our capacity planning process.

- [x] Security requirements tested? (EVIDENCE)

Manually tested the change in DEV.