### PR TITLE
mysql: make binlog duration configurable, default 3 days

### DIFF
--- a/nixos/roles/mysql.nix
+++ b/nixos/roles/mysql.nix
@@ -26,6 +26,15 @@ in
         # by itself and can't directly run on containers either.
         supportsContainers = fclib.mkDisableContainerSupport;
 
+        binlogExpireDays = mkOption {
+          type = types.ints.positive;
+          default = 3;
+          description = ''
+            Expire binlog after 3 days by default.
+            The MySQL/Percona default of 30 days is way too long for typical use cases.
+          '';
+        };
+
         listenAddresses = lib.mkOption {
           type = lib.types.listOf lib.types.str;
           default = fclib.network.lo.dualstack.addresses ++
@@ -177,6 +186,14 @@ in
         open_files_limit           = 65535
         sysdate-is-now             = ON
         sql_mode                   = NO_ENGINE_SUBSTITUTION
+
+        ${
+          if (lib.versionAtLeast package.version "8.0")
+          then
+          "binlog_expire_logs_seconds = ${toString (cfg.binlogExpireDays * 24 * 60 * 60)}"
+          else
+          "expire_logs_days = ${toString cfg.binlogExpireDays}"
+        }
 
         log_slow_verbosity = 'full'
         slow_query_log = ON


### PR DESCRIPTION
The default of 30 days is very long and consumes a lot of space on busy instances. 3 days are usually more than enough.

 #PL-131092

@flyingcircusio/release-managers

## Release process

Impact:

- MySQL service will be restarted.

Changelog:

* mysql/percona: set binlog duration to 3 days (72 hours) by default and make it configurable via `flyingcircus.mysql.binlogExpireHours`. The default of 30 days was very long and consumes a lot of space on busy instances (#PL-131092).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  -  don't keep data for longer as neccessary (binlog logs all modifying SQL statements)
- [x] Security requirements tested? (EVIDENCE)
  - checked on a test VM that the setting is reflected in mysql `show variables` output and logs are deleted when older than x hours