### PR TITLE
[22.05] fc-agent check shows (deprecation) warnings, related improvements

### DIFF
--- a/nixos/platform/agent.nix
+++ b/nixos/platform/agent.nix
@@ -84,6 +84,14 @@ in
   };
 
   config = mkMerge [
+    {
+      # Write NixOS warnings to a file, separated by two newlines.
+      # We use that for `fc-manage check` to display (deprecation) warnings.
+      environment.etc."fcio_nixos_warnings".text =
+        lib.optionalString (config.warnings != [])
+          ((lib.concatStringsSep "\n\n" config.warnings) + "\n");
+    }
+
     (mkIf cfg.agent.install {
       environment.systemPackages = [ pkgs.fc.agent ];
 

--- a/nixos/services/postgresql.nix
+++ b/nixos/services/postgresql.nix
@@ -46,8 +46,18 @@ let
   # Nix store
   localConfigPath = /etc/local/postgresql + "/${cfg.majorVersion}";
 
-  localConfig =
+  legacyConfigFiles =
     if pathExists localConfigPath
+    then filter (lib.hasSuffix ".conf") (fclib.files localConfigPath)
+    else [];
+
+  legacyConfigWarning =
+    ''Plain PostgreSQL configuration found in ${toString localConfigPath}.
+    This does not work properly anymore and must be migrated to NixOS configuration.
+    See https://doc.flyingcircus.io/roles/fc-22.05-production/postgresql.html for details.'';
+
+  localConfig =
+    if legacyConfigFiles != []
     then { include_dir = "${localConfigPath}"; }
     else {};
 
@@ -115,10 +125,8 @@ in {
     in {
 
       warnings =
-        if localConfig != {}
-        then [''Plain PostgreSQL configuration found in ${toString localConfigPath}.
-                This does not work properly anymore and must be migrated to NixOS configuration.
-                See https://doc.flyingcircus.io/roles/fc-22.05-production/postgresql.html for details.'']
+        if legacyConfigFiles != []
+        then [ legacyConfigWarning ]
         else [];
 
       systemd.services.postgresql.unitConfig = {
@@ -171,30 +179,35 @@ in {
       };
 
       environment.etc."local/postgresql/${cfg.majorVersion}/README.md".text = ''
-          __WARNING__: Putting plain configuration here doesn’t work properly
-          and must not be used anymore. Some options set here will be
-          ignored silently if they are already defined by our platform
-          code.
+        __WARNING__: Putting plain configuration here doesn’t work properly
+        and must not be used anymore. Some options set here will be
+        ignored silently if they are already defined by our platform
+        code.
+      '';
 
-          You can override platform and PostgreSQL defaults by using the
-          `services.postgresql.settings` option in a custom NixOS module. Place
-          it in `/etc/local/nixos/postgresql.nix`, for example:
+      environment.etc."local/postgresql/README.md".text = ''
+        ${if legacyConfigFiles != [] then "**WARNING: " + legacyConfigWarning + "**\n" else ""}
+        PostgreSQL ${cfg.majorVersion} is running on this system.
 
-          ```nix
-          { config, lib, ... }:
-          {
-            services.postgresql.settings = {
-                log_connections = true;
-                huge_pages = "try";
-                max_connections = lib.mkForce 1000;
-            }
+        You can override platform and PostgreSQL defaults by using the
+        `services.postgresql.settings` option in a custom NixOS module. Place
+        it in `/etc/local/nixos/postgresql.nix`, for example:
+
+        ```nix
+        { config, lib, ... }:
+        {
+          services.postgresql.settings = {
+              log_connections = true;
+              huge_pages = "try";
+              max_connections = lib.mkForce 1000;
           }
-          ```
+        }
+        ```
 
-          See the platform documentation for more details:
+        See the platform documentation for more details:
 
-          https://doc.flyingcircus.io/roles/fc-22.05-production/postgresql.html
-          '';
+        https://doc.flyingcircus.io/roles/fc-22.05-production/postgresql.html
+      '';
 
       flyingcircus.infrastructure.preferNoneSchedulerOnSsd = true;
 

--- a/pkgs/fc/agent/fc/manage/manage.py
+++ b/pkgs/fc/agent/fc/manage/manage.py
@@ -301,10 +301,10 @@ class CheckResult:
 
     def format_output(self) -> str:
         if self.errors:
-            return "CRITICAL: " + " ".join(self.errors + self.warnings)
+            return "CRITICAL: " + "\n".join(self.errors + self.warnings)
 
         if self.warnings:
-            return "WARNING: " + " ".join(self.warnings)
+            return "WARNING: " + "\n".join(self.warnings)
 
         return "OK: no problems found."
 
@@ -388,6 +388,19 @@ def check(log, enc) -> CheckResult:
                 )
     else:
         errors.append("`nixos` channel not set.")
+
+    nixos_warnings_file = Path("/etc/fcio_nixos_warnings")
+
+    if nixos_warnings_file.exists():
+        nixos_warnings_content = nixos_warnings_file.read_text()
+        if nixos_warnings_content:
+            nixos_warnings = [
+                warning
+                for w in nixos_warnings_content.split("\n\n")
+                if (warning := w.strip())
+            ]
+            warnings.append(f"NixOS warnings found ({len(nixos_warnings)})")
+            warnings.extend(nixos_warnings)
 
     return CheckResult(errors, warnings)
 

--- a/pkgs/fc/agent/fc/util/logging.py
+++ b/pkgs/fc/agent/fc/util/logging.py
@@ -601,13 +601,15 @@ def init_logging(
     log_cmd_output: bool = False,
     log_to_console: bool = True,
     syslog_identifier="fc-agent",
+    show_caller_info: bool = False,
 ):
 
     multi_renderer = MultiRenderer(
         journal=SystemdJournalRenderer(syslog_identifier, syslog.LOG_LOCAL1),
         cmd_output_file=CmdOutputFileRenderer(),
         text=ConsoleFileRenderer(
-            min_level="trace" if verbose else "info", show_caller_info=verbose
+            min_level="trace" if verbose else "info",
+            show_caller_info=show_caller_info,
         ),
     )
 


### PR DESCRIPTION
The main goal was to display deprecation warnings via the `fc-agent` sensu check. 

Besides that, this fixes a deprecation warning in PostgreSQL which is always displayed by mistake and would create a lot of noise in Sensu. I also reduced noise (no caller info anymore) when using the `-v` flag on agent commands which is handy to display warnings on build as they appear. Check warnings/errors are now separated by newline instead of a space for better readability in Sensu.

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

- `fc-manage check` now displays NixOS (deprecation) warnings, read from `/etc/fcio_nixos_warnings`. These warnings should be fixed before upgrading the platform (PL-131380).
- Verbose output of management commands like `fc-manage -v switch` is now more readable. The flag can be used to see debug messages, build output and NixOS (deprecation) warnings (PL-131380). 
- postgresql: fix deprecation warning which was always triggered, even if no legacy config in `/etc/local/postgresql/14` was present, for example (PL-131380).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - improves visibility of (deprecation) warnings that could lead to failing system builds on newer versions, for example. 
- [x] Security requirements tested? (EVIDENCE)
  -tried out fc-manage check on a test VM, looked at sensu output with and without warnings