### PR TITLE
Update nixpkgs

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "bed4ce58b2497f5af5dd8f98a43e349b2cbd57d9",
-    "sha256": "PRNi9I7p1ZpV+IMfFc7z3tMSebPbYof3jmH1d1Ndw4k="
+    "rev": "962bd9e48ae9fababd62bed7e023e3aa169d982b",
+    "sha256": "GvgunrWPhO476sc/aysm0WDHQ40cZNPYej/5OLjDrgs="
   },
   "nixos-mailserver": {
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/",


### PR DESCRIPTION
Pull upstream NixOS changes, security fixes and package updates:

- element-web: 1.11.29 -> 1.11.30 (CVE-2023-30609)
- ghostscript: add patch for CVE-2023-28879
- gitlab: 15.10.2 -> 15.11.1
- grafana: 9.4.7 -> 9.4.9 (CVE-2023-1387, CVE-2023-28119)
- imagemagick: 7.1.1-6 -> 7.1.1-8
- keycloak: 20.0.3 -> 20.0.5 (CVE-2022-1274)
- libtiff: add patches for many related CVEs
- libxml2: 2.10.3 → 2.10.4 (CVE-2023-29469, CVE-2023-28484)
- linux: 5.15.107 -> 5.15.109
- matrix-synapse: 1.81.0 -> 1.82.0
- php81: 8.1.17 -> 8.1.18
- python310: 3.10.10 -> 3.10.11
- python310: 3.10.9 -> 3.10.10
- python311: 3.11.1 -> 3.11.3
- redis: 7.0.10 -> 7.0.11 (CVE-2023-28856)
- screen: add patch from CVE-2023-24626
- systemd: 251.13 -> 251.15
- tcpdump: 4.99.1 -> 4.99.4

PL-131463

@flyingcircusio/release-managers

## Release process

Impact:

* \[NixOS 22.11] Most services will restarted because of a core dependency change. Machines will schedule a reboot to activate the changed kernel.

Changelog: (include changes from commit msg here)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - pull in upstream security fixes regularly
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still run, works on test VM and gitlab staging
  - checked commit log for fixed CVEs and possible problems with updates, looked at [synapse/upgrade.md](https://github.com/matrix-org/synapse/blob/develop/docs/upgrade.md), [Grafana changelog](https://github.com/grafana/grafana/blob/main/CHANGELOG.md/, [Releases | GitLab](https://about.gitlab.com/releases/categories/releases/) and [Upgrading GitLab](https://docs.gitlab.com/ee/update/#upgrade-paths)
