### PR TITLE
[21.05] Remove swap for physical machines

### DIFF
--- a/nixos/infrastructure/flyingcircus-physical.nix
+++ b/nixos/infrastructure/flyingcircus-physical.nix
@@ -31,6 +31,14 @@ mkIf (cfg.infrastructureModule == "flyingcircus-physical") {
       # Wanted by backy and Ceph servers
       kernel.sysctl."vm.vfs_cache_pressure" = 10;
 
+      kernel.sysctl."vm.swappiness" = config.fclib.mkPlatform 0;
+
+    };
+
+    flyingcircus.activationScripts = {
+      disableSwap = ''
+        swapoff -a
+      '';
     };
 
     environment.systemPackages = with pkgs; [
@@ -68,8 +76,6 @@ mkIf (cfg.infrastructureModule == "flyingcircus-physical") {
     # lead to massive/weird Ceph instabilities. Also, coordination tasks
     # like Qemu migrations run over ethmgm want to be trusted.
     networking.firewall.trustedInterfaces = [ "ethsto" "ethstb" "ethmgm" ];
-
-    swapDevices = [ { device = "/dev/disk/by-label/swap"; } ];
 
     users.users.root = {
       # Overriden in local.nix


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

none

Changelog:

* Disable swap on physical machines. (PL-130935)

  Over time we noticed that swap does not contribute any tangible benefits and has even caused stability problems. A recent KVM crash incident even indicated that swap usage (even though there was enough free memory on the host) caused the crash. As large physical host memory (512G and more) has no real reason to leverage a few GiB of swap and VMs and other infrastructure workloads will be impacted in unobvious ways when swap is involved, we decided retire swap as a concept completely in the future.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

designing for stability. this is a tradeoff however. if systems run out of memory they will face some kind of instability and we're trying to improve the tradeoff to get fast and immediate feedback over prolongued periods of massively reduced performance and also simplify the overall system.

- [x] Security requirements tested? (EVIDENCE)

manually tested the changes on a physical host.
