### PR TITLE
[21.11] sqlite: fix CVE-2022-35737

### DIFF
--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -345,6 +345,11 @@ in {
   sensu-plugins-redis = super.callPackage ./sensuplugins-rb/sensu-plugins-redis { };
   sensu-plugins-systemd = super.callPackage ./sensuplugins-rb/sensu-plugins-systemd { };
 
+  # fix CVE-2022-35737
+  sqlite = lib.lowPrio (super.sqlite.overrideAttrs (oldAttrs: {
+    patches = (if (oldAttrs ? "patches") then oldAttrs.patches else []) ++ [ ./sqlite/CVE-2022-35737.patch];
+  }));
+
   solr = super.solr.override { jre = self.jdk11_headless; };
 
   temporal_tables = super.callPackage ./postgresql/temporal_tables { };

--- a/pkgs/sqlite/COPYING.md
+++ b/pkgs/sqlite/COPYING.md
@@ -1,0 +1,3 @@
+The files in this directory are based on [MIT-licensed](https://github.com/NixOS/nixpkgs/blob/7269939a5d5610f2eec933607dc4d646394b29b8/COPYING) work done by other Nixpkgs/NixOS contributors, taken from revision 7269939a5d5610f2eec933607dc4d646394b29b8 in the [nixpkgs](https://github.com/NixOS/nixpkgs/) repository under the path [pkgs/tools/filesystems/ceph/](https://github.com/NixOS/nixpkgs/blob/7269939a5d5610f2eec933607dc4d646394b29b8/pkgs/development/libraries/sqlite/).
+
+The modifications made are licensed under the MIT License as well.

--- a/pkgs/sqlite/CVE-2022-35737.patch
+++ b/pkgs/sqlite/CVE-2022-35737.patch
@@ -1,0 +1,15 @@
+diff --git a/sqlite3.c b/sqlite3.c
+index eb8d7d5..3918a09 100644
+--- a/sqlite3.c
++++ b/sqlite3.c
+@@ -30231,8 +30231,8 @@ SQLITE_API void sqlite3_str_vappendf(
+       case etSQLESCAPE:           /* %q: Escape ' characters */
+       case etSQLESCAPE2:          /* %Q: Escape ' and enclose in '...' */
+       case etSQLESCAPE3: {        /* %w: Escape " characters */
+-        int i, j, k, n, isnull;
+-        int needQuote;
++        i64 i, j, k, n;
++        int needQuote, isnull;
+         char ch;
+         char q = ((xtype==etSQLESCAPE3)?'"':'\'');   /* Quote character */
+         char *escarg;


### PR DESCRIPTION
@flyingcircusio/release-managers

fix CVE-2022-35737 in sqlite3 by backporting the relevant patch

## Release process

Impact: Software using sqlite might need to be rebuilt against the fixed version

Changelog:
sqlite: fix CVE-2022-35737

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined?
  - fixes a vulnerability in sqlite
  - must not introduce regressions and break existing packages
- [x] Security requirements tested? (EVIDENCE)
  - automated tests check for package breakges
  - adopted a minimal CVE patch from upstream