### PR TITLE
install ethtool, mtr, tcpdump as default packages

### DIFF
--- a/nixos/platform/packages.nix
+++ b/nixos/platform/packages.nix
@@ -13,6 +13,7 @@
         db
         dnsutils
         dstat
+        ethtool
         file
         fc.logcheckhelper
         fio
@@ -62,6 +63,8 @@
         xfsprogs
         zip
     ];
+
+    programs.mtr.enable = config.fclib.mkPlatform true;
 
     flyingcircus.passwordlessSudoRules = [
       {

--- a/release/netboot-installer.nix
+++ b/release/netboot-installer.nix
@@ -319,6 +319,9 @@ in
       show_interfaces
       secure_erase
       ipmitool
+      ethtool
+      tcpdump
     ];
+    programs.mtr.enable = true;
   };
 }


### PR DESCRIPTION
These packages are useful basics for debugging network issues and often cannot be installed anymore without a functioning uplink, so it makes sense to keep them installed by default.
The netboot installer does not use the platform default package list, making it necessary to list these packages in that dedicated config again.

@flyingcircusio/release-managers

## Release process

Impact: additional packages use additional space

Changelog: ethtool, mtr, tcpdump installed as default packages on all machines

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined?
  - only installs new packages which have to be present
- [x] Security requirements tested? (EVIDENCE)
  - automated tests discover no regressions
  - manually verified that new packages are present in testvm and netbootinstaller
