### PR TITLE
Update nixpkgs

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "53e59fa176f52c831afc99ea7bcc6527ef6bf5cc",
-    "sha256": "st3cuPmyhKWr5DBJ3Oj7xttqtFVQLF0eQpqGR/IeZzA="
+    "rev": "fdb6f647b03d2099e2ca943b69895bd5f1dceb00",
+    "sha256": "B4bCYRCiXUZuIbsdbbF5nHQSi1PprtGYscO2s09Q7CQ="
   },
   "nixos-mailserver": {
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/",


### PR DESCRIPTION
Pull upstream NixOS changes, security fixes and package updates:

- gitlab: 15.4.2 -> 15.4.4
- linux: 5.10.150 -> 5.10.152
- sudo: apply patch for CVE-2022-43995

 #PL-131035

@flyingcircusio/release-managers

## Release process

Impact:

- \[NixOS 22.05\] Gitlab will be restarted. 

Changelog: (include changes from commit msg here)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - pull in upstream security fixes regularly
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still run, works on test VM
  - checked commit log for fixed CVEs and possible problems with updates; looked at Gitlab changes and tested the update on staging