### PR TITLE
container: Fix evaluation on NixOS >= 22.05

### DIFF
--- a/nixos/infrastructure/container.nix
+++ b/nixos/infrastructure/container.nix
@@ -86,22 +86,21 @@ in
       flyingcircus.services.redis.listenAddresses = [ "[::]" ];
       flyingcircus.services.rabbitmq.listenAddress = "::";
 
-      services.mysql.extraOptions= ''
-        [mysqld]
+      services.mysql.settings.mysqld = {        
         # We don't really care about the data and this speeds up things.
-        innodb_flush_method = nosync
+        innodb_flush_method = "nosync";
 
-        innodb_buffer_pool_size         = 200M
-        innodb_log_buffer_size          = 64M
-        innodb_file_per_table           = 1
-        innodb_read_io_threads          = 1
-        innodb_write_io_threads         = 1
+        innodb_buffer_pool_size = "200M";
+        innodb_log_buffer_size = "64M";
+        innodb_file_per_table = 1;
+        innodb_read_io_threads = 1;
+        innodb_write_io_threads = 1;
         # Percentage. Probably needs local tuning depending on the workload.
-        innodb_change_buffer_max_size   = 50
-        innodb_doublewrite              = 1
-        innodb_log_file_size            = 64M
-        innodb_log_files_in_group       = 2
-      '';
+        innodb_change_buffer_max_size = 50;
+        innodb_doublewrite = 1;
+        innodb_log_file_size = "64M";
+        innodb_log_files_in_group = 2;
+      };
 
       services.redis.bind = lib.mkForce "0.0.0.0 ::";
 


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

Changelog:
* container: Use new mysql settings style introduced upstream for compatibility with NixOS >=22.05 (PL-131443)
* container: Fix evaluation of containers with flyingcircus modules deprecated with `mkRemovedOptionModule`

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [ ] Security requirements tested? (EVIDENCE)
