### PR TITLE
[21.05] fc-ceph-mon/mgr: fix restart trigger

### DIFF
--- a/nixos/roles/ceph/mon.nix
+++ b/nixos/roles/ceph/mon.nix
@@ -86,7 +86,7 @@ in
         after = wants;
 
         restartTriggers = [
-          config.environment.etc."ceph/ceph.conf".text
+          config.environment.etc."ceph/ceph.conf".source
           fclib.ceph.releasePkgs.${role.cephRelease}
         ];
 
@@ -178,7 +178,7 @@ in
         after = wants;
 
         restartTriggers = [
-          config.environment.etc."ceph/ceph.conf".text
+          config.environment.etc."ceph/ceph.conf".source
         ];
 
         environment = {


### PR DESCRIPTION
Accidentally, when specifying the /etc/ceph/ceph.conf file as a restar trigger, not the file path but its text content had been specified as the trigger. This caused unescaped ini configuration content to be added to the systemd service file itself, potentially confusing the unit file parser.

Interestingly, this issue did not break anything in production yet, but it is worthwile nonetheless to be fixed.

@flyingcircusio/release-managers

## Release process

Impact: internal only, will cause ceph mon and mgr services to restart

Changelog:

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - bug fix, must not introduce any further regressions
  - ceph.conf changes still need to trigger a service restart at system rebuild
- [x] Security requirements tested? (EVIDENCE)
  - tested on a dev host that the services still work and are restarted once the config file changes
  - automatic unit tests pass
