### PR TITLE
statshost: fix renamed options, add metrics-relabel.yaml to Nix sandbox

### DIFF
--- a/nixos/roles/statshost/default.nix
+++ b/nixos/roles/statshost/default.nix
@@ -318,6 +318,12 @@ in
           import ./README.nix config.networking.hostName;
       };
 
+      nix.settings = {
+        extra-sandbox-paths = [
+          customRelabelPath
+        ];
+      };
+
       # Update relayed nodes.
       systemd.services.fc-prometheus-update-relayed-nodes =
         (mkIf (relayRGNodes != []) {

--- a/nixos/roles/statshost/default.nix
+++ b/nixos/roles/statshost/default.nix
@@ -440,9 +440,7 @@ in
 
       services.grafana = {
         enable = true;
-        port = 3001;
-        addr = "127.0.0.1";
-        rootUrl = "http://${cfgStats.hostName}/grafana";
+
         settings = {
           auth = {
             login_cookie_name = "grafana9_session";
@@ -455,6 +453,12 @@ in
 
           paths = {
             provisioning = grafanaProvisioningPath;
+          };
+
+          server = {
+            http_port = 3001;
+            http_addr = "127.0.0.1";
+            root_url = "http://${cfgStats.hostName}/grafana";
           };
 
         };


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* statshost: fix Grafana deprecation warnings and building of custom Prometheus config from `metrics-relabel.yaml` (PL-131424).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - doesn't change behaviour at run time, allows access to an additional file in `/etc/local/statshost` from the Nix sandbox which is needed for custom Prometheus config
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still run, manually checked on a test statshost that the deprecation warnings are gone and custom config builds
