### PR TITLE
Slurm platform integration

### DIFF
--- a/doc/src/index.md
+++ b/doc/src/index.md
@@ -39,6 +39,7 @@ nfs
 postgresql
 rabbitmq
 redis
+slurm
 statshost
 webgateway
 webproxy

--- a/doc/src/slurm.md
+++ b/doc/src/slurm.md
@@ -1,0 +1,259 @@
+(nixos-slurm)=
+
+# Slurm Workload Manager
+
+:::{note}
+Slurm support is in beta. Feel free to use it, but we suggest contacting
+our support before putting anything into production.
+:::
+
+[Slurm](https://www.schedmd.com/) is an open source, fault-tolerant, and
+highly scalable cluster management and job scheduling system. Slurm consists
+of various services which are represented by separate Flying Circus roles
+documented below.
+
+The remainder of this documentation assumes that you are aware of the basics of
+Slurm and understand the general terminology.
+
+We provide version 22.5.0 of Slurm.
+
+## Basic architecture and roles
+
+:::{warning}
+Keep in mind that Slurm is built to execute arbitrary commands on any Slurm node
+with the permissions of the user starting the command on possibly another
+machine. Keep sensitive data away from Slurm nodes and isolate Slurm as much as
+possible, using a dedicated resource group without other applications.
+:::
+
+You can run one Slurm cluster per resource group. We generally recommend to
+use separate clusters (and thus separate resource groups) for independent
+projects. This will give you the most flexibility and will integrate
+optimally into our platform aligning well on topics like access management,
+monitoring, SLAs, maintenance, etc.
+
+A resource group with Slurm roles can have additional machines which provide
+additional services which may be needed to run jobs in Slurm. Such required
+machines can also be included in the coordination of automated maintenance
+as described later.
+
+Machine authentication is handled by `munge`, using a shared secrets generated
+by our central management directory. New worker nodes are automatically added
+to existing clusters.
+
+
+### slurm-controller
+
+:::{notice}
+For new clusters, it's recommended to first set up a controller and add nodes
+after that. The controller service will only start if there's at least one
+node.
+:::
+
+This role runs {command}`slurmctld`. We add basic Cluster readiness monitoring
+via Sensu and telemetry via Telegraf which can be ingested by a
+{ref}`nixos-statshost` and displayed using a Grafana dashboard.
+
+At the moment, we only support exactly one controller per cluster.
+
+Maintenance of a machine with this role means that all worker nodes are
+drained and set to DOWN first. Maintenance activities only start when no jobs
+are running anymore in the whole cluster.
+
+After finishing a platform management task run (which happens every 10 minutes),
+the controller sets all nodes to `ready` that have been set to `down` by an
+automated maintenance if the nodes and all external dependency machines are not
+in maintenance.
+
+
+### slurm-dbdserver
+
+:::{notice}
+At the moment, this role must run on the same machine as `slurm-controller`.
+:::
+
+Runs `slurmdbd` which is needed for job accounting. Automatically sets up a
+{ref}`nixos-mysql` database with our platform defaults and
+monitoring/telemetry.
+
+
+
+### slurm-node
+
+Runs `slurmd` which is responsible for processing jobs. There should be
+multiple nodes in your cluster for production use but applying this role to a
+machine which is also running the controller services is also supported for
+testing purposes.
+
+Before running maintenance activities, the node is drained and stops accepting new
+jobs. Nodes don't set themselves to `ready` after maintenance. Instead, the
+controller activates nodes which are not in maintenance anymore after its own
+platform management task run (every 10 minutes).
+
+### slurm-external-dependency
+
+This role does not provide any Slurm services but something that is needed to
+run jobs via Slurm, for example a database accessed by job scripts. When such
+machines go into maintenance, all nodes are drained first, like for a
+controller maintenance. After the external dependency machine has finished
+maintenance, the next run of the platform management task on the controller will set
+the nodes to `ready`.
+
+## General Interaction
+
+The usual slurm commands are installed globally on every Slurm machine.
+
+In general, all users can run slurm commands on all machines with a `slurm-*`
+role. Some commands require the use of `sudo -u slurm` to run as slurm user.
+This is allowed for(human) user accounts with the `sudo-srv` permission
+without password.
+
+Use `slurm-readme` to show dynamically-generated documentation specific for
+this machine.
+
+
+## fc-slurm command
+
+
+You can use :command:`fc-slurm` to manage the state of slurm compute nodes.
+This command is also used by our platform management task before and after
+maintenance, to fetch telemetry data from Slurm and running monitoring
+checks.
+
+Dump node state info as JSON:
+
+`fc-slurm all-nodes state`
+
+Drain all nodes (no new jobs allowed) and set them to DOWN afterwards:
+
+`sudo fc-slurm all-nodes drain-and-down`
+
+:::{note}
+Nodes that have been drained/downed manually are not set to `ready`
+automatically by the platform management task. You have to do that
+manually with the following command.
+:::
+
+Mark all nodes as READY:
+
+`sudo fc-slurm all-nodes ready`
+
+
+### Cheat sheet
+
+View the dynamically-generated documentation for a machine:
+
+```console
+$ slurm-readme
+```
+Show the current configuration:
+
+```console
+$ slurm-show-configuration
+```
+
+Show running/pending jobs
+
+```console
+$ squeue
+```
+
+Show partition state:
+
+```console
+$ sinfo
+```
+
+Show node info:
+
+```console
+$ sinfo -N
+```
+
+Show job accounting info:
+
+```console
+$ sacct
+```
+
+## Configuration reference
+
+**flyingcircus.slurm.accountingStorageEnforce**
+
+This controls what level of association-based enforcement to impose on job
+submissions. Valid options are any combination of associations, limits,
+`nojobs`, `nosteps`, `qos`, `safe`, and `wckeys`, or all for all things
+(except `nojobs` and `nosteps`, which must be requested as well). If
+`limits`, `qos`, or `wckeys` are set, associations will automatically be
+set.
+
+By setting associations, no new job is allowed to run unless a
+corresponding association exists in the system. If limits are
+enforced, users can be limited by association to whatever job
+size or run time limits are defined.
+
+**flyingcircus.slurm.nodes**
+
+Names of the nodes that are added to the automatically generated partition.
+By default, all Slurm nodes in a resource group are part of the partition
+called `partitionName`.
+
+**flyingcircus.slurm.clusterName**
+
+Name of the cluster. Defaults to the name of the resource group.
+
+The cluster name is used in various places like state files or accounting
+table names and should normally stay unchanged. Changing this requires
+manual intervention in the state dir or slurmctld will not start anymore!
+
+**flyingcircus.slurm.partitionName**
+
+Name of the default partition which includes the machines defined via the `nodes` option.
+Don't use `default` as partition name, it will fail!
+
+**flyingcircus.slurm.realMemory**
+
+Memory in MiB used by a slurm compute node.
+
+**flyingcircus.slurm.cpus**
+
+Number of CPU cores used by a slurm compute node.
+
+**services.slurm.extraConfig**
+
+Extra configuration options that will be added verbatim at
+the end of the slurm configuration file.
+
+**services.slurm.dbdserver.extraConfig**
+
+Extra configuration for `slurmdbd.conf` See also:
+{manpage}`slurmdbd.conf(8)`.
+
+
+### Example custom local config
+
+```nix
+{ ... }:
+
+{
+  flyingcircus.slurm = {
+    accountingStorageEnforce = true;
+    partitionName = "processing";
+    realMemory = 62000;
+    cpus = 16;
+  };
+
+  services.slurm.extraConfig = ''
+    AccountingStorageEnforce=associations
+  '';
+}
+```
+
+## Known limitations
+
+- `slurm-dbdserver` and `slurm-controller` roles must be on the same machine.
+- we support only one `slurm-controller` per cluster at the moment.
+- For autoconfiguration, all nodes and the controller must have the same
+  amount of memory and CPU cores. If that's not the case, memory and CPU must
+  be set manually via Nix config to the same value on all slurm machines
+  because slurm expects the config file to be the same everywhere.

--- a/nixos/platform/agent.nix
+++ b/nixos/platform/agent.nix
@@ -37,6 +37,15 @@ let
     }
 
     compdef _fc_maintenance_completion fc-maintenance
+
+
+    #compdef fc-slurm
+
+    _fc_slurm_completion() {
+      eval $(env _TYPER_COMPLETE_ARGS="''${words[1,$CURRENT]}" _FC_SLURM_COMPLETE=complete_zsh fc-slurm)
+    }
+
+    compdef _fc_slurm_completion fc-slurm
   '';
 
   agentZshCompletionsPkg = pkgs.runCommand "agent-zshcomplete" {} ''

--- a/nixos/roles/default.nix
+++ b/nixos/roles/default.nix
@@ -31,6 +31,7 @@ in {
     ./rabbitmq.nix
     ./redis.nix
     ./servicecheck.nix
+    ./slurm
     ./statshost
     ./webdata_blackbee.nix
     ./webgateway.nix

--- a/nixos/roles/slurm/default.nix
+++ b/nixos/roles/slurm/default.nix
@@ -1,0 +1,529 @@
+{ config, pkgs, lib, ... }:
+
+with builtins;
+
+let
+  cfg = config.flyingcircus.slurm;
+  slurmCfg = config.services.slurm;
+  inherit (config) fclib;
+  controllerEnabled = config.flyingcircus.roles.slurm-controller.enable;
+  nodeEnabled = config.flyingcircus.roles.slurm-node.enable;
+  dbdserverEnabled = config.flyingcircus.roles.slurm-dbdserver.enable;
+  extDependencyEnabled = config.flyingcircus.roles.slurm-external-dependency.enable;
+  anyRoleEnabled = controllerEnabled || nodeEnabled || dbdserverEnabled || extDependencyEnabled;
+
+  serviceHostName = service: lib.head ( lib.splitString "." service.address );
+
+  # XXX: We expect controlMachine and dbdserverService to be the same at the moment.
+  # Exactly one control machine should exist at the moment
+  controlMachine = serviceHostName (fclib.findOneService "slurm-controller-controller");
+  # Having a dbdserver (accounting) is optional.
+  dbdserverService = fclib.findOneService "slurm-dbdserver-dbdserver";
+  # All eligible compute nodes in the RG.
+  defaultSlurmNodes = map serviceHostName (fclib.findServices "slurm-node-node");
+  # Other machines in the RG that are needed to run jobs, for example databases.
+  # Compute Nodes will not be set to ready if these machines are not
+  # in service (doing maintenance).
+  externalDependencyMachines = map serviceHostName (fclib.findServices "slurm-external-dependency-dep");
+
+  inherit (config.flyingcircus) enc;
+  params = if enc ? parameters then enc.parameters else {};
+
+
+  nodeStr = lib.concatStringsSep "," cfg.nodes;
+
+  thisNode = config.networking.hostName;
+
+  # XXX: C&P from upstream slurm to get access to the wrapper.
+  wrappedSlurm = pkgs.stdenv.mkDerivation {
+    name = "wrappedSlurm";
+
+    builder = pkgs.writeText "builder.sh" ''
+      source $stdenv/setup
+      mkdir -p $out/bin
+      find  ${lib.getBin slurmCfg.package}/bin -type f -executable | while read EXE
+      do
+        exename="$(basename $EXE)"
+        wrappername="$out/bin/$exename"
+        cat > "$wrappername" <<EOT
+      #!/bin/sh
+      if [ -z "$SLURM_CONF" ]
+      then
+        SLURM_CONF="${slurmCfg.etcSlurm}/slurm.conf" "$EXE" "\$@"
+      else
+        "$EXE" "\$0"
+      fi
+      EOT
+        chmod +x "$wrappername"
+      done
+
+      mkdir -p $out/share
+      ln -s ${lib.getBin slurmCfg.package}/share/man $out/share/man
+    '';
+  };
+
+in
+{
+
+  options = with lib; {
+    flyingcircus.slurm = {
+
+      clusterName = mkOption {
+        type = types.str;
+        default = params.resource_group or "default";
+        defaultText = lib.mdDoc "*resource group name*";
+        description = lib.mdDoc ''
+          Name of the cluster. Defaults to the name of the resource group.
+
+          The cluster name is used in various places like state files or accounting
+          table names and should normally stay unchanged. Changing this requires
+          manual intervention in the state dir or slurmctld will not start anymore!
+        '';
+      };
+
+      accountingStorageEnforce = mkOption {
+        type = with types; nullOr str;
+        default = null;
+        example = "associations";
+        description = lib.mdDoc ''
+          This controls what level of association-based enforcement to impose on
+          job submissions. Valid options are any combination of associations,
+          limits, nojobs, nosteps, qos, safe, and wckeys, or all for all
+          things (except nojobs and nosteps, which must be requested as well).
+          If limits, qos, or wckeys are set, associations will automatically be
+          set.
+
+          By setting associations, no new job is allowed to run unless a
+          corresponding association exists in the system. If limits are
+          enforced, users can be limited by association to whatever job
+          size or run time limits are defined.
+        '';
+      };
+
+      extraRequiredMachines = mkOption {
+        type = with types; listOf str;
+        default = [];
+        description = ''
+          XXX: this should probably be a separate role
+          A list of additional machine names that are required for running
+          jobs in the cluster, for example databases.
+        '';
+      };
+
+      partitionName = mkOption {
+        type = types.str;
+        default = "all";
+        description = lib.mdDoc ''
+          Name of the default partition which includes the machines defined via the `nodes` option.
+          Don't use `default` as partition name, it will fail!
+        '';
+      };
+
+      cpus = mkOption {
+        type = types.ints.positive;
+        default = params.cores or 1;
+        defaultText = lib.mdDoc "*number of VM cores*";
+        description = lib.mdDoc ''Number of CPU cores used by a slurm compute node.'';
+      };
+
+      realMemory = mkOption {
+        type = types.ints.positive;
+        default = floor ((params.memory or 1024) * 0.98) - 500;
+        defaultText = lib.mdDoc "*98% of physical RAM minus 500 MiB*";
+        description = lib.mdDoc ''Memory in MiB used by a slurm compute node.'';
+      };
+
+      mungeKeyFile = mkOption {
+        internal = true;
+        type = types.str;
+        default = "/var/lib/munge/munge.key";
+      };
+
+      nodes = mkOption {
+        type = types.listOf types.str;
+        default = defaultSlurmNodes;
+        defaultText = lib.mdDoc "*all Slurm nodes in the resource group*";
+        description = lib.mdDoc ''
+          Names of the nodes that are added to the automatically generated partition.
+          By default, all Slurm nodes in a resource group are part of the partition
+          called `partitionName`.
+        '';
+      };
+
+      requiresGlobalMaintenance = mkOption {
+        type = types.bool;
+        default = controllerEnabled || dbdserverEnabled || extDependencyEnabled;
+        description = ''
+          Before running maintenance tasks on this machine, ensure that all nodes
+          in the cluster are drained and set to a DOWN state. This is enabled by
+          default for controller, dbdserver and external slurm dependency machines.
+        '';
+      };
+
+    };
+
+    flyingcircus.roles = {
+      slurm-node = {
+        enable = mkEnableOption "";
+        supportsContainers = fclib.mkDisableContainerSupport;
+      };
+
+      slurm-controller = {
+        enable = mkEnableOption "";
+        supportsContainers = fclib.mkDisableContainerSupport;
+      };
+
+      slurm-dbdserver = {
+        enable = mkEnableOption "";
+        supportsContainers = fclib.mkDisableContainerSupport;
+      };
+
+      slurm-external-dependency = {
+        enable = mkEnableOption "";
+        supportsContainers = fclib.mkDisableContainerSupport;
+      };
+    };
+  };
+
+  config = lib.mkMerge [
+
+    (lib.mkIf anyRoleEnabled {
+
+    assertions =
+      [
+        {
+          assertion = dbdserverEnabled -> controllerEnabled;
+          message = "slurm-dbdserver requires the slurm-controller role on the same machine!";
+        }
+      ];
+
+      environment.etc.slurm.source = slurmCfg.etcSlurm;
+
+      environment.etc."local/slurm/README.md".text =
+        let
+          roleStr = lib.concatStringsSep ", "
+            (lib.optional controllerEnabled "*controller*" ++
+             lib.optional dbdserverEnabled "*dbdserver*" ++
+             lib.optional extDependencyEnabled "*external dependency*" ++
+             lib.optional nodeEnabled "*compute node*");
+        in
+        ''
+        # Slurm Workload Manager
+
+        ${lib.optionalString (roleStr != "")
+        "This VM is acting as: slurm ${roleStr}."
+        }
+
+        ${lib.optionalString cfg.requiresGlobalMaintenance
+        "This VM has the global maintenance flag set which means that all
+         compute nodes will be drained and set to DOWN before maintenance
+         tasks are executed."
+        }
+
+        Generated config is at `${slurmCfg.etcSlurm}` which is also linked to `/etc/slurm`.
+        You can use `slurm-show-config` to view contents of all config files.
+
+        Cluster name is `${cfg.clusterName}`.
+
+        Our slurm roles work without additional configuration.
+        They automatically set up and use a slurm partition named `${cfg.partitionName}`.
+
+        ${if cfg.nodes != [] then ''
+        Following nodes are members of the `${cfg.partitionName}` partition:
+        `${fclib.docList cfg.nodes}`
+        '' else ''
+        **Warning**: No nodes are configured! If default config is used, this
+        means that no machine with the *slurm-node* role was found in the
+        resource group.
+        *slurmctld* is disabled on this machine until nodes are added.
+        ''}
+
+        ## Slurm commands
+
+        The standard slurm commands like `srun`, `sacct`, `scontrol` and `sinfo` are
+        installed globally. Some require elevated privileges and must be run
+        with `sudo -u slurm`. `sudo-srv` users can run all commads as `slurm`
+        user.
+
+        ${lib.optionalString nodeEnabled ''
+        Usable real memory for this node is set to ${toString cfg.realMemory} MiB
+        and CPU count is ${toString cfg.cpus}.
+        ''}
+
+        ## fc-slurm Global/Controller Commands
+
+        You can use fc-slurm to manage the state of slurm compute nodes
+        managed by this controller.
+
+        Commands should be run with sudo.
+        `fc-slurm all-nodes state` works as normal user.
+
+        *sudo-srv* users may use `fc-slurm` without password.
+
+        Dump node state info as JSON:
+
+        `fc-slurm all-nodes state`
+
+        Drain all nodes (no new jobs allowed) and set them to DOWN afterwards:
+
+        `sudo fc-slurm all-nodes drain-and-down`
+
+        Mark all nodes as READY:
+
+        `sudo fc-slurm all-nodes ready`
+
+        ## NixOS Options
+        ${fclib.docOption "flyingcircus.slurm.accountingStorageEnforce"}
+
+        ${fclib.docOption "flyingcircus.slurm.nodes"}
+
+        ${fclib.docOption "flyingcircus.slurm.clusterName"}
+
+        ${fclib.docOption "flyingcircus.slurm.partitionName"}
+
+        ${fclib.docOption "flyingcircus.slurm.realMemory"}
+
+        ${fclib.docOption "flyingcircus.slurm.cpus"}
+
+        ${fclib.docOption "services.slurm.extraConfig"}
+
+        ${fclib.docOption "services.slurm.dbdserver.extraConfig"}
+      '';
+
+      environment.systemPackages = [
+        (pkgs.writeShellScriptBin "slurm-config-dir" "echo ${slurmCfg.etcSlurm}")
+        (pkgs.writeShellScriptBin
+          "slurm-readme"
+          "${pkgs.rich-cli}/bin/rich --pager /etc/local/slurm/README.md"
+        )
+        (pkgs.writeShellScriptBin "slurm-show-config" ''
+          for x in ${slurmCfg.etcSlurm}/*; do
+            echo "''${x}:"
+            cat $x
+          done
+        '')
+      ];
+
+      flyingcircus.passwordlessSudoRules = [
+        {
+          commands = [ "ALL" ];
+          groups = [ "sudo-srv" ];
+          runAs = "slurm";
+        }
+        {
+          commands = [ "${pkgs.fc.agent}/bin/fc-slurm" ];
+          groups = [ "sudo-srv" ];
+        }
+      ];
+
+      services.slurm = {
+        inherit (cfg) clusterName;
+        inherit controlMachine;
+        nodeName = [ "${nodeStr} State=UNKNOWN CPUs=${toString cfg.cpus} RealMemory=${toString cfg.realMemory}" ];
+        partitionName = [ "${cfg.partitionName} Nodes=${nodeStr} Default=YES MaxTime=INFINITE State=UP" ];
+        extraConfig = ''
+          # FCIO extra config
+          # XXX: Some settings probably be separate options later.
+
+          # JOB PRIORITY
+          PriorityType = priority/multifactor
+          PriorityWeightQOS = 2000
+
+          # SCHEDULING
+          # Allocate individual processors and memory
+          SelectType = select/cons_res
+          SelectTypeParameters = CR_CPU_Memory
+
+          # Upon registration with a valid configuration only if it was set
+          # DOWN due to being non-responsive.
+
+          ReturnToService = 1
+
+          SlurmctldDebug = info
+          SlurmdDebug = info
+
+          # Enables resource containment using sched_setaffinity(). This
+          # enables the --cpu-bind and/or --mem-bind srun options.
+          TaskPlugin = task/affinity
+
+        '' + (lib.optionalString (dbdserverService != null) ''
+          AccountingStorageType = accounting_storage/slurmdbd
+
+          ${lib.optionalString (cfg.accountingStorageEnforce != null)
+          "AccountingStorageEnforce = ${cfg.accountingStorageEnforce}"
+          }
+
+          # Include the job's comment field in the job complete message sent
+          # to the Accounting Storage database.
+          AccountingStoreFlags = job_comment
+          JobAcctGatherType = jobacct_gather/linux
+        '');
+      };
+
+      systemd.services.fc-set-munge-key = {
+        path = [ pkgs.jq ];
+        script = ''
+          umask 0266
+          mkdir -p $(dirname ${cfg.mungeKeyFile})
+          jq -r \
+            '.[] | select(.service =="slurm-controller-controller") | .password' \
+            /etc/nixos/services.json | sha256sum | head -c64 \
+            > ${cfg.mungeKeyFile}
+
+          chown munge:munge ${cfg.mungeKeyFile}
+          echo "fc-set-munge-key finished"
+        '';
+
+        serviceConfig = {
+          Type = "oneshot";
+        };
+      };
+
+      systemd.services.munged = {
+        after = [ "fc-set-munge-key.service" ];
+        requires = [ "fc-set-munge-key.service" ];
+        serviceConfig = {
+          ExecStartPre = lib.mkForce [
+            "${pkgs.coreutils}/bin/stat ${cfg.mungeKeyFile}"
+          ];
+        };
+      };
+
+      services.munge.password = cfg.mungeKeyFile;
+
+      services.slurm.enableStools = true;
+
+      users.users.slurm.extraGroups = [ "service" ];
+    })
+
+    (lib.mkIf cfg.requiresGlobalMaintenance {
+      flyingcircus.agent.maintenance.slurm-global-maintenance = {
+        enter = ''
+          fc-slurm -v all-nodes drain-and-down --reason "fc-agent: global maintenance"
+        '';
+      };
+    })
+
+    (lib.mkIf (controllerEnabled || nodeEnabled) {
+      flyingcircus.services.sensu-client.checks = {
+        slurm = {
+          notification = "Slurm is unable to process jobs.";
+          interval = 10;
+          command = ''
+            sudo -u slurm ${pkgs.fc.agent}/bin/fc-slurm check
+          '';
+        };
+      };
+
+      flyingcircus.services.telegraf.inputs = {
+        exec = [{
+          commands = [ "${pkgs.fc.agent}/bin/fc-slurm metrics" ];
+          timeout = "10s";
+          data_format = "json";
+          json_name_key = "name";
+          tag_keys = [ "account" ];
+        }];
+      };
+    })
+
+    # We need at least one compute node or the controller will crash on startup.
+    (lib.mkIf (controllerEnabled && cfg.nodes != []) {
+
+      # The controller must be out of maintenance for running jobs.
+      # Nodes are set to ready after controller maintenance is done
+      # (or not needed, the leave command is called on every agent run).
+      flyingcircus.agent.maintenance.slurm-controller = {
+        leave =
+          "fc-slurm -v all-nodes ready" +
+            (lib.concatMapStrings
+              (m: " --required-in-service ${m}")
+              externalDependencyMachines);
+      };
+
+      services.slurm = {
+        server.enable = true;
+      };
+
+      systemd.services.slurmctld = {
+        serviceConfig = {
+          Restart = "always";
+        };
+      };
+
+    })
+
+    (lib.mkIf (nodeEnabled && !controllerEnabled) {
+      flyingcircus.agent.maintenance.slurm-node = {
+        enter = ''
+          fc-slurm -v drain-and-down --reason "fc-agent: node maintenance"
+        '';
+      };
+    })
+
+    (lib.mkIf nodeEnabled {
+
+      services.slurm = {
+        client.enable = true;
+      };
+
+      systemd.services.slurmd = {
+        after = [ "munged.service" ];
+        serviceConfig = {
+          Restart = "always";
+        };
+      };
+
+      systemd.services.fc-agent.environment = {
+        SLURM_CONF = "${slurmCfg.etcSlurm}/slurm.conf";
+      };
+
+
+    })
+
+    (lib.mkIf dbdserverEnabled {
+
+      flyingcircus.roles.percona80 = {
+        enable = true;
+      };
+
+      flyingcircus.roles.mysql.extraConfig = ''
+        [mysqld]
+        # slurmdbd may refuse to start if we don't increase this setting.
+        innodb_lock_wait_timeout = 900
+      '';
+
+      systemd.services.fc-slurmdbd-mysql-setup = {
+        description = "Ensure slurm accounting user and database exist.";
+        documentation = [
+          "https://slurm.schedmd.com/accounting.html"
+        ];
+        partOf = [ "mysql.service" ];
+        requiredBy = [ "slurmdbd.service" ];
+        after = [ "mysql.service" "fc-mysql-post-init.service" ];
+
+        serviceConfig = {
+          Type = "oneshot";
+          RemainAfterExit = true;
+        };
+
+        script = let
+          ensureUserAndDatabase = ''
+            CREATE USER IF NOT EXISTS slurm@localhost;
+            CREATE DATABASE IF NOT EXISTS slurm_acct_db;
+            GRANT ALL ON slurm_acct_db.* TO slurm@localhost;
+          '';
+          mysqlCmd = sql:
+            "${config.services.percona.package}/bin/mysql" +
+            " --defaults-extra-file=/root/.my.cnf" +
+            " -v" +
+            " -e '${sql}'";
+        in
+        "${mysqlCmd ensureUserAndDatabase}";
+      };
+
+      services.slurm.dbdserver = {
+        enable = true;
+      };
+    })
+  ];
+}

--- a/pkgs/fc/agent/default.nix
+++ b/pkgs/fc/agent/default.nix
@@ -7,13 +7,13 @@
 , libyaml
 , multipath-tools
 , nix
-, python39
+, python310
 , util-linux
 , xfsprogs
 }:
 
 let
-  py = python39.pkgs;
+  py = python310.pkgs;
 
   # XXX: The newer version from nixpkgs fails with our code, keep the old one for now.
   pyyaml = py.buildPythonPackage rec {
@@ -80,10 +80,11 @@ py.buildPythonPackage rec {
     dmidecode
     gptfdisk
     multipath-tools
+    py.pyslurm
     py.systemd
     xfsprogs
   ];
   dontStrip = true;
-  passthru.pythonDevEnv = python39.withPackages (_: checkInputs ++ propagatedBuildInputs);
+  passthru.pythonDevEnv = py.withPackages (_: checkInputs ++ propagatedBuildInputs);
 
 }

--- a/pkgs/fc/agent/fc/manage/manage.py
+++ b/pkgs/fc/agent/fc/manage/manage.py
@@ -13,6 +13,7 @@ import fc.util.logging
 import requests
 from fc.maintenance.lib.shellscript import ShellScriptActivity
 from fc.util import nixos
+from fc.util.checks import CheckResult
 from fc.util.enc import STATE_VERSION_FILE
 from fc.util.nixos import RE_FC_CHANNEL
 
@@ -291,31 +292,6 @@ class Channel:
 
 class SwitchFailed(Exception):
     pass
-
-
-@dataclass
-class CheckResult:
-    errors: list[str]
-    warnings: list[str]
-
-    def format_output(self) -> str:
-        if self.errors:
-            return "CRITICAL: " + " ".join(self.errors + self.warnings)
-
-        if self.warnings:
-            return "WARNING: " + " ".join(self.warnings)
-
-        return "OK: no problems found."
-
-    @property
-    def exit_code(self) -> int:
-        if self.errors:
-            return 2
-
-        if self.warnings:
-            return 1
-
-        return 0
 
 
 def check(log, enc) -> CheckResult:

--- a/pkgs/fc/agent/fc/manage/slurm.py
+++ b/pkgs/fc/agent/fc/manage/slurm.py
@@ -1,0 +1,246 @@
+import json
+import os
+import socket
+import traceback
+from pathlib import Path
+from typing import NamedTuple, Optional
+
+import fc.util.slurm
+import rich
+import rich.syntax
+import structlog
+from fc.util.directory import directory_connection
+from fc.util.logging import init_logging
+from typer import Exit, Option, Typer
+
+
+class Context(NamedTuple):
+    logdir: Path
+    verbose: bool
+    enc_path: Path
+
+
+app = Typer(
+    pretty_exceptions_show_locals=bool(os.getenv("FC_AGENT_SHOW_LOCALS", False))
+)
+context: Context
+
+
+@app.callback(no_args_is_help=True)
+def fc_slurm(
+    verbose: bool = Option(
+        False, "--verbose", "-v", help="Show debug messages and code locations."
+    ),
+    logdir: Path = Option(
+        exists=True,
+        file_okay=False,
+        default="/var/log",
+        help="Directory for log files, expects a fc-agent subdirectory there.",
+    ),
+    enc_path: Path = Option(
+        dir_okay=False,
+        # We don't need enc_path for every command.
+        # XXX: should we move commands that don't need sudo somewhere else?
+        readable=False,
+        default="/etc/nixos/enc.json",
+        help="Path to enc.json",
+    ),
+):
+    global context
+
+    context = Context(
+        logdir=logdir,
+        verbose=verbose,
+        enc_path=enc_path,
+    )
+
+    # Use logdir if it's writable for the current user.
+    logdir_to_use = logdir if os.access(logdir, os.W_OK) else None
+    init_logging(verbose, logdir_to_use, syslog_identifier="fc-slurm")
+
+
+@app.command(
+    help="Drain this node and wait for completion",
+)
+def drain(
+    timeout: int = Option(
+        default=300, help="Wait for seconds for every job to finish."
+    ),
+    reason: str = Option(
+        default="executed fc-slurm drain", help="reason for draining the node"
+    ),
+    strict_state_check: Optional[bool] = False,
+):
+    log = structlog.get_logger()
+    hostname = socket.gethostname()
+    fc.util.slurm.drain(log, hostname, timeout, reason, strict_state_check)
+
+
+@app.command(
+    help="Drain, wait for completion and down this node",
+)
+def drain_and_down(
+    timeout: int = Option(
+        default=300, help="Wait for seconds for every job to finish."
+    ),
+    reason: str = Option(
+        default="executed fc-slurm drain-and-down",
+        help="reason for draining and downing the node",
+    ),
+    strict_state_check: Optional[bool] = False,
+):
+    log = structlog.get_logger()
+    hostname = socket.gethostname()
+    fc.util.slurm.drain(log, hostname, timeout, reason, strict_state_check)
+    fc.util.slurm.down(log, hostname, reason, strict_state_check)
+
+
+@app.command()
+def down(
+    strict_state_check: Optional[bool] = False,
+    reason: str = Option(
+        default="executed fc-slurm down",
+        help="reason for draining the nodes",
+    ),
+):
+    log = structlog.get_logger()
+    hostname = socket.gethostname()
+    fc.util.slurm.down(log, hostname, reason, strict_state_check)
+
+
+@app.command()
+def ready(
+    strict_state_check: Optional[bool] = False,
+):
+    log = structlog.get_logger()
+    hostname = socket.gethostname()
+    fc.util.slurm.ready(log, hostname, strict_state_check)
+
+
+@app.command(help="Checks state of this machine")
+def check():
+    log = structlog.get_logger()
+    hostname = socket.gethostname()
+    try:
+        result = fc.util.slurm.check(log, hostname)
+    except Exception:
+        print("UNKNOWN: Exception occurred while running checks")
+        traceback.print_exc()
+        raise Exit(3)
+
+    print(result.format_output())
+    if result.exit_code:
+        raise Exit(result.exit_code)
+
+
+@app.command(help="Produces metrics for telegraf's JSON input")
+def metrics():
+    log = structlog.get_logger()
+    jso = json.dumps(fc.util.slurm.get_metrics(log))
+    print(jso)
+
+
+all_nodes_app = Typer(
+    pretty_exceptions_show_locals=False,
+    help="Commands that affect all nodes in the cluster",
+    no_args_is_help=True,
+)
+app.add_typer(all_nodes_app, name="all-nodes")
+
+
+@all_nodes_app.command(help="Drain and down all nodes", name="drain-and-down")
+def drain_and_down_all(
+    timeout: int = Option(
+        default=300, help="Wait for seconds for every job to finish."
+    ),
+    reason: str = Option(
+        default="executed fc-slurm all-nodes drain-and-down",
+        help="reason for draining the nodes",
+    ),
+    strict_state_check: Optional[bool] = False,
+):
+    log = structlog.get_logger()
+    # This drains all nodes in parallel.
+    log.info("drain-all", _replace_msg="Draining all nodes in the cluster.")
+    fc.util.slurm.drain_many(
+        log,
+        fc.util.slurm.get_all_node_names(),
+        timeout,
+        reason,
+        strict_state_check,
+    )
+    # Setting the state is fast, we can do it sequentially.
+    log.info("down-all", _replace_msg="Setting all nodes to down.")
+    for node_name in fc.util.slurm.get_all_node_names():
+        fc.util.slurm.down(log, node_name, reason, strict_state_check)
+
+
+@all_nodes_app.command(
+    name="ready",
+    help="Mark nodes as ready",
+)
+def ready_all(
+    required_in_service: list[str] = Option(
+        default=[],
+        help=(
+            "Machine that should also be checked for its maintenance state."
+            "If any of the given machines are still in maintenance, no node "
+            "will be set to ready."
+        ),
+    ),
+    strict_state_check: Optional[bool] = False,
+    reason_must_match: Optional[str] = Option(
+        default=None,
+        help="Only set nodes to ready which match a given reason string.",
+    ),
+    skip_nodes_in_maintenance: Optional[bool] = Option(
+        default=True,
+        help="Check maintenance state of nodes and skip when not in service.",
+    ),
+):
+    log = structlog.get_logger()
+    node_names = fc.util.slurm.get_all_node_names()
+    if required_in_service:
+        # We have to check maintenance (or in-service) state against the
+        # directory for some machines before we can start action.
+        with directory_connection(context.enc_path) as directory:
+            # Stop action when any required machine is not in-service
+            required_machines_not_in_service = []
+            for machine in required_in_service:
+                log.debug("ready-all-check-required-machine", machine=machine)
+                if not fc.util.directory.is_node_in_service(directory, machine):
+                    required_machines_not_in_service.append(machine)
+
+            if required_machines_not_in_service:
+                log.info(
+                    "ready-all-required-machines-not-in-service",
+                    _replace_msg=(
+                        "Cannot set nodes to ready. "
+                        "Required machines not in service: "
+                        "{not_in_service}"
+                    ),
+                    not_in_service=required_machines_not_in_service,
+                )
+                return
+
+    with directory_connection(context.enc_path) as directory:
+        for node_name in node_names:
+            fc.util.slurm.ready(
+                log,
+                node_name,
+                strict_state_check,
+                reason_must_match,
+                skip_nodes_in_maintenance,
+                directory,
+            )
+
+
+@all_nodes_app.command()
+def state(as_json: bool = True):
+    node_names = fc.util.slurm.get_all_node_names()
+    node_info = [fc.util.slurm.get_node_info(name) for name in node_names]
+    if as_json:
+        output = json.dumps(node_info, indent=2)
+    else:
+        output = node_info
+    rich.print(output)

--- a/pkgs/fc/agent/fc/util/checks.py
+++ b/pkgs/fc/agent/fc/util/checks.py
@@ -1,0 +1,40 @@
+# Common code for Nagios-style checks.
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+@dataclass
+class CheckResult:
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    ok_info: list[str] = field(default_factory=list)
+
+    def format_output(self) -> str:
+        if self.errors:
+            return "CRITICAL: " + " ".join(self.errors + self.warnings)
+
+        if self.warnings:
+            return "WARNING: " + " ".join(self.warnings)
+
+        if self.ok_info:
+            return "OK: " + " ".join(self.ok_info)
+
+        return "OK"
+
+    @property
+    def exit_code(self) -> int:
+        if self.errors:
+            return 2
+
+        if self.warnings:
+            return 1
+
+        return 0
+
+    @staticmethod
+    def merge(first, second):
+        return CheckResult(
+            first.errors + second.errors,
+            first.warnings + second.warnings,
+            first.ok_info + second.ok_info,
+        )

--- a/pkgs/fc/agent/fc/util/directory.py
+++ b/pkgs/fc/agent/fc/util/directory.py
@@ -65,3 +65,7 @@ def directory_cli():
     cmd = sys.argv[1]
     d = connect(ring="max")
     exec(cmd)
+
+
+def is_node_in_service(directory, node) -> bool:
+    return directory.lookup_node(node)["parameters"]["servicing"]

--- a/pkgs/fc/agent/fc/util/logging.py
+++ b/pkgs/fc/agent/fc/util/logging.py
@@ -597,12 +597,14 @@ def init_logging(
     log_cmd_output: bool = False,
     log_to_console: bool = True,
     syslog_identifier="fc-agent",
+    show_caller_info: bool = False,
 ):
     multi_renderer = MultiRenderer(
         journal=SystemdJournalRenderer(syslog_identifier, syslog.LOG_LOCAL1),
         cmd_output_file=CmdOutputFileRenderer(),
         text=ConsoleFileRenderer(
-            min_level="trace" if verbose else "info", show_caller_info=verbose
+            min_level="trace" if verbose else "info",
+            show_caller_info=show_caller_info,
         ),
     )
 
@@ -620,7 +622,7 @@ def init_logging(
     loggers = {}
 
     if logdir is not None:
-        main_log_file = open(logdir / "fc-agent.log", "a")
+        main_log_file = open(logdir / f"{syslog_identifier}.log", "a")
         loggers["file"] = structlog.PrintLoggerFactory(main_log_file)
     if journal:
         loggers["journal"] = JournalLoggerFactory()

--- a/pkgs/fc/agent/fc/util/slurm.py
+++ b/pkgs/fc/agent/fc/util/slurm.py
@@ -1,0 +1,754 @@
+import socket
+import subprocess
+import time
+from collections import Counter
+from enum import Enum
+from functools import reduce
+from typing import NamedTuple, Optional
+
+import pyslurm
+from fc.util.checks import CheckResult
+from fc.util.directory import directory_connection, is_node_in_service
+
+
+class NodeStateError(Exception):
+    def __init__(self, state: str, flags: list[str]):
+        self.state = state
+        self.flags = flags
+
+
+class NodeStateTimeout(Exception):
+    def __init__(self, remaining_node_states: dict[str, str]):
+        self.remaining_node_states = remaining_node_states
+
+
+class DrainingAction(Enum):
+    NO_OP = 0
+    DRAIN = 1
+    WAIT = 2
+
+
+class DrainPreCheckResult(NamedTuple):
+    state: str
+    flags: list[str]
+    draining_action: DrainingAction
+
+
+def get_node_info(node_name):
+    return pyslurm.node().get_node(node_name)[node_name]
+
+
+def is_node_in_error(node_info):
+    state, *flags = node_info["state"].split("+")
+    return state == "ERROR"
+
+
+def is_node_state_mixed(node_info):
+    state, *flags = node_info["state"].split("+")
+    return state == "MIXED"
+
+
+def is_node_failed(node_info):
+    state, *flags = node_info["state"].split("+")
+    return state == "FAILED"
+
+
+def is_node_idle(node_info):
+    state, *flags = node_info["state"].split("+")
+    return state == "IDLE"
+
+
+def is_node_down(node_info):
+    state, *flags = node_info["state"].split("+")
+    return state == "DOWN"
+
+
+def is_node_draining(node_info):
+    state, *flags = node_info["state"].split("+")
+    return "DRAIN" in flags
+
+
+def is_node_completing(node_info):
+    state, *flags = node_info["state"].split("+")
+    return state == "COMPLETING"
+
+
+def is_node_allocated(node_info):
+    state, *flags = node_info["state"].split("+")
+    return state == "ALLOCATED"
+
+
+def is_node_drained(log, node_info):
+    state, *flags = node_info["state"].split("+")
+    drained = state in ("IDLE", "IDLE*", "DOWN", "DOWN*") and "DRAIN" in flags
+    log.debug(
+        "is-node-drained",
+        drained=drained,
+        node=node_info["name"],
+        state=state,
+        flags=flags,
+    )
+    return drained
+
+
+def get_all_node_names():
+    return pyslurm.node().get().keys()
+
+
+def update_nodes(state_change: dict):
+    return pyslurm.node().update(state_change)
+
+
+def run_drain_pre_checks(log, node_name, strict_state_check):
+    log = log.bind(node=node_name)
+
+    node_info = get_node_info(node_name)
+    state, *flags = node_info["state"].split("+")
+
+    if is_node_drained(log.bind(op="pre-check"), node_info):
+        if strict_state_check:
+            log.error("drain-pre-check-state-error", state=state, flags=flags)
+            raise NodeStateError(state, flags)
+        else:
+            log.info(
+                "drain-pre-already-drained",
+                _replace_msg="{node} is already drained",
+            )
+            return DrainPreCheckResult(state, flags, DrainingAction.NO_OP)
+
+    if "DRAIN" in flags:
+        if strict_state_check:
+            log.error("drain-state-error", state=state, flags=flags)
+            raise NodeStateError(state, flags)
+        else:
+            log.info(
+                "drain-pre-already-draining",
+                _replace_msg=(
+                    "{node} already started draining. Will wait until the node "
+                    " is drained."
+                ),
+            )
+            return DrainPreCheckResult(state, flags, DrainingAction.WAIT)
+
+    if "*" in state:
+        log.warn(
+            "drain-pre-unresponsive",
+            _replace_msg=(
+                "{node} does need draining in state {state} and does not "
+                "respond at the moment. Will still try to drain the node."
+            ),
+            state=state,
+            flags=flags,
+        )
+    else:
+        log.info(
+            "drain-pre-needs-draining",
+            _replace_msg="{node} is in state {state} and needs draining.",
+            state=state,
+            flags=flags,
+        )
+
+    return DrainPreCheckResult(state, flags, DrainingAction.DRAIN)
+
+
+def drain(
+    log,
+    node_name,
+    timeout: int,
+    reason: str,
+    strict_state_check: bool = False,
+):
+    log.debug(
+        "drain-start",
+        timeout=timeout,
+        reason=reason,
+        node=node_name,
+        strict_state_check=strict_state_check,
+    )
+
+    check_result = run_drain_pre_checks(log, node_name, strict_state_check)
+
+    match check_result.draining_action:
+        case DrainingAction.NO_OP:
+            return
+        case DrainingAction.WAIT:
+            pass
+        case DrainingAction.DRAIN:
+            state_change_drain = {
+                "node_names": node_name,
+                "node_state": pyslurm.NODE_STATE_DRAIN,
+                "reason": reason,
+            }
+            result = update_nodes(state_change_drain)
+            log.debug("node-update-result", result=result)
+
+    start_time = time.time()
+    elapsed = 0.0
+    ii = 0
+
+    while elapsed < timeout:
+        node_info = get_node_info(node_name)
+
+        drain_log = log.bind(
+            op="drain-wait", elapsed=int(elapsed), timeout=timeout
+        )
+        if is_node_drained(drain_log, node_info):
+            log.info(
+                "drain-finished",
+                elapsed=int(elapsed),
+                node=node_name,
+                state=node_info["state"],
+            )
+            return
+
+        pause = min([15, 2**ii])
+        log.debug("drain-wait", sleep=pause)
+        time.sleep(pause)
+        ii += 1
+        elapsed = time.time() - start_time
+
+    state_str = get_node_info(node_name)["state"]
+    state, *flags = state_str.split("+")
+    log.error(
+        "drain-timeout",
+        _replace_msg=(
+            "{node} did not finish draining in time, waited {timeout} "
+            "seconds. State is '{state}' with flags {flags}."
+        ),
+        flags=flags,
+        state=state,
+        timeout=timeout,
+    )
+    raise NodeStateTimeout({node_name: state_str})
+
+
+def drain_many(
+    log,
+    node_names,
+    timeout: int,
+    reason: str,
+    strict_state_check: bool = False,
+):
+    log.debug("drain-many-start", nodes=node_names)
+
+    nodes_to_drain = set()
+    nodes_to_wait_for = set()
+
+    for node_name in node_names:
+        check_result = run_drain_pre_checks(log, node_name, strict_state_check)
+
+        match check_result.draining_action:
+            case DrainingAction.NO_OP:
+                pass
+            case DrainingAction.WAIT:
+                nodes_to_wait_for.add(node_name)
+            case DrainingAction.DRAIN:
+                nodes_to_drain.add(node_name)
+                nodes_to_wait_for.add(node_name)
+
+    if not nodes_to_wait_for:
+        log.info(
+            "drain-many-nothing-to-do",
+            _replace_msg="OK: All nodes are already drained.",
+        )
+        return
+
+    if nodes_to_drain:
+        state_change_drain = {
+            "node_names": ",".join(nodes_to_drain),
+            "node_state": pyslurm.NODE_STATE_DRAIN,
+            "reason": reason,
+        }
+        result = update_nodes(state_change_drain)
+        log.debug("node-update-result", result=result)
+
+    log.info(
+        "drain-many-waiting",
+        num_waiting_nodes=len(nodes_to_wait_for),
+        _replace_msg="Waiting for {num_waiting_nodes} nodes to drain.",
+    )
+
+    start_time = time.time()
+    elapsed = 0.0
+    ii = 0
+
+    while elapsed < timeout:
+        drained_nodes = set()
+        for node_name in nodes_to_wait_for:
+            node_info = get_node_info(node_name)
+
+            drain_log = log.bind(
+                op="drain-wait", elapsed=int(elapsed), timeout=timeout
+            )
+
+            if is_node_drained(drain_log, node_info):
+                log.info(
+                    "node-drained",
+                    _replace_msg="{node} is now fully drained.",
+                    node=node_name,
+                )
+
+                drained_nodes.add(node_name)
+
+        for node_name in drained_nodes:
+            nodes_to_wait_for.remove(node_name)
+
+        if not nodes_to_wait_for:
+            log.info(
+                "drain-many-finished",
+                _replace_msg="All nodes are drained after {elapsed} seconds.",
+                elapsed=int(elapsed),
+            )
+            return
+
+        log.debug(
+            "drain-all-wait",
+            elapsed=int(elapsed),
+            timeout=timeout,
+            num_waiting_nodes=len(nodes_to_wait_for),
+        )
+
+        pause = min([15, 2**ii])
+        log.debug("drain-wait", sleep=pause)
+        time.sleep(pause)
+        ii += 1
+        elapsed = time.time() - start_time
+
+    # Loop finished => time limit reached
+
+    remaining_node_states = {
+        o: get_node_info(o)["state"] for o in nodes_to_wait_for
+    }
+
+    log.error(
+        "drain-many-timeout",
+        timeout=timeout,
+        remaining_node_states=remaining_node_states,
+        num_remaining=len(nodes_to_wait_for),
+        _replace_msg=(
+            "{num_remaining} node(s) did not drain in time, waited "
+            "{timeout} seconds for: {remaining_node_states}"
+        ),
+    )
+    raise NodeStateTimeout(remaining_node_states)
+
+
+def down(log, node_name, reason: str, strict_state_check: bool = False):
+    log = log.bind(node=node_name)
+    log.debug("down-start")
+
+    node_info = get_node_info(node_name)
+    state, *flags = node_info["state"].split("+")
+    log.debug("down-state-pre", state=state, flags=flags)
+
+    if state in ("DOWN", "DOWN*"):
+        if strict_state_check:
+            log.error("down-state-error", state=state, flags=flags)
+            raise NodeStateError(state, flags)
+        else:
+            log.info(
+                "down-already-reached",
+                _replace_msg="{node} is already in {state} state.",
+                state=state,
+            )
+            return
+
+    state_change_down = {
+        "node_names": node_name,
+        "node_state": pyslurm.NODE_STATE_DOWN,
+        "reason": reason,
+    }
+    result = update_nodes(state_change_down)
+    log.debug("node-update-result", result=result)
+    log.info(
+        "down-finished",
+        _replace_msg="{node} is set to DOWN.",
+    )
+
+
+class ReadyPreCheckResult(NamedTuple):
+    state: str
+    flags: list[str]
+    action: bool
+
+
+def run_ready_pre_checks(
+    log,
+    node_name,
+    strict_state_check,
+    reason_must_match,
+    skip_in_maintenance,
+    directory,
+):
+    log = log.bind(node=node_name)
+    node_info = get_node_info(node_name)
+    state, *flags = node_info["state"].split("+")
+    log.debug("ready-pre-node-state", state=state, flags=flags)
+
+    if state in ("ALLOCATED", "IDLE", "MIXED"):
+        if strict_state_check:
+            log.error("ready-state-error", state=state, flags=flags)
+            raise NodeStateError(state, flags)
+        else:
+            log.info(
+                "ready-already-reached",
+                _replace_msg=(
+                    "{node} is already in a ready state ({state}). No change."
+                ),
+                state=state,
+            )
+            return ReadyPreCheckResult(state, flags, action=False)
+
+    if state in ("ALLOCATED*", "IDLE*", "MIXED*"):
+        if strict_state_check:
+            log.error("ready-state-error", state=state, flags=flags)
+            raise NodeStateError(state, flags)
+        else:
+            log.warn(
+                "ready-already-reached-unresponsive",
+                _replace_msg=(
+                    "{node} is already in a ready state ({state}) but not "
+                    "responding at the moment. No change."
+                ),
+                state=state,
+            )
+            return ReadyPreCheckResult(state, flags, action=False)
+
+    if reason_must_match and reason_must_match not in node_info["reason"]:
+        log.info(
+            "ready-pre-reason-not-matched",
+            _replace_msg=(
+                "{node} cannot be ready because the reason '{reason}'"
+                "does not contain the expected string {expected}"
+            ),
+            expected=reason_must_match,
+            reason=node_info["reason"],
+        )
+        return ReadyPreCheckResult(state, flags, action=False)
+
+    if skip_in_maintenance and not is_node_in_service(directory, node_name):
+        log.info(
+            "ready-pre-not-in-service",
+            node=node_name,
+            _replace_msg="{node} is still in maintenance, skipping.",
+        )
+        return ReadyPreCheckResult(state, flags, action=False)
+
+    if "*" in state:
+        log.warn(
+            "ready-pre-doit-unresponsive",
+            _replace_msg=(
+                "{node} is in state {state} and does not respond at the "
+                "moment but can still be set to ready."
+            ),
+            state=state,
+            flags=flags,
+        )
+    else:
+        log.info(
+            "ready-pre-doit",
+            _replace_msg="{node} is in state {state} and can be set to ready.",
+            state=state,
+            flags=flags,
+        )
+    return ReadyPreCheckResult(state, flags, action=True)
+
+
+def ready(
+    log,
+    node_name,
+    strict_state_check: bool = False,
+    reason_must_match: Optional[str] = None,
+    skip_in_maintenance=False,
+    directory=None,
+):
+    log = log.bind(node=node_name)
+    log.debug("ready-start")
+
+    result = run_ready_pre_checks(
+        log,
+        node_name,
+        strict_state_check,
+        reason_must_match,
+        skip_in_maintenance,
+        directory,
+    )
+
+    if not result.action:
+        return
+
+    state_change_ready = {
+        "node_names": node_name,
+        "node_state": pyslurm.NODE_RESUME,
+    }
+    result = update_nodes(state_change_ready)
+    log.debug("node-update-result", result=result)
+
+    log.info(
+        "ready-finished",
+        _replace_msg="{node} set to ready.",
+    )
+
+
+def check_controller(log, hostname):
+    errors = []
+    warnings = []
+
+    try:
+        pyslurm.slurm_ping(0)
+    except ValueError as e:
+        log.error("slurm-controller-ping-failed", exc_info=True)
+        errors.append(f"Failed - {e.args[0]}")
+
+    all_nodes_info = pyslurm.node().get().items()
+
+    if not all_nodes_info:
+        errors.append("No nodes configured")
+        return CheckResult(errors)
+
+    nodes_out = {}
+    nodes_in = {}
+    nodes_offline = {}
+    nodes_unexpected = {}
+
+    num_nodes = len(all_nodes_info)
+
+    for name, info in all_nodes_info:
+        state_parts = info["state"].split("+")
+        match state_parts:
+            case [
+                ("IDLE*" | "DOWN*" | "ALLOCATED*" | "MIXED*" | "COMPLETING*"),
+                *_,
+            ]:
+                nodes_offline[name] = info
+            case [("DOWN"), *_]:
+                nodes_out[name] = info
+            case [("ALLOCATED" | "IDLE" | "COMPLETING" | "MIXED"), *flags]:
+                if "DRAIN" in flags:
+                    nodes_out[name] = info
+                else:
+                    nodes_in[name] = info
+            case unexpected:
+                nodes_unexpected[name] = info
+                log.warn("check-unexpected-node-state", state=unexpected)
+
+    if nodes_unexpected:
+        nodes_with_state = [
+            f"{n} ({o['state']})" for n, o in nodes_unexpected.items()
+        ]
+        node_state_str = ", ".join(nodes_with_state)
+        warnings.append(
+            f"{len(nodes_unexpected)}/{num_nodes} nodes are in an unexpected "
+            f"state: " + node_state_str
+        )
+
+    if not nodes_in:
+        nodes_with_state = [
+            f"{n} ({o['state']}, \"{o['reason']}\")"
+            for n, o in nodes_out.items()
+        ] + [f"{n} (not responding)" for n in nodes_offline]
+
+        node_state_str = ", ".join(nodes_with_state)
+        errors.append(f"All nodes cannot accept jobs: {node_state_str}.")
+
+    elif nodes_out or nodes_offline:
+        nodes_with_state = [
+            f"{n} ({o['state']}, \"{o['reason']}\")"
+            for n, o in nodes_out.items()
+        ] + [f"{n} (not responding)" for n in nodes_offline]
+
+        node_state_str = ", ".join(nodes_with_state)
+        num_offline_out = len(nodes_offline) + len(nodes_out)
+        warnings.append(
+            f"{num_offline_out}/{num_nodes} nodes cannot accept jobs: "
+            + node_state_str
+            + "."
+        )
+
+    stats = pyslurm.statistics().get()
+
+    info = [
+        f"All {num_nodes} nodes are operational.",
+        f"Running jobs: {stats['jobs_running']}.",
+        f"Pending jobs: {stats['jobs_pending']}.",
+        f"Total started jobs: {stats['jobs_started']}.",
+        f"Slurm version:" f" {pyslurm.version()}",
+    ]
+
+    return CheckResult(errors, warnings, info)
+
+
+def check_node(log, hostname):
+    errors = []
+    warnings = []
+    info = []
+
+    slurmd_active_proc = subprocess.run(
+        ["systemctl", "is-active", "--quiet", "slurmd"]
+    )
+    if slurmd_active_proc.returncode > 0:
+        errors.append("slurm daemon is inactive, no jobs will be run.")
+
+    munged_active_proc = subprocess.run(
+        ["systemctl", "is-active", "--quiet", "munged"]
+    )
+    if munged_active_proc.returncode > 0:
+        errors.append(
+            "munge daemon is inactive, no slurm API interaction possible."
+        )
+        return CheckResult(errors)
+
+    try:
+        node_info = get_node_info(hostname)
+    except Exception as e:
+        log.error("check-node-api-error", exc_info=True)
+        errors.append("Cannot get node info from API: {e}")
+        return CheckResult(errors)
+
+    state, *flags = node_info["state"].split("+")
+
+    if state == "DOWN":
+        warnings.append("Node is marked as DOWN, no jobs will be run.")
+    elif "DRAIN" in flags:
+        warnings.append("Node is draining, no new jobs will be accepted.")
+    else:
+        info = [f"Node state is {state}."]
+
+    return CheckResult(errors, warnings, info)
+
+
+def check(log, hostname) -> CheckResult:
+    results = []
+
+    try:
+        controller_names = pyslurm.get_controllers()
+    except ValueError as e:
+        return CheckResult(errors=[e.args[0]], warnings=[])
+
+    if hostname in controller_names:
+        results.append(check_controller(log, hostname))
+
+    if hostname in pyslurm.node().get():
+        results.append(check_node(log, hostname))
+
+    return reduce(CheckResult.merge, results)
+
+
+def get_account_metrics(account, running, pending, suspended) -> dict:
+    return {
+        "name": "slurm_account",
+        "account": account,
+        "cpus_running": sum(j["num_cpus"] for j in running),
+        "jobs_running": len(running),
+        "jobs_pending": len(pending),
+        "jobs_suspended": len(suspended),
+    }
+
+
+def get_accounts_metrics(log, jobs) -> list[dict]:
+    running_per_acc = {}
+    pending_per_acc = {}
+    suspended_per_acc = {}
+
+    for job in jobs:
+        acc = job["account"]
+        match job["job_state"]:
+            case "RUNNING":
+                running_for_acc = running_per_acc.setdefault(acc, [])
+                running_for_acc.append(job)
+            case "PENDING":
+                pending_for_acc = pending_per_acc.setdefault(acc, [])
+                pending_for_acc.append(job)
+            case "SUSPENDED":
+                suspended_for_acc = suspended_per_acc.setdefault(acc, [])
+                suspended_for_acc.append(job)
+            case "COMPLETED" | "CANCELLED":
+                pass
+            case other:
+                log.warn("slurm-metrics-unknown-job-state", state=other)
+
+    accounts_metrics = []
+
+    for account in (
+        running_per_acc.keys()
+        | pending_per_acc.keys()
+        | suspended_per_acc.keys()
+    ):
+        running = running_per_acc.get(acc, [])
+        pending = pending_per_acc.get(acc, [])
+        suspended = suspended_per_acc.get(acc, [])
+
+        accounts_metrics.append(
+            get_account_metrics(account, running, pending, suspended)
+        )
+
+    return accounts_metrics
+
+
+def get_cpu_metrics(nodes) -> dict:
+    return {
+        "name": "slurm_cpus",
+        "total": sum(o["cpus"] for o in nodes),
+        "alloc": sum(o["alloc_cpus"] for o in nodes),
+    }
+
+
+def get_node_metrics(nodes) -> dict:
+    return {
+        "name": "slurm_nodes",
+        "total": len(nodes),
+        "idle": len([1 for o in nodes if is_node_idle(o)]),
+        "alloc": len([1 for o in nodes if is_node_allocated(o)]),
+        "comp": len([1 for o in nodes if is_node_completing(o)]),
+        "down": len([1 for o in nodes if is_node_down(o)]),
+        "drain": len([1 for o in nodes if is_node_draining(o)]),
+        "err": len([1 for o in nodes if is_node_in_error(o)]),
+        "fail": len([1 for o in nodes if is_node_failed(o)]),
+        "mix": len([1 for o in nodes if is_node_state_mixed(o)]),
+    }
+
+
+def get_queue_metrics(jobs) -> dict:
+    state_counter = Counter(j["job_state"].lower() for j in jobs)
+    return {"name": "slurm_queue", **state_counter}
+
+
+def get_scheduler_metrics(stats) -> dict:
+    sched_count = stats["schedule_cycle_counter"]
+    bf_count = stats["bf_cycle_counter"]
+    mean_cycle = (
+        stats["schedule_cycle_sum"] / sched_count if sched_count > 0 else 0
+    )
+    backfill_mean_cycle = (
+        stats["bf_cycle_sum"] / bf_count if bf_count > 0 else 0
+    )
+    backfill_depth_mean = (
+        stats["bf_depth_sum"] / bf_count if bf_count > 0 else 0
+    )
+
+    return {
+        "name": "slurm_scheduler",
+        "threads": stats["server_thread_count"],
+        "queue_size": stats["schedule_queue_len"],
+        "last_cycle": stats["schedule_cycle_last"],
+        "mean_cycle": mean_cycle,
+        "backfill_last_cycle": stats["bf_cycle_last"],
+        "backfill_mean_cycle": backfill_mean_cycle,
+        "backfill_depth_mean": backfill_depth_mean,
+        "backfilled_jobs_since_start_total": stats["bf_backfilled_jobs"],
+        "backfilled_jobs_since_cycle_total": stats["bf_last_backfilled_jobs"],
+    }
+
+
+def get_metrics(log) -> list[dict]:
+    stats = pyslurm.statistics().get()
+    nodes = pyslurm.node().get().values()
+    jobs = pyslurm.job().get().values()
+
+    return [
+        *get_accounts_metrics(log, jobs),
+        get_cpu_metrics(nodes),
+        get_node_metrics(nodes),
+        get_queue_metrics(jobs),
+        get_scheduler_metrics(stats),
+    ]

--- a/pkgs/fc/agent/fc/util/tests/test_slurm.py
+++ b/pkgs/fc/agent/fc/util/tests/test_slurm.py
@@ -1,0 +1,307 @@
+import sys
+import unittest.mock
+from itertools import chain, repeat
+from unittest.mock import MagicMock
+
+from fc.util.logging import init_logging
+from pytest import fixture, raises
+
+pyslurm = type(sys)("pyslurm")
+pyslurm.node = MagicMock()
+pyslurm.NODE_STATE_DRAIN = 1
+pyslurm.NODE_STATE_DOWN = 2
+pyslurm.NODE_RESUME = 3
+pyslurm.slurm_ping = MagicMock()
+pyslurm.statistics = MagicMock()
+pyslurm.statistics.return_value.get.return_value = {
+    "jobs_running": 1,
+    "jobs_pending": 2,
+    "jobs_started": 3,
+}
+pyslurm.version = lambda: "22.5.0"
+sys.modules["pyslurm"] = pyslurm
+
+
+init_logging(verbose=True, syslog_identifier="slurm-test")
+
+import fc.util.slurm
+from fc.util.slurm import NodeStateError, NodeStateTimeout, drain
+
+
+@unittest.mock.patch("fc.util.slurm.get_node_info")
+@unittest.mock.patch("fc.util.slurm.update_nodes")
+def test_ready(update_nodes: MagicMock, get_node_info, logger):
+    get_node_info.return_value = {"name": "test20", "state": "DOWN+DRAIN"}
+    fc.util.slurm.ready(logger, "test20")
+    update_nodes.assert_called_once_with(
+        {
+            "node_names": "test20",
+            "node_state": pyslurm.NODE_RESUME,
+        }
+    )
+
+
+@unittest.mock.patch("fc.util.slurm.get_node_info")
+@unittest.mock.patch("fc.util.slurm.update_nodes")
+def test_ready_noop(update_nodes: MagicMock, get_node_info, logger):
+    get_node_info.return_value = {"name": "test20", "state": "IDLE"}
+    fc.util.slurm.ready(logger, "test20")
+    update_nodes.assert_not_called()
+
+
+@unittest.mock.patch("fc.util.slurm.get_node_info")
+@unittest.mock.patch("fc.util.slurm.update_nodes")
+def test_ready_offline(update_nodes: MagicMock, get_node_info, logger):
+    get_node_info.return_value = {"name": "test20", "state": "IDLE*"}
+    fc.util.slurm.ready(logger, "test20")
+    update_nodes.assert_not_called()
+
+
+@unittest.mock.patch("fc.util.slurm.get_node_info")
+@unittest.mock.patch("fc.util.slurm.update_nodes")
+def test_down(update_nodes: MagicMock, get_node_info, logger, monkeypatch):
+    get_node_info.return_value = {"name": "test20", "state": "IDLE+DRAIN"}
+    fc.util.slurm.down(logger, "test20", "test down")
+    update_nodes.assert_called_once_with(
+        {
+            "node_names": "test20",
+            "node_state": pyslurm.NODE_STATE_DOWN,
+            "reason": "test down",
+        }
+    )
+
+
+@unittest.mock.patch("fc.util.slurm.get_node_info")
+@unittest.mock.patch("fc.util.slurm.update_nodes")
+def test_down_noop(update_nodes: MagicMock, get_node_info, logger, monkeypatch):
+    get_node_info.return_value = {"name": "test20", "state": "DOWN+DRAIN"}
+    fc.util.slurm.down(logger, "test20", "test down noop")
+    update_nodes.assert_not_called()
+
+
+@unittest.mock.patch("fc.util.slurm.update_nodes")
+def test_drain(update_nodes, logger, monkeypatch):
+    iter_states = iter(
+        [
+            "ALLOCATED",
+            "MIXED+DRAIN",
+            "IDLE+DRAIN",
+        ]
+    )
+
+    def fake_get_node_info(node_name):
+        return {
+            "name": "test20",
+            "state": next(iter_states),
+        }
+
+    monkeypatch.setattr(fc.util.slurm, "get_node_info", fake_get_node_info)
+    drain(logger, "test20", 3, "test drain")
+
+    update_nodes.assert_called_once_with(
+        {
+            "node_names": "test20",
+            "node_state": pyslurm.NODE_STATE_DRAIN,
+            "reason": "test drain",
+        }
+    )
+
+
+@unittest.mock.patch("fc.util.slurm.get_node_info")
+@unittest.mock.patch("fc.util.slurm.update_nodes")
+def test_drain_noop_when_already_drained(
+    update_nodes: MagicMock, get_node_info, logger
+):
+    get_node_info.return_value = {
+        "name": "test20",
+        "state": "IDLE+DRAIN",
+    }
+    drain(logger, "test20", 3, "test drain")
+
+    update_nodes.assert_not_called()
+
+
+def test_drain_timeout(logger, monkeypatch):
+    iter_states = chain(iter(["MIXED"]), repeat("MIXED+DRAIN"))
+
+    def fake_get_node_info(node_name):
+        return {
+            "name": "test20",
+            "state": next(iter_states),
+        }
+
+    monkeypatch.setattr(fc.util.slurm, "get_node_info", fake_get_node_info)
+    with raises(NodeStateTimeout) as e:
+        drain(logger, "test20", 2, "test drain")
+
+    assert e.value.remaining_node_states == {"test20": "MIXED+DRAIN"}
+
+
+def test_drain_many_noop(logger, monkeypatch):
+    def fake_get_node_info(node_name):
+        return {"name": node_name, "state": "IDLE+DRAIN"}
+
+    monkeypatch.setattr(fc.util.slurm, "get_node_info", fake_get_node_info)
+
+    fc.util.slurm.drain_many(logger, ["test20", "test21"], 3, "test drain noop")
+
+
+def test_check_controller(logger):
+    pyslurm.node.return_value.get.return_value = {
+        "test20": {"state": "IDLE"},
+        "test21": {"state": "ALLOCATED"},
+        "test22": {"state": "MIXED"},
+    }
+    res = fc.util.slurm.check_controller(logger, "test20")
+    assert res.errors == []
+    assert res.warnings == []
+    assert res.ok_info == [
+        "All 3 nodes are operational.",
+        "Running jobs: " "1.",
+        "Pending jobs: 2.",
+        "Total started jobs: 3.",
+        "Slurm version: 22.5.0",
+    ]
+
+
+def test_check_controller_warning(logger):
+    pyslurm.node.return_value.get.return_value = {
+        "test20": {"state": "IDLE"},
+        "test21": {"state": "ALLOCATED"},
+        "test22": {"state": "MIXED"},
+        "test23": {"state": "DOWN", "reason": "down"},
+        "test24": {"state": "DOWN*", "reason": "down unresp"},
+    }
+    res = fc.util.slurm.check_controller(logger, "test20")
+    assert res.errors == []
+    assert res.warnings == [
+        '2/5 nodes cannot accept jobs: test23 (DOWN, "down"), test24 (not '
+        "responding)."
+    ]
+
+
+def test_check_controller_critical(logger):
+    pyslurm.node.return_value.get.return_value = {
+        "test22": {"state": "IDLE+DRAIN", "reason": "drain"},
+        "test23": {"state": "DOWN", "reason": "down"},
+        "test24": {"state": "DOWN*", "reason": "down unresp"},
+    }
+    res = fc.util.slurm.check_controller(logger, "test20")
+    assert res.errors == [
+        "All nodes cannot accept jobs: "
+        'test22 (IDLE+DRAIN, "drain"), '
+        'test23 (DOWN, "down"), '
+        "test24 (not responding)."
+    ]
+
+
+def test_drain_many(logger, monkeypatch):
+    iter_states = {
+        "test20": iter(
+            [
+                "ALLOCATED+DRAIN",
+                "MIXED+DRAIN",
+                "IDLE+DRAIN",
+                "IDLE+DRAIN",
+            ]
+        ),
+        "test21": iter(
+            [
+                "MIXED",
+                "MIXED+DRAIN",
+                "IDLE+DRAIN",
+            ]
+        ),
+        "test22": iter(
+            [
+                "IDLE",
+                "IDLE+DRAIN",
+            ]
+        ),
+        "test23": iter(
+            [
+                "IDLE+DRAIN",
+            ]
+        ),
+        "test24": iter(
+            [
+                "IDLE*",
+                "IDLE*+DRAIN",
+            ]
+        ),
+        "test25": iter(
+            [
+                "DOWN",
+                "DOWN+DRAIN",
+            ]
+        ),
+        "test26": iter(
+            [
+                "DOWN*",
+                "DOWN*+DRAIN",
+            ]
+        ),
+        "test27": iter(
+            [
+                "ALLOCATED*",
+                "ALLOCATED*+DRAIN",
+                "IDLE+DRAIN",
+            ]
+        ),
+    }
+
+    def fake_get_node_info(node_name):
+        return {
+            "name": node_name,
+            "state": next(iter_states[node_name]),
+        }
+
+    monkeypatch.setattr(fc.util.slurm, "get_node_info", fake_get_node_info)
+    fc.util.slurm.drain_many(
+        logger, list(iter_states.keys()), 3, "test drain many"
+    )
+
+
+def test_drain_many_timeout(logger, log, monkeypatch):
+    iter_states = {
+        "test20": iter(
+            [
+                "ALLOCATED+DRAIN",
+                "MIXED+DRAIN",
+                "IDLE+DRAIN",
+                "IDLE+DRAIN",
+            ]
+        ),
+        "test21": iter(
+            [
+                "IDLE+DRAIN",
+            ]
+        ),
+        "test22": chain(
+            iter(["MIXED"]),
+            repeat("MIXED+DRAIN"),
+        ),
+    }
+
+    def fake_get_node_info(node_name):
+        return {
+            "name": node_name,
+            "state": next(iter_states[node_name]),
+        }
+
+    monkeypatch.setattr(fc.util.slurm, "get_node_info", fake_get_node_info)
+
+    with raises(NodeStateTimeout) as e:
+        fc.util.slurm.drain_many(
+            logger, list(iter_states.keys()), 3, "test drain many timeout"
+        )
+
+    remaining_node_states = {"test22": "MIXED+DRAIN"}
+
+    assert e.value.remaining_node_states == remaining_node_states
+
+    assert log.has(
+        "drain-many-timeout",
+        timeout=3,
+        remaining_node_states=remaining_node_states,
+    )

--- a/pkgs/fc/agent/setup.py
+++ b/pkgs/fc/agent/setup.py
@@ -33,8 +33,7 @@ setup(
         "Development Status :: 5 - Production/Stable",
         "Environment :: Console",
         "License :: OSI Approved :: Zope Public License",
-        "Programming Language :: Python :: 3.5",
-        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.10",
         "Topic :: System :: Systems Administration",
     ],
     packages=[
@@ -70,6 +69,7 @@ setup(
             "fc-monitor=fc.manage.monitor:main",
             "fc-resize-disk=fc.manage.resize_disk:app",
             "fc-postgresql=fc.manage.postgresql:app",
+            "fc-slurm=fc.manage.slurm:app",
             "fctl=fc.util.fctl:app",
         ],
     },


### PR DESCRIPTION
Implement slurm roles

- slurm-controller: central control service (server, slurmctld)
  - should be set up first, nodes later.
  - controller doesn't start when no nodes are present
  - drain jobs on all nodes before going into maintenance
  - resume all in-service nodes after coming back from maintenance
- slurm-node: compute node that does the work (client, slurmd)
  - automatically join the partition all
  - drain jobs before going into maintenance
- slurm-dbdserver: job accounting, has to run on the same machine as the controlle
  - Starts dbdserver and a local Percona 8 DB configured for local access
    by the slurm user to the slurm_acct_db database.
  - stores job comments.
  - uses jobacct_gather/linux.
- slurm-external-dependency
  Machines use the role slurm-external-dependency to signal that
  they have to be in service in order for the cluster to run jobs,
  for example databases. These machines are checked by the controller
  for their service state before nodes are enabled. If any of these
  machines are not in service, no nodes will be set to ready.
- fc-slurm command is used by agent for maintenance entry+exit and can
  be used as interactive tool
- sudo-srv users are allowed to to sudo-run fc-slurm and other commands as slurm user
- set real memory and cpus to reasonable defaults, configurable with options
  Currently, memory and CPU has to be the same on all nodes and controller machines,
  configure manually if that's not the case.
- default settings
  - job priority: priority/multifactor, QOS=2000
  - TaskPlugin task/affinity
- telegraf metrics and sensu checks
  - sensu checks for controller readyness (ping) and node state via
    fc-slurm check which uses pyslurm (slurm C API) to get information.
    Shows basic job stats if everything is OK.
  - telegraf gets metrics from fc-slurm metrics in JSON format. Field naming
    is taken from the GO prometheus exporter to fit the dashboard available for that.
- agent: use Python 3.10
- logging: separate caller info and verbose options in init_logging

PL-131067


@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - As slurm is basically a "remote shell" which is designed to execute arbitrary commands wtih the same UID on the target machine as the user starting the command on another machine, and even providing interactive remote shells, it must be documented that Slurm clusters must only be run in resource groups designated for this purpose, without other applications and sensitive data which doesn't have to be in the same RG. 
  - Access to the slurm API is restricted to machines that participate in the Slurm cluster (= have a slurm-* role)
  - Other than that, we rely on the Slurm permission system, for example to deny admin commands run by unprivileged users
- [x] Security requirements tested? (EVIDENCE)
  - manual testing on slurm test cluster
    - slurm admin commands are only usable as slurm user
    - Python tests cover all slurm maintenance operations
    - checked Munge setup which manages the secret key needed to access the Slurm API. The key is provided via directory secrets, generated for slurm-controller services and only accessible by machines with `slurm-*` roles.
  - role documentation states that slurm clusters must run in a separate RG