### PR TITLE
Update nixpkgs

### DIFF
--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -262,10 +262,6 @@ in {
 
   # This is our default version.
   nginxStable = (super.nginxStable.override {
-    # XXX: can be removed when openssl 3.0.7 is released.
-    # We downgrade to 1.1 avoid the critical issue that
-    # will be released on 2022-11-01.
-    openssl = super.openssl_1_1;
     modules = with super.nginxModules; [
       dav
       modsecurity-nginx
@@ -281,10 +277,6 @@ in {
   nginx = self.nginxStable;
 
   nginxMainline = (super.nginxMainline.override {
-    # XXX: can be removed when openssl 3.0.7 is released.
-    # We downgrade to 1.1 avoid the critical issue that
-    # will be released on 2022-11-01.
-    openssl = super.openssl_1_1;
     modules = with super.nginxModules; [
       dav
       modsecurity-nginx

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -37,14 +37,6 @@ in {
   check_md_raid = super.callPackage ./check_md_raid { };
   check_megaraid = super.callPackage ./check_megaraid { };
 
-  clamav = super.clamav.overrideAttrs(oldAttrs: rec {
-    pname = "clamav";
-    version = "0.105.1";
-    src = fetchurl {
-      url = "https://www.clamav.net/downloads/production/${pname}-${version}.tar.gz";
-      hash = "sha256-0rwWN024iablpqxA+MbnACVKA5rKpTaIWgnu6kuFKfY=";
-    };
-  });
   # XXX: ceph doesn't build
   # ceph = (super.callPackage ./ceph {
   #     pythonPackages = super.python3Packages;

--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "28678fc261b58453e2c64b70c838b70d8c11fc38",
-    "sha256": "ZBcE8kWRzbJ2Jr6HxikD5bwsV33IUB4HDkFEGeOkTxs="
+    "rev": "53e59fa176f52c831afc99ea7bcc6527ef6bf5cc",
+    "sha256": "st3cuPmyhKWr5DBJ3Oj7xttqtFVQLF0eQpqGR/IeZzA="
   },
   "nixos-mailserver": {
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/",


### PR DESCRIPTION
Pull upstream NixOS changes, security fixes and package updates:

- dbus: 1.14.0 -> 1.14.4 (CVE-2022-42010, CVE-2022-42011, CVE-2022-42012)
- go_1_18: 1.18.6 -> 1.18.7
- grafana: 8.5.13 -> 8.5.14
- linux: 5.10.148 -> 5.10.150
- matrix-synapse: 1.68.0 -> 1.70.0
- mysql80: 8.0.29 -> 8.0.31
- nginxMainline: 1.23.0 -> 1.23.2
- nginxStable: 1.22.0 -> 1.22.1
- openssl: 3.0.5 -> 3.0.7 (CVE-2022-3786, CVE-2022-3602)
- php80: 8.0.24 -> 8.0.25
- php81: 8.1.11 -> 8.1.12
- qemu: add patch for CVE-2022-3165
- rabbitmq-server: 3.9.14 -> 3.9.18

 #PL-131035


Clamav override could be removed because upstream updated it to 0.105.1; openssl override for nginx could be removed as openssl 3 is now at 3.0.7

@flyingcircusio/release-managers

## Release process

* \[NixOS 22.05\] Grafana, Matrix, RabbitMQ and PHP-FPM will be restarted (versions 8.0 and 8.1). Machines will schedule a reboot to activate the changed kernel.

Changelog: (include changes from commit msg here)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - pull in upstream security fixes regularly
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still run, works on test VM
  - checked commit log for fixed CVEs and possible problems with updates, looked at synapse changes
