### PR TITLE
[21.05] fc-ceph-clean-deleted-vms: continue at errors

### DIFF
--- a/pkgs/fc/ceph/src/fc/ceph/main.py
+++ b/pkgs/fc/ceph/src/fc/ceph/main.py
@@ -350,4 +350,8 @@ requests. Useful for identifying slacky OSDs.""",
     environment = Environment(CONFIG_FILE_PATH)
     subsystem = environment.prepare(subsystem_factory)
     action = getattr(subsystem, action)
-    action(**args)
+    action_statuscode = action(**args)
+
+    # optionally allow actions to return a statuscode
+    if isinstance(action_statuscode, int):
+        sys.exit(action_statuscode)


### PR DESCRIPTION
When encountering errors at deleting rbd images or snapshots, or creating new rbd pools, the service does not immediately fail but continues processing the remaining tasks. This allows unaffected tasks to still be executed within their deadline and not being blocked. The errors encountered are still printed to the log and the overall exit code of the service remains a failing one, to make the issues appear in monitoring.

@flyingcircusio/release-managers

## Release process

Impact: internal only

Changelog:
[internal] make fc-ceph-clean-deleted-vms.service and fc-ceph-purge-old-snapshots.service more resilient against failure of individual subtasks

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - adds the *fail safely* property to both cleanup tasks
  - a series of tasks containing failures must still signal the overall failure to monitoring (non-zero exit status), despite continuing to process other non-failing tasks
- [x] Security requirements tested? (EVIDENCE)
  - tested behaviour of 3 VM image deletion tasks, one of them prepared to fail, in our dev cluster. A single failing task now does not block the processing of further non-failing tasks anymore
  - other cleanup tasks (snapshot deletions) have not been tested manually, but utilise the exact same mechanisms having been demonstrated as successful with the manual test
  - Overall, automated unit (pytest) and integration (NixOS) tests would be desirable, but require a lot of setup and mocking in this current state. Setting up that testing infrastructure for this project in this state is something I do not feel comfortable with right now, additionally the complexity of that task is not proportionate to the complexity of this small fix. A regular ticket has been created for that.