### PR TITLE
Add a stub test for nodejs packages

### DIFF
--- a/tests/default.nix
+++ b/tests/default.nix
@@ -88,6 +88,7 @@ in {
   network = callSubTests ./network {};
   nfs = callTest ./nfs.nix {};
   nginx = callTest ./nginx.nix {};
+  nodejs = callTest ./nodejs.nix {};
   openvpn = callTest ./openvpn.nix {};
   percona80 = callTest ./mysql.nix { rolename = "percona80"; };
   physical-installer = callTest ./physical-installer.nix { inherit nixpkgs; };

--- a/tests/nodejs.nix
+++ b/tests/nodejs.nix
@@ -18,6 +18,11 @@ import ./make-test-python.nix ({ pkgs, testlib, ... }:
       "${nodejs-14_x}": "14",
       "${nodejs-16_x}": "16",
       "${nodejs-18_x}": "18",
+      "${nodejs-slim-14_x}": "14",
+      "${nodejs-slim-16_x}": "16",
+      "${nodejs-slim-18_x}": "18",
+      "${nodejs-slim}": "16",
+      "${nodejs}": "16",
     }
 
     for package, version in package_versions.items():

--- a/tests/nodejs.nix
+++ b/tests/nodejs.nix
@@ -1,0 +1,28 @@
+# This is just a stub to check if nodejs packages can display their version.
+# The test makes sure that the nodejs packages we want still exist and are
+# built by our hydra or are available upstream.
+import ./make-test-python.nix ({ pkgs, testlib, ... }:
+{
+  name = "nodejs";
+
+  nodes.machine =
+    { pkgs, config, ... }:
+    {
+      imports = [
+        (testlib.fcConfig { })
+      ];
+    };
+
+  testScript = with pkgs; ''
+    package_versions = {
+      "${nodejs-14_x}": "14",
+      "${nodejs-16_x}": "16",
+      "${nodejs-18_x}": "18",
+    }
+
+    for package, version in package_versions.items():
+      with subtest(f"Checking package {package}"):
+        out = machine.succeed(f"{package}/bin/node -v").strip()
+        assert out.startswith(f"v{version}."), "unexpected version: " + out
+  '';
+})


### PR DESCRIPTION
Ensures that Hydra builds the packages, if needed.

PL-131331

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - avoid high load on VMs caused by package building (which may even repeat forever when hitting the agent timeout)
- [x] Security requirements tested? (EVIDENCE)
  - automated test makes sure that packages are built on our hydra. 
