### PR TITLE
statshost: use default nginx user for rg-relay

### DIFF
--- a/nixos/roles/statshost/rg-relay.nix
+++ b/nixos/roles/statshost/rg-relay.nix
@@ -8,7 +8,6 @@ with lib;
   config = mkIf config.flyingcircus.roles.statshost-relay.enable {
 
     flyingcircus.services.nginx.enable = true;
-    services.nginx.masterUser = "root";
     services.nginx.appendHttpConfig = ''
       server {
         listen ${config.services.prometheus.listenAddress};


### PR DESCRIPTION
This was a leftover from 22.05, where webgateway set masterUser to root and rg relay did the same for its Nginx config to avoid conflicts with the webgateway role. Should be just the default of nginx now.

PL-131347

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* statshost-master: also use nginx as user, like the webgateway role does on 22.11 (PL-131347).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - principle of least privilege: don't run things as root that don't need it 
- [x] Security requirements tested? (EVIDENCE)
  - automated test still runs 
