### PR TITLE
[21.05] backy: bump revision

### DIFF
--- a/pkgs/backy/default.nix
+++ b/pkgs/backy/default.nix
@@ -9,8 +9,8 @@ let
   src = fetchFromGitHub {
     owner = "flyingcircusio";
     repo = "backy";
-    rev = "93b18b09b3db1cba4a10c6613bfec0ad0d82895a";
-    hash = "sha256-HRndYUW08c8ncxwGdSOZWyXszzJ0JDKBAlFSS+UiQRU=";
+    rev = "5fa55f0c512e557bea3802f0be10e997e6f33f03";
+    hash = "sha256-n3q8xr7o/REiftxHc2LYRvKnhu7Ab2MuQ+OfhSniOhk=";
   };
 
 in poetry2nix.mkPoetryApplication {


### PR DESCRIPTION
changes: https://github.com/flyingcircusio/backy/compare/93b18b09b3db1cba4a10c6613bfec0ad0d82895a..5fa55f0c512e557bea3802f0be10e997e6f33f03#diff-59130575b4fb2932c957db2922977d7d89afb0b2085357db1a14615a2fcad776

@flyingcircusio/release-managers

## Release process

Impact: none/internal

Changelog:
- backy:
  - Use structlog for logging
  - Static typechecking with mypy
  - List all manual tags in `backy check`
  - Fix crash for non-numeric Ceph version strings

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - [x] keep software up to date
  - [x] bring minor but urgent bugfixes to production
  - [x] changes need to be tested
- [x] Security requirements tested? (EVIDENCE)
  - [x] automated tests still pass
  - [x] deployed to dev cluster, manually tested `backy-extract`, `restore-single-files`, `backy status`, `backy backup`

PL-131449