### PR TITLE
[21.11] nginx: downgrade to openssl 1.1 to avoid critical vuln

### DIFF
--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -262,6 +262,10 @@ in {
 
   # This is our default version.
   nginxStable = (super.nginxStable.override {
+    # XXX: can be removed when openssl 3.0.7 is released.
+    # We downgrade to 1.1 avoid the critical issue that
+    # will be released on 2022-11-01.
+    openssl = super.openssl_1_1;
     modules = with super.nginxModules; [
       dav
       modsecurity-nginx
@@ -277,6 +281,10 @@ in {
   nginx = self.nginxStable;
 
   nginxMainline = (super.nginxMainline.override {
+    # XXX: can be removed when openssl 3.0.7 is released.
+    # We downgrade to 1.1 avoid the critical issue that
+    # will be released on 2022-11-01.
+    openssl = super.openssl_1_1;
     modules = with super.nginxModules; [
       dav
       modsecurity-nginx


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

## Security implications

- [ ] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [ ] Security requirements tested? (EVIDENCE)
