### PR TITLE
docker: restrict access to containers by resource group

### DIFF
--- a/nixos/roles/docker.nix
+++ b/nixos/roles/docker.nix
@@ -16,12 +16,33 @@ in
     flyingcircus.users.serviceUsers.extraGroups = [ "docker" ];
     virtualisation.docker.enable = true;
 
-    networking.firewall.extraCommands = ''
+    networking.firewall.extraCommands = lib.mkOrder 1200 ''
+      # FC docker rules (1200)
       # allow access to host from docker networks, we consider this identical
       # to access from locally running processes.
       # We grant the full RFC1918 172.16.0.0/12 range.
-      iptables -A nixos-fw -i br-+ -s 172.16.0.0/12 -j nixos-fw-accept
-      iptables -A nixos-fw -i docker+ -s 172.16.0.0/12 -j nixos-fw-accept
+      iptables -w -A nixos-fw -i br-+ -s 172.16.0.0/12 -j nixos-fw-accept
+      iptables -w -A nixos-fw -i docker+ -s 172.16.0.0/12 -j nixos-fw-accept
+
+      ip46tables -N fc-docker 2>/dev/null || true
+      ip46tables -A fc-docker -m conntrack --ctstate RELATED,ESTABLISHED -j nixos-fw-accept
+      ip46tables -A fc-docker -i ethsrv -j fc-resource-group
+      ip46tables -A fc-docker -i ethsrv -j nixos-fw-refuse
+      ip46tables -A fc-docker -i ethfe -j nixos-fw-refuse
+
+      ip46tables -N DOCKER-USER 2>/dev/null || true
+      ip46tables -I DOCKER-USER 1 ! -i docker+ -o docker+ -j fc-docker
+      # End FC docker rules (1200)
+    '';
+
+    networking.firewall.extraStopCommands = lib.mkOrder 1100 ''
+      # FC docker rules (1100)
+      iptables -w -D nixos-fw -i br-+ -s 172.16.0.0/12 -j nixos-fw-accept 2>/dev/null || true
+      iptables -w -D nixos-fw -i docker+ -s 172.16.0.0/12 -j nixos-fw-accept 2>/dev/null || true
+      ip46tables -D DOCKER-USER ! -i docker+ -o docker+ -j fc-docker 2>/dev/null || true
+      ip46tables -F fc-docker 2>/dev/null || true
+      ip46tables -X fc-docker 2>/dev/null || true
+      # End FC docker rules (1100)
     '';
 
   };


### PR DESCRIPTION
docker binds container services to 0.0.0.0 and no firewall rules currently restrict access to containers. For SRV,
we want to apply the same restrictions as for normal host traffic, allowing only machines from the same RG.
FE access to containers is dropped completely.

PL-131042

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

- docker: restrict access to forwarded container ports so that they are only accessible to hosts within the same resource group, and not accessible over the public internet (PL-131042).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Ensure that applications running inside containers are not directly accessible over the public internet.
- [x] Security requirements tested? (EVIDENCE)
  - Tested manually to ensure:
    - The firewall activation script runs correctly when applying this change to an existing system.
    - The new firewall rules created by this change correctly block external access to ports forwarded to containers by docker.
    - The new firewall rules continue to allow outgoing connections from processes running inside containers.
    - Changes to firewall rules managed by the platform do not disrupt network connectivity for containers.