### PR TITLE
Update nixpkgs, Gitlab 15.4.2

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "f31aacb0e776ec6d8a6b3936caf1ad6ea1cbf09b",
-    "sha256": "mI/HuxpruH980JMgyzP+a7EzwR38WLwp4fD8lZqr+10="
+    "rev": "15c1a6ad051456efd0d8b8e53b8b168155f63326",
+    "sha256": "f7E7doSVxJ4lHWE/gTjArUoFFUjujGlFHQRvL7zcMGU="
   },
   "nixos-mailserver": {
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/",


### PR DESCRIPTION
Pull upstream NixOS changes, security fixes and package updates:

- bind: 9.18.3 -> 9.18.7
- cacert: 3.80 -> 3.83
- consul: 1.12.1 -> 1.12.5
- discourse: 2.9.0.beta9 -> 2.9.0.beta10
- docker: 20.10.17 -> 20.10.18
- docker: fix build by using go 1.18
- element-web: 1.11.5 -> 1.11.8
- gitlab: 15.3.3 -> 15.4.2
- grafana: 8.5.11 -> 8.5.13, fix CVE-2022-35957 & CVE-2022-36062
- libtiff: add patch for CVE-2022-2953
- linux: 5.10.143 -> 5.10.146
- matrix-synapse: 1.67.0 -> 1.68.0
- mediawiki: 1.37.4 -> 1.37.6
- nodejs-14_x: 14.20.0 -> 14.20.1
- nodejs-16_x: 16.16.0 -> 16.17.1
- nodejs-18_x: 18.7.0 -> 18.9.1
- nodejs-18_x: fix cross compilation to aarch64-linux
- nspr: 4.34.1 -> 4.35
- php74: 7.4.30 -> 7.4.32
- php80: 8.0.23 -> 8.0.24
- php81: 8.1.10 -> 8.1.11
- redis: 7.0.4 -> 7.0.5

 #PL-130958

@flyingcircusio/release-managers

## Release process

Impact:

* Gitlab will be restarted. VM will schedule a reboot to activate the new kernel version.

Changelog:

* (include package changes from above)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - pull in upstream security fixes regularly
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still run, works on test VM and staging Gitlab VM
  - checked commit log for fixed CVEs and possible problems with updates, checked matrix-synapse and Gitlab changelog
