### PR TITLE
Add Oliver's emergency root key.

### DIFF
--- a/nixos/platform/static.nix
+++ b/nixos/platform/static.nix
@@ -130,6 +130,7 @@ with lib;
         cs = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKIlrvXV9TzM1uppd8oAbph1dcab6h28VZSUthsp2eZL christians@colbert";
         ts = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOpJ59uGzQAB/n9YFQoOPWHiUFaKPGj2OivAxQmTkeyN ts";
         nm = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDFBloz5mf4SxX0/GwvOmTD2itWTRjyrmxh13Nzc2oSP nm";
+        os = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJemLKFmr09o6zBscLJSD3KcAs/dnIYBjgxYzJ59VvHx os@Olivers-MBP-3";
       };
 
     };


### PR DESCRIPTION
Backport to all releases!

Re HR-146591

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

Emergency root keys only for Administrators. Oliver is being made an admin in HR-146591.

- [x] Security requirements tested? (EVIDENCE)

Key communicated by trusted, verified matrix channel.