### PR TITLE
[21.05] sudo: fix CVE-2022-43995

### DIFF
--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -483,6 +483,14 @@ in {
     patches = (if (oldAttrs ? "patches") then oldAttrs.patches else []) ++ [ ./sqlite/CVE-2022-35737.patch];
   }));
 
+  sudo = super.sudo.overrideAttrs (oldAttrs: {
+    patches = (if (oldAttrs ? "patches") then oldAttrs.patches else []) ++ [
+    (fetchpatch {
+      name = "CVE-2022-43995.patch";
+      url = "https://github.com/sudo-project/sudo/commit/bd209b9f16fcd1270c13db27ae3329c677d48050.patch";
+      sha256 = "sha256-JUdoStoSyv6KBPsyzxuMIxqwZMZsjUPj8zUqOSvmZ1A=";
+    })];
+  });
 
   temporal_tables = super.callPackage ./postgresql/temporal_tables { };
   tideways_daemon = super.callPackage ./tideways/daemon.nix {};


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

- sudo: add patch for CVE-2022-43995 (#PL-131049).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - patch sudo CVE (potential heap buffer overflow when checking passwords)
- [x] Security requirements tested? (EVIDENCE)
  - patch taken from 22.05/22.11, automated sudo test still runs, checked that patch is applied (nix show-derivation)  
