### PR TITLE
[21.05] ceph: make luminous the default release

### DIFF
--- a/nixos/lib/ceph-common.nix
+++ b/nixos/lib/ceph-common.nix
@@ -8,7 +8,7 @@ let
     "luminous" = pkgs.ceph-luminous;
   };
   cephReleaseType = types.enum (builtins.attrNames releasePkgs);
-  defaultRelease = "jewel";
+  defaultRelease = "luminous";
 in
 {
   # constants

--- a/pkgs/fc/default.nix
+++ b/pkgs/fc/default.nix
@@ -31,8 +31,8 @@ rec {
       src = pkgs.fetchFromGitHub {
         owner = "flyingcircusio";
         repo = "fc.qemu";
-        rev = "8e50d7c7c19d345d5e4ec20bd36a473e52be0762";
-        sha256 = "sha256-9hGnpmtXpWUXNYDklJVHRWVwATiDjej6rAvrhq1t9mI";
+        rev = "efbd2df73e236fa8a799c3ab5cdfbe7ecb561c8e";
+        hash = "sha256-gcfZ113kI3aeyH55gzVlROiVcZI1ZlGHYboCN2eIte4";
       };
   };
 

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -35,7 +35,7 @@ in {
   check_md_raid = super.callPackage ./check_md_raid { };
   check_megaraid = super.callPackage ./check_megaraid { };
 
-  ceph = self.ceph-jewel;
+  ceph = self.ceph-luminous;
   ceph-jewel = (super.callPackage ./ceph/jewel {
       pythonPackages = super.python2Packages;
       boost = super.boost155;

--- a/tests/ceph-jewel.nix
+++ b/tests/ceph-jewel.nix
@@ -44,9 +44,18 @@ let
       # the keys etc.
       environment.etc."nixos/services.json".text = builtins.toJSON config.flyingcircus.encServices;
 
-      flyingcircus.roles.ceph_osd.enable = true;
-      flyingcircus.roles.ceph_mon.enable = true;
-      flyingcircus.roles.ceph_rgw.enable = true;
+      flyingcircus.roles.ceph_osd = {
+        enable = true;
+        cephRelease = "jewel";
+      };
+      flyingcircus.roles.ceph_mon = {
+        enable = true;
+        cephRelease = "jewel";
+      };
+      flyingcircus.roles.ceph_rgw = {
+        enable = true;
+        cephRelease = "jewel";
+      };
 
       flyingcircus.static.ceph.fsids.test.test = "d118a9a4-8be5-4703-84c1-87eada2e6b60";
 

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -32,10 +32,10 @@ in {
 
   antivirus = callTest ./antivirus.nix {};
   audit = callTest ./audit.nix {};
-  backyserver = callTest ./backyserver.nix { clientCephRelease = "jewel"; };
+  backyserver_ceph-jewel = callTest ./backyserver.nix { clientCephRelease = "jewel"; };
   backyserver_ceph-luminous = callTest ./backyserver.nix { clientCephRelease = "luminous"; };
   channel = callTest ./channel.nix {};
-  ceph-jewel = callTest ./ceph.nix {};
+  ceph-jewel = callTest ./ceph-jewel.nix {};
   ceph-luminous = callTest ./ceph-luminous.nix {};
   coturn = callTest ./coturn.nix {};
   devhost = callTest ./devhost.nix {};

--- a/tests/kvm_host_ceph-jewel.nix
+++ b/tests/kvm_host_ceph-jewel.nix
@@ -7,13 +7,21 @@ let
   makeHostConfig = { id }:
     { config, pkgs, lib, ... }:
     let
+      qemu_ceph_jewel = pkgs.qemu_ceph.override {
+        ceph = config.fclib.ceph.releasePkgs.jewel;
+      };
       testPackage = if useCheckout then
         pkgs.callPackage <fc/pkgs/fc/qemu> {
           version = "dev";
           # builtins.toPath (testPath + "/.")
           src = ../../fc.qemu/.;
+          ceph = config.fclib.ceph.releasePkgs.jewel;
+          qemu_ceph = qemu_ceph_jewel;
         }
-        else pkgs.fc.qemu;
+        else pkgs.fc.qemu.override {
+          ceph = config.fclib.ceph.releasePkgs.jewel;
+          qemu_ceph = qemu_ceph_jewel;
+        };
     in
     {
 

--- a/tests/kvm_host_ceph-jewel.nix
+++ b/tests/kvm_host_ceph-jewel.nix
@@ -123,8 +123,15 @@ let
       environment.etc."nixos/services.json".text = builtins.toJSON config.flyingcircus.encServices;
 
       # Ceph
-      flyingcircus.roles.ceph_osd.enable = true;
-      flyingcircus.roles.ceph_mon.enable = true;
+      flyingcircus.roles.ceph_osd = {
+        enable = true;
+        cephRelease = "jewel";
+      };
+      flyingcircus.roles.ceph_mon = {
+        enable = true;
+        cephRelease = "jewel";
+      };
+
       flyingcircus.static.ceph.fsids.test.test = "d118a9a4-8be5-4703-84c1-87eada2e6b60";
       flyingcircus.services.ceph.extraConfig = ''
             mon clock drift allowed = 1
@@ -134,6 +141,7 @@ let
       flyingcircus.roles.kvm_host = {
         enable = true;
         package = testPackage;
+        cephRelease = "jewel";
       };
 
       environment.sessionVariables = {

--- a/tests/kvm_host_ceph-luminous.nix
+++ b/tests/kvm_host_ceph-luminous.nix
@@ -7,13 +7,21 @@ let
   makeHostConfig = { id }:
     { config, pkgs, lib, ... }:
     let
+      qemu_ceph_versioned = pkgs.qemu_ceph.override {
+        ceph = config.fclib.ceph.releasePkgs.${clientCephRelease};
+      };
       testPackage = if useCheckout then
         pkgs.callPackage <fc/pkgs/fc/qemu> {
           version = "dev";
           # builtins.toPath (testPath + "/.")
           src = ../../fc.qemu/.;
+          ceph = config.fclib.ceph.releasePkgs.${clientCephRelease};
+          qemu_ceph = qemu_ceph_versioned;
         }
-        else pkgs.fc.qemu;
+        else pkgs.fc.qemu.override {
+          ceph = config.fclib.ceph.releasePkgs.${clientCephRelease};
+          qemu_ceph = qemu_ceph_versioned;
+        };
     in
     {
 
@@ -122,7 +130,6 @@ let
       # the keys etc.
       environment.etc."nixos/services.json".text = builtins.toJSON config.flyingcircus.encServices;
 
-      # Ceph: use jewel
       flyingcircus.roles.ceph_osd = {
         enable = true;
         cephRelease = "luminous";


### PR DESCRIPTION
This PR mainly just changes the default Ceph release used by the platform (packages and roles) to Luminous.
While doing this, I discovered and fixed a few issues with the NixOS tests:
- a version impurity in the kvm_host test: the used fc.qemu test-package did not use the correct ceph packages by release
- a mocked exception in the qemu tests was constructed in an incorrect way 

@flyingcircusio/release-managers

## Release process

Impact: Can cause the following ceph daemons to restart:
- fc-ceph-mgr.service
- fc-ceph-mon.service
- fc-ceph-rgw.service

Changelog: internal only, changes default ceph release (package and roles) to Luminous

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined?
  - only changes the defaults of existing configuration
  - new default configuration must be consistent, existing configuration adjustments must still have the same effect
- [x] Security requirements tested? (EVIDENCE)
  - NixOS unit and integration tests still succeed (after some adjustments)
  - manually tested on a ceph and KVM host in our dev cluster (although only for luminous, not for jewel)