### PR TITLE
jitsi-meet: update packages to latest stable

### DIFF
--- a/nixos/roles/jitsi/default.nix
+++ b/nixos/roles/jitsi/default.nix
@@ -284,8 +284,6 @@ in {
 
       };
 
-      services.jitsi-videobridge.apis = [ "rest" ];
-
       services.nginx.virtualHosts = {
         "${cfg.hostName}" = {
           listenAddresses = [ cfg.listenAddress (fclib.quoteIPv6Address cfg.listenAddress6) ];

--- a/nixos/services/jitsi/jicofo.nix
+++ b/nixos/services/jitsi/jicofo.nix
@@ -139,12 +139,8 @@ in
 
         watchdog $$ &
 
-        ${pkgs.jicofo}/bin/jicofo \
-          --host=${cfg.xmppHost} \
-          --domain=${if cfg.xmppDomain == null then cfg.xmppHost else cfg.xmppDomain} \
-          --user_name=${cfg.userName} \
-          --user_domain=${cfg.userDomain} \
-          --user_password="$(cat ${cfg.userPasswordFile})"
+        export JICOFO_AUTH_PASSWORD=$(cat ${cfg.userPasswordFile})
+        ${pkgs.jicofo}/bin/jicofo
       '';
 
       serviceConfig = {
@@ -185,6 +181,11 @@ in
         xmpp {
           client {
             client-proxy: focus.${cfg.xmppDomain}
+            domain: ${cfg.userDomain}
+            xmpp-domain: ${if cfg.xmppDomain == null then cfg.xmppHost else cfg.xmppDomain}
+            username: ${cfg.userName}
+            # The password is set via an environment var in the start script.
+            password: ''${JICOFO_AUTH_PASSWORD}
           }
         }
       }

--- a/nixos/services/jitsi/jitsi-videobridge.nix
+++ b/nixos/services/jitsi/jitsi-videobridge.nix
@@ -23,6 +23,11 @@ let
 
   defaultJvbConfig = {
     videobridge = {
+      apis = {
+        rest = {
+          enabled = true;
+        };
+      };
       ice = {
         udp.port = 10000;
       };
@@ -187,16 +192,6 @@ in
         Whether to open ports in the firewall for the videobridge.
       '';
     };
-
-    apis = mkOption {
-      type = with types; listOf str;
-      description = ''
-        What is passed as --apis= parameter. If this is empty, "none" is passed.
-        Needed for monitoring jitsi.
-      '';
-      default = [];
-      example = literalExample "[ \"colibri\" \"rest\" ]";
-    };
   };
 
   config = mkIf cfg.enable {
@@ -271,8 +266,7 @@ in
 
         echo "Starting videobridge"
 
-        ${pkgs.jitsi-videobridge}/bin/jitsi-videobridge \
-          --apis=${if (cfg.apis == []) then "none" else concatStringsSep "," cfg.apis}
+        ${pkgs.jitsi-videobridge}/bin/jitsi-videobridge
       '';
 
       serviceConfig = {

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -91,29 +91,29 @@ in {
 
   jicofo = super.jicofo.overrideAttrs(oldAttrs: rec {
     pname = "jicofo";
-    version = "1.0-940";
+    version = "1.0-968";
     src = fetchurl {
       url = "https://download.jitsi.org/stable/${pname}_${version}-1_all.deb";
-      hash = "sha256-vx7aUHfKxG+tZ0sM8eWr1tTKf//bMxdKVhE5I4P4mLo=";
+      hash = "sha256-TaIS+FpzjdAO2bqYN9beMNwJTOcGmQMy49pglKzz6fQ=";
     };
   });
 
   jitsi-meet = super.jitsi-meet.overrideAttrs(oldAttrs: rec {
     pname = "jitsi-meet";
-    version = "1.0.6644";
+    version = "1.0.6854";
     src = fetchurl {
       url = "https://download.jitsi.org/jitsi-meet/src/jitsi-meet-${version}.tar.bz2";
-      hash = "sha256-y1oI3nxIu7breYNPhdX7PU5GfnCyxdEbAYlyZmif2Uo=";
+      hash = "sha256-BOGghB1drxe241+Zk1p/DHjEAuTNyiMEx8c3lDERwP4=";
     };
 
   });
 
   jitsi-videobridge = super.jitsi-videobridge.overrideAttrs(oldAttrs: rec {
     pname = "jitsi-videobridge2";
-    version = "2.2-45-ge8b20f06";
+    version = "2.2-63-g252d14bc";
     src = fetchurl {
       url = "https://download.jitsi.org/stable/${pname}_${version}-1_all.deb";
-      hash = "sha256-fbSpjLdx9xbLdp7vzHTW9B/cDf3DahpwuI4IcqEqpas=";
+      hash = "sha256-8MEy7km65pMXhbC7QhS8O+IcqCRLuleKwOuKJo/I7Yk=";
     };
     # jvb complained about missing libcrypto.so.3, add openssl 3 here.
     installPhase = ''


### PR DESCRIPTION
Jicofo and JVB needed a config update because some settings got moved to the
HOCON config file and the command line args are not supported anymore. Also
removed the apis option because there's not really a choice to make here
anymore and we always want the REST API.

PL-131178

@flyingcircusio/release-managers

## Release process

Impact:

* \[NixOS 22.05\] Jitsi will be restarted and conferences will be interrupted for a short period of time.

Changelog:

* Jitsi: update all packages to latest stable release (#PL-131178).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - use recent stable version 
- [x] Security requirements tested? (EVIDENCE)
  - checked video, auth and screen sharing on a test VM
  - checked [Changelog](https://github.com/jitsi/jitsi-meet-release-notes/blob/master/CHANGELOG-WEB.md) for security-related changes: nothing important
