### PR TITLE
[21.05] add video surveillance vlan

### DIFF
--- a/nixos/platform/static.nix
+++ b/nixos/platform/static.nix
@@ -59,6 +59,8 @@ with lib;
         "tr3" = 18;
         # dynamic hardware pool: local endpoints for Kamp DHP tunnels
         "dhp" = 19;
+        # video surveillance
+        "video" = 23;
       };
 
       mtus = {


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

-

Changelog:

* Extend list of well-known VLAN ids to include the new video surveillance network. (PL-130006)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

just data that is safe to be public

- [x] Security requirements tested? (EVIDENCE)

n/a