### PR TITLE
Restore build compatibility with Nix 2.3/ NixOS 21.11

### DIFF
--- a/nixos/platform/agent.nix
+++ b/nixos/platform/agent.nix
@@ -227,7 +227,12 @@ in
       # rule, no logrotate rule needed
       services.logrotate.settings = {
         "/var/log/fc-agent.log" = {
-          rotate = builtins.ceil (logDaysKeep / 30);
+          # `builtins.ceil` is only available in Nix 2.4+ <=> NixOS 22.05+, blocking
+          # updates from 21.11. The alternative, integer division, implicitly applies a
+          # `floor`. With the current logDaysKeep = 180, this does not make any difference anyways.
+          rotate = if (builtins ? ceil)
+            then builtins.ceil (logDaysKeep / (30 + 0.0))  # enforce floating point division
+            else (logDaysKeep / 30);
           frequency = "monthly";
         };
       };


### PR DESCRIPTION
To ensure upgradability from NixOS 21.11 to 22.05, the `builtins.ceil` had to be removed as it is only introduced in Nix 2.4, while NixOS 21.11 still evaluates the config with Nix 2.3 at upgrade time.

Semantically, and with the currently chosen rotation times, this does not change anything.

Fixup for 9992ef28ef3af9d53afeda153804604a3a991824

@flyingcircusio/release-managers

## Release process

Impact: none for customers

Changelog: restores the upgrade path from 21.11 to 22.05

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - [x] automated tests must still pass
  - [x] as this is an issue in upgrading between releases, verify the upgrade path to be fixed
  - [x] consider how to avoid this class of issues in the future
- [x] Security requirements tested? (EVIDENCE)
  - [x] NixOS tests still pass
  - [x] successfully upgraded a testvm from 21.11 to 22.05; the fc-agent platform code is always built in such scenarios
  - [x] for future discussions on regularly verifying upgradability: PL-131310