### PR TITLE
fc-postgresql: fix --no-existing-db-check option, use reflinks if possible

### DIFF
--- a/pkgs/fc/agent/fc/conftest.py
+++ b/pkgs/fc/agent/fc/conftest.py
@@ -62,4 +62,6 @@ def request_population(tmpdir, agent_maintenance_config):
 
 @fixture
 def logger():
-    return structlog.get_logger()
+    _logger = structlog.get_logger()
+    _logger.trace = lambda *a, **k: None
+    return _logger

--- a/pkgs/fc/agent/fc/manage/postgresql.py
+++ b/pkgs/fc/agent/fc/manage/postgresql.py
@@ -52,6 +52,10 @@ def stop_pg(log, old_data_dir: Path, stop: bool):
             text=True,
             check=True,
         )
+        log.info(
+            "upgrade-postgresql-stopped",
+            _replace_msg="Postgresql is stopped now.",
+        )
         postgres_running = False
     old_dir_stopper = old_data_dir / "fcio_stopper"
     old_dir_stopper.write_text(STOPPER_TEMPLATE.format(pid=os.getpid()))

--- a/pkgs/fc/agent/fc/util/postgresql.py
+++ b/pkgs/fc/agent/fc/util/postgresql.py
@@ -1,5 +1,6 @@
 import getpass
 import os
+import tempfile
 import re
 import shutil
 from datetime import datetime
@@ -374,12 +375,73 @@ def prepare_upgrade(
         )
 
 
+def pg_upgrade_clone_available(
+    log, new_bin_dir: Path, old_data_dir: Path, new_data_dir: Path
+):
+    """
+    Check if pg_upgrade supports --clone (copy-on-write, reflink) which speeds
+    up migration considerably.
+    """
+    pg_upgrade_help_out = run_as_postgres(
+        [new_bin_dir / "pg_upgrade", "--help"],
+        capture_output=True,
+    ).stdout
+
+    pg_upgrade_has_clone = "--clone" in pg_upgrade_help_out
+
+    src = old_data_dir / "fcio-clone-test"
+    src.touch()
+    dest = new_data_dir / "fcio-clone-test"
+    clone_test = run(
+        ["cp", "--reflink=always", src, dest], capture_output=True, text=True
+    )
+
+    log.debug(
+        "upgrade-clone-check",
+        pg_upgrade_has_clone=pg_upgrade_has_clone,
+        copy_returncode=clone_test.returncode,
+        copy_stderr=clone_test.stderr,
+    )
+
+    clone_available = pg_upgrade_has_clone and not clone_test.returncode
+
+    src.unlink(missing_ok=True)
+    dest.unlink(missing_ok=True)
+
+    if clone_available:
+        log.info(
+            "upgrade-clone-supported",
+            _replace_msg=(
+                "Copying the old database should be very "
+                "fast as the pg_upgrade command can use the --clone option."
+            ),
+        )
+    else:
+        log.warn(
+            "upgrade-clone-not-supported",
+            _replace_msg=(
+                "Copying the old database may take some time as the pg_upgrade "
+                "command does not support the --clone option."
+            ),
+        )
+
+    return clone_available
+
+
 def run_pg_upgrade_check(
     log,
     new_bin_dir,
     new_data_dir,
     old_data_dir,
 ):
+    # Tell the user if fast --clone is available.
+    pg_upgrade_clone_available(
+        log,
+        new_bin_dir=new_bin_dir,
+        old_data_dir=old_data_dir,
+        new_data_dir=new_data_dir,
+    )
+
     upgrade_cmd = [
         new_bin_dir / "pg_upgrade",
         "--old-datadir",
@@ -427,6 +489,15 @@ def run_pg_upgrade(
         "--new-bindir",
         new_bin_dir,
     ]
+
+    if pg_upgrade_clone_available(
+        log,
+        new_bin_dir=new_bin_dir,
+        old_data_dir=old_data_dir,
+        new_data_dir=new_data_dir,
+    ):
+        upgrade_cmd.append("--clone")
+
     log.debug("upgrade-pg_upgrade-cmd", cmd=upgrade_cmd)
     # pg_upgrade wants to write log files to the current work dir.
     os.chdir(new_data_dir)

--- a/pkgs/fc/agent/fc/util/postgresql.py
+++ b/pkgs/fc/agent/fc/util/postgresql.py
@@ -1,8 +1,8 @@
 import getpass
 import os
-import tempfile
 import re
 import shutil
+import tempfile
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
@@ -264,17 +264,17 @@ def get_existing_dbs(log, data_dir, postgres_running, expected_dbs=None):
                     existing_dbs[current_db["datname"]] = current_db
                 current_db = {}
 
-    expected_existing_dbs = {
-        "nagios",
-        "postgres",
-        "root",
-        "template0",
-        "template1",
-        *expected_dbs,
-    }
     if expected_dbs is None:
         log.debug("get-existing-dbs", existing_dbs=existing_dbs)
     else:
+        expected_existing_dbs = {
+            "nagios",
+            "postgres",
+            "root",
+            "template0",
+            "template1",
+            *expected_dbs,
+        }
         unexpected_dbs = set(existing_dbs) - expected_existing_dbs
         log.debug(
             "get-existing-dbs-unexpected-db-check",

--- a/pkgs/fc/agent/fc/util/tests/test_postgresql.py
+++ b/pkgs/fc/agent/fc/util/tests/test_postgresql.py
@@ -67,6 +67,9 @@ def test_prepare_upgrade(logger, pg10_data_dir, monkeypatch, tmp_path):
 
 def test_run_pg_upgrade(logger, tmp_path, pg10_data_dir, monkeypatch):
     monkeypatch.setattr("fc.util.postgresql.run_as_postgres", Mock())
+    monkeypatch.setattr(
+        "fc.util.postgresql.pg_upgrade_clone_available", Mock(return_value=True)
+    )
     new_data_dir = tmp_path / "postgresql/11"
     new_data_dir.mkdir()
     new_bin_dir = new_data_dir


### PR DESCRIPTION
fc-postgresql upgrade: use --clone flag if possible

Speeds up upgrades of large database clusters by using the reflink
feature of XFS (copy-on-write) which is activated by the `--clone` flag.

Available when target version is > 11, file system supports reflinks
and target data dir is on the same file system. The command
automatically checks if --clone is usable and reports it.

fc-postgresql: fix --no-existing-db-check option

Also add some tests for the get_existing_dbs function that contained the
error when handling expected_dbs=None which is the case when
--no-existing-db-check is given.

 #PL-131056


@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

- fc-postgresql upgrade: use fast cloning mode of pg_upgrade (using XFS reflinks) if possible; fix `--no-existing-db-check` option (#PL-131056). 

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - nothing new, just a performance improvement and a bug fix 
- [x] Security requirements tested? (EVIDENCE)
  - Python tests now check get_existing_dbs function, existing Python and NixOS tests still work
  - checked on a test VM that the option works and cloning is used when possible