### PR TITLE
[21.05] linuxPackages: 5.10.159->5.10.175 including kernel IPMI patches

### DIFF
--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -258,9 +258,9 @@ in {
     argsOverride = rec {
       src = self.fetchurl {
         url = "mirror://kernel/linux/kernel/v5.x/linux-${version}.tar.xz";
-        sha256 = "sha256-G6m/V7a/NtdkR9UES4C3Rstf1h2YHIEWA9x2O3eJzqc=";
+        sha256 = "sha256-4ndWLijyNONmZa4St1hflVeoOoa8So3ohAowWvYwe84=";
       };
-      version = "5.10.159";
+      version = "5.10.175";
       modDirVersion = version;
     };
   });


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:
- machines need to schedule a reboot maintenance for activating the kernel

Changelog:
- linuxPackages: 5.10.159->5.10.175, includes a backport fix for our IPMI logging problems

## Security implications

- [ ] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - [x] backport relevant bugfixes, update used packages: linux kernel
  - [x] must not introduce new (known) regression: system still boots, tests still pass
  - [x]  verify that the bugfix backport actually fixes our IPMI issues
- [ ] Security requirements tested? (EVIDENCE)
  - [x] NixOS tests still pass
  - [x] deployed on two dev hosts (patty, kyle08), they still boot fine into the new kernel
  - [x] verified that this fixes our IPMI logging issue