### PR TITLE
[21.11] Fix GitHub CI and pre-commit

### DIFF
--- a/.pre-commit-config-local.yaml
+++ b/.pre-commit-config-local.yaml
@@ -1,0 +1,1 @@
+exclude: "pkgs/fc/sensusyntax/fixtures/(syntaxerror|empty).json|(nixos/infrastructure/container.nix|tests/testlib.nix)"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,39 +1,28 @@
-# See https://pre-commit.com for more information
-# See https://pre-commit.com/hooks.html for more hooks
+exclude: ^secrets/|^appenv$|pkgs/fc/sensusyntax/fixtures/(syntaxerror|empty).json|(nixos/infrastructure/container.nix|tests/testlib.nix)
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
-    hooks:
-    -   id: trailing-whitespace
-        exclude: |
-          (?x)^(
-            secrets/|environments/.*/secrets\.cfg|
-            .*\.patch
-          )$
-    -   id: end-of-file-fixer
-        exclude: |
-          (?x)^(
-            secrets/|environments/.*/secrets\.cfg|
-            .*\.patch
-          )$
-    -   id: check-yaml
-    -   id: check-added-large-files
-    -   id: check-json
-        exclude: pkgs/fc/sensusyntax/fixtures/(syntaxerror|empty)\.json
-    -   id: check-xml
-    -   id: check-toml
-    -   id: check-yaml
-    -   id: detect-private-key
-        exclude: (nixos/infrastructure/container\.nix|tests/testlib\.nix)
-
--   repo: https://github.com/pycqa/isort
-    rev: 5.10.1
-    hooks:
-      - id: isort
-        name: isort (python)
-        args: ["--profile", "black", "--filter-files"]
-
--   repo: https://github.com/psf/black
-    rev: 22.3.0
-    hooks:
-    -   id: black
+- hooks:
+  - exclude: "(?x)^(\n  secrets/|environments/.*/secret.*|\n  .*\\.patch\n)$\n"
+    id: trailing-whitespace
+  - exclude: "(?x)^(\n  environments/.*/secret.*|\n  .*\\.patch\n)$\n"
+    id: end-of-file-fixer
+  - id: check-yaml
+  - id: check-added-large-files
+  - id: check-json
+  - id: check-xml
+  - id: check-toml
+  - id: detect-private-key
+  repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v3.2.0
+- hooks:
+  - args:
+    - --profile
+    - black
+    - --filter-files
+    id: isort
+    name: isort (python)
+  repo: https://github.com/pycqa/isort
+  rev: 5.12.0
+- hooks:
+  - id: black
+  repo: https://github.com/psf/black
+  rev: 22.3.0


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

Changelog: just fix the GithubCI, as already done in 22.05 and 21.05

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - [x] keep CI operational
- [x] Security requirements tested? (EVIDENCE)
  - [x] cherry-picked from 21.05 and 22.05 branches where this fixes CI
  - [x] no re-formats after a `pre-commit run -a`