### PR TITLE
Various postgresql role improvements

### DIFF
--- a/nixos/services/postgresql.nix
+++ b/nixos/services/postgresql.nix
@@ -163,22 +163,15 @@ in {
       let
         psql = "${postgresqlPkg}/bin/psql --port=${toString upstreamCfg.port}";
       in ''
-        if ! ${psql} -c '\du' template1 | grep -q '^ *nagios *|'; then
-          ${psql} -c 'CREATE ROLE nagios NOSUPERUSER NOCREATEDB NOCREATEROLE NOINHERIT LOGIN' template1
-        fi
-        if ! ${psql} -l | grep -q '^ *nagios *|'; then
-          ${postgresqlPkg}/bin/createdb --port ${toString upstreamCfg.port} nagios
-        fi
-        ${psql} -q -d nagios -c 'REVOKE ALL ON SCHEMA public FROM PUBLIC CASCADE;'
-
         ln -sfT ${postgresqlPkg} ${upstreamCfg.dataDir}/package
         ln -sfT ${upstreamCfg.dataDir}/package /nix/var/nix/gcroots/per-user/postgres/package_${cfg.majorVersion}
       '';
 
-      systemd.services.postgresql.serviceConfig =
-        lib.optionalAttrs (lib.versionAtLeast cfg.majorVersion "12") {
-          RuntimeDirectory = "postgresql";
-        };
+      systemd.services.postgresql.serviceConfig = {
+        Restart = "always";
+      } // lib.optionalAttrs (lib.versionAtLeast cfg.majorVersion "12") {
+        RuntimeDirectory = "postgresql";
+      };
 
       users.users.postgres = {
         shell = "/run/current-system/sw/bin/bash";
@@ -273,11 +266,22 @@ in {
         logLinePrefix = "user=%u,db=%d ";
         package = postgresqlPkg;
 
+        ensureDatabases = [ "fcio_monitoring" ];
+        ensureUsers = [ {
+          name = "fcio_monitoring";
+        } ];
+
+        identMap = ''
+          # Map the sensuclient and telegraf system users to the fcio_monitoring database user.
+          monitoring sensuclient fcio_monitoring
+          monitoring telegraf fcio_monitoring
+        '';
+
         authentication = ''
-          local postgres root       trust
-          # trusted access for Nagios
-          host    nagios          nagios          0.0.0.0/0               trust
-          host    nagios          nagios          ::/0                    trust
+          # Passwordless UNIX socket access for monitoring.
+          # Used by telegraf and sensu.
+          local fcio_monitoring fcio_monitoring peer map=monitoring
+
           # authenticated access for others
           host all  all  0.0.0.0/0  md5
           host all  all  ::/0       md5
@@ -351,40 +355,40 @@ in {
           postgresqlPkg
         ];
 
-        sensu-client.checks =
-          lib.optionalAttrs (cfg.autoUpgrade.enable && cfg.autoUpgrade.checkExpectedDatabases) {
+        sensu-client.checks = {
+          postgresql-alive = {
+            notification = "PostgreSQL not reachable via UNIX socket in /run/postgresql";
+            command = ''
+              ${pkgs.sensu-plugins-postgres}/bin/check-postgres-alive.rb \
+                -u fcio_monitoring -d fcio_monitoring -h /run/postgresql -T 10
+              '';
+            interval = 30;
+          };
+        } // lib.optionalAttrs (cfg.autoUpgrade.enable && cfg.autoUpgrade.checkExpectedDatabases) {
             postgresql-autoupgrade-possible = {
               notification = "Unexpected PostgreSQL databases present, autoupgrade will fail!";
               command = "sudo -u postgres ${pkgs.fc.agent}/bin/fc-postgresql check-autoupgrade-unexpected-dbs";
               interval = 600;
             };
-          } // (lib.listToAttrs (
-          map (host:
-              let saneHost = replaceStrings [":"] ["_"] host;
-              in
-              { name = "postgresql-listen-${saneHost}-5432";
-                value = {
-                  notification = "PostgreSQL listening on ${host}:5432";
-                  command = ''
-                    ${pkgs.sensu-plugins-postgres}/bin/check-postgres-alive.rb \
-                      -h ${host} -u nagios -d nagios -P 5432 -T 10
-                  '';
-                  interval = 120;
-                };
-              })
-            listenAddresses));
+        } // (lib.listToAttrs (map (host:
+            let
+              saneHost = replaceStrings [":"] ["_"] host;
+            in
+            { name = "postgresql-listen-${saneHost}-5432";
+              value = {
+                notification = "PostgreSQL not reachable on ${host}:5432";
+                command = "${pkgs.monitoring-plugins}/bin/check_tcp -H ${host} -p 5432";
+                interval = 60;
+              };
+            })
+          listenAddresses));
 
         telegraf.inputs = {
-          postgresql = [
-            (if (lib.versionOlder cfg.majorVersion "12") then {
-              address = "host=/tmp user=root sslmode=disable dbname=postgres";
-            }
-            else {
-              address = "host=/run/postgresql user=root sslmode=disable dbname=postgres";
-              # Workaround for a telegraf bug: https://github.com/influxdata/telegraf/issues/6712
-              ignored_databases = [ "postgres" "template0" "template1" ];
-            })
-          ];
+          postgresql = [{
+            address = "host=/run/postgresql user=fcio_monitoring sslmode=disable dbname=fcio_monitoring";
+            # Workaround for a telegraf bug: https://github.com/influxdata/telegraf/issues/6712
+            ignored_databases = [ "postgres" "template0" "template1" ];
+          }];
         };
       };
 

--- a/pkgs/fc/agent/fc/util/postgresql.py
+++ b/pkgs/fc/agent/fc/util/postgresql.py
@@ -268,6 +268,7 @@ def get_existing_dbs(log, data_dir, postgres_running, expected_dbs=None):
         log.debug("get-existing-dbs", existing_dbs=existing_dbs)
     else:
         expected_existing_dbs = {
+            "fcio_monitoring",
             "nagios",
             "postgres",
             "root",


### PR DESCRIPTION
postgresql: monitoring permissions, restart=always, better test

- telegraf and Sensu now use the `fcio_monitoring` database user and database,
  which they can access using peer auth with an ident mapping from system to database users.
- set Restart=always for the postgresql service
- improve NixOS test with various permission and monitoring subtests.
- add `postgresql-alive` Sensu check which connect via the UNIX socket
- `postgresql-listen` Sensu checks now use a simple connection check with check_tcp
  to avoid setting up authentication and speed up the tests.
- more detailed documentation of our monitoring setup.

PL-131358

@flyingcircusio/release-managers

**Will be backported to all releases starting with 21.05**

## Release process

Impact:

- \[NixOS 22.11\] PostgreSQL will be restarted.

Changelog:

- postgresql: reduce permissions for monitoring, add `postgresql-alive` UNIX socket database connection check, change `postgresql-listen-*` checks to simple TCP connection checks, always restart `postgresql` service (#PL-131358).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - monitoring database user should have very restricted access, only local and from known monitoring users (telegraf, sensuclient) 
  - require password for all non-local database accesses
  -  use peer auth for local UNIX socket connections
- [x] Security requirements tested? (EVIDENCE)
  - automated test now checks various dangerous access paths using standard postgres, root and monitoring roles
  - looked at generated pg_hba.conf and tried out various access paths on a test VMs