### PR TITLE
[21.05] fc-ceph maintenance: lock timeouts

### DIFF
--- a/pkgs/fc/ceph/src/fc/ceph/maintenance/nautilus.py
+++ b/pkgs/fc/ceph/src/fc/ceph/maintenance/nautilus.py
@@ -3,8 +3,8 @@
 import json
 import subprocess
 import sys
+import time
 import traceback
-from time import sleep
 
 import fc.util.directory
 from fc.ceph.api import Cluster, Pools
@@ -230,7 +230,7 @@ class MaintenanceTasks(object):
             except subprocess.TimeoutExpired as e:
                 print(f"WARNING: Maintenance leave timed out at {e.cmd}.")
                 last_exc = e
-                sleep(
+                time.sleep(
                     self.LOCKTOOL_TIMEOUT_SECS / 5
                 )  # cooldown time for cluster
                 continue

--- a/pkgs/fc/ceph/src/fc/ceph/tests/test_maintenance.py
+++ b/pkgs/fc/ceph/src/fc/ceph/tests/test_maintenance.py
@@ -1,0 +1,299 @@
+import subprocess
+import time
+from unittest import mock
+
+import fc.ceph.maintenance
+import pytest
+
+
+@pytest.fixture
+def nosleep(monkeypatch):
+    monkeypatch.setattr(time, "sleep", lambda x: None)
+
+
+@pytest.fixture
+def locktoolcalls(monkeypatch):
+    locktoolcalls = mock.Mock()
+    monkeypatch.setattr("fc.ceph.util.run.rbd_locktool", locktoolcalls)
+    return locktoolcalls
+
+
+@pytest.fixture
+def rbdcalls(monkeypatch):
+    rbdcalls = mock.Mock()
+    monkeypatch.setattr("fc.ceph.util.run.rbd", rbdcalls)
+    return rbdcalls
+
+
+@pytest.fixture
+def ceph_json_calls(monkeypatch):
+    ceph_json_calls = mock.Mock()
+    monkeypatch.setattr("fc.ceph.util.run.json.ceph", ceph_json_calls)
+    return ceph_json_calls
+
+
+# FIXME: so far only testing nautilus behaviour
+def test_successful_maintenance_cycle(ceph_json_calls, locktoolcalls):
+    maintenance_task = fc.ceph.maintenance.nautilus.MaintenanceTasks()
+
+    locktoolcalls.side_effect = [
+        # enter
+        # "-q", "-i", "rbd/.maintenance"
+        "",
+        # "-l", "rbd/.maintenance", timeout=self.LOCKTOOL_TIMEOUT_SECS
+        "",
+        # leave
+        # "-q", "-i", "rbd/.maintenance"
+        "",
+        # "-q", "-u", "rbd/.maintenance",
+        "",
+    ]
+    ceph_json_calls.return_value = {
+        "status": "HEALTH_OK",
+    }
+
+    maintenance_task.enter()
+    maintenance_task.leave()
+
+    assert ceph_json_calls.call_count == 1
+    assert locktoolcalls.call_count == 4
+
+
+def test_maintenance_enter_lock_timeout_causes_leave(rbdcalls, locktoolcalls):
+    maintenance_task = fc.ceph.maintenance.nautilus.MaintenanceTasks()
+
+    locktoolcalls.side_effect = [
+        # enter
+        # "-q", "-i", "rbd/.maintenance"
+        "",
+        # "-l", "rbd/.maintenance", timeout=self.LOCKTOOL_TIMEOUT_SECS
+        subprocess.TimeoutExpired("rbd-locktool -l rbd/.maintenance", 30),
+        # leave
+        # "-q", "-i", "rbd/.maintenance"
+        "",
+        # "-q", "-u", "rbd/.maintenance",
+        "",
+    ]
+
+    with pytest.raises(SystemExit, match="75") as exit_info:
+        maintenance_task.enter()
+
+    locktoolcalls.assert_has_calls(
+        [
+            mock.call("-q", "-i", "rbd/.maintenance", timeout=30),
+            mock.call("-l", "rbd/.maintenance", timeout=30),
+            mock.call("-q", "-i", "rbd/.maintenance", timeout=30),
+            mock.call("-q", "-u", "rbd/.maintenance", timeout=30),
+        ]
+    )
+
+
+def test_lockimage_created(locktoolcalls, rbdcalls, ceph_json_calls):
+    maintenance_task = fc.ceph.maintenance.nautilus.MaintenanceTasks()
+
+    for opname in ["enter", "leave"]:
+        locktoolcalls.side_effect = [
+            # enter
+            # "-q", "-i", "rbd/.maintenance"
+            subprocess.CalledProcessError(1, "-q -i rbd/.maintenance"),
+            # "-l", "rbd/.maintenance", timeout=self.LOCKTOOL_TIMEOUT_SECS
+            "",
+        ]
+        rbdcalls.return_value = ""
+        ceph_json_calls.return_value = {
+            "status": "HEALTH_OK",
+        }
+
+        maintenance_task.__getattribute__(opname)()
+
+        rbdcalls.assert_has_calls(
+            [mock.call("create", "--size", "1", "rbd/.maintenance")]
+        )
+
+
+def test_tempfail_when_another_lockholder(locktoolcalls):
+    maintenance_task = fc.ceph.maintenance.nautilus.MaintenanceTasks()
+
+    locktoolcalls.side_effect = [
+        # enter
+        # "-q", "-i", "rbd/.maintenance"
+        "",
+        # "-l", "rbd/.maintenance", timeout=self.LOCKTOOL_TIMEOUT_SECS
+        subprocess.CalledProcessError(1, "-l rbd/.maintenance"),
+        # leave
+        # "-q", "-i", "rbd/.maintenance"
+        "",
+        # "-q", "-u", "rbd/.maintenance",
+        "",
+    ]
+
+    with pytest.raises(SystemExit, match="75"):
+        maintenance_task.enter()
+
+    assert locktoolcalls.call_count == 2
+    locktoolcalls.assert_has_calls(
+        [
+            mock.call("-q", "-i", "rbd/.maintenance", timeout=30),
+            mock.call("-l", "rbd/.maintenance", timeout=30),
+        ]
+    )
+
+
+def test_postpone_and_leave_when_unclean(locktoolcalls, ceph_json_calls):
+    maintenance_task = fc.ceph.maintenance.nautilus.MaintenanceTasks()
+
+    locktoolcalls.side_effect = [
+        # enter
+        # "-q", "-i", "rbd/.maintenance"
+        "",
+        # "-l", "rbd/.maintenance", timeout=self.LOCKTOOL_TIMEOUT_SECS
+        "",
+        # leave
+        # "-q", "-i", "rbd/.maintenance"
+        "",
+        # "-q", "-u", "rbd/.maintenance",
+        "",
+    ]
+    ceph_json_calls.return_value = {
+        "status": "HEALTH_ERR",
+    }
+
+    with pytest.raises(SystemExit, match="69"):
+        maintenance_task.enter()
+
+    assert ceph_json_calls.call_count == 1
+    locktoolcalls.assert_has_calls(
+        [
+            mock.call("-q", "-i", "rbd/.maintenance", timeout=30),
+            mock.call("-l", "rbd/.maintenance", timeout=30),
+            mock.call("-q", "-i", "rbd/.maintenance", timeout=30),
+            mock.call("-q", "-u", "rbd/.maintenance", timeout=30),
+        ]
+    )
+
+
+def test_leave_unlock_timeout_retries(locktoolcalls, nosleep):
+    maintenance_task = fc.ceph.maintenance.nautilus.MaintenanceTasks()
+
+    locktoolcalls.side_effect = 4 * [
+        # "-q", "-i", "rbd/.maintenance"
+        "",
+        # "-l", "rbd/.maintenance", timeout=self.LOCKTOOL_TIMEOUT_SECS
+        subprocess.TimeoutExpired("rbd-locktool -l rbd/.maintenance", 30),
+    ] + [
+        # "-q", "-i", "rbd/.maintenance"
+        "",
+        # successful unlock
+        "",
+    ]
+
+    maintenance_task.leave()
+
+    locktoolcalls.assert_has_calls(
+        5
+        * [
+            mock.call("-q", "-i", "rbd/.maintenance", timeout=30),
+            mock.call("-q", "-u", "rbd/.maintenance", timeout=30),
+        ]
+    )
+
+    assert locktoolcalls.call_count == 10
+
+
+def test_leave_unlock_timeout_retries_exceeded(locktoolcalls, nosleep):
+    maintenance_task = fc.ceph.maintenance.nautilus.MaintenanceTasks()
+
+    locktoolcalls.side_effect = 5 * [
+        # "-q", "-i", "rbd/.maintenance"
+        "",
+        # "-l", "rbd/.maintenance", timeout=self.LOCKTOOL_TIMEOUT_SECS
+        subprocess.TimeoutExpired("rbd-locktool -l rbd/.maintenance", 30),
+    ]
+
+    with pytest.raises(subprocess.TimeoutExpired):
+        maintenance_task.leave()
+
+    locktoolcalls.assert_has_calls(
+        5
+        * [
+            mock.call("-q", "-i", "rbd/.maintenance", timeout=30),
+            mock.call("-q", "-u", "rbd/.maintenance", timeout=30),
+        ]
+    )
+    assert locktoolcalls.call_count == 10
+
+
+def test_lockimage_check_timeout(locktoolcalls):
+    maintenance_task = fc.ceph.maintenance.nautilus.MaintenanceTasks()
+
+    locktoolcalls.side_effect = [
+        # enter
+        # "-q", "-i", "rbd/.maintenance"
+        subprocess.TimeoutExpired("rbd-locktool -l rbd/.maintenance", 30),
+        # for simplicity, assume that unlock attempts do not time-out
+        # leave
+        # "-q", "-i", "rbd/.maintenance"
+        "",
+        # "-q", "-u", "rbd/.maintenance",
+        "",
+    ]
+
+    with pytest.raises(SystemExit, match="75") as exit_info:
+        maintenance_task.enter()
+
+    locktoolcalls.assert_has_calls(
+        [
+            mock.call("-q", "-i", "rbd/.maintenance", timeout=30),
+            mock.call("-q", "-i", "rbd/.maintenance", timeout=30),
+            mock.call("-q", "-u", "rbd/.maintenance", timeout=30),
+        ]
+    )
+
+    assert locktoolcalls.call_count == 3
+
+
+def test_check_cluster_maintenance():
+    maintenance_task = fc.ceph.maintenance.nautilus.MaintenanceTasks()
+
+    assert maintenance_task.check_cluster_maintenance(
+        {
+            "status": "HEALTH_OK",
+        }
+    )
+
+    # some warnings can be ignored
+    assert maintenance_task.check_cluster_maintenance(
+        {
+            "status": "HEALTH_WARN",
+            "checks": {
+                "PG_NOT_DEEP_SCRUBBED": "foo",
+                "PG_NOT_SCRUBBED": "bar",
+                "LARGE_OMAP_OBJECTS": "baz",
+            },
+        }
+    )
+
+    # but some cannot
+    assert not maintenance_task.check_cluster_maintenance(
+        {
+            "status": "HEALTH_WARN",
+            "checks": {
+                "PG_NOT_DEEP_SCRUBBED": "foo",
+                "PG_NOT_SCRUBBED": "bar",
+                "OSDMAP_FLAGS": {
+                    "severity": "HEALTH_WARN",
+                    "summary": {"message": "noout flag(s) set"},
+                },
+            },
+        }
+    )
+
+    # and health errors always block maintenance
+    assert not maintenance_task.check_cluster_maintenance(
+        {
+            "status": "HEALTH_ERR",
+            "checks": {
+                "PG_NOT_SCRUBBED": "bar",
+            },
+        }
+    )


### PR DESCRIPTION
@flyingcircusio/release-managers

fc-ceph maintenance enter can block for a very long time on a broken/ busy cluster. If it is called by the fc-agent, this also blocks the agent execution, causes the agent lock to be held for a very long time and thus blocks all other agent actions.

On a busy or broken cluster, the rbd-locktool actions might take a very long time. These subprocess calls need to have a timeout.
As we cannot know whether e.g. the lock has been acquired successfully despite the subprocess (seemingly) getting killed by a timeout, the lock needs to be freed (or at least an attempt has to be made) explicitly in case of a locking timeout. This free of course gets its own timeout as well.

In case the unlock operation/ maintenance leave operation times out, it
is retried several times. If all retries exceeded, the situation
might need to be handled by an operator though.

**Note**: This has only been implemented for Ceph Nautilus so far, as Jewel and Luminous support will soon be deprecated in fc-nixos

## Release process

Impact: internal only

Changelog:
- introduce timeouts for `fc-ceph` maintenance hooks
- better signalling of exitcodes to fc-agent
- add unit tests for fc-ceph maintenance hooks

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - [x] avoid stale and blocking locks in fc-ceph maintenance hooks -> fail securely
  - [x] improve test coverage of ceph maintenance hooks 
- [x] Security requirements tested? (EVIDENCE)
  - [x] unit tests pass
  - [x] successful manual test in dev cluster (note: timeout situations not tested manually)
  - [ ] hydra build still passes
