### PR TITLE
clamav: 0.105.0 -> 0.105.1

### DIFF
--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -37,6 +37,14 @@ in {
   check_md_raid = super.callPackage ./check_md_raid { };
   check_megaraid = super.callPackage ./check_megaraid { };
 
+  clamav = super.clamav.overrideAttrs(oldAttrs: rec {
+    pname = "clamav";
+    version = "0.105.1";
+    src = fetchurl {
+      url = "https://www.clamav.net/downloads/production/${pname}-${version}.tar.gz";
+      hash = "sha256-0rwWN024iablpqxA+MbnACVKA5rKpTaIWgnu6kuFKfY=";
+    };
+  });
   # XXX: ceph doesn't build
   # ceph = (super.callPackage ./ceph {
   #     pythonPackages = super.python3Packages;


### PR DESCRIPTION
Backport from nixos-unstable, just a simple version update.

 #PL-130991

@flyingcircusio/release-managers

## Release process

Impact:

- \[NixOS 22.05\] antivirus/clamav will be restarted.

Changelog:

- antivirus/clamav: update to 0.105.1 (#PL-130991).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - nothing new, just a bugfix release 
- [x] Security requirements tested? (EVIDENCE)
  - looked at changelog
  - checked on a test VM that clamav-daemon and freshclam run