### PR TITLE
[21.05] kvm: set mkfs-xfs flags for compatibility with NixOS 15.09

### DIFF
--- a/nixos/roles/kvm.nix
+++ b/nixos/roles/kvm.nix
@@ -21,6 +21,12 @@ in
     flyingcircus.roles.kvm_host = {
       enable = lib.mkEnableOption "Qemu/KVM server";
       supportsContainers = fclib.mkDisableContainerSupport;
+      mkfsXfsFlags = lib.mkOption {
+        type = with lib.types; nullOr str;
+        # XXX: reflink=0 can be removed when 15.09 is out. See #PL-130977
+        # XXX: set reflink=0 to make file systems compatible with NixOS 15.09
+        default = "-q -f -K -m crc=1,finobt=1,reflink=0 -d su=4m,sw=1";
+      };
       package = lib.mkOption {
         type = lib.types.package;
         description = ''
@@ -101,6 +107,8 @@ in
         cluster = ceph
         lock_host = ${hostname}
         create-vm = ${pkgs.fc.agent}/bin/fc-create-vm -I {name}
+     '' + lib.optionalString (role.mkfsXfsFlags != null) ''
+        mkfs-xfs = ${role.mkfsXfsFlags}
      '';
 
     # This needs to stay as is because the path is kept alive during live

--- a/tests/kvm_host_ceph-jewel.nix
+++ b/tests/kvm_host_ceph-jewel.nix
@@ -22,6 +22,10 @@ let
       virtualisation.emptyDiskImages = [ 4000 4000 ];
       imports = [ <fc/nixos> <fc/nixos/roles> ];
 
+      # Use the default flags defined by fc-qemu regardless of
+      # what the platform sets or the fc-qemu unit tests will fail.
+      flyingcircus.roles.kvm_host.mkfsXfsFlags = null;
+
       flyingcircus.static.mtus.sto = 1500;
       flyingcircus.static.mtus.stb = 1500;
 

--- a/tests/kvm_host_ceph-luminous.nix
+++ b/tests/kvm_host_ceph-luminous.nix
@@ -22,6 +22,10 @@ let
       virtualisation.emptyDiskImages = [ 4000 4000 ];
       imports = [ <fc/nixos> <fc/nixos/roles> ];
 
+      # Use the default flags defined by fc-qemu regardless of
+      # what the platform sets or the fc-qemu unit tests will fail.
+      flyingcircus.roles.kvm_host.mkfsXfsFlags = null;
+
       flyingcircus.static.mtus.sto = 1500;
       flyingcircus.static.mtus.stb = 1500;
 


### PR DESCRIPTION
The kernel used on 15.09 doesn't support the reflink feature so mounting /tmp on boot fails when it's activated. The tmp image is created on every start so changes in feature flags become effective then. reflink=1 is the default in newer versions so we have to set it explicitly to reflink=0 until we don't have 15.09 VMs anymore.

 #PL-130977

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - 15.09 VMs should start  
- [x] Security requirements tested? (EVIDENCE)
  - tested manually in test that 15.09 VMs start