### PR TITLE
Update nixpkgs

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "60117df4d63c97a2ad1870cb29e8c5b0775048db",
-    "sha256": "SLXQLYvWd2SN2E+E6drfhcEp8chbODWgoOPKvBrPNxA="
+    "rev": "631c55323a67a20854056fb7e289edb7a7950e49",
+    "sha256": "LI0vaaA7Dhidyr1FMrAr8HNaBUeD1kNrCVoYguXzzGI="
   },
   "nixos-mailserver": {
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/",


### PR DESCRIPTION
Pull upstream NixOS changes, security fixes and package updates:

- containerd: 1.6.10 -> 1.6.18
- curl: fix CVE-2023-23914, CVE-2023-23915, CVE-2023-23916,
- git: 2.38.3 -> 2.38.4 (CVE-2023-22490, CVE-2023-23946)
- grafana: 9.3.6 -> 9.4.3
- haproxy: 2.6.6 -> 2.6.9 (CVE-2023-25725)
- linux: 5.15.94 -> 5.15.97
- matrix-synapse: 1.77.0 -> 1.78.0
- nodejs-14_x: 14.21.1 -> 14.21.3 (CVE-2023-23918, CVE-2023-23920)
- nodejs-16_x: 16.18.1 -> 16.19.1 (CVE-2023-23918, CVE-2023-23919, CVE-2023-23920)
- nodejs-18_x: 18.12.1 -> 18.14.1 (CVE-2023-23918, CVE-2023-23919, CVE-2023-23920, CVE-2023-23936, CVE-2023-24807)
- nodejs-19_x: 19.1.0 -> 19.6.1 (CVE-2023-23918, CVE-2023-23919, CVE-2023-23920)
- postgresql_11: 11.18 -> 11.19
- postgresql_12: 12.13 -> 12.14 (CVE-2022-41862)
- postgresql_13: 13.9 -> 13.10 (CVE-2022-41862)
- postgresql_14: 14.6 -> 14.7 (CVE-2022-41862)
- postgresql_15: 15.1 -> 15.2 (CVE-2022-41862)
- strace: 6.1 -> 6.2
- strongswan: fix CVE-2023-26463
- systemd: 251.11 -> 251.12
- xorg.libX11: 1.8.1 -> 1.8.3

 #PL-131338

@flyingcircusio/release-managers

## Release process


Impact:

* \[NixOS 22.11] Gitlab will restart. Most services will restarted because of a core dependency change. Machines will schedule a reboot to activate the changed kernel.

Changelog: (include changes from commit msg here)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - pull in upstream security fixes regularly
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still run, works on test VM
  - checked commit log for fixed CVEs and possible problems with updates, looked at [synapse/upgrade.md](https://github.com/matrix-org/synapse/blob/develop/docs/upgrade.md), [What's new | Grafana documentation](https://grafana.com/docs/grafana/latest/whatsnew/) and [Releases | GitLab](https://about.gitlab.com/releases/categories/releases/)
