### PR TITLE
platform: reset IPv6 address generation sysctl upon link configuration.

### DIFF
--- a/nixos/platform/network.nix
+++ b/nixos/platform/network.nix
@@ -220,6 +220,14 @@ in
                 sysctl net.ipv6.conf.$IFACE.autoconf=0
                 sysctl net.ipv6.conf.$IFACE.temp_valid_lft=0
                 sysctl net.ipv6.conf.$IFACE.temp_prefered_lft=0
+
+                # If an interface has previously been managed by dhcpcd this sysctl might be
+                # set to a non-zero value, which disables automatic generation of link-local
+                # addresses. This can leave the interface without a link-local address when
+                # dhcpcd deletes addresses from the interface when it exits. Resetting this
+                # to 0 restores the default kernel behaviour.
+                sysctl net.ipv6.conf.$IFACE.addr_gen_mode=0
+
                 for oldtmp in `ip -6 address show dev $IFACE dynamic scope global  | grep inet6 | cut -d ' ' -f6`; do
                   ip addr del $oldtmp dev $IFACE
                 done
@@ -232,6 +240,10 @@ in
                 sysctl net.ipv6.conf.${interface.device}.autoconf=0
                 sysctl net.ipv6.conf.${interface.device}.temp_valid_lft=0
                 sysctl net.ipv6.conf.${interface.device}.temp_prefered_lft=0
+
+                # See above.
+                sysctl net.ipv6.conf.${interface.device}.addr_gen_mode=0
+
                 for oldtmp in `ip -6 address show dev ${interface.device} dynamic scope global  | grep inet6 | cut -d ' ' -f6`; do
                   ip addr del $oldtmp dev ${interface.device}
                 done


### PR DESCRIPTION
When new hosts are booted from the bootstrap image for the first time, they use dhcpcd for dynamic network configuration. dhcpcd disables the kernel's handling of automatic IPv6 configuration and performs this function itself, however this can sometimes lead to dhcpcd removing link-local addresses when it exits without the kernel replacing them. There is a sysctl for controlling the kernel's automatic address configuration behaviour, which can be set when interfaces are configured during system activation to restore the default (and desired) behaviour.

@flyingcircusio/release-managers

## Release process

Impact: Internal

Changelog:

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Ensure that network devices are configured appropriately so that IPv6 works as expected.
- [x] Security requirements tested? (EVIDENCE)
  - Tested manually in a freshly bootstrapped VM where link-local addresses were missing on all external (i.e. non-loopback) interfaces, verified that link-local addresses were present on all interfaces after applying this change.