### PR TITLE
fc-agent: optional stack trace and nix command

### DIFF
--- a/nixos/platform/default.nix
+++ b/nixos/platform/default.nix
@@ -236,6 +236,7 @@ in {
       extraOptions = ''
         fallback = true
         http-connections = 2
+        extra-experimental-features = nix-command flakes
       '';
     };
 

--- a/pkgs/fc/agent/fc/manage/tests/test_cli.py
+++ b/pkgs/fc/agent/fc/manage/tests/test_cli.py
@@ -75,6 +75,7 @@ def test_invoke_switch(
         "log": switch.call_args.kwargs["log"],
         "enc": ENC,
         "lazy": False,
+        "show_trace": False,
     }
     assert switch.call_args.kwargs == expected
 
@@ -114,6 +115,7 @@ def test_invoke_switch_with_channel_update(
         "log": switch_with_update.call_args.kwargs["log"],
         "enc": ENC,
         "lazy": False,
+        "show_trace": False,
     }
     assert switch_with_update.call_args.kwargs == expected
 
@@ -194,5 +196,6 @@ def test_invoke_dry_activate(manage_func, log, logger, invoke_app):
     expected = {
         "log": manage_func.call_args.kwargs["log"],
         "channel_url": channel_url,
+        "show_trace": False,
     }
     assert manage_func.call_args.kwargs == expected

--- a/pkgs/fc/agent/fc/util/nixos.py
+++ b/pkgs/fc/agent/fc/util/nixos.py
@@ -357,7 +357,6 @@ def build_system(channel_url=None, build_options=None, out_link=None, log=_log):
     cmd = [
         "nix-build",
         "--no-build-output",
-        "--show-trace",
         "<nixpkgs/nixos>",
         "-A",
         "system",

--- a/pkgs/fc/agent/fc/util/tests/test_nixos.py
+++ b/pkgs/fc/agent/fc/util/tests/test_nixos.py
@@ -71,7 +71,7 @@ def test_build_system_with_changes(log, monkeypatch):
     )
 
     cmd = shlex.split(
-        f"nix-build --no-build-output --show-trace <nixpkgs/nixos> -A system -I {channel} --out-link /run/fc-agent-test -v"
+        f"nix-build --no-build-output <nixpkgs/nixos> -A system -I {channel} --out-link /run/fc-agent-test -v"
     )
 
     nix_build_fake = PollingFakePopen(
@@ -102,7 +102,7 @@ def test_build_system_unchanged(log, monkeypatch):
     build_output = "\n"
 
     cmd = shlex.split(
-        f"nix-build --no-build-output --show-trace <nixpkgs/nixos> -A system -I {channel} --no-out-link"
+        f"nix-build --no-build-output <nixpkgs/nixos> -A system -I {channel} --no-out-link"
     )
 
     nix_build_fake = PollingFakePopen(


### PR DESCRIPTION
Nix: activate experimental nix-command and flakes

Some things cannot be used anymore without the nix-command and flakes features, like nix search. 
We still don't document them, though.

agent: add --show-trace option to fc-manage

Before, --show-trace was always on which may result in very long output with recent Nix versions, moving the important error messages out of sight. Most of the time, the error message itself is enough and traces can be enabled if needed.

 @flyingcircusio/release-managers

## Release process

Impact:

Changelog:

- fc-manage: add `--show-trace` option to show detailed stack traces for Nix errors. Stack traces are disabled by default now because they tend to be very long and don't provide helpful information for common error classes (#PL-130985).
- Enable the experimental `nix` command which, for example provides `nix search` to search for packages. This change also enables Nix flakes, which are still experimental but required to make proper use of `nix search`, for example `nix search nixpkgs rich-cli`. Note that this doesn't search for the versions from the Flying Circus platform but the newest available package from unstable so versions and available packages may differ. (#PL-130985).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - the show-trace change just changes the default, no impact here
  - enabling nix command and flakes provides more ways to install packages for users, but they could already do that using the experimental flags or custom nix user config
- [x] Security requirements tested? (EVIDENCE)
  - tested manually that nix commands using flakes work properly and that the `--show-trace` flag works like expected 