### PR TITLE
nginx: fix allow/deny rules for ipv6 + keep-alive, update nginx mainline

### DIFF
--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -286,11 +286,6 @@ in {
     patches = a.patches ++ [
       ./remote_addr_anon.patch
     ];
-    version = "1.23.0";
-    src = fetchurl {
-      url = "https://nginx.org/download/nginx-${version}.tar.gz";
-      hash = "sha256-ggrKo1uScr6ennL23vpKXykhgkcJ+KpHcseKsx7ZTNE=";
-  };
   });
 
   openldap_2_4 = super.callPackage ./openldap_2_4.nix { };

--- a/pkgs/remote_addr_anon.patch
+++ b/pkgs/remote_addr_anon.patch
@@ -1,29 +1,18 @@
-From 222c9f32c7be62e8789b71e70395fddef8f0fa76 Mon Sep 17 00:00:00 2001
-From: Christian Theune <ct@flyingcircus.io>
-Date: Wed, 16 Sep 2020 17:15:14 +0200
-Subject: [PATCH] Anonymize logs by default, provide remote_addr_anon as a
- builtin variable.
-
----
- src/http/modules/ngx_http_log_module.c |  2 +-
- src/http/ngx_http_variables.c          | 84 ++++++++++++++++++++++++++
- 2 files changed, 85 insertions(+), 1 deletion(-)
-
 diff --git a/src/http/modules/ngx_http_log_module.c b/src/http/modules/ngx_http_log_module.c
 index f7c4bd2f..615b2c36 100644
 --- a/src/http/modules/ngx_http_log_module.c
 +++ b/src/http/modules/ngx_http_log_module.c
 @@ -225,7 +225,7 @@ static ngx_str_t  ngx_http_access_log = ngx_string(NGX_HTTP_LOG_PATH);
-
-
+ 
+ 
  static ngx_str_t  ngx_http_combined_fmt =
 -    ngx_string("$remote_addr - $remote_user [$time_local] "
 +    ngx_string("$remote_addr_anon - $remote_user [$time_local] "
                 "\"$request\" $status $body_bytes_sent "
                 "\"$http_referer\" \"$http_user_agent\"");
-
+ 
 diff --git a/src/http/ngx_http_variables.c b/src/http/ngx_http_variables.c
-index c25d80cc..94c4a864 100644
+index e067cf0c..b4c04a26 100644
 --- a/src/http/ngx_http_variables.c
 +++ b/src/http/ngx_http_variables.c
 @@ -57,6 +57,8 @@ static ngx_int_t ngx_http_variable_binary_remote_addr(ngx_http_request_t *r,
@@ -35,19 +24,19 @@ index c25d80cc..94c4a864 100644
  static ngx_int_t ngx_http_variable_remote_port(ngx_http_request_t *r,
      ngx_http_variable_value_t *v, uintptr_t data);
  static ngx_int_t ngx_http_variable_proxy_protocol_addr(ngx_http_request_t *r,
-@@ -198,6 +200,8 @@ static ngx_http_variable_t  ngx_http_core_variables[] = {
-
+@@ -196,6 +198,8 @@ static ngx_http_variable_t  ngx_http_core_variables[] = {
+ 
      { ngx_string("remote_addr"), NULL, ngx_http_variable_remote_addr, 0, 0, 0 },
-
+ 
 +    { ngx_string("remote_addr_anon"), NULL, ngx_http_variable_remote_addr_anon, 0, 0, 0 },
 +
      { ngx_string("remote_port"), NULL, ngx_http_variable_remote_port, 0, 0, 0 },
-
+ 
      { ngx_string("proxy_protocol_addr"), NULL,
-@@ -1278,6 +1282,86 @@ ngx_http_variable_remote_addr(ngx_http_request_t *r,
+@@ -1273,6 +1277,91 @@ ngx_http_variable_remote_addr(ngx_http_request_t *r,
  }
-
-
+ 
+ 
 +static ngx_int_t
 +ngx_http_variable_remote_addr_anon(ngx_http_request_t *r,
 +    ngx_http_variable_value_t *v, uintptr_t data)
@@ -60,6 +49,7 @@ index c25d80cc..94c4a864 100644
 +    struct sockaddr_in   *sin;
 +#if (NGX_HAVE_INET6)
 +    struct sockaddr_in6  *sin6;
++    u_char               s6_addr_anon[16];
 +#endif
 +
 +    switch (r->connection->sockaddr->sa_family) {
@@ -69,7 +59,7 @@ index c25d80cc..94c4a864 100644
 +        sin6 = (struct sockaddr_in6 *) r->connection->sockaddr;
 +
 +        len = NGX_UNIX_ADDRSTRLEN;
-+        p = (u_char *) &sin6->sin6_addr;
++        p = (u_char *) sin6->sin6_addr.s6_addr;
 +
 +        v->len = 0;
 +        v->valid = 1;
@@ -81,11 +71,15 @@ index c25d80cc..94c4a864 100644
 +            return NGX_ERROR;
 +        }
 +
-+        for (i=6; i<16; i++) {
-+          p[i] = 0;
++        for (i=0; i<6; i++) {
++          s6_addr_anon[i] = p[i];
 +        }
 +
-+        v->len = ngx_inet6_ntop(p, v->data, len);
++        for (i=6; i<16; i++) {
++          s6_addr_anon[i] = 0;
++        }
++
++        v->len = ngx_inet6_ntop(s6_addr_anon, v->data, len);
 +
 +        break;
 +#endif
@@ -131,5 +125,3 @@ index c25d80cc..94c4a864 100644
  static ngx_int_t
  ngx_http_variable_remote_port(ngx_http_request_t *r,
      ngx_http_variable_value_t *v, uintptr_t data)
---
-2.32.0


### PR DESCRIPTION
When keep-alive is on, newer nginx versions seem to recycle data structures our old anon patch changes. This caused failures because allow/deny rules were evaluated against the anonymized IPv6 address instead of the original one. The first request always worked as intended, but subsequent requests did not.

The new patch copies the IPv6 address instead of changing it in-place.

This change also removes the version override for nginx mainline as upstream nixpkgs has a newer 1.23 version (that version isn't used by default by our platform).

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* nginx: fix allow/deny rule checking for IPv6 + keepalive and update nginxMainline to 1.23.3 (platform default is still stable 1.22). Our IP anonymization patch caused an issue where subsequent requests in a keepalive connection were matched against the anonymized address instead of the real one (PL-131209).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - IP addresses have to be logged anonymized by default
  - allow/deny rules must use the original IP address for matching, not the anonymized one 
- [x] Security requirements tested? (EVIDENCE)
  - checked on a test VM that IP 4+6 adresses are anonymized in the access logs and that allow/deny rules work properly with keepalive + IPv6 on the 2nd request