### PR TITLE
[22.05] Various postgresql role improvements

### DIFF
--- a/pkgs/fc/agent/fc/util/postgresql.py
+++ b/pkgs/fc/agent/fc/util/postgresql.py
@@ -268,6 +268,7 @@ def get_existing_dbs(log, data_dir, postgres_running, expected_dbs=None):
         log.debug("get-existing-dbs", existing_dbs=existing_dbs)
     else:
         expected_existing_dbs = {
+            "fcio_monitoring",
             "nagios",
             "postgres",
             "root",

--- a/tests/postgresql/default.nix
+++ b/tests/postgresql/default.nix
@@ -15,6 +15,7 @@ in {
   };
 
   testScript =
+  { nodes, ... }:
     let
       insertSql = pkgs.writeText "insert.sql" ''
         CREATE TABLE employee (
@@ -41,30 +42,63 @@ in {
         if lib.versionAtLeast version "12"
         then "CREATE EXTENSION periods CASCADE"
         else "CREATE EXTENSION temporal_tables";
+
+      sensuCheck = testlib.sensuCheckCmd nodes.machine;
     in
     ''
       machine.wait_for_unit("postgresql.service")
       machine.wait_for_open_port(5432)
 
-      # simple data round trip
-      machine.succeed('sudo -u postgres -- sh ${dataTest}')
+      with subtest("simple data round trip should work"):
+        machine.succeed('sudo -u postgres -- sh ${dataTest}')
 
-      # connection tests with password
-      machine.succeed('${psql} -c "CREATE USER test; ALTER USER test WITH PASSWORD \'test\'"')
-      machine.succeed('${psql} postgresql://test:test@${ipv4}:5432/postgres -c "SELECT \'hello\'" | grep hello')
-      machine.succeed('${psql} postgresql://test:test@[${ipv6}]:5432/postgres -c "SELECT \'hello\'" | grep hello')
+      with subtest("postgres user should be able to connect via local socket"):
+        machine.succeed('${psql} -c "SELECT \'hello\'" | grep hello')
 
-      # should not trust connections via TCP
-      machine.fail('psql --no-password -h localhost -l')
+      with subtest("creating a test user with a password should work"):
+        machine.succeed('${psql} -c "CREATE USER test; ALTER USER test WITH PASSWORD \'test\'"')
 
-      # service user should be able to write to local config dir
-      machine.succeed('sudo -u postgres touch `echo /etc/local/postgresql/*`/test')
+      with subtest("test user should be able to connect via IPv4"):
+        machine.succeed('${psql} postgresql://test:test@${ipv4}:5432/postgres -c "SELECT \'hello IPv4\'" | grep IPv4')
 
-      machine.succeed('${psql} employees -c "CREATE EXTENSION pg_stat_statements;"')
-      machine.succeed('${psql} employees -c "CREATE EXTENSION rum;"')
-      machine.succeed('${psql} employees -c "${createTemporalExtension};"')
-      machine.succeed('${psql} employees -c "CREATE EXTENSION postgis;"')
+      with subtest("test user should be able to connect via IPv6"):
+        machine.succeed('${psql} postgresql://test:test@[${ipv6}]:5432/postgres -c "SELECT \'hello IPv6\'" | grep IPv6')
+
+      with subtest("should not trust connections via TCP"):
+        machine.fail('psql --no-password -h localhost -l')
+
+      with subtest("unprivileged user should not be able to access postgres DB via predefined roles"):
+        machine.fail("sudo -u nobody psql -U postgres -l")
+        machine.fail("sudo -u nobody psql -U root -l")
+        machine.fail("sudo -u nobody psql -U fcio_monitoring -l")
+        machine.fail("sudo -u nobody sudo -nu postgres psql -l")
+
+      with subtest("user telegraf should be able to connect to monitoring DB via socket"):
+        machine.succeed("sudo -u telegraf psql -U fcio_monitoring fcio_monitoring -l")
+
+      with subtest("user sensuclient should be able to connect to monitoring DB via socket"):
+        machine.succeed("sudo -u sensuclient psql -U fcio_monitoring fcio_monitoring -l")
+
+      with subtest("service user should be able to write to local config dir"):
+        machine.succeed('sudo -u postgres touch /etc/local/postgresql/${version}/test')
+
+      with subtest("creating supported extensions should work"):
+        machine.succeed('${psql} employees -c "CREATE EXTENSION pg_stat_statements;"')
+        machine.succeed('${psql} employees -c "CREATE EXTENSION rum;"')
+        machine.succeed('${psql} employees -c "${createTemporalExtension};"')
+        machine.succeed('${psql} employees -c "CREATE EXTENSION postgis;"')
+
+      with subtest("sensu check should be green"):
+        machine.succeed("sudo -u sensuclient ${sensuCheck "postgresql-alive"}")
+
+      with subtest("killing the postgres process should trigger an automatic restart"):
+        machine.succeed("systemctl kill -s KILL postgresql")
+        machine.sleep(1)
+        machine.wait_until_succeeds("sudo -u sensuclient ${sensuCheck "postgresql-alive"}")
+
+      with subtest("status check should be red after shutting down postgresql"):
+        machine.systemctl('stop postgresql')
+        machine.wait_until_fails("sudo -u sensuclient ${sensuCheck "postgresql-alive"}")
     '';
-
 
 })


### PR DESCRIPTION
Backport of #682

- telegraf and Sensu now use the `fcio_monitoring` database user and database, which they can access using peer auth with an ident mapping from system to database users.
- set Restart=always for the postgresql service
- improve NixOS test with various permission and monitoring subtests.
- add `postgresql-alive` Sensu check which connect via the UNIX socket
- `postgresql-listen` Sensu checks now use a simple connection check with check_tcp to avoid setting up authentication and speed up the tests.
- more detailed documentation of our monitoring setup.
- add a warning that postgis before 12 requires a dump/restore upgrade.

PL-131358
PL-131271


