### PR TITLE
fc-postgresql: improve error reporting and docs

### DIFF
--- a/doc/src/postgresql.md
+++ b/doc/src/postgresql.md
@@ -63,17 +63,23 @@ The default monitoring setup checks that the PostgreSQL server process is
 running and that it responds to connection attempts to the standard PostgreSQL
 port.
 
+## Platform-created Databases
+
+We create the `nagios` database for monitoring purposes and `root` for the
+root user. In a fresh installation, the following databases are present:
+`nagios`, `postgres`, `root`, `template0`, `template1`
+
 ## Major Version Upgrades
 
 Upgrading to a new major version, for example from 13.x to 14.x, requires a
 migration of the old database cluster living in {file}`/srv/postgresql/13` to
 the new data directory at {file}`/srv/postgresql/14`. A common way to do this
 is to use {command}`pg_upgrade` bundled with PostgreSQL. This works on our
-platform but finding the right arguments for the command is not trivial.
+platform but doing it properly is not trivial.
 
-To make it easy, we have a `fc-postgresql` command which can show the
-current state of data directories for the available major versions, prepare
-and run upgrade migrations.
+To make it easy and to prevent common errors, we provide a `fc-postgresql`
+command which prepares and runs upgrade migrations. It can also show the
+current state of data directories for the available major versions.
 
 :::{note}
 {command}`fc-postgresql` has to be run as `postgres` user. Prefix the
@@ -83,20 +89,31 @@ users.
 :::
 
 To show which data directories exists, their migration status and which
-service version is running, use {command}`fc-postgresql list-versions`.
+service version is running, use {command}`sudo -u postgres fc-postgresql list-versions`.
+Add `--help` to see details about the meaning of the columns.
 
 :::{note}
-Please look at the output of {command}`fc-postgresql list-versions`
+Please look at the output of {command}`sudo -u postgres fc-postgresql list-versions`
 before performing an upgrade and make sure that your assumptions about
 the current state (which version is active, which data dirs are there, ...)
 are correct.
 :::
 
-To prepare an upgrade, for example, when you use the `postgresql13` role at
-the moment and you want to change to `postgresql14`, run
-{command}`fc-postgresql upgrade --new-version 14` while the old role is
-still active. It's safe to run the command while PostgreSQL is running as it
-does not have an impact on the current cluster and downtime is not required.
+The upgrade commands need to know which databases are expected to be present
+in the cluster. Default databases created by PostgreSQL or our platform code
+are always accepted and don't have to be specified.
+
+If you have two databases, `mydb` and `otherdb`, for example, specify both on
+the command line.
+
+To prepare an upgrade, when you use the `postgresql13` role at the moment and
+you want to change to `postgresql14`, run::
+
+    sudo -u postgres fc-postgresql upgrade --new-version 14 --expected mydb --expected otherdb
+
+Note that this is done while the old role is still active. It's safe to run
+the command while PostgreSQL is running as it does not have an impact on the
+current cluster and downtime is not required.
 
 The command should automatically find the old data directory for 13, set up
 the new data directory and succeed if no problems with the old cluster were
@@ -110,13 +127,16 @@ Depending on the machine and the amount of data, the next step may take
 some time. PostgreSQL will not be available during the upgrade!
 :::
 
-To actually run the upgrade, use {command}`fc-postgresql upgrade --new-version
-14 --upgrade-now`. This will stop the postgresql service, migrate data and
-mark the old data directory as migrated. It cannot be used by the postgresql
-service anymore after this point.
+To actually run the upgrade, use::
 
-Run {command}`fc-postgresql list-versions` to see how the status of the old
-and new data dir has changed.
+    sudo -u postgres fc-postgresql upgrade --new-version 14 --expected mydb --expected otherdb --upgrade-now
+
+This will stop the postgresql service, prevent it from starting during the
+upgrade, migrate data and mark the old data directory as migrated. This data
+directory cannot be used by the postgresql service anymore after this point.
+
+Run {command}`sudo -u postgres fc-postgresql list-versions` to see how the
+status of the old and new data dir has changed.
 
 After the migration, postgresql is still stopped and you have to change your
 configuration to the new major version, for example by disabling the
@@ -126,9 +146,8 @@ If you really need to go back to the old version, delete the new data directory
 as `postgres` user, remove the {file}`fcio_migrated_to*` files in the old data
 directory and switch back to the old postgresql role.
 
-
 ## Miscellaneous
 
-Our PostgreSQL installations have the autoexplain feature enabled by default.
+- Our PostgreSQL installations have the autoexplain feature enabled by default.
 
 % vim: set spell spelllang=en:

--- a/pkgs/fc/agent/fc/util/postgresql.py
+++ b/pkgs/fc/agent/fc/util/postgresql.py
@@ -105,7 +105,7 @@ def build_new_bin_dir(log, pg_data_root: Path, new_version: PGVersion):
 
 
 class MultipleOldDirsFound(Exception):
-    def __int__(self, found_dirs):
+    def __init__(self, found_dirs):
         self.found_dirs = found_dirs
 
 


### PR DESCRIPTION
This is a follow-up to #PL-130197 / PR #605

- Handle more exceptions and display helpful log messages instead.
- Improve documentation and help text wording.
- Document that expected databases have to be specified for the upgrade subcommand.
- Fix some mistakes in log messages.

@flyingcircusio/release-managers

## Release process

Impact: -

Changelog: -

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - nothing new, just cosmetic changes 
- [x] Security requirements tested? (EVIDENCE)
  - checked manually if proper errors are displayed for expected failure modes and that upgrades still work as expected