### PR TITLE
[21.05] install ethtool, mtr, tcpdump as default packages

### DIFF
--- a/nixos/platform/packages.nix
+++ b/nixos/platform/packages.nix
@@ -16,6 +16,7 @@
         db
         dnsutils
         dstat
+        ethtool
         file
         fc.logcheckhelper
         fio
@@ -77,6 +78,8 @@
         xfsprogs
         zip
     ];
+
+    programs.mtr.enable = config.fclib.mkPlatform true;
 
     flyingcircus.passwordlessSudoRules = [
       {

--- a/release/netboot-installer.nix
+++ b/release/netboot-installer.nix
@@ -324,5 +324,6 @@ in
       ethtool
       tcpdump
     ];
+    programs.mtr.enable = true;
   };
 }


### PR DESCRIPTION
backport of #622 to 21.05, see parent PR for details