### PR TITLE
devhost: increase container startup timeout for slow containers and b…

### DIFF
--- a/nixos/roles/devhost/default.nix
+++ b/nixos/roles/devhost/default.nix
@@ -242,7 +242,7 @@ in
           builtins.listToAttrs (map generateContainerVhost containers))
         else {};
 
-       systemd.services."container@".serviceConfig = { TimeoutStartSec = lib.mkForce "1min"; };
+       systemd.services."container@".serviceConfig = { TimeoutStartSec = lib.mkForce "10min"; };
 
        # Start containers on system startup, ensure they get started before
        # nginx.


### PR DESCRIPTION
…usy hosts.

Re PL-131407

@flyingcircusio/release-managers

## Release process

Impact:

none

Changelog:

* Increase timeout for NixOS containers on devhosts from 1min to 10min to ensure successfull startup for slow containers and during boot. (PL-131407)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

Ensure sufficient availability.

- [x] Security requirements tested? (EVIDENCE)

Manually tested with local config on rldev00.
