### PR TITLE
[21.11] add nodejs builds to our Hydra jobset

### DIFF
--- a/release/default.nix
+++ b/release/default.nix
@@ -106,10 +106,19 @@ let
     "backy"
   ];
 
+  # we need to ensure all nodejs packages are built, as they might differ from nixpkgs upstream
+  nodejsPkgNames = let
+    nodeReleases = [ 10 14 16 17 18 ];
+    in
+    # in case we ever want to also ensure the nodejs-small packages, this needs to be a fold instead
+    builtins.map (releaseNum: "nodejs-${toString releaseNum}_x") nodeReleases
+    # ensure the default nodejs version is being built
+    ++ [ "nodejs" ];
+
   includedPkgNames = [
     "calibre"
     "gitlab-ee"
-  ];
+  ] ++ nodejsPkgNames;
 
   testPkgNames = includedPkgNames ++
     lib.subtractLists excludedPkgNames modifiedPkgNames;


### PR DESCRIPTION
@flyingcircusio/release-managers

It turned out that hosts on 21.11 had to build nodejs-18_x locally, as the package in our overlay now differs from upstream due to the sqlite CVE fixes. This caused excessive build times on hosts.
This PR adds all nodejs releases of 21.11 to our Hydra build job set to ensure they are present in the binary cache.

## Release process

Impact:

Changelog: internal Hydra jobset config only

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
 - None, just a build pipeline jobset change
 - the "slim" variant of an already allowed insecure package isn't any more insecure than the full variant
- [x] Security requirements tested? (EVIDENCE)
  - [x] Hydra jobset succeeds
