### PR TITLE
Update nixpkgs

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "37fc54a5f81db6bafcc4f6b1656c586661c0800c",
-    "sha256": "sT9LcW3ZJqazxU2e+ITUhrKeIufHA6K+RK8qext3rOk="
+    "rev": "09ba0ca4298d5b850a74c7b00495c1d962f1d083",
+    "sha256": "csWBRs9dArRnM0/g+CNULyOjp7yYXggaC0w1sgBGOkg="
   },
   "nixos-mailserver": {
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/",


### PR DESCRIPTION
Pull upstream NixOS changes, security fixes and package updates:

- apacheHttpd: 2.4.55 -> 2.4.56 (CVE-2023-27522, CVE-2023-25690)
- curl: fix CVE-2023-27533, CVE-2023-27534, CVE-2023-27535, CVE-2023-27536, CVE-2023-27537, CVE-2023-27538
- gitlab: 15.8.4 -> 15.10.1
- grafana: 9.4.3 -> 9.4.7
- imagemagick: 7.1.1-2 -> 7.1.1-5
- linux: 5.15.103 -> 5.15.105
- matrix-synapse: 1.79.0 -> 1.80.0
- php81: 8.1.16 -> 8.1.17
- redis: 7.0.9 -> 7.0.10 (CVE-2023-28425)
- systemd: 251.12 -> 251.13

 #PL-131399

@flyingcircusio/release-managers

## Release process

Impact:

* \[NixOS 22.11]  Most services will be restarted due to a core dependency change. Machines will schedule a reboot to activate the changed kernel.

Changelog: (include changes from commit msg here)

## Security implication

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - pull in upstream security fixes regularly
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still run, works on test VM
  - checked commit log for fixed CVEs and possible problems with updates, looked at [synapse/upgrade.md](https://github.com/matrix-org/synapse/blob/develop/docs/upgrade.md) and [Releases | GitLab](https://about.gitlab.com/releases/categories/releases/)
