### PR TITLE
antivirus RAM assertion: clarify error message

### DIFF
--- a/nixos/roles/antivirus.nix
+++ b/nixos/roles/antivirus.nix
@@ -26,7 +26,7 @@ in
 
     assertions = [{
       assertion = config.flyingcircus.enc.parameters.memory >= 3072;
-      message = "antivirus role: ClamAV needs at least 3GiB to run stable";
+      message = "antivirus role: ClamAV needs at least 3GiB of memory to run stable";
     }];
 
     # The update service isn't critical enough to wake up people.


### PR DESCRIPTION
clarifies PL-130703 0de3b1391a0675977600e59d68da0320df1b50ae fixup! antivirus: prevent role activation for machines with <3GiB RAM

@flyingcircusio/release-managers

## Release process

Impact: none, just a string message change

Changelog:

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - [x] error messages need to be understandable
- [x] Security requirements tested? (EVIDENCE)
  - [x] clarify an error message after having encountered confusion in real-world deployments
