### PR TITLE
antivirus: prevent role activation for machines with <3GiB RAM

### DIFF
--- a/nixos/roles/antivirus.nix
+++ b/nixos/roles/antivirus.nix
@@ -24,6 +24,11 @@ in
 
   config = lib.mkIf cfg.enable {
 
+    assertions = [{
+      assertion = config.flyingcircus.enc.parameters.memory >= 3072;
+      message = "antivirus role: ClamAV needs at least 3GiB to run stable";
+    }];
+
     # The update service isn't critical enough to wake up people.
     # We'll catch errors when the file age check for the database update goes critical.
     services.clamav.daemon = {

--- a/tests/antivirus.nix
+++ b/tests/antivirus.nix
@@ -7,13 +7,14 @@ let
   ipv6 = "2001:db8:f030:1c3::1";
 in {
   name = "antivirus";
-  machine =
+  nodes.machine =
     { lib, pkgs, ... }:
     {
       imports = [ ../nixos ../nixos/roles ];
       flyingcircus.roles.antivirus.enable = true;
       flyingcircus.enc.parameters = {
         resource_group = "test";
+        memory = 3072;    #lower limit for allowing the enabling of antivirus
         interfaces.srv = {
           mac = "52:54:00:12:34:56";
           bridged = false;


### PR DESCRIPTION
motivation: Otherwise the update causes massive spikes and has caused outages and noise before.

@flyingcircusio/release-managers

## Release process

Impact:
- machines with <3GiB of memory and enabled antivirus role will fail to build, until either memory is increased or the antivirus role is disabled

Changelog:
- antivirus role: prevent activation for machines with <3GiB RAM

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - [x] manual testing needs to happen
  - [x] no (known) regressions: track through automated tests, adapt tests if necessary   
- [x] Security requirements tested? (EVIDENCE)
  - [x] manually tested in testvm with 2GiB (negative case), 3GiB and 4 GiB (positive case)
  - [x] adapted NixOS test, tests still pass