### PR TITLE
Update nixpkgs

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "631c55323a67a20854056fb7e289edb7a7950e49",
-    "sha256": "LI0vaaA7Dhidyr1FMrAr8HNaBUeD1kNrCVoYguXzzGI="
+    "rev": "37fc54a5f81db6bafcc4f6b1656c586661c0800c",
+    "sha256": "sT9LcW3ZJqazxU2e+ITUhrKeIufHA6K+RK8qext3rOk="
   },
   "nixos-mailserver": {
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/",


### PR DESCRIPTION
Pull upstream NixOS changes, security fixes and package updates:

- github-runner: 2.302.1 -> 2.303.0
- imagemagick: 7.1.0-62 -> 7.1.1-2
- libX11: 1.8.3 -> 1.8.4
- linux: 5.15.97 -> 5.15.103
- matrix-synapse: 1.78.0 -> 1.79.0
- nss_latest: 3.88.1 -> 3.89
- redis: 7.0.8 -> 7.0.9 (CVE-2023-25155, CVE-2022-36021)
- sudo: 1.9.13 -> 1.9.13p3

 #PL-131361

@flyingcircusio/release-managers

## Release process

Impact:

* \[NixOS 22.11]  Redis and Matrix-Synapse will be restarted. Machines will schedule a reboot to activate the changed kernel.

Changelog: (include changes from commit msg here)

## Security implication

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - pull in upstream security fixes regularly
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still run, works on test VM
  - checked commit log for fixed CVEs and possible problems with updates, looked at [synapse/upgrade.md](https://github.com/matrix-org/synapse/blob/develop/docs/upgrade.md)