### PR TITLE
statshost-relay: fcio nginx service, log rotation

### DIFF
--- a/nixos/roles/statshost/rg-relay.nix
+++ b/nixos/roles/statshost/rg-relay.nix
@@ -7,7 +7,7 @@ with lib;
 {
   config = mkIf config.flyingcircus.roles.statshost-relay.enable {
 
-    services.nginx.enable = true;
+    flyingcircus.services.nginx.enable = true;
     services.nginx.masterUser = "root";
     services.nginx.appendHttpConfig = ''
       server {

--- a/tests/statshost/rg-relay.nix
+++ b/tests/statshost/rg-relay.nix
@@ -51,7 +51,13 @@ import ../make-test-python.nix ({ pkgs, ... }:
       relay.succeed('grep "metrics" /var/log/nginx/statshost-relay_access.log')
 
     with subtest("nginx only opens expected ports"):
-      # look for ports that are not 80 (nginx default for status info) or 9090
-      relay.fail("netstat -tlpn | grep nginx | egrep -v ':80 |:9090 '")
+      # Look for ports that are not 81 (nginx status page port) or 9090.
+      relay.fail("netstat -tlpn | grep nginx | egrep -v ':81 |:9090 '")
+
+    with subtest("logrotate should work"):
+      relay.execute("echo test > /var/log/nginx/statshost-relay_error.log")
+      relay.succeed("fc-logrotate -f")
+      relay.succeed("stat /var/log/nginx/statshost-relay_access.log-*")
+      relay.succeed("stat /var/log/nginx/statshost-relay_error.log-*")
   '';
 })


### PR DESCRIPTION
Enable the flyingcircus nginx service instead of the upstream one.

On most machines running the statshost-relay (rg-relay), webgateway is also running which enables the flyingcircus nginx service. This service sets up log rotation for the whole /var/log/nginx dir.

If webgateway is not enabled, this role currently behaves differently, using the upstream nginx module which means that there is no log rotation for the relay access/error log. This change unifies the behaviour.

 #PL-131140

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* statshost-relay: fix log rotation on machines which don't have the webgateway role (#PL-131140).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - don't fill the file system with ever-growing log files  
- [x] Security requirements tested? (EVIDENCE)
  - automated test now checks for proper log rotation
