### PR TITLE
Update nixpkgs

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "973d2539f628b3b1a3e9d18b47f43b91d01f9aee",
-    "sha256": "YPejUpw15jOwvxUiVnSUKBOFwiqnymEMZr4dvNZkWdE="
+    "rev": "aa6548b0c705de7ae3cf225636563fd3a76e064b",
+    "sha256": "86IlyIm1ZFfPqoePao8YVjufwKLO7/Co4XW9X86fW/w="
   },
   "nixos-mailserver": {
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/",


### PR DESCRIPTION
Pull upstream NixOS changes, security fixes and package updates:

- discourse: 2.9.0.beta10 -> 2.9.0.beta14 (CVE-2022-41921, CVE-2022-41944, CVE-2022-46150, CVE-2022-46159)
- gitlab: 15.4.4 -> 15.4.6
- imagemagick6: 6.9.12-26 -> 6.9.12-68 (CVE-2022-1114, CVE-2022-1115, CVE-2022-3213, CVE-2022-32545, CVE-2022-32546, CVE-2022-32547)
- imagemagick: 7.1.0-52 -> 7.1.0-53
- linux: 5.10.155 -> 5.10.158
- matrix-synapse: 1.72.0 -> 1.73.0
- python311: 3.11.0 -> 3.11.1 (CVE-2022-45061)
- python38: 3.8.15 -> 3.8.16 (CVE-2022-37454, CVE-2022-45061, CVE-2015-20107)

 #PL-131134

@flyingcircusio/release-managers

## Release process

Impact:

* \[NixOS 22.05\] Synapse (Matrix) and Gitlab will restart. Machines will schedule a reboot to activate the changed kernel.

Changelog: (include changes from commit msg here)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - pull in upstream security fixes regularly
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still run, works on test VM
  - checked commit log for fixed CVEs and possible problems with updates, looked at synapse changes
