### PR TITLE
Update nixpkgs

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "fdb6f647b03d2099e2ca943b69895bd5f1dceb00",
-    "sha256": "B4bCYRCiXUZuIbsdbbF5nHQSi1PprtGYscO2s09Q7CQ="
+    "rev": "973d2539f628b3b1a3e9d18b47f43b91d01f9aee",
+    "sha256": "YPejUpw15jOwvxUiVnSUKBOFwiqnymEMZr4dvNZkWdE="
   },
   "nixos-mailserver": {
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/",


### PR DESCRIPTION
Pull upstream NixOS changes, security fixes and package updates:

- curl: add patches for CVE-2022-35252, CVE-2022-32221, CVE-2022-42915, CVE-2022-42916
- github-runner: 2.296.2 -> 2.299.1
- grafana: 8.5.14 -> 8.5.15
- imagemagick: 7.1.0-48 -> 7.1.0-52
- libtiff: add patches for CVE-2022-3626, CVE-2022-3627, CVE-2022-3597, CVE-2022-3598, CVE-2022-3570
- linux: 5.10.152 -> 5.10.155
- matrix-synapse: 1.70.1 -> 1.72.0
- nss: 3.79.1 -> 3.79.2
- php74: 7.4.32 -> 7.4.33 (CVE-2022-31630, CVE-2022-37454)
- python310: 3.10.4 -> 3.10.8 (CVE-2020-10735)
- python38: 3.8.13 -> 3.8.15 (CVE-2020-10735)
- python39: 3.9.13 -> 3.9.15 (CVE-2020-10735)
- redis: patch for CVE-2022-3647
- strace: 5.19 -> 6.0
- systemd: 250.4 -> 250.8
- tomcat9: 9.0.53 -> 9.0.68 (CVE-2021-42340, CVE-2021-43980, CVE-2022-23181, CVE-2022-29885, CVE-2022-34305, CVE-2022-42252)
- tomcat10: 10.0.11 -> 10.0.27 (CVE-2021-42340, CVE-2021-43980 CVE-2022-23181, CVE-2022-29885, CVE-2022-34305, CVE-2022-42252)

 #PL-131090

@flyingcircusio/release-managers

## Release process

* \[NixOS 22.05\] Most services will be restarted because of a core dependency change. Machines will schedule a reboot to activate the changed kernel.

Changelog: (include changes from commit msg here)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - pull in upstream security fixes regularly
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still run, works on test VM
  - checked commit log for fixed CVEs and possible problems with updates, looked at synapse changes