### PR TITLE
Opensearch roles

### DIFF
--- a/doc/src/index.md
+++ b/doc/src/index.md
@@ -37,6 +37,7 @@ memcached
 mongodb
 mysql
 nfs
+opensearch
 postgresql
 rabbitmq
 redis

--- a/doc/src/opensearch.md
+++ b/doc/src/opensearch.md
@@ -1,0 +1,150 @@
+(nixos-opensearch)=
+
+# OpenSearch
+
+Managed instance of [OpenSearch](https://opensearch.org) which was originally
+forked from Elasticsearch 7.10.2.
+
+
+## Interaction
+
+Run `opensearch-readme` to show a dynamic README file which shows information
+about the running OpenSearch config and role documentation.
+
+The `opensearch-plugin` command can be run as `opensearch` user.
+Changing to that user is allowed for service and sudo-srv users:
+
+```shell
+sudo -u opensearch bash
+opensearch-plugin list
+```
+
+### API
+
+The OpenSearch API is listening on the SRV interface. You can access
+the API of nodes in the same project via HTTP without authentication.
+Some examples:
+
+Show active nodes:
+
+```shell
+curl example00:9200/_cat/nodes
+```
+
+Show cluster health:
+
+```shell
+curl example00:9200/_cat/health
+```
+
+Show indices:
+
+```shell
+curl example00:9200/_cat/indices
+```
+
+## Configuration
+
+The role works without additional config for single-node setups.
+By default, the cluster name is the host name of the machine.
+
+Custom config can be set via NixOS options and is required for multi-node
+setups.
+
+Example:
+
+```nix
+{ config, pkgs, lib, ...}:
+{
+  flyingcircus.roles.opensearch = {
+    clusterName = "example";
+    nodes = [ "example00", "example02" ];
+    heapPercentage = 50;
+
+    #Only for initialization of new multi-node clusters!
+    initialMasterNodes = [ "example00" ];
+  };
+  services.opensearch.settings = {
+    "action.destructive_requires_name" = true;
+  };
+}
+
+```
+
+See `/etc/local/opensearch/opensearch.nix.example`.
+
+Copy the content to `/etc/local/nixos/opensearch.nix` to include it in
+the system config.
+
+To activate config changes, run `sudo fc-manage switch`.
+
+Run `opensearch-show-config` as `service` or `sudo-srv` user to see
+the active configuration used by OpenSearch.
+
+### Role NixOS Options
+
+**flyingcircus.roles.opensearch.clusterName**
+
+The cluster name OpenSearch will use. By default, the host name is
+used. Because of this, you have to set the cluster name explicitly
+if you want to set up a multi-node cluster.
+
+**flyingcircus.roles.opensearch.nodes**
+
+Names of the nodes that join this cluster and are eligible as masters.
+By default, all OpenSearch nodes in a resource group are part of this cluster
+and master-eligible.
+
+Note that all of them have to use the same clusterName which must be
+set explicitly when you want to set up a multi-node cluster.
+
+If only one node is given here, the node will start in single-node
+mode which means that it won't try to find other OpenSearch nodes before
+initializing the cluster.
+
+Values must use the same format as nodeName (just the hostname
+by default) or cluster initialization will fail.
+
+**flyingcircus.roles.opensearch.initialMasterNodes**
+
+Name of the nodes that should take a part in the initial master election.
+WARNING: This should only be set when initializing a cluster with multiple nodes
+from scratch and removed after the cluster has formed!
+By default, this is empty which means that the node will join an existing
+cluster or run in single-node mode when nodes has only one entry.
+You can set this to `config.flyingcircus.services.opensearch.nodes` to include
+all nodes.
+
+**flyingcircus.roles.opensearch.heapPercentage**
+
+Percentage of memory to use for OpenSearch heap. Defaults to 50 % of
+available RAM: *systemMemory * heapPercentage / 100*
+
+### Upstream NixOS Options
+
+**services.opensearch.settings**
+
+Add arbitrary OpenSearch settings here. See
+[OpenSearch/opensearch.yml](https://github.com/opensearch-project/OpenSearch/blob/main/distribution/src/config/opensearch.yml)
+for an example config file.
+
+OpenSearch settings are specified as flat key value pairs like
+`"action.destructive_requires_name" = true`;
+
+Note that the key must be quoted to stop Nix from interpreting the name
+of the setting as a path to a nested attribute.
+
+
+## Upgrades
+
+We will offer an upgrade path from Elasticsearch 6/7 in the future.
+
+## Monitoring
+
+The following checks are provided by our opensearch service:
+
+- Circuit breakers active
+- Cluster health
+- Heap too full
+- Node status
+- Shard allocation status

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -8,6 +8,7 @@ with builtins;
     ./lib
     ./platform
     ./services
+    ./upstream_services
     ./version.nix
   ];
 

--- a/nixos/lib/doc.nix
+++ b/nixos/lib/doc.nix
@@ -1,11 +1,26 @@
 # Utilities for documentation strings/files.
-{ lib, options, ...}:
+{ lib, config, options, ...}:
 
 with builtins;
 
 rec {
   docList = list:
     "[ ${lib.concatMapStringsSep " " (n: ''"${n}"'') list} ]";
+
+  roleDocUrl = name:
+  let
+    inherit (config.flyingcircus.platform) editions;
+    encEnv =
+      lib.attrByPath
+        [ "parameters" "environment" ]
+        "unknown"
+        config.flyingcircus.enc;
+    environment =
+      if (elem encEnv editions) then encEnv
+      else head editions;
+
+  in
+    "https://doc.flyingcircus.io/roles/${environment}/${name}.html";
 
   docOption = name:
     let

--- a/nixos/platform/default.nix
+++ b/nixos/platform/default.nix
@@ -171,6 +171,21 @@ in {
       example = ./test_cfg;
     };
 
+    flyingcircus.platform = {
+      version = mkOption {
+        readOnly = true;
+        default = "22.11";
+      };
+
+      editions = mkOption {
+        readOnly = true;
+        description = ''
+          Documented branches of this platform version.
+        '';
+        default = [ "fc-22.11-production" "fc-22.11-staging" "fc-22.11-dev" ];
+      };
+    };
+
     flyingcircus.passwordlessSudoRules = mkOption {
       description = ''
         Works like security.sudo.extraRules, but sets passwordless mode and

--- a/nixos/platform/static.nix
+++ b/nixos/platform/static.nix
@@ -145,6 +145,9 @@ with lib;
       # removed by upstream, we want to keep it
       memcached = 177;
       redis = 181;
+
+      # Same as elasticsearch
+      opensearch = 92;
     };
 
     ids.gids = {
@@ -167,6 +170,9 @@ with lib;
       sensuclient = 31004;
       powerdns = 31005;
       tideways = 31006;
+
+      # Same as elasticsearch
+      opensearch = 92;
     };
 
   };

--- a/nixos/roles/default.nix
+++ b/nixos/roles/default.nix
@@ -28,6 +28,8 @@ in {
     ./mysql.nix
     ./nfs.nix
     ./nginx.nix
+    ./opensearch.nix
+    ./opensearch_dashboards.nix
     ./postgresql.nix
     ./rabbitmq.nix
     ./redis.nix

--- a/nixos/roles/opensearch.nix
+++ b/nixos/roles/opensearch.nix
@@ -1,0 +1,141 @@
+{ options, config, lib, pkgs, ... }:
+
+with builtins;
+
+let
+  cfg = config.flyingcircus.roles.opensearch;
+  cfg_service = config.services.opensearch;
+  inherit (config) fclib;
+
+  localConfigDir = "/etc/local/opensearch";
+
+  exampleConfig = ''
+    { config, pkgs, lib, ...}:
+    {
+      flyingcircus.roles.opensearch = {
+        # clusterName = "example";
+        # nodes = [ "example00", "example02" ];
+        # heapPercentage = 50;
+
+        ## Only for initialization of new multi-node clusters!
+        # initialMasterNodes = [ "example00" ];
+      };
+      services.opensearch.settings = {
+        # "action.destructive_requires_name" = true;
+      };
+    }
+  '';
+
+  defaultNodes =
+    map
+      (service: head (lib.splitString "." service.address))
+      (fclib.findServices "opensearch-node");
+in
+{
+
+  options = with lib; {
+
+    flyingcircus.roles.opensearch = {
+      enable = mkEnableOption "Enable the Flying Circus OpenSearch role.";
+      supportsContainers = fclib.mkEnableContainerSupport;
+
+      clusterName = mkOption {
+        type = types.str;
+        default = config.networking.hostName;
+        defaultText = "host name";
+        description = ''
+          The cluster name OpenSearch will use. By default, the host name is
+          used. Because of this, you have to set the cluster name explicitly
+          if you want to set up a multi-node cluster.
+        '';
+      };
+
+      nodes = mkOption {
+        type = types.listOf types.str;
+        default = defaultNodes;
+        defaultText = "all OpenSearch nodes in the resource group";
+        description = ''
+          Names of the nodes that join this cluster and are eligible as masters.
+          By default, all OpenSearch nodes in a resource group are part of this cluster
+          and master-eligible.
+
+          Note that all of them have to use the same clusterName which must be
+          set explicitly when you want to set up a multi-node cluster.
+
+          If only one node is given here, the node will start in single-node
+          mode which means that it won't try to find other OpenSearch nodes before
+          initializing the cluster.
+
+          Values must use the same format as nodeName (just the hostname
+          by default) or cluster initialization will fail.
+        '';
+      };
+
+      inherit (options.flyingcircus.services.opensearch) heapPercentage initialMasterNodes;
+    };
+
+  };
+
+  config = lib.mkIf cfg.enable {
+
+    environment.etc."local/opensearch/opensearch.nix.example".text =
+      fclib.mkPlatform exampleConfig;
+
+    environment.etc."local/opensearch/README.md".text = lib.mkAfter ''
+      ## Role Configuration
+
+      For more details, see the [opensearch role documentation](${fclib.roleDocUrl "opensearch"}).
+
+      The role works without additional config for single-node setups.
+      By default, the cluster name is the host name of the machine.
+
+      Custom config can be set via NixOS options and is required for multi-node
+      setups.
+
+      Example:
+
+      ```nix
+      ${replaceStrings ["# "] [""] exampleConfig}
+      ```
+
+      See `${localConfigDir}/opensearch.nix.example`.
+
+      Copy the content to `/etc/local/nixos/opensearch.nix` to include it in
+      the system config.
+
+      To activate config changes, run `sudo fc-manage switch`.
+
+      Run `opensearch-show-config` as `service` or `sudo-srv` user to see
+      the active configuration used by OpenSearch.
+
+
+      ### Role NixOS Options
+
+      ${fclib.docOption "flyingcircus.roles.opensearch.clusterName"}
+
+      ${fclib.docOption "flyingcircus.roles.opensearch.nodes"}
+
+      ${fclib.docOption "flyingcircus.roles.opensearch.initialMasterNodes"}
+
+      ${fclib.docOption "flyingcircus.roles.opensearch.heapPercentage"}
+
+      ### Upstream NixOS Options
+
+      ${fclib.docOption "services.opensearch.settings"}
+      Add arbitrary OpenSearch settings here. See
+      [OpenSearch/opensearch.yml](https://github.com/opensearch-project/OpenSearch/blob/main/distribution/src/config/opensearch.yml)
+      for an example config file.
+
+      OpenSearch settings are specified as flat key value pairs like
+      `"action.destructive_requires_name" = true`;
+
+      Note that the key must be quoted to stop Nix from interpreting the name
+      of the setting as a path to a nested attribute.
+    '';
+
+    flyingcircus.services.opensearch = {
+      enable = true;
+      inherit (cfg) clusterName heapPercentage initialMasterNodes nodes;
+    };
+  };
+}

--- a/nixos/roles/opensearch_dashboards.nix
+++ b/nixos/roles/opensearch_dashboards.nix
@@ -1,0 +1,63 @@
+{ config, lib, pkgs, ... }:
+
+with builtins;
+
+let
+  cfg = config.flyingcircus.roles.opensearch_dashboards;
+  fclib = config.fclib;
+  opensearchCfg = config.services.opensearch;
+
+  # Determine the opensearch URL, in order:
+  # 1. opensearchUrl option
+  # 2. Local opensearch service
+  # 3. no URL, don't activate opensearchDashboards
+  opensearchUrl =
+    if cfg.opensearchUrl != null
+    then cfg.opensearchUrl
+    else
+      if opensearchCfg.enable
+      then "http://${opensearchCfg.settings."network.host"}:${toString opensearchCfg.settings."http.port"}"
+      else null;
+
+  opensearchDashboardsShowConfig = pkgs.writeScriptBin "opensearch-dashboards-show-config" ''
+    cat $(systemctl cat opensearch-dashboards | grep "ExecStart" | cut -d" " -f3)
+  '';
+
+in
+{
+  options = with lib; {
+
+    flyingcircus.roles.opensearch_dashboards = {
+
+      enable = mkEnableOption "Enable the Flying Circus opensearch dashboards role.";
+      supportsContainers = fclib.mkEnableContainerSupport;
+
+      opensearchUrl = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        example = "http://opensearchhost:9200";
+      };
+
+    };
+
+  };
+
+  config = (lib.mkIf (cfg.enable && opensearchUrl != null) {
+    environment.systemPackages = [
+      opensearchDashboardsShowConfig
+    ];
+
+    flyingcircus.services.opensearch-dashboards = {
+      enable = true;
+      # Unlike opensearch, opensearch-dashboards cannot listen to both IPv4 and IPv6.
+      # We choose to use IPv4 here.
+      listenAddress = head fclib.network.srv.v4.addresses;
+      opensearch.hosts = [ opensearchUrl ];
+    };
+
+    systemd.services.opensearch-dashboards.serviceConfig = {
+      Restart = "always";
+    };
+  });
+
+}

--- a/nixos/services/default.nix
+++ b/nixos/services/default.nix
@@ -30,6 +30,8 @@ in {
     ./matomo.nix
     ./nginx
     ./nullmailer.nix
+    ./opensearch.nix
+    ./opensearch_dashboards.nix
     ./percona.nix
     ./postgresql.nix
     ./prometheus.nix

--- a/nixos/services/opensearch.nix
+++ b/nixos/services/opensearch.nix
@@ -1,0 +1,329 @@
+{ options, config, lib, pkgs, ... }:
+
+with builtins;
+
+let
+  inherit (config) fclib;
+  cfg = config.flyingcircus.services.opensearch;
+  opts = options.flyingcircus.services.opensearch;
+  cfgUpstream = config.services.opensearch;
+
+  localConfigDir = "/etc/local/opensearch";
+
+  thisNode =
+    if config.networking.domain != null
+    then "${config.networking.hostName}.${config.networking.domain}"
+    else "localhost";
+
+  currentMemory = fclib.currentMemory 1024;
+
+  openSearchHeap = fclib.min
+    [ (currentMemory * cfg.heapPercentage / 100)
+      (31 * 1024)];
+
+  usingDefaultDataDir = cfgUpstream.dataDir == "/var/lib/opensearch";
+  usingDefaultUserAndGroup = cfgUpstream.user == "opensearch" && cfgUpstream.group == "opensearch";
+in
+{
+
+  options = with lib; {
+
+    flyingcircus.services.opensearch = {
+
+      enable = mkEnableOption "Enable the Flying Circus OpenSearch service.";
+
+      heapPercentage = mkOption {
+        type = types.int;
+        default = 50;
+        description = ''
+          Percentage of memory to use for OpenSearch heap. Defaults to 50 % of
+          available RAM: *systemMemory * heapPercentage / 100*
+        '';
+      };
+
+      nodes = mkOption {
+        type = types.listOf types.str;
+        description = ''
+          Names of the nodes that join this cluster and are eligible as masters.
+
+          Note that all of them have to use the same cluster name which must be
+          set explicitly when you want to set up a multi-node cluster.
+
+          If only one nodes is given here, the node will start in single-node
+          mode which means that it won't try to find other OpenSearch nodes before
+          initializing the cluster.
+
+          Values must use the same format as nodeName (just the hostname
+          by default) or cluster initialization will fail.
+        '';
+      };
+
+      initialMasterNodes = mkOption {
+        type = types.listOf types.str;
+        default = [];
+        description = ''
+          Name of the nodes that should take a part in the initial master election.
+          WARNING: This should only be set when initializing a cluster with multiple nodes
+          from scratch and removed after the cluster has formed!
+          By default, this is empty which means that the node will join an existing
+          cluster or run in single-node mode when nodes has only one entry.
+          You can set this to `config.flyingcircus.services.opensearch.nodes` to include
+          all nodes.
+        '';
+      };
+
+      clusterName = mkOption {
+        type = types.str;
+        description = ''
+          The cluster name OpenSearch will use.
+        '';
+      };
+
+
+      nodeName = mkOption {
+        type = types.nullOr types.string;
+        default = config.networking.hostName;
+        description = ''
+          The name for this node. Defaults to the hostname.
+        '';
+      };
+    };
+
+  };
+
+  config = lib.mkMerge [
+
+    (lib.mkIf cfg.enable {
+
+    environment.systemPackages = [
+      (pkgs.writeShellScriptBin "opensearch-show-config" ''
+        ${pkgs.rich-cli}/bin/rich --pager /etc/current-config/opensearch.yml
+      '')
+      (pkgs.writeShellScriptBin "opensearch-readme" ''
+        ${pkgs.rich-cli}/bin/rich --pager ${localConfigDir}/README.md
+      '')
+    ];
+
+    services.opensearch = {
+      enable = true;
+
+      settings = {
+        "bootstrap.memory_lock" = true;
+        "cluster.name" = cfg.clusterName;
+        "discovery.seed_hosts" = cfg.nodes;
+        "discovery.type" = if lib.length cfg.nodes == 1 then "single-node" else "";
+        "network.host" = thisNode;
+        "node.name" = cfg.nodeName;
+      } // lib.optionalAttrs (cfg.initialMasterNodes != []) {
+        "cluster.initial_master_nodes" = cfg.initialMasterNodes;
+      };
+
+      extraJavaOptions = [
+        "-Des.path.scripts=${cfgUpstream.dataDir}/scripts"
+        # Xms and Xmx are already defined as cmdline args by config/jvm.options.
+        # Appending the next two lines overrides the former.
+        "-Xms${toString openSearchHeap}m"
+        "-Xmx${toString openSearchHeap}m"
+        "-Dopensearch.transport.cname_in_publish_address=true"
+      ];
+    };
+
+    # Allow sudo-srv and service users to run commands as opensearch.
+    # There are various opensearch utilities that have to be run as
+    # opensearch user.
+    flyingcircus.passwordlessSudoRules = [
+      {
+        commands = [ "ALL" ];
+        groups = [ "sudo-srv" "service" "opensearch" ];
+        runAs = "opensearch";
+      }
+    ];
+
+    flyingcircus.services.sensu-client = {
+      expectedDiskCapacity = {
+        # These values match the OpenSearch defaults for watermark.low and .high.
+        # See https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-settings/
+        # for an explanation of what they do.
+        warning = 85;
+        critical = 90;
+      };
+    };
+
+    systemd.services.opensearch = {
+      startLimitIntervalSec = 480;
+      startLimitBurst = 3;
+      serviceConfig = {
+        DynamicUser = lib.mkOverride 90 false;
+        LimitMEMLOCK = "infinity";
+        ExecStartPre =
+          let
+            migrateDataDir = ''
+              set -e
+              echo "Running as $(id opensearch)."
+              if ls -A /srv/opensearch/*; then
+                echo "Old data dir /srv/opensearch is not empty."
+                if ls -A /var/lib/opensearch/*; then
+                  echo "Not moving old data, new data dir /var/lib/opensearch already has content!"
+                else
+                  echo "Migrating existing data to /var/lib/opensearch..."
+                  mv /srv/opensearch/* /var/lib/opensearch/
+                  rm -rf /srv/opensearch
+                  ln -s /var/lib/opensearch /srv/opensearch
+                fi
+              else echo "Nothing found in old data dir.".
+              fi
+
+              chown -R opensearch:opensearch ${cfgUpstream.dataDir}/
+            '';
+          in
+            lib.mkBefore
+              (lib.optionals (usingDefaultDataDir && usingDefaultUserAndGroup) [
+              "+${pkgs.writeShellScript "opensearch-migrate-datadir" migrateDataDir}"
+            ] ++ [
+              "${pkgs.writeShellScript "opensearch-link-jdk" "ln -sfT ${pkgs.jre_headless} ${cfgUpstream.dataDir}/jdk"}"
+            ]);
+      };
+    };
+
+    environment.variables = {
+      OPENSEARCH_HOME = cfgUpstream.dataDir;
+    };
+
+    environment.etc."current-config/opensearch.yml".source = cfgUpstream.configFile;
+    environment.etc."local/opensearch/README.md".text = let
+      discoveryType = if cfgUpstream.settings."discovery.type" != "" then cfgUpstream.settings."discovery.type" else "multi-node";
+    in
+    ''
+      # OpenSearch
+
+      [OpenSearch](https://opensearch.org) version ${cfgUpstream.package.version} is running on this VM, with node
+      name `${cfgUpstream.settings."node.name"}`. It is forming the cluster named
+      `${cfgUpstream.settings."cluster.name"}` (${discoveryType}).
+
+      The following nodes are eligible to be elected as master nodes:
+      `${fclib.docList cfg.nodes}`
+
+      ${lib.optionalString (cfg.initialMasterNodes != []) ''
+      The node is running in multi-node bootstrap mode, `initialMasterNodes` is set to:
+      `${fclib.docList cfg.initialMasterNodes}`
+
+      WARNING: the `initialMasterNodes` setting should be removed after the cluster has formed!
+      ''}
+
+      ## Interaction
+
+      The OpenSearch API is listening on the SRV interface. You can access
+      the API of nodes in the same project via HTTP without authentication.
+      Some examples:
+
+      Show active nodes:
+
+      ```
+      curl ${thisNode}:9200/_cat/nodes
+      ```
+
+      Show cluster health:
+
+      ```
+      curl ${thisNode}:9200/_cat/health
+      ```
+
+      Show indices:
+
+      ```
+      curl ${thisNode}:9200/_cat/indices
+      ```
+
+      ### Running Configuration
+
+      `/etc/current-config/opensearch.yml`:
+
+      ```yaml
+      ${readFile cfgUpstream.configFile}
+      ```
+    '';
+
+    flyingcircus.services.sensu-client.checks = {
+
+      opensearch_circuit_breakers = {
+        notification = "OpenSearch: Circuit Breakers active";
+        command = ''
+          ${pkgs.sensu-plugins-elasticsearch}/bin/check-es-circuit-breakers.rb \
+            -h ${thisNode}
+        '';
+        interval = 300;
+      };
+
+      opensearch_cluster_health = {
+        notification = "OpenSearch: Cluster Health";
+        command = ''
+        ${pkgs.sensu-plugins-elasticsearch}/bin/check-es-cluster-health.rb \
+          -h ${thisNode}
+        '';
+      };
+
+      opensearch_heap = {
+        notification = "OpenSearch: Heap too full";
+        command = ''
+          ${pkgs.sensu-plugins-elasticsearch}/bin/check-es-heap.rb \
+            -h ${thisNode} -w 80 -c 90 -P
+        '';
+        interval = 300;
+      };
+
+      opensearch_node_status = {
+        notification = "OpenSearch: Node status";
+        command = ''
+          ${pkgs.sensu-plugins-elasticsearch}/bin/check-es-node-status.rb \
+            -h ${thisNode}
+        '';
+      };
+
+      opensearch_shard_allocation_status = {
+        notification = "OpenSearch: Shard allocation status";
+        command = ''
+          ${pkgs.sensu-plugins-elasticsearch}/bin/check-es-shard-allocation-status.rb \
+            -s ${thisNode}
+        '';
+        interval = 300;
+      };
+
+    };
+
+    systemd.services.prometheus-opensearch-exporter = {
+      description = "Prometheus exporter for opensearch metrics";
+      wantedBy = [ "multi-user.target" ];
+      path = [ pkgs.prometheus-elasticsearch-exporter ];
+      script = ''
+        exec elasticsearch_exporter\
+            --es.uri http://${thisNode}:9200 \
+            --web.listen-address localhost:9108
+      '';
+      serviceConfig = {
+        User = "nobody";
+        Restart = "always";
+        PrivateTmp = true;
+        WorkingDirectory = /tmp;
+        ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
+      };
+    };
+
+    flyingcircus.services.telegraf.inputs = {
+      prometheus  = [{
+        urls = [ "http://localhost:9108/metrics" ];
+      }];
+    };
+
+    users = {
+      groups.opensearch.gid = config.ids.gids.opensearch;
+      users.opensearch = {
+        uid = config.ids.uids.opensearch;
+        description = "Opensearch daemon user";
+        home = cfgUpstream.dataDir;
+        group = "opensearch";
+      };
+    };
+  })
+
+  ];
+}

--- a/nixos/services/opensearch_dashboards.nix
+++ b/nixos/services/opensearch_dashboards.nix
@@ -1,0 +1,187 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.flyingcircus.services.opensearch-dashboards;
+
+  cfgFile = pkgs.writeText "opensearch-dashboards.json" (builtins.toJSON (
+    (filterAttrsRecursive (n: v: v != null && v != []) ({
+      server.host = cfg.listenAddress;
+      server.port = cfg.port;
+      server.ssl.certificate = cfg.cert;
+      server.ssl.key = cfg.key;
+
+      opensearchDashboards.index = cfg.index;
+      opensearchDashboards.defaultAppId = cfg.defaultAppId;
+
+      opensearch.hosts = cfg.opensearch.hosts;
+      opensearch.username = cfg.opensearch.username;
+      opensearch.password = cfg.opensearch.password;
+
+      opensearch.ssl.certificate = cfg.opensearch.cert;
+      opensearch.ssl.key = cfg.opensearch.key;
+      opensearch.ssl.certificateAuthorities = cfg.opensearch.certificateAuthorities;
+    } // cfg.extraConf)
+  )));
+
+in {
+  options.flyingcircus.services.opensearch-dashboards = {
+    enable = mkEnableOption "opensearch-dashboards service";
+
+    listenAddress = mkOption {
+      description = "opensearch-dashboards listening host";
+      default = "127.0.0.1";
+      type = types.str;
+    };
+
+    port = mkOption {
+      description = "opensearch-dashboards listening port";
+      default = 5601;
+      type = types.int;
+    };
+
+    cert = mkOption {
+      description = "opensearch-dashboards ssl certificate.";
+      default = null;
+      type = types.nullOr types.path;
+    };
+
+    key = mkOption {
+      description = "opensearch-dashboards ssl key.";
+      default = null;
+      type = types.nullOr types.path;
+    };
+
+    index = mkOption {
+      description = "opensearch index to use for saving kibana config.";
+      default = ".opensearch_dashboards";
+      type = types.str;
+    };
+
+    defaultAppId = mkOption {
+      description = "opensearch default application id.";
+      default = "discover";
+      type = types.str;
+    };
+
+    opensearch = {
+
+      hosts = mkOption {
+        description = ''
+          The URLs of the opensearch instances to use for all your queries.
+          All nodes listed here must be on the same cluster.
+
+          Defaults to <literal>[ "http://localhost:9200" ]</literal>.
+        '';
+        default = null;
+        type = types.nullOr (types.listOf types.str);
+      };
+
+      username = mkOption {
+        description = "Username for opensearch basic auth.";
+        default = null;
+        type = types.nullOr types.str;
+      };
+
+      password = mkOption {
+        description = "Password for opensearch basic auth.";
+        default = null;
+        type = types.nullOr types.str;
+      };
+
+      ca = mkOption {
+        description = ''
+          CA file to auth against opensearch.
+          It's recommended to use the <option>certificateAuthorities</option> option
+          when using kibana-5.4 or newer.
+        '';
+        default = null;
+        type = types.nullOr types.path;
+      };
+
+      certificateAuthorities = mkOption {
+        description = ''
+          CA files to auth against opensearch.
+
+          Please use the <option>ca</option> option when using kibana &lt; 5.4
+          because those old versions don't support setting multiple CA's.
+
+          This defaults to the singleton list [ca] when the <option>ca</option> option is defined.
+        '';
+        default = if cfg.opensearch.ca == null then [] else [ca];
+        type = types.listOf types.path;
+      };
+
+      cert = mkOption {
+        description = "Certificate file to auth against opensearch.";
+        default = null;
+        type = types.nullOr types.path;
+      };
+
+      key = mkOption {
+        description = "Key file to auth against opensearch.";
+        default = null;
+        type = types.nullOr types.path;
+      };
+    };
+
+    package = mkOption {
+      description = "opensearch-dashboards package to use";
+      default = pkgs.opensearch-dashboards;
+      defaultText = literalExpression "pkgs.opensearch-dashboards";
+      type = types.package;
+    };
+
+    dataDir = mkOption {
+      description = "opensearch-dashboards data directory";
+      default = "/var/lib/opensearch-dashboards";
+      type = types.path;
+    };
+
+    extraConf = mkOption {
+      description = "opensearch-dashboards extra configuration";
+      default = {};
+      type = types.attrs;
+    };
+  };
+
+  config = mkIf (cfg.enable) {
+    systemd.services.opensearch-dashboards = {
+      description = "opensearch-dashboards Service";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" "elasticsearch.service" "opensearch.service" ];
+      environment = { BABEL_CACHE_PATH = "${cfg.dataDir}/.babelcache.json"; };
+      preStart = ''
+        pkg_dir=$STATE_DIRECTORY/package
+        rm -rf $pkg_dir
+        cp -r ${cfg.package} $pkg_dir
+        chmod -R u+w $pkg_dir
+        rm -rf $pkg_dir/libexec/opensearch-dashboards/plugins/securityDashboards
+        ls -a $pkg_dir/libexec/opensearch-dashboards/plugins
+        sed -i "s|${cfg.package}|$pkg_dir|g" $pkg_dir/bin/opensearch-dashboards
+      '';
+      script = ''
+        $STATE_DIRECTORY/package/bin/opensearch-dashboards \
+          --config ${cfgFile} \
+          --path.data ${cfg.dataDir}
+      '';
+      serviceConfig = {
+        User = "opensearch-dashboards";
+        WorkingDirectory = cfg.dataDir;
+        StateDirectory = "opensearch-dashboards";
+      };
+    };
+
+    environment.systemPackages = [ cfg.package ];
+
+    users.users.opensearch-dashboards = {
+      isSystemUser = true;
+      description = "opensearch-dashboards service user";
+      home = cfg.dataDir;
+      createHome = true;
+      group = "opensearch-dashboards";
+    };
+    users.groups.opensearch-dashboards = {};
+  };
+}

--- a/nixos/upstream_services/default.nix
+++ b/nixos/upstream_services/default.nix
@@ -1,0 +1,16 @@
+# Modules taken from upstream NixOS.
+# Can be from the same or different NixOS versions.
+{ lib, ... }:
+let
+  modulesFromHere = [
+    "services/search/opensearch.nix"
+  ];
+
+in {
+  disabledModules = modulesFromHere;
+
+  imports = with lib; [
+    # from nixos-23.05
+    ./opensearch
+  ];
+}

--- a/nixos/upstream_services/opensearch/COPYING.md
+++ b/nixos/upstream_services/opensearch/COPYING.md
@@ -1,0 +1,3 @@
+The files in this directory are based on [MIT-licensed](https://github.com/NixOS/nixpkgs/blob/e78d25df6f1036b3fa76750ed4603dd9d5fe90fc/COPYING) work done by other Nixpkgs/NixOS contributors, taken from revision e78d25df6f1036b3fa76750ed4603dd9d5fe90fc in the [nixpkgs](https://github.com/NixOS/nixpkgs/) repository under the path [nixos/modules/services/search/opensearch.nix](https://github.com/NixOS/nixpkgs/blob/e78d25df6f1036b3fa76750ed4603dd9d5fe90fc/nixos/modules/services/search/opensearch.nix).
+
+The modifications made are licensed under the MIT License as well.

--- a/nixos/upstream_services/opensearch/default.nix
+++ b/nixos/upstream_services/opensearch/default.nix
@@ -1,0 +1,248 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.opensearch;
+
+  settingsFormat = pkgs.formats.yaml {};
+
+  configDir = cfg.dataDir + "/config";
+
+  usingDefaultDataDir = cfg.dataDir == "/var/lib/opensearch";
+  usingDefaultUserAndGroup = cfg.user == "opensearch" && cfg.group == "opensearch";
+
+  opensearchYml = settingsFormat.generate "opensearch.yml" cfg.settings;
+
+  loggingConfigFilename = "log4j2.properties";
+  loggingConfigFile = pkgs.writeTextFile {
+    name = loggingConfigFilename;
+    text = cfg.logging;
+  };
+in
+{
+
+  options.services.opensearch = {
+    enable = mkEnableOption (lib.mdDoc "OpenSearch");
+
+    package = lib.mkPackageOptionMD pkgs "OpenSearch" {
+      default = [ "opensearch" ];
+    };
+
+    settings = lib.mkOption {
+      type = lib.types.submodule {
+        freeformType = settingsFormat.type;
+
+        options."network.host" = lib.mkOption {
+          type = lib.types.str;
+          default = "127.0.0.1";
+          description = lib.mdDoc ''
+            Which port this service should listen on.
+          '';
+        };
+
+        options."cluster.name" = lib.mkOption {
+          type = lib.types.str;
+          default = "opensearch";
+          description = lib.mdDoc ''
+            The name of the cluster.
+          '';
+        };
+
+        options."discovery.type" = lib.mkOption {
+          type = lib.types.str;
+          default = "single-node";
+          description = lib.mdDoc ''
+            The type of discovery to use.
+          '';
+        };
+
+        options."http.port" = lib.mkOption {
+          type = lib.types.port;
+          default = 9200;
+          description = lib.mdDoc ''
+            The port to listen on for HTTP traffic.
+          '';
+        };
+
+        options."transport.port" = lib.mkOption {
+          type = lib.types.port;
+          default = 9300;
+          description = lib.mdDoc ''
+            The port to listen on for transport traffic.
+          '';
+        };
+      };
+
+      default = {};
+
+      description = lib.mdDoc ''
+        OpenSearch configuration.
+      '';
+    };
+
+    logging = lib.mkOption {
+      description = lib.mdDoc "opensearch logging configuration.";
+
+      default = ''
+        logger.action.name = org.opensearch.action
+        logger.action.level = info
+
+        appender.console.type = Console
+        appender.console.name = console
+        appender.console.layout.type = PatternLayout
+        appender.console.layout.pattern = [%d{ISO8601}][%-5p][%-25c{1.}] %marker%m%n
+
+        rootLogger.level = info
+        rootLogger.appenderRef.console.ref = console
+      '';
+      type = types.str;
+    };
+
+    dataDir = lib.mkOption {
+      type = lib.types.path;
+      default = "/var/lib/opensearch";
+      apply = converge (removeSuffix "/");
+      description = lib.mdDoc ''
+        Data directory for OpenSearch. If you change this, you need to
+        manually create the directory. You also need to create the
+        `opensearch` user and group, or change
+        [](#opt-services.opensearch.user) and
+        [](#opt-services.opensearch.group) to existing ones with
+        access to the directory.
+      '';
+    };
+
+    user = lib.mkOption {
+      type = lib.types.str;
+      default = "opensearch";
+      description = lib.mdDoc ''
+        The user OpenSearch runs as. Should be left at default unless
+        you have very specific needs.
+      '';
+    };
+
+    group = lib.mkOption {
+      type = lib.types.str;
+      default = "opensearch";
+      description = lib.mdDoc ''
+        The group OpenSearch runs as. Should be left at default unless
+        you have very specific needs.
+      '';
+    };
+
+    extraCmdLineOptions = lib.mkOption {
+      description = lib.mdDoc "Extra command line options for the OpenSearch launcher.";
+      default = [ ];
+      type = lib.types.listOf lib.types.str;
+    };
+
+    extraJavaOptions = lib.mkOption {
+      description = lib.mdDoc "Extra command line options for Java.";
+      default = [ ];
+      type = lib.types.listOf lib.types.str;
+      example = [ "-Djava.net.preferIPv4Stack=true" ];
+    };
+
+    restartIfChanged = lib.mkOption {
+      type = lib.types.bool;
+      description = lib.mdDoc ''
+        Automatically restart the service on config change.
+        This can be set to false to defer restarts on a server or cluster.
+        Please consider the security implications of inadvertently running an older version,
+        and the possibility of unexpected behavior caused by inconsistent versions across a cluster when disabling this option.
+      '';
+      default = true;
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.opensearch = {
+      description = "OpenSearch Daemon";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+      path = [ pkgs.inetutils ];
+      inherit (cfg) restartIfChanged;
+      environment = {
+        OPENSEARCH_HOME = cfg.dataDir;
+        OPENSEARCH_JAVA_OPTS = toString cfg.extraJavaOptions;
+        OPENSEARCH_PATH_CONF = configDir;
+      };
+      serviceConfig = {
+        ExecStartPre =
+          let
+            startPreFullPrivileges = ''
+              set -o errexit -o pipefail -o nounset -o errtrace
+              shopt -s inherit_errexit
+            '' + (optionalString (!config.boot.isContainer) ''
+              # Only set vm.max_map_count if lower than ES required minimum
+              # This avoids conflict if configured via boot.kernel.sysctl
+              if [ $(${pkgs.procps}/bin/sysctl -n vm.max_map_count) -lt 262144 ]; then
+                ${pkgs.procps}/bin/sysctl -w vm.max_map_count=262144
+              fi
+            '');
+            startPreUnprivileged = ''
+              set -o errexit -o pipefail -o nounset -o errtrace
+              shopt -s inherit_errexit
+
+              # Install plugins
+              ln -sfT ${cfg.package}/lib ${cfg.dataDir}/lib
+              ln -sfT ${cfg.package}/modules ${cfg.dataDir}/modules
+
+              # opensearch needs to create the opensearch.keystore in the config directory
+              # so this directory needs to be writable.
+              mkdir -p ${configDir}
+              chmod 0700 ${configDir}
+
+              # Note that we copy config files from the nix store instead of symbolically linking them
+              # because otherwise X-Pack Security will raise the following exception:
+              # java.security.AccessControlException:
+              # access denied ("java.io.FilePermission" "/var/lib/opensearch/config/opensearch.yml" "read")
+
+              rm -f ${configDir}/opensearch.yml
+              cp ${opensearchYml} ${configDir}/opensearch.yml
+
+              # Make sure the logging configuration for old OpenSearch versions is removed:
+              rm -f "${configDir}/logging.yml"
+              rm -f ${configDir}/${loggingConfigFilename}
+              cp ${loggingConfigFile} ${configDir}/${loggingConfigFilename}
+              mkdir -p ${configDir}/scripts
+
+              rm -f ${configDir}/jvm.options
+              cp ${cfg.package}/config/jvm.options ${configDir}/jvm.options
+
+              # redirect jvm logs to the data directory
+              mkdir -p ${cfg.dataDir}/logs
+              chmod 0700 ${cfg.dataDir}/logs
+              sed -e '#logs/gc.log#${cfg.dataDir}/logs/gc.log#' -i ${configDir}/jvm.options
+            '';
+          in [
+            "+${pkgs.writeShellScript "opensearch-start-pre-full-privileges" startPreFullPrivileges}"
+            "${pkgs.writeShellScript "opensearch-start-pre-unprivileged" startPreUnprivileged}"
+          ];
+        ExecStartPost = pkgs.writeShellScript "opensearch-start-post" ''
+          set -o errexit -o pipefail -o nounset -o errtrace
+          shopt -s inherit_errexit
+
+          # Make sure opensearch is up and running before dependents
+          # are started
+          while ! ${pkgs.curl}/bin/curl -sS -f http://${cfg.settings."network.host"}:${toString cfg.settings."http.port"} 2>/dev/null; do
+            sleep 1
+          done
+        '';
+        ExecStart = "${cfg.package}/bin/opensearch ${toString cfg.extraCmdLineOptions}";
+        User = cfg.user;
+        Group = cfg.group;
+        LimitNOFILE = "1024000";
+        Restart = "always";
+        TimeoutStartSec = "infinity";
+        DynamicUser = usingDefaultUserAndGroup && usingDefaultDataDir;
+      } // (optionalAttrs (usingDefaultDataDir) {
+        StateDirectory = "opensearch";
+        StateDirectoryMode = "0700";
+      });
+    };
+
+    environment.systemPackages = [ cfg.package ];
+  };
+}

--- a/nixos/upstream_services/opensearch/default.nix
+++ b/nixos/upstream_services/opensearch/default.nix
@@ -154,6 +154,16 @@ in
       '';
       default = true;
     };
+
+    configFile = lib.mkOption {
+      type = types.path;
+      default = opensearchYml;
+      description = ''
+        opensearch config path.
+      '';
+    };
+
+
   };
 
   config = mkIf cfg.enable {
@@ -200,7 +210,7 @@ in
               # access denied ("java.io.FilePermission" "/var/lib/opensearch/config/opensearch.yml" "read")
 
               rm -f ${configDir}/opensearch.yml
-              cp ${opensearchYml} ${configDir}/opensearch.yml
+              cp ${cfg.configFile} ${configDir}/opensearch.yml
 
               # Make sure the logging configuration for old OpenSearch versions is removed:
               rm -f "${configDir}/logging.yml"

--- a/pkgs/opensearch-dashboards/default.nix
+++ b/pkgs/opensearch-dashboards/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, stdenv
+, makeWrapper
+, fetchurl
+, nodejs-14_x
+, coreutils
+, which
+}:
+
+with lib;
+let
+  nodejs = nodejs-14_x;
+
+in stdenv.mkDerivation rec {
+  pname = "opensearch-dashboards";
+  version = "2.6.0";
+
+  src = fetchurl {
+    url = "https://artifacts.opensearch.org/releases/bundle/opensearch-dashboards/${version}/${pname}-${version}-linux-x64.tar.gz";
+    sha256 = "sha256-1U9BExZh/hoJKkPC08oEs3U6KWZv6xvHBm8HEYsr2Ls=";
+  };
+
+  patches = [
+    # OpenSearch Dashboard specifies that it wants nodejs 14.20.1 but nodejs in nixpkgs is at 14.21.1.
+    ./disable-nodejs-version-check.patch
+  ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    mkdir -p $out/libexec/opensearch-dashboards $out/bin
+    mv * $out/libexec/opensearch-dashboards/
+    rm -r $out/libexec/opensearch-dashboards/node
+    makeWrapper $out/libexec/opensearch-dashboards/bin/opensearch-dashboards $out/bin/opensearch-dashboards \
+      --prefix PATH : "${lib.makeBinPath [ nodejs coreutils which ]}"
+    sed -i 's@NODE=.*@NODE=${nodejs}/bin/node@' $out/libexec/opensearch-dashboards/bin/opensearch-dashboards
+  '';
+
+  meta = {
+    description = "Visualization and user interface for OpenSearch";
+    homepage = "https://opensearch.org";
+    license = licenses.asl20;
+    platforms = with platforms; linux;
+  };
+}

--- a/pkgs/opensearch-dashboards/disable-nodejs-version-check.patch
+++ b/pkgs/opensearch-dashboards/disable-nodejs-version-check.patch
@@ -1,0 +1,10 @@
+diff --git a/src/setup_node_env/no_transpilation.js b/src/setup_node_env/no_transpilation.js
+index dae489e0..0d2dc056 100644
+--- a/src/setup_node_env/no_transpilation.js
++++ b/src/setup_node_env/no_transpilation.js
+@@ -41,4 +41,3 @@ require('source-map-support/register');
+
+ require('./root');
+
+-require('./node_version_validator');
+\ No newline at end of file

--- a/pkgs/opensearch/default.nix
+++ b/pkgs/opensearch/default.nix
@@ -1,0 +1,56 @@
+{ lib
+, stdenv
+, stdenvNoCC
+, fetchurl
+, makeWrapper
+, jre_headless
+, util-linux
+, gnugrep
+, coreutils
+, autoPatchelfHook
+, zlib
+, nixosTests
+}:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "opensearch";
+  version = "2.6.0";
+
+  src = fetchurl {
+    url = "https://artifacts.opensearch.org/releases/bundle/opensearch/${version}/opensearch-${version}-linux-x64.tar.gz";
+    hash = "sha256-qJrgWF8JCR4jmnF239gaiRr4Y7Tin0TyYjzxd1Q4Wko";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ jre_headless util-linux ];
+  patches = [./opensearch-home-fix.patch ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out
+    cp -R bin config lib modules plugins $out
+
+    substituteInPlace $out/bin/opensearch \
+      --replace 'bin/opensearch-keystore' "$out/bin/opensearch-keystore"
+
+    wrapProgram $out/bin/opensearch \
+      --prefix PATH : "${lib.makeBinPath [ util-linux gnugrep coreutils ]}" \
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ stdenv.cc.cc.lib ]}:$out/plugins/opensearch-knn/lib/" \
+      --set JAVA_HOME "${jre_headless}"
+
+    wrapProgram $out/bin/opensearch-plugin --set JAVA_HOME "${jre_headless}"
+
+    runHook postInstall
+  '';
+
+  passthru.tests = nixosTests.opensearch;
+
+  meta = {
+    description = "Open Source, Distributed, RESTful Search Engine";
+    homepage = "https://github.com/opensearch-project/OpenSearch";
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ shyim ];
+  };
+}

--- a/pkgs/opensearch/opensearch-home-fix.patch
+++ b/pkgs/opensearch/opensearch-home-fix.patch
@@ -1,0 +1,26 @@
+diff -Naur a/bin/opensearch-env b/bin/opensearch-env
+--- a/bin/opensearch-env	2017-12-12 13:31:51.000000000 +0100
++++ b/bin/opensearch-env	2017-12-18 19:51:12.282809695 +0100
+@@ -19,18 +19,10 @@
+   fi
+ done
+ 
+-# determine OpenSearch home; to do this, we strip from the path until we find
+-# bin, and then strip bin (there is an assumption here that there is no nested
+-# directory under bin also named bin)
+-OPENSEARCH_HOME=`dirname "$SCRIPT"`
+-
+-# now make OPENSEARCH_HOME absolute
+-OPENSEARCH_HOME=`cd "$OPENSEARCH_HOME"; pwd`
+-
+-while [ "`basename "$OPENSEARCH_HOME"`" != "bin" ]; do
+-  OPENSEARCH_HOME=`dirname "$OPENSEARCH_HOME"`
+-done
+-OPENSEARCH_HOME=`dirname "$OPENSEARCH_HOME"`
++if [ -z "$OPENSEARCH_HOME" ]; then
++    echo "You must set the OPENSEARCH_HOME var" >&2
++    exit 1
++fi
+ 
+ # now set the classpath
+ OPENSEARCH_CLASSPATH="$OPENSEARCH_HOME/lib/*"

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -296,6 +296,9 @@ in {
 
   openldap_2_4 = super.callPackage ./openldap_2_4.nix { };
 
+  opensearch = super.callPackage ./opensearch { };
+  opensearch-dashboards = super.callPackage ./opensearch-dashboards { };
+
   percona = self.percona80;
   percona-toolkit = super.perlPackages.PerconaToolkit.overrideAttrs(oldAttrs: {
     # The script uses usr/bin/env perl and the Perl builder adds PERL5LIB to it.

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -80,6 +80,8 @@ in {
   nfs = callTest ./nfs.nix {};
   nginx = callTest ./nginx.nix {};
   nodejs = callTest ./nodejs.nix {};
+  opensearch = callTest ./opensearch.nix {};
+  opensearch_dashboards = callTest ./opensearch_dashboards.nix {};
   openvpn = callTest ./openvpn.nix {};
   percona80 = callTest ./mysql.nix { rolename = "percona80"; };
   physical-installer = callTest ./physical-installer.nix { inherit nixpkgs; };

--- a/tests/opensearch.nix
+++ b/tests/opensearch.nix
@@ -1,0 +1,75 @@
+import ./make-test-python.nix ({ pkgs, testlib, ... }:
+let
+  ipv4 = testlib.fcIP.srv4 1;
+  ipv6 = testlib.fcIP.srv6 1;
+in
+{
+  name = "opensearch";
+
+  nodes.machine =
+    { pkgs, config, ... }:
+    {
+      imports = [
+        (testlib.fcConfig { net.fe = false; })
+      ];
+
+      networking.domain = "test";
+      networking.extraHosts = ''
+        ${ipv6} machine.test
+      '';
+      virtualisation.memorySize = 3072;
+      virtualisation.qemu.options = [ "-smp 2" ];
+      flyingcircus.roles.opensearch.enable = true;
+      flyingcircus.roles.opensearch.nodes = [ "machine" ];
+    };
+
+  testScript = { nodes, ... }:
+  let
+    sensuCheck = testlib.sensuCheckCmd nodes.machine;
+  in ''
+    import json
+
+    checks = [
+      "${sensuCheck "opensearch_node_status"}",
+      "${sensuCheck "opensearch_circuit_breakers"}",
+      "${sensuCheck "opensearch_cluster_health"}",
+      "${sensuCheck "opensearch_heap"}",
+      "${sensuCheck "opensearch_shard_allocation_status"}",
+    ]
+
+    expected_sockets = [
+      "${ipv4}:9200",
+      "${ipv6}:9200",
+      "${ipv4}:9300",
+      "${ipv6}:9300",
+    ]
+
+    def assert_listen(machine, process_name, expected_sockets):
+      result = machine.succeed(f"netstat -tlpn | grep {process_name} | awk '{{ print $4 }}'")
+      actual = set(result.splitlines())
+      assert set(expected_sockets) == actual, f"expected sockets: {expected_sockets}, found: {actual}"
+
+    machine.wait_for_unit("opensearch")
+
+    with subtest("opensearch API should respond"):
+        api_result = json.loads(machine.wait_until_succeeds("curl ${ipv4}:9200"))
+        cluster_name = api_result["cluster_name"]
+        assert cluster_name == "machine", f"expected cluster name 'machine', got '{cluster_name}'"
+
+    with subtest("opensearch (java) opens expected ports"):
+      assert_listen(machine, "java", expected_sockets)
+
+    with subtest("all sensu checks should be green"):
+      for check_cmd in checks:
+        machine.succeed(check_cmd)
+
+    with subtest("killing the opensearch process should trigger an automatic restart"):
+      machine.succeed("systemctl kill -s KILL opensearch")
+      machine.sleep(1)
+      machine.wait_until_succeeds("${sensuCheck "opensearch_node_status"}")
+
+    with subtest("status check should be red after shutting down nginx"):
+      machine.systemctl('stop opensearch')
+      machine.wait_until_fails("${sensuCheck "opensearch_node_status"}")
+  '';
+})

--- a/tests/opensearch_dashboards.nix
+++ b/tests/opensearch_dashboards.nix
@@ -1,0 +1,53 @@
+import ./make-test-python.nix ({ pkgs, testlib, ... }:
+let
+  ipv4 = testlib.fcIP.srv4 1;
+in
+{
+  name = "opensearch-dashboards";
+
+  nodes.machine =
+    { pkgs, config, lib, ... }:
+    {
+
+      imports = [
+        (testlib.fcConfig { net.fe = false; })
+      ];
+
+      networking.domain = "test";
+      virtualisation.memorySize = 3072;
+      virtualisation.diskSize = lib.mkForce 2000;
+      virtualisation.qemu.options = [ "-smp 2" ];
+      flyingcircus.roles.opensearch.enable = true;
+      flyingcircus.roles.opensearch.nodes = [ "machine" ];
+      flyingcircus.roles.opensearch_dashboards.enable = true;
+      systemd.services.opensearch-dashboards.serviceConfig.TimeoutStartSec = 900;
+    };
+
+  testScript = ''
+    start_all()
+
+    machine.wait_for_unit("opensearch")
+    machine.wait_for_unit("opensearch-dashboards")
+
+    status_check = """
+      for count in {0..100}; do
+        echo "Checking..." | logger -t opensearch-dashboards-status
+        curl -s "${ipv4}:5601/api/status" | grep -q '"state":"green' && exit
+        sleep 5
+      done
+      echo "Failed" | logger -t opensearch-dashboards-status
+      curl -s "${ipv4}:5601/api/status"
+      exit 1
+    """
+
+    with subtest("Opensearch dashboards status check should pass"):
+        machine.succeed(status_check)
+
+    with subtest("killing the opensearch-dashboards process should trigger an automatic restart"):
+        machine.succeed(
+            "kill -9 $(systemctl show opensearch-dashboards.service --property MainPID --value)"
+        )
+        machine.wait_for_unit("opensearch-dashboards")
+        machine.succeed(status_check)
+  '';
+})


### PR DESCRIPTION
Add opensearch roles

- Add roles opensearch and opensearch_dashboards
- We use a static user instead of the upstream DynamicUser to allow running
  scripts as opensearch user.
- state dir is the upstream default of `/var/lib/opensearch`. We often changed
  these defaults to something in `/srv`. A link from `/srv/opensearch` points to
  the state dir in case someone is searching for the state in the wrong place.
- `opensearch-plugin` command can be run as opensearch user.
- Add an option to the upstream service to be able to access the config YAML.
- `opensearch-readme` displays a formatted (rich-cli) Markdown README file
  from the local config dir.
- local config dir isn't actually used for config anymore, it just has the
  readme and example NixOS config.
- Listens on SRV like Elasticsearch did.


@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

- add opensearch and opensearch_dashboards roles, version 2.6.0. They are intended to replace Elasticsearch/Kibana 7.10.2 but the roles should only be used for new installations right now. We will provide automatic migrations from ES to OpenSearch later (PL-130611).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - mostly the same as Elasticsearch which we want to replace with OpenSearch
  - service implementation is taken from 23.05
  - OpenSearch only listens on SRV
  - state dir only readable by opensearch user
    -  upstream uses DynamicUser which would be more secure but we want to be able to use `opensearch-*` scripts as opensearch users so we had to disable the option. This is not a big issue because we allow full API access to data anyway and permissions are still limited.  
- [x] Security requirements tested? (EVIDENCE)
  - automated test checks functionality, sensu checks and open ports
  - manually checked on test VM that a fresh installation and upgrading from pre-role opensearch works, checked open ports