### PR TITLE
Update nixpkgs

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "aa6548b0c705de7ae3cf225636563fd3a76e064b",
-    "sha256": "86IlyIm1ZFfPqoePao8YVjufwKLO7/Co4XW9X86fW/w="
+    "rev": "e4de71784c346c987e715ed370f05866d68a6604",
+    "sha256": "PjOH1kZ7sUFOw8Cm4GrRHnodpM74sgFyJ8SiwDma4LA="
   },
   "nixos-mailserver": {
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/",


### PR DESCRIPTION
Pull upstream NixOS changes, security fixes and package updates:

- cacert: 3.83 -> 3.86
- cacert: Distrust TrustCor root certificates
- curl: backport 7.87.0 security fixes (CVE-2022-43551, CVE-2022-43552)
- imagemagick: 7.1.0-53 -> 7.1.0-56
- libtiff: add patch for CVE-2022-3970
- linux: 5.10.158 -> 5.10.161
- matrix-synapse: 1.73.0 -> 1.74.0
- nss_latest: 3.84 -> 3.86
- python310: 3.10.8 -> 3.10.9 (CVE-2022-37454, CVE-2022-45061, CVE-2022-42919)
- python310: revert asyncio changes done in 3.10.9
- python39: 3.9.15 -> 3.9.16 (CVE-2022-37454, CVE-2022-42919, CVE-2022-45061, CVE-2015-20107)
- python3Packages.pillow: add patch for CVE-2022-45198, test for CVE-2022-45199
- qemu: add patches for CVE-2022-4172 & CVE-2022-4144
- sqlite: add patch for CVE-2022-46908
- systemd: 250.8 -> 250.9

PL-131189

@flyingcircusio/release-managers

## Release process

* \[NixOS 22.05\] Most services will be restarted because of a core dependency change. Machines will schedule a reboot to activate the changed kernel.

Changelog: (include changes from commit msg here)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - pull in upstream security fixes regularly
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still run, works on test VM
  - checked commit log for fixed CVEs and possible problems with updates, looked at [synapse/CHANGES.md](https://github.com/matrix-org/synapse/blob/develop/CHANGES.md) and [synapse/upgrade.md](https://github.com/matrix-org/synapse/blob/develop/docs/upgrade.md)