### PR TITLE
postgresql: monitoring permissions, restart=always, better test

### DIFF
--- a/doc/src/postgresql.rst
+++ b/doc/src/postgresql.rst
@@ -35,7 +35,7 @@ Place it in :file:`/etc/local/nixos/postgresql.nix`, for example:
         log_connections = true;
         huge_pages = "try";
         max_connections = lib.mkForce 1000;
-    }
+    };
   }
 
 To override platform defaults, use :code:`lib.mkForce` before the wanted value

--- a/nixos/services/postgresql.nix
+++ b/nixos/services/postgresql.nix
@@ -82,23 +82,11 @@ in {
 
     systemd.services.postgresql.bindsTo = [ "network-addresses-${fclib.network.srv.device}.service" ];
 
-    systemd.services.postgresql.postStart =
-    let
-      psql = "${postgresqlPkg}/bin/psql --port=${toString config.services.postgresql.port}";
-    in ''
-      if ! ${psql} -c '\du' template1 | grep -q '^ *nagios *|'; then
-        ${psql} -c 'CREATE ROLE nagios NOSUPERUSER NOCREATEDB NOCREATEROLE NOINHERIT LOGIN' template1
-      fi
-      if ! ${psql} -l | grep -q '^ *nagios *|'; then
-        ${postgresqlPkg}/bin/createdb --port ${toString config.services.postgresql.port} nagios
-      fi
-      ${psql} -q -d nagios -c 'REVOKE ALL ON SCHEMA public FROM PUBLIC CASCADE;'
-    '';
-
-    systemd.services.postgresql.serviceConfig =
-      lib.optionalAttrs (lib.versionAtLeast cfg.majorVersion "12") {
-        RuntimeDirectory = "postgresql";
-      };
+    systemd.services.postgresql.serviceConfig = {
+      Restart = "always";
+    } // lib.optionalAttrs (lib.versionAtLeast cfg.majorVersion "12") {
+      RuntimeDirectory = "postgresql";
+    };
 
     users.users.postgres = {
       shell = "/run/current-system/sw/bin/bash";
@@ -159,11 +147,22 @@ in {
       logLinePrefix = "user=%u,db=%d ";
       package = postgresqlPkg;
 
+      ensureDatabases = [ "fcio_monitoring" ];
+      ensureUsers = [ {
+        name = "fcio_monitoring";
+      } ];
+
+      identMap = ''
+        # Map the sensuclient and telegraf system users to the fcio_monitoring database user.
+        monitoring sensuclient fcio_monitoring
+        monitoring telegraf fcio_monitoring
+      '';
+
       authentication = ''
-        local postgres root       trust
-        # trusted access for Nagios
-        host    nagios          nagios          0.0.0.0/0               trust
-        host    nagios          nagios          ::/0                    trust
+        # Passwordless UNIX socket access for monitoring.
+        # Used by telegraf and sensu.
+        local fcio_monitoring fcio_monitoring peer map=monitoring
+
         # authenticated access for others
         host all  all  0.0.0.0/0  md5
         host all  all  ::/0       md5
@@ -232,30 +231,35 @@ in {
 
     flyingcircus.services = {
 
-      sensu-client.checks =
-        lib.listToAttrs (
-        map (host:
-            let saneHost = replaceStrings [":"] ["_"] host;
-            in
-            { name = "postgresql-listen-${saneHost}-5432";
-              value = {
-                notification = "PostgreSQL listening on ${host}:5432";
-                command = ''
-                  ${pkgs.sensu-plugins-postgres}/bin/check-postgres-alive.rb \
-                    -h ${host} -u nagios -d nagios -P 5432
-                '';
-                interval = 120;
-              };
-            })
-          listenAddresses);
+      sensu-client.checks = {
+        postgresql-alive = {
+          notification = "PostgreSQL not reachable via UNIX socket in /run/postgresql";
+          command = ''
+            ${pkgs.sensu-plugins-postgres}/bin/check-postgres-alive.rb \
+              -u fcio_monitoring -d fcio_monitoring -h /run/postgresql -T 10
+            '';
+          interval = 30;
+        };
+      } // (lib.listToAttrs (map (host:
+          let
+            saneHost = replaceStrings [":"] ["_"] host;
+          in
+          { name = "postgresql-listen-${saneHost}-5432";
+            value = {
+              notification = "PostgreSQL not reachable on ${host}:5432";
+              command = "${pkgs.monitoring-plugins}/bin/check_tcp -H ${host} -p 5432";
+              interval = 60;
+            };
+          })
+        listenAddresses));
 
       telegraf.inputs = {
         postgresql = [
           (if (lib.versionOlder cfg.majorVersion "12") then {
-            address = "host=/tmp user=root sslmode=disable dbname=postgres";
+            address = "host=/tmp user=fcio_monitoring sslmode=disable dbname=fcio_monitoring";
           }
           else {
-            address = "host=/run/postgresql user=root sslmode=disable dbname=postgres";
+            address = "host=/run/postgresql user=fcio_monitoring sslmode=disable dbname=fcio_monitoring";
             # Workaround for a telegraf bug: https://github.com/influxdata/telegraf/issues/6712
             ignored_databases = [ "postgres" "template0" "template1" ];
           })

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -103,11 +103,11 @@ in {
   openvpn = callTest ./openvpn.nix {};
   percona80 = callTest ./mysql.nix { rolename = "percona80"; };
   physical-installer = callTest ./physical-installer.nix { inherit nixpkgs; };
-  postgresql10 = callTest ./postgresql.nix { rolename = "postgresql10"; };
-  postgresql11 = callTest ./postgresql.nix { rolename = "postgresql11"; };
-  postgresql12 = callTest ./postgresql.nix { rolename = "postgresql12"; };
-  postgresql13 = callTest ./postgresql.nix { rolename = "postgresql13"; };
-  postgresql96 = callTest ./postgresql.nix { rolename = "postgresql96"; };
+  postgresql96 = callTest ./postgresql.nix { version = "96"; };
+  postgresql10 = callTest ./postgresql.nix { version = "10"; };
+  postgresql11 = callTest ./postgresql.nix { version = "11"; };
+  postgresql12 = callTest ./postgresql.nix { version = "12"; };
+  postgresql13 = callTest ./postgresql.nix { version = "13"; };
   prometheus = callTest ./prometheus.nix {};
   rabbitmq = callTest ./rabbitmq.nix {};
   redis = callTest ./redis.nix {};

--- a/tests/postgresql.nix
+++ b/tests/postgresql.nix
@@ -1,14 +1,14 @@
-import ./make-test-python.nix ({ rolename ? "postgresql13", lib, pkgs, ... }:
+import ./make-test-python.nix ({ version ? "13", lib, testlib, pkgs, ... }:
 let
   ipv4 = "192.168.101.1";
   ipv6 = "2001:db8:f030:1c3::1";
 in {
-  name = "postgresql";
+  name = "postgresql${version}";
   machine =
     { ... }:
     {
       imports = [ ../nixos ../nixos/roles ];
-      flyingcircus.roles.${rolename}.enable = true;
+      flyingcircus.roles."postgresql${version}".enable = true;
 
       flyingcircus.enc.parameters = {
         resource_group = "test";
@@ -25,6 +25,7 @@ in {
     };
 
   testScript =
+  { nodes, ... }:
     let
       insertSql = pkgs.writeText "insert.sql" ''
         CREATE TABLE employee (
@@ -48,38 +49,73 @@ in {
       psql = "sudo -u postgres -- psql";
 
       createTemporalExtension =
-        if (rolename == "postgresql12" || rolename == "postgresql13")
+        if (version == "12" || version == "13")
         then "CREATE EXTENSION periods CASCADE"
         else "CREATE EXTENSION temporal_tables";
+
+      sensuCheck = testlib.sensuCheckCmd nodes.machine;
     in
     ''
+
       machine.wait_for_unit("postgresql.service")
       machine.wait_for_open_port(5432)
 
-      # simple data round trip
-      machine.succeed('sudo -u postgres -- sh ${dataTest}')
+      with subtest("simple data round trip should work"):
+        machine.succeed('sudo -u postgres -- sh ${dataTest}')
 
-      # connection tests with password
-      machine.succeed('${psql} -c "CREATE USER test; ALTER USER test WITH PASSWORD \'test\'"')
-      machine.succeed('${psql} postgresql://test:test@${ipv4}:5432/postgres -c "SELECT \'hello\'" | grep hello')
-      machine.succeed('${psql} postgresql://test:test@[${ipv6}]:5432/postgres -c "SELECT \'hello\'" | grep hello')
+      with subtest("postgres user should be able to connect via local socket"):
+        machine.succeed('${psql} -c "SELECT \'hello\'" | grep hello')
 
-      # should not trust connections via TCP
-      machine.fail('psql --no-password -h localhost -l')
+      with subtest("creating a test user with a password should work"):
+        machine.succeed('${psql} -c "CREATE USER test; ALTER USER test WITH PASSWORD \'test\'"')
 
-      # service user should be able to write to local config dir
-      machine.succeed('sudo -u postgres touch `echo /etc/local/postgresql/*`/test')
+      with subtest("test user should be able to connect via IPv4"):
+        machine.succeed('${psql} postgresql://test:test@${ipv4}:5432/postgres -c "SELECT \'hello IPv4\'" | grep IPv4')
 
-      machine.succeed('${psql} employees -c "CREATE EXTENSION pg_stat_statements;"')
-      machine.succeed('${psql} employees -c "CREATE EXTENSION rum;"')
-      machine.succeed('${psql} employees -c "${createTemporalExtension};"')
-    '' + lib.optionalString (rolename != "postgresql12") ''
-      # Postgis fails only on postgresql12 with an OOM that produces no other output
-      # for debugging. It's caused by the shared library for pg_stat_statements.
-      # It works on real VMs so just skip it here. Creating it in the test
-      # works on NixOS 21.11, though, we can re-enable it there.
-      machine.succeed('${psql} employees -c "CREATE EXTENSION postgis;"')
+      with subtest("test user should be able to connect via IPv6"):
+        machine.succeed('${psql} postgresql://test:test@[${ipv6}]:5432/postgres -c "SELECT \'hello IPv6\'" | grep IPv6')
+
+      with subtest("should not trust connections via TCP"):
+        machine.fail('psql --no-password -h localhost -l')
+
+      with subtest("unprivileged user should not be able to access postgres DB via predefined roles"):
+        machine.fail("sudo -u nobody psql -U postgres -l")
+        machine.fail("sudo -u nobody psql -U root -l")
+        machine.fail("sudo -u nobody psql -U fcio_monitoring -l")
+        machine.fail("sudo -u nobody sudo -nu postgres psql -l")
+
+      with subtest("user telegraf should be able to connect to monitoring DB via socket"):
+        machine.succeed("sudo -u telegraf psql -U fcio_monitoring fcio_monitoring -c 'SELECT' > /dev/null")
+
+      with subtest("user sensuclient should be able to connect to monitoring DB via socket"):
+        machine.succeed("sudo -u sensuclient psql -U fcio_monitoring fcio_monitoring -c 'SELECT' > /dev/null")
+
+      with subtest("service user should be able to write to local config dir"):
+        machine.succeed('sudo -u postgres touch `echo /etc/local/postgresql/*`/test')
+
+      with subtest("creating supported extensions should work"):
+        machine.succeed('${psql} employees -c "CREATE EXTENSION pg_stat_statements;"')
+        machine.succeed('${psql} employees -c "CREATE EXTENSION rum;"')
+        machine.succeed('${psql} employees -c "${createTemporalExtension};"')
+
+        # Postgis fails only on postgresql12 with an OOM that produces no other output
+        # for debugging. It's caused by the shared library for pg_stat_statements.
+        # It works on real VMs so just skip it here. This just happens on NixOS 21.05.
+        ${lib.optionalString (version != "12") ''
+        machine.succeed('${psql} employees -c "CREATE EXTENSION postgis;"')
+        ''}
+
+      with subtest("sensu check should be green"):
+        machine.succeed("sudo -u sensuclient ${sensuCheck "postgresql-alive"}")
+
+      with subtest("killing the postgres process should trigger an automatic restart"):
+        machine.succeed("systemctl kill -s KILL postgresql")
+        machine.sleep(1)
+        machine.wait_until_succeeds("sudo -u sensuclient ${sensuCheck "postgresql-alive"}")
+
+      with subtest("status check should be red after shutting down postgresql"):
+        machine.systemctl('stop postgresql')
+        machine.wait_until_fails("sudo -u sensuclient ${sensuCheck "postgresql-alive"}")
     '';
-
 
 })


### PR DESCRIPTION
Backport of #682 (without the doc changes)

- telegraf and Sensu now use the `fcio_monitoring` database user and database, which they can access using peer auth with an ident mapping from system to database users.
- set Restart=always for the postgresql service
- improve NixOS test with various permission and monitoring subtests.
- add `postgresql-alive` Sensu check which connect via the UNIX socket
- `postgresql-listen` Sensu checks now use a simple connection check with check_tcp to avoid setting up authentication and speed up the tests.

PL-131358

@flyingcircusio/release-managers
