### PR TITLE
nginx: downgrade to openssl 1.1 to avoid critical vulnerability

### DIFF
--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -270,6 +270,10 @@ in {
 
   # This is our default version.
   nginxStable = (super.nginxStable.override {
+    # XXX: can be removed when openssl 3.0.7 is released.
+    # We downgrade to 1.1 avoid the critical issue that
+    # will be released on 2022-11-01.
+    openssl = super.openssl_1_1;
     modules = with super.nginxModules; [
       dav
       modsecurity-nginx
@@ -285,6 +289,10 @@ in {
   nginx = self.nginxStable;
 
   nginxMainline = (super.nginxMainline.override {
+    # XXX: can be removed when openssl 3.0.7 is released.
+    # We downgrade to 1.1 avoid the critical issue that
+    # will be released on 2022-11-01.
+    openssl = super.openssl_1_1;
     modules = with super.nginxModules; [
       dav
       modsecurity-nginx


### PR DESCRIPTION
nginx: downgrade to openssl 1.1 to avoid critical vulnerability

Then openssl project announced an update for openssl 3 which will be
released on 2022-11-01 to fix a critical vulnerability that can possibly
be exploited in-the-wild. openssl 1.1 is not affected so we downgrade
it for nginx to avoid the vulnerability. We can go back to 3.0.7 when
it is released.

https://mta.openssl.org/pipermail/openssl-announce/2022-October/000238.html

 #PL-131034

This will be released as a hotfix to production on Monday.

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* [hotfix] nginx: use openssl 1.1 instead of openssl 3.0 to avoid a critical vulnerability which will be released on 2022-11-01.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - use a safe version of openssl 
- [x] Security requirements tested? (EVIDENCE)
  - openssl 1.1.1 is not affected
  - verified on a test VM that nginx still works and uses openssl 1.1 only (ldd, nix-store --query)