### PR TITLE
[21.05] fc-check-ceph: quickfix for matching nearfull OSDs

### DIFF
--- a/pkgs/fc/check-ceph/luminous/fc/check_ceph/ceph.py
+++ b/pkgs/fc/check-ceph/luminous/fc/check_ceph/ceph.py
@@ -133,7 +133,7 @@ class Ceph(nagiosplugin.Resource):
         yield nagiosplugin.Metric(
             "net data", self.stat.data_bytes, "B", min=0, context="default"
         )
-        m = re.search(r"(\d+) near full osd", self.summary)
+        m = re.search(r"(\d+) nearfull osd", self.summary)
         nearfull = int(m.group(1)) if m else 0
         yield nagiosplugin.Metric(
             "nearfull", nearfull, min=0, context="nearfull"


### PR DESCRIPTION
The plaintext message for near full OSDs has changed from Jewel to Luminous from "near full" to "nearfull", breaking regular expression matching and thus alerting.

This is just a quickfix, for a sustainable development persperctive the checks need to be refactored towards using the structured JSON status output, see PL-131031

@flyingcircusio/release-managers

## Release process

Impact: internal only

Changelog:
[internal]
Fix alerting for nearfull OSDs by raising the priority to critical again

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - must fix the issue (functional requirement)
  - must not introduce any further regresseions
- [x] Security requirements tested? (EVIDENCE)
  - changes just a single character in a regular expression, that change has been tested on a ceph host in a cluster with nearfull OSDs. The check for that host became critical again 
