### PR TITLE
rotate /var/log/fc-agent.log

### DIFF
--- a/.pre-commit-config-local.yaml
+++ b/.pre-commit-config-local.yaml
@@ -1,0 +1,1 @@
+exclude: "pkgs/fc/sensusyntax/fixtures/(syntaxerror|empty).json|(nixos/infrastructure/container.nix|tests/testlib.nix)"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,39 +1,28 @@
-# See https://pre-commit.com for more information
-# See https://pre-commit.com/hooks.html for more hooks
+exclude: ^secrets/|^appenv$|pkgs/fc/sensusyntax/fixtures/(syntaxerror|empty).json|(nixos/infrastructure/container.nix|tests/testlib.nix)
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
-    hooks:
-    -   id: trailing-whitespace
-        exclude: |
-          (?x)^(
-            secrets/|environments/.*/secrets\.cfg|
-            .*\.patch
-          )$
-    -   id: end-of-file-fixer
-        exclude: |
-          (?x)^(
-            secrets/|environments/.*/secrets\.cfg|
-            .*\.patch
-          )$
-    -   id: check-yaml
-    -   id: check-added-large-files
-    -   id: check-json
-        exclude: pkgs/fc/sensusyntax/fixtures/(syntaxerror|empty)\.json
-    -   id: check-xml
-    -   id: check-toml
-    -   id: check-yaml
-    -   id: detect-private-key
-        exclude: (nixos/infrastructure/container\.nix|tests/testlib\.nix)
-
--   repo: https://github.com/pycqa/isort
-    rev: 5.10.1
-    hooks:
-      - id: isort
-        name: isort (python)
-        args: ["--profile", "black", "--filter-files"]
-
--   repo: https://github.com/psf/black
-    rev: 22.3.0
-    hooks:
-    -   id: black
+- hooks:
+  - exclude: "(?x)^(\n  secrets/|environments/.*/secret.*|\n  .*\\.patch\n)$\n"
+    id: trailing-whitespace
+  - exclude: "(?x)^(\n  environments/.*/secret.*|\n  .*\\.patch\n)$\n"
+    id: end-of-file-fixer
+  - id: check-yaml
+  - id: check-added-large-files
+  - id: check-json
+  - id: check-xml
+  - id: check-toml
+  - id: detect-private-key
+  repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v3.2.0
+- hooks:
+  - args:
+    - --profile
+    - black
+    - --filter-files
+    id: isort
+    name: isort (python)
+  repo: https://github.com/pycqa/isort
+  rev: 5.12.0
+- hooks:
+  - id: black
+  repo: https://github.com/psf/black
+  rev: 22.3.0


### PR DESCRIPTION
The log file /var/lib/fc-agent.log was missing a rotation rule and thus kept growing without limits over time. This adds monthly rotation of fc-agent.log, the keep time of the file is chosen to be similar (due to rounding) as the build logs in /var/lib/fc-agent/*.log

@flyingcircusio/release-managers

## Release process

Impact: will delete fc-agent.log content older than 180d at some point, but right after updating old logs will just be moved to another file

Changelog:
- rotate /var/log/fc-agent.log monthly, logs gone after 6 months
- update pre-commit hooks to unblock GitHub CI

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined?
  - [x] reduce chance of fc-agent log filling up the disk by trimming its history (log rotation)
  - [x] use defaults and maintain existing behaviour defaults where possible
  - [x] new functionality needs to be tested manually
  - [x] automated tests need to pass as regression tests
- [x] Security requirements tested? (EVIDENCE)
  - [x] behaviour of new rotation rule checked on a testvm with `fc-logrotate -d` and multiple manipulations of logrotate state
  - [x] rotation times adapted according to existing agent logfile keep policies
  - [x] automated tests pass
  - [x] while out-of-scope from the functionality perspective, some cleanups had to be made to unblock the CI