### PR TITLE
matomo: 4.11.0 -> 4.12.0, use PHP 8.1

### DIFF
--- a/nixos/services/matomo.nix
+++ b/nixos/services/matomo.nix
@@ -262,6 +262,7 @@ in {
           error_log = 'stderr'
           log_errors = on
         '';
+        phpPackage = pkgs.php81;
         settings = mapAttrs (name: mkDefault) {
           "listen.owner" = socketOwner;
           "listen.group" = "root";

--- a/pkgs/matomo/default.nix
+++ b/pkgs/matomo/default.nix
@@ -3,16 +3,16 @@
 let
   versions = {
     matomo = {
-      version = "4.11.0";
-      sha256 = "sha256-qjpSzF/icSi03zCjWHAU69CNK5iNVMbfFxX9flqB+3Y=";
+      version = "4.12.0";
+      sha256 = "sha256-WAiUfiNNJ40aXTNQkBQZfoiC5dFdejG+d7Mc7iWcSSg=";
     };
 
     matomo-beta = {
-      version = "4.11.0";
+      version = "4.12.0";
       # `beta` examples: "b1", "rc1", null
       # when updating: use null if stable version is >= latest beta or release candidate
       beta = null;
-      sha256 = "sha256-qjpSzF/icSi03zCjWHAU69CNK5iNVMbfFxX9flqB+3Y=";
+      sha256 = "sha256-WAiUfiNNJ40aXTNQkBQZfoiC5dFdejG+d7Mc7iWcSSg=";
     };
   };
   common = pname: { version, sha256, beta ? null }:


### PR DESCRIPTION
matomo complained about PHP 7.3 which is still the default.
It's happy with 8.1 and we can override the version easily for FPM.

* https://matomo.org/changelog/matomo-4-12-0/
* https://developer.matomo.org/changelog

@flyingcircusio/release-managers

## Release process

Impact:

* Matomo will be restarted.

Changelog:

* matomo: update to 4.12.0 (#PL-130982).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - same as before, check that update does not introduce new risks  
- [x] Security requirements tested? (EVIDENCE)
  - checked matomo changelog for breaking and security-related changes: nothing relevant for operations, just some breaking API changes for developers
  - checked on a test VM that upgrading and setting up new matomo instances works
  - looked at matomo system check: no critical warnings