### PR TITLE
Write warnings to /etc, show them in fc-manage check

### DIFF
--- a/nixos/platform/agent.nix
+++ b/nixos/platform/agent.nix
@@ -118,6 +118,14 @@ in
   };
 
   config = mkMerge [
+    {
+      # Write NixOS warnings to a file, separated by two newlines.
+      # We use that for `fc-manage check` to display (deprecation) warnings.
+      environment.etc."fcio_nixos_warnings".text =
+        lib.optionalString (config.warnings != [])
+          ((lib.concatStringsSep "\n\n" config.warnings) + "\n");
+    }
+
     (mkIf cfg.agent.install {
       environment.systemPackages = [
         pkgs.fc.agent

--- a/pkgs/fc/agent/fc/manage/manage.py
+++ b/pkgs/fc/agent/fc/manage/manage.py
@@ -364,6 +364,19 @@ def check(log, enc) -> CheckResult:
     else:
         errors.append("`nixos` channel not set.")
 
+    nixos_warnings_file = Path("/etc/fcio_nixos_warnings")
+
+    if nixos_warnings_file.exists():
+        nixos_warnings_content = nixos_warnings_file.read_text()
+        if nixos_warnings_content:
+            nixos_warnings = [
+                warning
+                for w in nixos_warnings_content.split("\n\n")
+                if (warning := w.strip())
+            ]
+            warnings.append(f"NixOS warnings found ({len(nixos_warnings)})")
+            warnings.extend(nixos_warnings)
+
     return CheckResult(errors, warnings)
 
 

--- a/pkgs/fc/agent/fc/util/checks.py
+++ b/pkgs/fc/agent/fc/util/checks.py
@@ -11,13 +11,13 @@ class CheckResult:
 
     def format_output(self) -> str:
         if self.errors:
-            return "CRITICAL: " + " ".join(self.errors + self.warnings)
+            return "CRITICAL: " + "\n".join(self.errors + self.warnings)
 
         if self.warnings:
-            return "WARNING: " + " ".join(self.warnings)
+            return "WARNING: " + "\n".join(self.warnings)
 
         if self.ok_info:
-            return "OK: " + " ".join(self.ok_info)
+            return "OK: " + "\n".join(self.ok_info)
 
         return "OK"
 

--- a/pkgs/fc/agent/fc/util/tests/test_checks.py
+++ b/pkgs/fc/agent/fc/util/tests/test_checks.py
@@ -1,0 +1,64 @@
+import textwrap
+
+from fc.util.checks import CheckResult
+
+
+def test_check_result_ok():
+    check_result = CheckResult(ok_info=["Everything is as expected."])
+    out = check_result.format_output()
+    expected = "OK: Everything is as expected."
+    assert out == expected
+    assert check_result.exit_code == 0
+
+
+def test_check_result_ok_multi():
+    check_result = CheckResult(
+        ok_info=["Everything is as expected.", "Also additional info: 5, 3, 7."]
+    )
+    out = check_result.format_output()
+    expected = textwrap.dedent(
+        """
+        OK: Everything is as expected.
+        Also additional info: 5, 3, 7.
+        """
+    ).strip()
+
+    assert out == expected
+
+
+def test_check_result_warnings():
+    check_result = CheckResult(
+        warnings=["First warning.", "Second warning."],
+        ok_info=["Everything is as expected."],
+    )
+    out = check_result.format_output()
+    expected = textwrap.dedent(
+        """
+        WARNING: First warning.
+        Second warning.
+        """
+    ).strip()
+
+    assert out == expected
+    assert check_result.exit_code == 1
+
+
+def test_check_result_everything():
+    check_result = CheckResult(
+        errors=["First error.", "Second error."],
+        warnings=["First warning.", "Second warning."],
+        ok_info=["Everything is as expected."],
+    )
+    out = check_result.format_output()
+    expected = textwrap.dedent(
+        """
+        CRITICAL: First error.
+        Second error.
+        First warning.
+        Second warning.
+        """
+    ).strip()
+
+    assert check_result.exit_code == 2
+
+    assert out == expected


### PR DESCRIPTION
When warnings are present, they are written to `/etc/fcio_nixos_warnings` on build. `fc-manage check` reads the file ands displays them which is also picked up by the Sensu check `fc-agent`.

Forward-port of #689 which already has been merged into 22.05 

PL-131380

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

## Security implications

- [ ] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [ ] Security requirements tested? (EVIDENCE)
