### PR TITLE
[21.05] ceph nautilus refinements

### DIFF
--- a/nixos/infrastructure/flyingcircus-physical.nix
+++ b/nixos/infrastructure/flyingcircus-physical.nix
@@ -48,7 +48,7 @@ mkIf (cfg.infrastructureModule == "flyingcircus-physical") {
       pciutils
       smartmontools
       # ensure that `rbd-locktool` uses the correct ceph tooling version
-      config.fclib.ceph.utilPhysicalPkgs.${cfg.services.ceph.client.cephRelease}
+      config.fclib.ceph.releasePkgs.${cfg.services.ceph.client.cephRelease}.utilPhysical
     ];
 
     fileSystems = {

--- a/nixos/lib/ceph-common.nix
+++ b/nixos/lib/ceph-common.nix
@@ -79,15 +79,14 @@ rec {
     in _: definitionAttrs: selectFirst releaseOrder (builtins.catAttrs "value" definitionAttrs);
   };
   # returns true if the provided current release is the target release or newer
-  # FIXME: could this be done as a fold?
   releaseAtLeast = targetRelease: currentRelease:
     let
     _releaseRecurser = rList: acc:
-      if rList == [] then false
+      if rList == [] then false   # exit condition 1
       # order matters here, do not consume the list head but only set to true and re-call
       else if (builtins.head rList == targetRelease && !acc) then _releaseRecurser rList true
       # this advances the list consumption but then also catches the case currentRelease == targetRelease
-      else if builtins.head rList == currentRelease then acc
+      else if builtins.head rList == currentRelease then acc  # exit condition 2
       else _releaseRecurser (builtins.tail rList) acc;
     in _releaseRecurser (lib.reverseList releaseOrder) false;
 

--- a/nixos/lib/ceph-common.nix
+++ b/nixos/lib/ceph-common.nix
@@ -41,7 +41,7 @@ let
       # both the C lib and the python modules
       libceph = pkgs.ceph-nautilus.libceph;
       fcQemu = pkgs.fc.qemu-py3.override {
-        inherit libceph;
+        inherit libceph ceph;
         qemu_ceph = qemu_ceph_versioned "nautilus";
       };
       utilPhysical = pkgs.fc.util-physical.nautilus.override {ceph = ceph-client;};

--- a/nixos/lib/ceph-common.nix
+++ b/nixos/lib/ceph-common.nix
@@ -11,52 +11,51 @@ let
   defaultRelease = "luminous";
 
   # ====== mapping of packages per ceph release =======
-  # FIXME: possible change structure from <package>.<cephRelease> to <ceph
 
   releasePkgs = {
-    "jewel" = pkgs.ceph-jewel;
-    "luminous" = pkgs.ceph-luminous;
-    "nautilus" = pkgs.ceph-nautilus.ceph;
-  };
-  # temporary map until all actively used ceph releases are packaged in form of the new
-  # schema with subpackages
-  clientPkgs = {
-    "jewel" = pkgs.ceph-jewel;
-    "luminous" = pkgs.ceph-luminous;
-    "nautilus" = pkgs.ceph-nautilus.ceph-client;
+    "jewel" = rec {
+      ceph = pkgs.ceph-jewel;
+      # temporary mapping until all actively used ceph releases are packaged in form of
+      # the new schema with subpackages
+      ceph-client = pkgs.ceph-jewel;
+      libceph = pkgs.ceph-jewel;
+      fcQemu = pkgs.fc.qemu-py2.override {
+        ceph = libceph;
+        qemu_ceph = qemu_ceph_versioned "jewel";
+      };
+      utilPhysical = pkgs.fc.util-physical.jewel.override {ceph = ceph-client;};
+    };
+    "luminous" = rec {
+      ceph = pkgs.ceph-luminous;
+      ceph-client = pkgs.ceph-luminous;
+      libceph = pkgs.ceph-luminous;
+      fcQemu = pkgs.fc.qemu-py2.override {
+        ceph = libceph;
+        qemu_ceph = qemu_ceph_versioned "luminous";
+      };
+      utilPhysical = pkgs.fc.util-physical.luminous.override {ceph = ceph-client;};
+    };
+    "nautilus" = rec {
+      ceph = pkgs.ceph-nautilus.ceph;
+      ceph-client = pkgs.ceph-nautilus.ceph-client;
+      # both the C lib and the python modules
+      libceph = pkgs.ceph-nautilus.libceph;
+      fcQemu = pkgs.fc.qemu-py3.override {
+        inherit libceph;
+        qemu_ceph = qemu_ceph_versioned "nautilus";
+      };
+      utilPhysical = pkgs.fc.util-physical.nautilus.override {ceph = ceph-client;};
+    };
   };
   qemu_ceph_versioned = cephReleaseName: (pkgs.qemu_ceph.override {
-     ceph = releasePkgs.${cephReleaseName};
+     # Needs full ceph package, because
+     #`libceph` is missing the dev output headers
+     ceph = releasePkgs.${cephReleaseName}.ceph;
      });
-  # both the C liab and the python modules
-  libcephPkgs = {
-    "jewel" = pkgs.ceph-jewel;
-    "luminous" = pkgs.ceph-luminous;
-    "nautilus" = pkgs.ceph-nautilus.libceph;
-  };
-  fcQemuPkgs = {
-    jewel = pkgs.fc.qemu-py2.override {
-      ceph = libcephPkgs.jewel;
-      qemu_ceph = qemu_ceph_versioned "jewel";
-    };
-    luminous = pkgs.fc.qemu-py2.override {
-      ceph = libcephPkgs.luminous;
-      qemu_ceph = qemu_ceph_versioned "luminous";
-    };
-    nautilus = pkgs.fc.qemu-py3.override {
-      libceph = libcephPkgs.nautilus;
-      qemu_ceph = qemu_ceph_versioned "nautilus";
-    };
-  };
-  utilPhysicalPkgs = {
-    "jewel" = pkgs.fc.util-physical.jewel.override {ceph = clientPkgs.jewel;};
-    "luminous" = pkgs.fc.util-physical.luminous.override {ceph = clientPkgs.luminous;};
-    "nautilus" = pkgs.fc.util-physical.nautilus.override {ceph = clientPkgs.nautilus;};
-  };
 in
 rec {
   # constants
-  inherit releasePkgs clientPkgs fcQemuPkgs libcephPkgs utilPhysicalPkgs defaultRelease qemu_ceph_versioned;
+  inherit releasePkgs defaultRelease qemu_ceph_versioned;
   releaseOption = lib.mkOption {
     type = cephReleaseType;
     # centrally manage the default release for all roles here
@@ -102,7 +101,7 @@ rec {
     pkgs.systemd
     pkgs.gptfdisk
     pkgs.coreutils
-    utilPhysicalPkgs.${cephPkg.codename} # required for rbd-locktool
+    releasePkgs.${cephPkg.codename}.utilPhysical # required for rbd-locktool
     pkgs.lz4  # required by image loading task
     ];
 

--- a/nixos/lib/ceph-common.nix
+++ b/nixos/lib/ceph-common.nix
@@ -8,7 +8,7 @@ let
   # generated from this ist
   releaseOrder = [ "nautilus" "luminous" "jewel"];
   cephReleaseType = types.enum (builtins.attrNames releasePkgs);
-  defaultRelease = "luminous";
+  defaultRelease = "nautilus";
 
   # ====== mapping of packages per ceph release =======
 

--- a/nixos/roles/backyserver.nix
+++ b/nixos/roles/backyserver.nix
@@ -23,7 +23,7 @@ let
   restoreSingleFiles = pkgs.callPackage ../../pkgs/restore-single-files {};
 
   backyRbdVersioned = cephReleaseName: {
-    BACKY_RBD = "${fclib.ceph.releasePkgs.${cephReleaseName}}/bin/rbd";
+    BACKY_RBD = "${fclib.ceph.releasePkgs.${cephReleaseName}.ceph-client}/bin/rbd";
   };
 
 in

--- a/nixos/roles/ceph/mon.nix
+++ b/nixos/roles/ceph/mon.nix
@@ -13,7 +13,7 @@ let
   first_mon = if mons == [ ] then "" else head (lib.splitString "." (head mons));
 
   fc-check-ceph-withVersion = pkgs.fc.check-ceph.${role.cephRelease};
-  fc-ceph = pkgs.fc.cephWith fclib.ceph.releasePkgs.${role.cephRelease};
+  fc-ceph = pkgs.fc.cephWith fclib.ceph.releasePkgs.${role.cephRelease}.ceph;
 
   # FIXME: expose this as a config option (overridable)
   # modules to be explicitly activated via this config
@@ -106,7 +106,7 @@ in
         fc-ceph.settings = let
           monSettings =  {
             release = role.cephRelease;
-            path = fclib.ceph.fc-ceph-path fclib.ceph.releasePkgs.${role.cephRelease};
+            path = fclib.ceph.fc-ceph-path fclib.ceph.releasePkgs.${role.cephRelease}.ceph;
           };
         in {
           # fc-ceph monitor components
@@ -133,7 +133,7 @@ in
 
         restartTriggers = [
           config.environment.etc."ceph/ceph.conf".source
-          fclib.ceph.releasePkgs.${role.cephRelease}
+          fclib.ceph.releasePkgs.${role.cephRelease}.ceph
         ];
 
         environment = {
@@ -242,7 +242,7 @@ in
 
         restartTriggers = [
           config.environment.etc."ceph/ceph.conf".source
-          fclib.ceph.releasePkgs.${role.cephRelease}
+          fclib.ceph.releasePkgs.${role.cephRelease}.ceph
         ];
 
         environment = {
@@ -263,15 +263,15 @@ in
           lib.optionalString (role.cephRelease == "luminous") ''
             echo "ensure mgr dashboard binds to localhost only"
             # make _all_ hosts bind the dashboard to localhost (v4) only (default port: 7000)
-            ${fclib.ceph.releasePkgs.${role.cephRelease}}/bin/ceph config-key set mgr/dashboard/server_addr 127.0.0.1
+            ${fclib.ceph.releasePkgs.${role.cephRelease}.ceph}/bin/ceph config-key set mgr/dashboard/server_addr 127.0.0.1
           ''
           # imperatively ensure mgr modules
           + lib.concatStringsSep "\n" (
-              lib.forEach mgrEnabledModules.${role.cephRelease} (mod: "${fclib.ceph.releasePkgs.${role.cephRelease}}/bin/ceph mgr module enable ${mod} --force")
+              lib.forEach mgrEnabledModules.${role.cephRelease} (mod: "${fclib.ceph.releasePkgs.${role.cephRelease}.ceph}/bin/ceph mgr module enable ${mod} --force")
             )
           + "\n"
           + lib.concatStringsSep "\n" (
-              lib.forEach mgrDisabledModules.${role.cephRelease} (mod: "${fclib.ceph.releasePkgs.${role.cephRelease}}/bin/ceph mgr module disable ${mod}")
+              lib.forEach mgrDisabledModules.${role.cephRelease} (mod: "${fclib.ceph.releasePkgs.${role.cephRelease}.ceph}/bin/ceph mgr module disable ${mod}")
             )
           ;
 

--- a/nixos/roles/ceph/osd.nix
+++ b/nixos/roles/ceph/osd.nix
@@ -21,6 +21,12 @@ let
     # (auto detected) device classes for now.
     osdCrushUpdateOnStart = false;
 
+    # automatically repairing PGs at scrub mismatches is reliable due to Bluestore
+    # internal checksumming
+    osdScrubAutoRepair = true;
+    # we use the default value of max. number of automatically corrected errors
+    # "osd_scrub_auto_repair_num_errors": "5",
+
     # Various
 
     msDispatchThrottleBytes = 1048576000;

--- a/nixos/roles/ceph/osd.nix
+++ b/nixos/roles/ceph/osd.nix
@@ -8,7 +8,7 @@ let
   enc = config.flyingcircus.enc;
   inherit (fclib.ceph) expandCamelCaseAttrs expandCamelCaseSection;
 
-  fc-ceph = pkgs.fc.cephWith fclib.ceph.releasePkgs.${role.cephRelease};
+  fc-ceph = pkgs.fc.cephWith fclib.ceph.releasePkgs.${role.cephRelease}.ceph;
 
   defaultOsdSettings = {
     # Assist speedy but balanced recovery
@@ -164,7 +164,7 @@ in
         fc-ceph.settings = let
           osdSettings =  {
             release = role.cephRelease;
-            path = fclib.ceph.fc-ceph-path fclib.ceph.releasePkgs.${role.cephRelease};
+            path = fclib.ceph.fc-ceph-path fclib.ceph.releasePkgs.${role.cephRelease}.ceph;
           };
         in {
           # fc-ceph OSD

--- a/nixos/roles/ceph/rgw.nix
+++ b/nixos/roles/ceph/rgw.nix
@@ -22,6 +22,7 @@ let
     adminSocket = "/run/ceph/radosgw.asok";
     rgwData = "/srv/ceph/radosgw/ceph-$id";
     rgwEnableOpsLog = false;
+    rgwMimeTypesFile = "${pkgs.mime-types}/etc/mime.types";
     # FIXME: use different frontend in Nautilus
     rgwFrontends = "civetweb port=80";
     debugRgw = "0 5";

--- a/nixos/roles/ceph/rgw.nix
+++ b/nixos/roles/ceph/rgw.nix
@@ -108,7 +108,7 @@ in
         serviceConfig = {
           Type = "simple";
           Restart = "always";
-          ExecStart = "${fclib.ceph.releasePkgs.${role.cephRelease}}/bin/radosgw -n ${username} -f -c /etc/ceph/ceph.conf";
+          ExecStart = "${fclib.ceph.releasePkgs.${role.cephRelease}.ceph}/bin/radosgw -n ${username} -f -c /etc/ceph/ceph.conf";
         };
       };
 
@@ -149,7 +149,7 @@ in
       systemd.services.fc-ceph-rgw-update-stats = {
         description = "Update RGW stats";
         serviceConfig.Type = "oneshot";
-        path = [ fclib.ceph.releasePkgs.${role.cephRelease} pkgs.jq ];
+        path = [ fclib.ceph.releasePkgs.${role.cephRelease}.ceph pkgs.jq ];
         script = ''
           for uid in $(radosgw-admin metadata list user | jq -r '.[]'); do
             echo $uid

--- a/nixos/roles/ceph/rgw.nix
+++ b/nixos/roles/ceph/rgw.nix
@@ -6,7 +6,7 @@ let
   fclib = config.fclib;
   role = config.flyingcircus.roles.ceph_rgw;
   enc = config.flyingcircus.enc;
-  inherit (fclib.ceph) expandCamelCaseAttrs expandCamelCaseSection;
+  inherit (fclib.ceph) expandCamelCaseAttrs expandCamelCaseSection releaseAtLeast;
 
   username = "client.radosgw.${config.networking.hostName}";
 
@@ -23,12 +23,16 @@ let
     rgwData = "/srv/ceph/radosgw/ceph-$id";
     rgwEnableOpsLog = false;
     rgwMimeTypesFile = "${pkgs.mime-types}/etc/mime.types";
-    # FIXME: use different frontend in Nautilus
-    rgwFrontends = "civetweb port=80";
     debugRgw = "0 5";
-    debugCivetweb = "1 5";
     debugRados = "1 5";
-  };
+  } // (if releaseAtLeast "nautilus" role.cephRelease
+    then {
+      rgwFrontends = "beast port=80";
+      debugBeast = "1 5";
+    } else {
+      rgwFrontends = "civetweb port=80";
+      debugCivetweb = "1 5";
+    });
 in
 {
   options = {

--- a/nixos/roles/kvm.nix
+++ b/nixos/roles/kvm.nix
@@ -32,7 +32,7 @@ in
 
           Can be replaced for development and testing purposes.
         '';
-        default = fclib.ceph.fcQemuPkgs.${role.cephRelease};
+        default = fclib.ceph.releasePkgs.${role.cephRelease}.fcQemu;
         defaultText = literalExpression "pkgs.fc.qemu [parameterised with cephRelease]";
       };
       cephRelease = fclib.ceph.releaseOption // {
@@ -50,7 +50,7 @@ in
 
     # toolpath for agent (fc-create-vm)
     flyingcircus.agent.extraSettings.Node.path = lib.makeBinPath [
-      fclib.ceph.releasePkgs.${role.cephRelease}
+      fclib.ceph.releasePkgs.${role.cephRelease}.ceph-client
       pkgs.util-linux
       pkgs.e2fsprogs
     ];

--- a/nixos/services/ceph/client.nix
+++ b/nixos/services/ceph/client.nix
@@ -135,7 +135,7 @@ in
           description = "Main ceph package to be used on the system and to be put into PATH. "
             + "The package set must belong to the release series defined in the `cephRelease` option. "
             + "Only modify if really necessary, otherwise the default ceph package from the defined series is used.";
-          default =  fclib.ceph.clientPkgs.${cfg.client.cephRelease};
+          default =  fclib.ceph.releasePkgs.${cfg.client.cephRelease}.ceph-client;
         };
 
         # legacy config for pre-Nautilus hosts (and migration to it), default value will

--- a/nixos/services/ceph/client.nix
+++ b/nixos/services/ceph/client.nix
@@ -88,9 +88,8 @@ in
           Extra config in the [global] section.
         '';
       };
-      # FIXME: ensure override priority, documentation
       extraSettings = lib.mkOption {
-        # FIXME: explicitly factoring out certain config options, like done in the
+        # TODO: explicitly factoring out certain config options, like done in the
         # nixpkgs upstream ceph module, might allow for better type checking
         type = with lib.types; attrsOf (oneOf [ str int float bool ]);
         default = {};   # defaults are provided in the config section with a lower priority
@@ -149,8 +148,6 @@ in
           '';
         };
         extraSettings = lib.mkOption {
-          # FIXME: explicitly factoring out certain config options, like done in the
-          # nixpkgs upstream ceph module, might allow for better type checking
           type = with lib.types; attrsOf (oneOf [ str int float bool ]);
           default = {};   # defaults are provided in the config section with a lower priority
           description = ''

--- a/nixos/services/ceph/client.nix
+++ b/nixos/services/ceph/client.nix
@@ -193,11 +193,7 @@ in
 
     services.udev.extraRules =
       if fclib.ceph.releaseAtLeast "nautilus" cfg.client.cephRelease
-      then
-      ''
-        KERNEL=="rbd[0-9]*", ENV{DEVTYPE}=="disk", PROGRAM="${cfg.client.package}/bin/ceph-rbdnamer %k", SYMLINK+="rbd/%c"
-        KERNEL=="rbd[0-9]*", ENV{DEVTYPE}=="partition", PROGRAM="${cfg.client.package}/bin/ceph-rbdnamer %k", SYMLINK+="rbd/%c-part%n"
-      ''
+      then builtins.readFile "${cfg.client.package}/etc/udev/50-rbd.rules"
       else
       ''
         KERNEL=="rbd[0-9]*", ENV{DEVTYPE}=="disk", PROGRAM="${cfg.client.package}/bin/ceph-rbdnamer %k", SYMLINK+="rbd/%c{1}/%c{2}"

--- a/nixos/services/ceph/client.nix
+++ b/nixos/services/ceph/client.nix
@@ -47,7 +47,7 @@ let
 
     monData = "/srv/ceph/mon/$cluster-$id";
     monOsdAllowPrimaryAffinity = true;
-    monPgWarnMaxObjectSkew = 20;
+    monPgWarnMaxObjectSkew = 30;
 
     mgrData = "/srv/ceph/mgr/$cluster-$id";
   } // lib.optionalAttrs (cfg.cluster_network != null) { clusterNetwork = cfg.cluster_network;}

--- a/nixos/services/ceph/server.nix
+++ b/nixos/services/ceph/server.nix
@@ -31,7 +31,7 @@ in
         description = "Main ceph package to be used on the system and to be put into PATH. "
           + "The package set must belong to the release series defined in the `cephRelease` option. "
           + "Only modify if really necessary, otherwise the default ceph package from the defined series is used.";
-        default = fclib.ceph.releasePkgs.${cfg.cephRelease};
+        default = fclib.ceph.releasePkgs.${cfg.cephRelease}.ceph;
       };
     };
   };

--- a/pkgs/ceph/nautilus/default.nix
+++ b/pkgs/ceph/nautilus/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, runCommand, fetchurl
+{ stdenv, runCommand, fetchzip
 , lib, ensureNewerSourcesHook
 , cmake, pkgconfig
 , which, git
@@ -98,15 +98,15 @@ let
 
   version = "14.2.22";
   codename = "nautilus";
+
+  src = fetchzip {
+    url = "http://download.ceph.com/tarballs/ceph-${version}.tar.gz";
+    sha256 = "sha256-L/SnaAZHURiynJILBW+c9FMyV3IMG36CmZ9x6Psd3hQ";
+  };
 in rec {
   ceph = stdenv.mkDerivation {
     pname = "ceph";
-    inherit version;
-
-    src = fetchurl {
-      url = "http://download.ceph.com/tarballs/ceph-${version}.tar.gz";
-      sha256 = "sha256-KfBpdLSFIe4f7UbsHfOs6eAxjahOB44xORdNGh2JTQ4";
-    };
+    inherit version src;
 
     patches = [
       ./0000-fix-SPDK-build-env.patch
@@ -219,7 +219,10 @@ in rec {
       substituteInPlace $out/bin/ceph          --replace ${ceph} $out
       substituteInPlace $out/bin/.ceph-wrapped --replace ${ceph} $out
 
-      mkdir -p $man/
-      cp -r ${ceph.man}/share $man/
+      mkdir -p "$man/"
+      cp -r "${ceph.man}/share" "$man/"
+
+      cp -r "${src}/udev" "$out/etc/"
+      substituteInPlace $out/etc/udev/* --replace "/usr/bin/" "$out/bin/"
    '';
 }

--- a/pkgs/fc/ceph/src/fc/ceph/maintenance/nautilus.py
+++ b/pkgs/fc/ceph/src/fc/ceph/maintenance/nautilus.py
@@ -117,6 +117,7 @@ class MaintenanceTasks(object):
         "PG_NOT_DEEP_SCRUBBED",
         "PG_NOT_SCRUBBED",
         "LARGE_OMAP_OBJECTS",
+        "MANY_OBJECTS_PER_PG",
     ]
 
     LOCKTOOL_TIMEOUT_SECS = 30

--- a/pkgs/fc/ceph/src/fc/ceph/osd/nautilus.py
+++ b/pkgs/fc/ceph/src/fc/ceph/osd/nautilus.py
@@ -77,6 +77,17 @@ class OSDManager(object):
         assert journal in ["internal", "external"]
         assert os.path.exists(device)
 
+        # FIXME: I also thought of requiring a `--legacy` confirmation flag for
+        # operations involving filestore. But I guess a warn message is sufficient, as
+        # this is a task only done manually where operators (hopefully) read logs.
+        print(
+            "WARN: From Ceph Luminous on, we are deprecating the platform support "
+            "for running FileStore OSDs.\n"
+            "We may enable features not playing well with FileStore, among them:\n"
+            "  - osd_scrub_auto_repair, this might spread data corruption in FileStore",
+            end="\n\n",
+        )
+
         print("Creating OSD ...")
 
         id_ = int(run.json.ceph("osd", "create")["osdid"])

--- a/pkgs/fc/ceph/src/fc/ceph/osd/nautilus.py
+++ b/pkgs/fc/ceph/src/fc/ceph/osd/nautilus.py
@@ -31,9 +31,6 @@ def wait_for_clean_cluster():
 
         stopper_check_names = ["PG_AVAILABILITY", "PG_DEGRADED", "SLOW_OPS"]
 
-        # FIXME: The previous code explicitly checked for the 3 conditions
-        # peering, down, and blocked.
-        # Are all of these cases covered again?
         if not any(
             map(
                 lambda checkn: _eval_health_check(status, checkn),
@@ -295,10 +292,6 @@ class GenericOSD(object):
             - crush_location: string describing the crush location as taken by
               `ceph osd crush`
             - journal_size: string of numeric size and a unit suffix"""
-        # FIXME: Other generic operations are implemented in a bottom-up approach, this
-        # is the only operation so far using a top-down approach with hooks.
-        # Sticking to a bottom-up approach would've made the whole call flow too fractal
-        # and split up.
 
         # 1. prepare physical volumes and mountpoints
         if not os.path.exists(self.datadir):
@@ -684,14 +677,13 @@ class FileStoreOSD(GenericOSD):
 
         oldosd_properties = self._collect_rebuild_information()
 
-        # FIXME: If the existing filestore OSD was created with a non-default journal
+        # NOTE: If the existing filestore OSD was created with a non-default journal
         # size, this is not discovered and re-used. For now, non-default journal sizes
         # always need to be specified explicitly.
         # As the jewel code did not read existing journal size,
         # I'll keep it as is for now.
 
         # this is filestore/ bluestore specific
-        # FIXME: test both internal as well as external journal osd creation
         # Is the journal internal or external?
         lvs = run.json.lvs("-S", f"vg_name={self.lvm_vg}")
         if len(lvs) == 1:

--- a/pkgs/fc/ceph/src/fc/ceph/tests/conftest.py
+++ b/pkgs/fc/ceph/src/fc/ceph/tests/conftest.py
@@ -1,0 +1,14 @@
+import fc.ceph.maintenance as maintSub
+import pytest
+
+
+@pytest.fixture(params=[maintSub.jewel, maintSub.luminous, maintSub.nautilus])
+def maintenance_manager_legacy(request):
+    """returns a maintenance manager for all Ceph releases supported by fc-ceph"""
+    return request.param
+
+
+@pytest.fixture
+def maintenance_manager():
+    """returns a maintenance manager just for the latest Ceph release supported by fc-ceph"""
+    return maintSub.nautilus

--- a/pkgs/fc/ceph/src/fc/ceph/tests/test_ceph.py
+++ b/pkgs/fc/ceph/src/fc/ceph/tests/test_ceph.py
@@ -60,9 +60,8 @@ def pools(cluster, monkeypatch):
     return fc.ceph.api.pools.Pools(cluster)
 
 
-def test_node_deletion(fake_directory, cluster, pools):
-    # FIXME: test all release-dependent submodules, e.g. with pytest.parametrize
-    v = fc.ceph.maintenance.nautilus.VolumeDeletions(fake_directory, cluster)
+def test_node_deletion(fake_directory, cluster, pools, maintenance_manager):
+    v = maintenance_manager.VolumeDeletions(fake_directory, cluster)
     v.ensure()
 
     assert cluster.rbd.call_args_list == [

--- a/pkgs/fc/ceph/src/fc/ceph/tests/test_maintenance.py
+++ b/pkgs/fc/ceph/src/fc/ceph/tests/test_maintenance.py
@@ -32,9 +32,10 @@ def ceph_json_calls(monkeypatch):
     return ceph_json_calls
 
 
-# FIXME: so far only testing nautilus behaviour
-def test_successful_maintenance_cycle(ceph_json_calls, locktoolcalls):
-    maintenance_task = fc.ceph.maintenance.nautilus.MaintenanceTasks()
+def test_successful_maintenance_cycle(
+    ceph_json_calls, locktoolcalls, maintenance_manager
+):
+    maintenance_task = maintenance_manager.MaintenanceTasks()
 
     locktoolcalls.side_effect = [
         # enter
@@ -59,8 +60,10 @@ def test_successful_maintenance_cycle(ceph_json_calls, locktoolcalls):
     assert locktoolcalls.call_count == 4
 
 
-def test_maintenance_enter_lock_timeout_causes_leave(rbdcalls, locktoolcalls):
-    maintenance_task = fc.ceph.maintenance.nautilus.MaintenanceTasks()
+def test_maintenance_enter_lock_timeout_causes_leave(
+    rbdcalls, locktoolcalls, maintenance_manager
+):
+    maintenance_task = maintenance_manager.MaintenanceTasks()
 
     locktoolcalls.side_effect = [
         # enter
@@ -88,8 +91,10 @@ def test_maintenance_enter_lock_timeout_causes_leave(rbdcalls, locktoolcalls):
     )
 
 
-def test_lockimage_created(locktoolcalls, rbdcalls, ceph_json_calls):
-    maintenance_task = fc.ceph.maintenance.nautilus.MaintenanceTasks()
+def test_lockimage_created(
+    locktoolcalls, rbdcalls, ceph_json_calls, maintenance_manager
+):
+    maintenance_task = maintenance_manager.MaintenanceTasks()
 
     for opname in ["enter", "leave"]:
         locktoolcalls.side_effect = [
@@ -111,8 +116,8 @@ def test_lockimage_created(locktoolcalls, rbdcalls, ceph_json_calls):
         )
 
 
-def test_tempfail_when_another_lockholder(locktoolcalls):
-    maintenance_task = fc.ceph.maintenance.nautilus.MaintenanceTasks()
+def test_tempfail_when_another_lockholder(locktoolcalls, maintenance_manager):
+    maintenance_task = maintenance_manager.MaintenanceTasks()
 
     locktoolcalls.side_effect = [
         # enter
@@ -139,8 +144,10 @@ def test_tempfail_when_another_lockholder(locktoolcalls):
     )
 
 
-def test_postpone_and_leave_when_unclean(locktoolcalls, ceph_json_calls):
-    maintenance_task = fc.ceph.maintenance.nautilus.MaintenanceTasks()
+def test_postpone_and_leave_when_unclean(
+    locktoolcalls, ceph_json_calls, maintenance_manager
+):
+    maintenance_task = maintenance_manager.MaintenanceTasks()
 
     locktoolcalls.side_effect = [
         # enter
@@ -172,8 +179,10 @@ def test_postpone_and_leave_when_unclean(locktoolcalls, ceph_json_calls):
     )
 
 
-def test_leave_unlock_timeout_retries(locktoolcalls, nosleep):
-    maintenance_task = fc.ceph.maintenance.nautilus.MaintenanceTasks()
+def test_leave_unlock_timeout_retries(
+    locktoolcalls, nosleep, maintenance_manager
+):
+    maintenance_task = maintenance_manager.MaintenanceTasks()
 
     locktoolcalls.side_effect = 4 * [
         # "-q", "-i", "rbd/.maintenance"
@@ -200,8 +209,10 @@ def test_leave_unlock_timeout_retries(locktoolcalls, nosleep):
     assert locktoolcalls.call_count == 10
 
 
-def test_leave_unlock_timeout_retries_exceeded(locktoolcalls, nosleep):
-    maintenance_task = fc.ceph.maintenance.nautilus.MaintenanceTasks()
+def test_leave_unlock_timeout_retries_exceeded(
+    locktoolcalls, nosleep, maintenance_manager
+):
+    maintenance_task = maintenance_manager.MaintenanceTasks()
 
     locktoolcalls.side_effect = 5 * [
         # "-q", "-i", "rbd/.maintenance"
@@ -223,8 +234,8 @@ def test_leave_unlock_timeout_retries_exceeded(locktoolcalls, nosleep):
     assert locktoolcalls.call_count == 10
 
 
-def test_lockimage_check_timeout(locktoolcalls):
-    maintenance_task = fc.ceph.maintenance.nautilus.MaintenanceTasks()
+def test_lockimage_check_timeout(locktoolcalls, maintenance_manager):
+    maintenance_task = maintenance_manager.MaintenanceTasks()
 
     locktoolcalls.side_effect = [
         # enter
@@ -252,8 +263,9 @@ def test_lockimage_check_timeout(locktoolcalls):
     assert locktoolcalls.call_count == 3
 
 
-def test_check_cluster_maintenance():
-    maintenance_task = fc.ceph.maintenance.nautilus.MaintenanceTasks()
+def test_check_cluster_maintenance(maintenance_manager):
+
+    maintenance_task = maintenance_manager.MaintenanceTasks()
 
     assert maintenance_task.check_cluster_maintenance(
         {

--- a/pkgs/fc/ceph/src/fc/ceph/tests/test_maintenance.py
+++ b/pkgs/fc/ceph/src/fc/ceph/tests/test_maintenance.py
@@ -281,6 +281,7 @@ def test_check_cluster_maintenance(maintenance_manager):
                 "PG_NOT_DEEP_SCRUBBED": "foo",
                 "PG_NOT_SCRUBBED": "bar",
                 "LARGE_OMAP_OBJECTS": "baz",
+                "MANY_OBJECTS_PER_PG": "baozi",
             },
         }
     )

--- a/pkgs/fc/default.nix
+++ b/pkgs/fc/default.nix
@@ -61,9 +61,6 @@ rec {
       rev = version;
       hash = "sha256-eTJxhdSelMJ8UFE8mtgntFVgY/+Ne2K4niH5X9JP9Tc=";
     };
-    # TODO: once `ceph` in our overlay points to a release with Python3 support
-    # (>= Nautilus), use that alias instead
-    inherit (pkgs.ceph-nautilus) ceph libceph;
   };
 
   secure-erase = callPackage ./secure-erase {};

--- a/pkgs/fc/default.nix
+++ b/pkgs/fc/default.nix
@@ -61,7 +61,9 @@ rec {
       rev = version;
       hash = "sha256-eTJxhdSelMJ8UFE8mtgntFVgY/+Ne2K4niH5X9JP9Tc=";
     };
-    libceph = pkgs.ceph-nautilus.libceph;
+    # TODO: once `ceph` in our overlay points to a release with Python3 support
+    # (>= Nautilus), use that alias instead
+    inherit (pkgs.ceph-nautilus) ceph libceph;
   };
 
   secure-erase = callPackage ./secure-erase {};

--- a/pkgs/fc/qemu/py3.nix
+++ b/pkgs/fc/qemu/py3.nix
@@ -4,18 +4,6 @@ let
   # Python must be the same as the one used by Ceph
   py = python3Packages;
 
-  # FIXME: try upgrading to 21.1.0 shipped with nixpkgs-21.05
-  py_structlog = py.buildPythonPackage rec {
-    pname = "structlog";
-    version = "16.1.0";
-    src = py.fetchPypi {
-      inherit pname version;
-      sha256 = "00dywyg3bqlkrmbrfrql21hpjjjkc4zjd6xxjyxyd15brfnzlkdl";
-    };
-    propagatedBuildInputs = [ py.six ];
-    doCheck = false;
-  };
-
   # unreleased version
   py_consulate = py.buildPythonPackage rec {
     pname = "consulate";
@@ -54,7 +42,7 @@ in
       py.requests
       py.future
       py.colorama
-      py_structlog
+      py.structlog
       py_consulate
       py.psutil
       py.pyyaml

--- a/pkgs/fc/qemu/py3.nix
+++ b/pkgs/fc/qemu/py3.nix
@@ -1,4 +1,21 @@
-{ version, src, pkgs, python3Packages, lib, libceph, ceph-client, fetchFromGitHub, qemu_ceph, stdenv, gptfdisk, parted, xfsprogs, procps }:
+{
+  version,
+  src,
+  pkgs,
+  python3Packages,
+  lib,
+  libceph,
+  # as long as `qemu_ceph` pulls in the full `ceph` due to requiring ceph.dev, use that
+  # package here as well instead of ceph-client
+  ceph,
+  fetchFromGitHub,
+  qemu_ceph,
+  stdenv,
+  gptfdisk,
+  parted,
+  xfsprogs,
+  procps
+}:
 
 let
   # Python must be the same as the one used by Ceph
@@ -55,6 +72,6 @@ in
       xfsprogs
       # XXX is in PATH anyways due to services.ceph.client, but specified here for
       # completeness sake. If necessary, fc.qemu needs to be parameterised via /etc/ceph/fc-ceph.conf
-      ceph-client
+      ceph
     ];
   }

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -37,7 +37,8 @@ in {
   check_md_raid = super.callPackage ./check_md_raid { };
   check_megaraid = super.callPackage ./check_megaraid { };
 
-  ceph = self.ceph-luminous;
+  # default ceph packages
+  inherit (self.ceph-nautilus) ceph ceph-client libceph;
   ceph-jewel = (super.callPackage ./ceph/jewel {
       pythonPackages = super.python2Packages;
       boost = super.boost155;

--- a/tests/ceph-luminous.nix
+++ b/tests/ceph-luminous.nix
@@ -257,7 +257,6 @@ in
       result = host1.succeed("radosgw-admin metadata list user")
       assert '"user"' in result
       # New pools = more PGs
-      # FIXME: radosgw creates fewer additional pools than it did in jewel. Is this normal?
       show(host2, 'ceph osd lspools')
       assert_clean_cluster(host2, 3, 3, 3, 320)
 

--- a/tests/ceph-nautilus.nix
+++ b/tests/ceph-nautilus.nix
@@ -272,7 +272,6 @@ in
       result = host1.succeed("radosgw-admin metadata list user")
       assert '"user"' in result
       # New pools = more PGs
-      # FIXME: radosgw creates fewer additional pools than it did in jewel. Is this normal?
       show(host2, 'ceph osd lspools')
       assert_clean_cluster(host2, 3, 3, 3, 320)
 

--- a/tests/ceph-nautilus.nix
+++ b/tests/ceph-nautilus.nix
@@ -357,6 +357,8 @@ in
       host1.succeed('fc-ceph osd create-bluestore /dev/vdc > /dev/kmsg 2>&1')
       assert_clean_cluster(host2, 3, 3, 3, 320)
 
+    # TODO: include test for rbd map rbdnamer udev rule functionality, after having rebased onto PL-130691
+
     print("Time spent waiting", time_waiting)
   '';
 })

--- a/tests/kvm_host_ceph-jewel.nix
+++ b/tests/kvm_host_ceph-jewel.nix
@@ -12,12 +12,10 @@ let
           version = "dev";
           # builtins.toPath (testPath + "/.")
           src = ../../fc.qemu/.;
-          ceph = config.fclib.ceph.releasePkgs.jewel;
-          qemu_ceph = pkgs.qemu_ceph.override {
-            ceph = config.fclib.ceph.releasePkgs.jewel;
-          };
+          ceph = config.fclib.ceph.releasePkgs.jewel.libceph;
+          qemu_ceph = config.fclib.ceph.qemu_ceph_versioned "jewel";
         }
-        else config.fclib.ceph.fcQemuPkgs.jewel;
+        else config.fclib.ceph.releasePkgs.jewel.fcQemu;
     in
     {
 
@@ -106,7 +104,7 @@ let
 
             # This should be included through the propagatedBuildInputs
             # from fc.qemu already but apparently it isn't.
-            (pyPkgs.toPythonModule config.fclib.ceph.libcephPkgs.jewel)
+            (pyPkgs.toPythonModule config.fclib.ceph.releasePkgs.jewel.libceph)
 
             # Additional packages to run the tests
             pyPkgs.pytest

--- a/tests/kvm_host_ceph-luminous.nix
+++ b/tests/kvm_host_ceph-luminous.nix
@@ -12,12 +12,10 @@ let
           version = "dev";
           # builtins.toPath (testPath + "/.")
           src = ../../fc.qemu/.;
-          ceph = config.fclib.ceph.releasePkgs.${clientCephRelease};
-          qemu_ceph = pkgs.qemu_ceph.override {
-            ceph = config.fclib.ceph.releasePkgs.${clientCephRelease};
-          };
+          ceph = config.fclib.ceph.releasePkgs.${clientCephRelease}.libceph;
+          qemu_ceph = config.fclib.ceph.qemu_ceph_versioned clientCephRelease;
         }
-        else config.fclib.ceph.fcQemuPkgs.${clientCephRelease};
+        else config.fclib.ceph.releasePkgs.${clientCephRelease}.fcQemu;
     in
     {
 
@@ -106,7 +104,7 @@ let
 
             # This should be included through the propagatedBuildInputs
             # from fc.qemu already but apparently it isn't.
-            (pyPkgs.toPythonModule config.fclib.ceph.libcephPkgs.${clientCephRelease})
+            (pyPkgs.toPythonModule config.fclib.ceph.releasePkgs.${clientCephRelease}.libceph)
 
             # Additional packages to run the tests
             pyPkgs.pytest

--- a/tests/kvm_host_ceph-nautilus.nix
+++ b/tests/kvm_host_ceph-nautilus.nix
@@ -16,12 +16,10 @@ let
             version = "dev";
             # builtins.toPath (testPath + "/.")
             src = ../../fc.qemu/.;
-            "${lib.optionalString py3 "lib"}ceph" = config.fclib.ceph.libcephPkgs.${clientCephRelease};
-            qemu_ceph = pkgs.qemu_ceph.override {
-              ceph = config.fclib.ceph.releasePkgs.${clientCephRelease};
-            };
+            "${lib.optionalString py3 "lib"}ceph" = config.fclib.ceph.releasePkgs.${clientCephRelease}.libceph;
+            qemu_ceph = config.fclib.ceph.qemu_ceph_versioned clientCephRelease;
           }
-        else config.fclib.ceph.fcQemuPkgs.${clientCephRelease};
+        else config.fclib.ceph.releasePkgs.${clientCephRelease}.fcQemu;
 
     in
     {
@@ -112,7 +110,7 @@ let
 
             # This should be included through the propagatedBuildInputs
             # from fc.qemu already but apparently it isn't.
-            (pyPkgs.toPythonModule config.fclib.ceph.libcephPkgs.${clientCephRelease})
+            (pyPkgs.toPythonModule config.fclib.ceph.releasePkgs.${clientCephRelease}.libceph)
 
             # Additional packages to run the tests
             pyPkgs.pytest


### PR DESCRIPTION
PL-131024

@flyingcircusio/release-managers

## Release process

Impact: internal only

Changelog:
- raise the platform default Ceph release to Nautilus. Jewel and Luminous remain available, but need to be explicitly specified in NixOS config
- cleanups and restructuring of Ceph-related platform code

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - [x] must not introduce new known regressions
  - [x] needs to work on real machines
  - [x] removing the pinning of a ceph release in local config results in Nautilus being used
- [x] Security requirements tested? (EVIDENCE)
  - [x] NixOS tests still pass
  - [x] tested on 1 host in the dev cluster