### PR TITLE
Update nixpkgs

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "09ba0ca4298d5b850a74c7b00495c1d962f1d083",
-    "sha256": "csWBRs9dArRnM0/g+CNULyOjp7yYXggaC0w1sgBGOkg="
+    "rev": "bed4ce58b2497f5af5dd8f98a43e349b2cbd57d9",
+    "sha256": "PRNi9I7p1ZpV+IMfFc7z3tMSebPbYof3jmH1d1Ndw4k="
   },
   "nixos-mailserver": {
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/",


### PR DESCRIPTION
Pull upstream NixOS changes, security fixes and package updates:

- consul: 1.14.0 -> 1.14.5
- gitlab: 15.10.1 -> 15.10.3
- imagemagick: 7.1.1-5 -> 7.1.1-6
- linux: 5.15.105 -> 5.15.107
- element-web: 1.11.28 -> 1.11.29
- matrix-synapse: 1.80.0 -> 1.81.0
- mediawiki: 1.38.5 -> 1.38.6
- runc: 1.1.4 -> 1.1.5
- samba: 4.17.5 -> 4.17.7

@flyingcircusio/release-managers

## Release process

Impact:

* \[NixOS 22.11\] PostgreSQL, PHP-FPM, Gitlab and Synapse will be restarted. Machines will schedule a reboot to activate the changed kernel.

Changelog: (include changes fromhttps://github.com/flyingcircusio/fc-nixos/pulls commit msg here)

## Security implication

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - pull in upstream security fixes regularly
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still run, works on test VM, manually tested Gitlab on staging VM
  - checked commit log for fixed CVEs and possible problems with updates, looked at [synapse/upgrade.md](https://github.com/matrix-org/synapse/blob/develop/docs/upgrade.md) and [Releases | GitLab](https://about.gitlab.com/releases/categories/releases/)
