### PR TITLE
matomo: 4.12.3 -> 4.13.0

### DIFF
--- a/pkgs/matomo/change-path-geoip2.patch
+++ b/pkgs/matomo/change-path-geoip2.patch
@@ -1,10 +1,12 @@
+diff --git a/plugins/GeoIp2/config/config.php b/plugins/GeoIp2/config/config.php
+index f00289035a..7aeccccb01 100644
 --- a/plugins/GeoIp2/config/config.php
 +++ b/plugins/GeoIp2/config/config.php
-@@ -1,5 +1,5 @@
+@@ -1,6 +1,6 @@
  <?php
-
+ 
  return [
 -    'path.geoip2' => DI\string('{path.root}/misc/'),
 +    'path.geoip2' => PIWIK_USER_PATH . '/misc/',
+     'geopip2.ispEnabled' => true
  ];
-\ Pas de fin de ligne à la fin du fichier

--- a/pkgs/matomo/default.nix
+++ b/pkgs/matomo/default.nix
@@ -3,16 +3,16 @@
 let
   versions = {
     matomo = {
-      version = "4.12.3";
-      sha256 = "sha256-AO/kM1yc7p8mm16KM3Amr38RXAXN4emuR0hVkjcrN+4=";
+      version = "4.13.0";
+      sha256 = "sha256-WWFPv6hw01T4q8Y0zCHbvr2iuf3jFZLfjIE8OeHf+YE=";
     };
 
     matomo-beta = {
-      version = "4.12.3";
+      version = "4.13.0";
       # `beta` examples: "b1", "rc1", null
       # when updating: use null if stable version is >= latest beta or release candidate
       beta = null;
-      sha256 = "sha256-AO/kM1yc7p8mm16KM3Amr38RXAXN4emuR0hVkjcrN+4=";
+      sha256 = "sha256-WWFPv6hw01T4q8Y0zCHbvr2iuf3jFZLfjIE8OeHf+YE=";
     };
   };
   common = pname: { version, sha256, beta ? null }:


### PR DESCRIPTION
GeoIP patch needed a fix, other than that just a regular version bump.

PL-131146

@flyingcircusio/release-managers

## Release process

Impact:

- \[NixOS 22.05\] matomo will be restarted.

Changelog:

- matomo: update to 4.13.0 (#PL-131146).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - same as before, check that update does not introduce new risks  
- [x] Security requirements tested? (EVIDENCE)
  - checked matomo changelog for breaking and security-related changes: nothing relevant for operations
  - checked on a test VM that updating and setting up a new matomo instance works
  - looked at matomo system check: no critical warnings
