### PR TITLE
Update nixpkgs

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "15c1a6ad051456efd0d8b8e53b8b168155f63326",
-    "sha256": "f7E7doSVxJ4lHWE/gTjArUoFFUjujGlFHQRvL7zcMGU="
+    "rev": "28678fc261b58453e2c64b70c838b70d8c11fc38",
+    "sha256": "ZBcE8kWRzbJ2Jr6HxikD5bwsV33IUB4HDkFEGeOkTxs="
   },
   "nixos-mailserver": {
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/",


### PR DESCRIPTION
Pull upstream NixOS changes, security fixes and package updates:

- dnsmasq: add patch for CVE-2022-0934
- linux: 5.10.146 -> 5.10.148
- nss: 3.68.4 -> 3.79.1
- nss_latest: 3.82 -> 3.84

 #PL-130983

@flyingcircusio/release-managers

## Release process

Impact:

* \[NixOS 22.05\] Machines will schedule a reboot to activate the changed kernel.

Changelog: (include changes from commit msg here)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - pull in upstream security fixes regularly
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still run, works on test VM
  - checked commit log for fixed CVEs and possible problems with updates
