### PR TITLE
matomo: 4.13.0 -> 4.13.3

### DIFF
--- a/pkgs/matomo/default.nix
+++ b/pkgs/matomo/default.nix
@@ -3,16 +3,16 @@
 let
   versions = {
     matomo = {
-      version = "4.13.0";
-      sha256 = "sha256-WWFPv6hw01T4q8Y0zCHbvr2iuf3jFZLfjIE8OeHf+YE=";
+      version = "4.13.3";
+      sha256 = "sha256-17y0xFy6aa/ZyEm9VUvIi4/GlxdpwfWv+ZdiO6wF4Kw=";
     };
 
     matomo-beta = {
-      version = "4.13.0";
+      version = "4.13.3";
       # `beta` examples: "b1", "rc1", null
       # when updating: use null if stable version is >= latest beta or release candidate
       beta = null;
-      sha256 = "sha256-WWFPv6hw01T4q8Y0zCHbvr2iuf3jFZLfjIE8OeHf+YE=";
+      sha256 = "sha256-17y0xFy6aa/ZyEm9VUvIi4/GlxdpwfWv+ZdiO6wF4Kw=";
     };
   };
   common = pname: { version, sha256, beta ? null }:


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

- \[NixOS 22.05\] matomo will be restarted.

Changelog:

- matomo: update to 4.13.3 (PL-131281).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - same as before, check that update does not introduce new risks  
- [x] Security requirements tested? (EVIDENCE)
  - checked matomo changelog for breaking and security-related changes: nothing relevant for operations
  - checked on a test VM that updating a matomo instance works
  - looked at matomo system check: no critical warnings