### PR TITLE
Percona 8.0.32

### DIFF
--- a/pkgs/percona/8.0.nix
+++ b/pkgs/percona/8.0.nix
@@ -9,11 +9,11 @@
 
 stdenv.mkDerivation rec {
   pname = "percona";
-  version = "8.0.30-22";
+  version = "8.0.32-24";
 
   src = fetchurl {
     url = "https://www.percona.com/downloads/Percona-Server-8.0/Percona-Server-${version}/source/tarball/percona-server-${version}.tar.gz";
-    sha256 = "sha256-5TbX95esTYauPON9VfimoO5zmLQxzWfDgzJWbV+nQRQ=";
+    sha256 = "sha256-KGdwbpFFl8s6UWF1FXPFRjyvg0NoTtfur8rR648tCB4=";
   };
 
   preConfigure = lib.optional stdenv.isDarwin ''
@@ -77,6 +77,8 @@ stdenv.mkDerivation rec {
     "-DWITH_BLACKHOLE_STORAGE_ENGINE=1"
     "-DWITH_INNOBASE_STORAGE_ENGINE=1"
     "-DWITHOUT_EXAMPLE_STORAGE_ENGINE=1"
+    # Fails the SSE 4.2 check and forcing it doesn't work, too.
+    "-DWITHOUT_ROCKSDB=1"
   ] ++ lib.optionals stdenv.isLinux [
     "-DWITH_JEMALLOC=1"
     "-DWITH_SYSTEMD=1"

--- a/pkgs/percona/xtrabackup.nix
+++ b/pkgs/percona/xtrabackup.nix
@@ -6,11 +6,11 @@
 
 stdenv.mkDerivation rec {
   name = "xtrabackup-${version}";
-  version = "8.0.30-23";
+  version = "8.0.32-26";
 
   src = fetchurl {
     url = "https://www.percona.com/downloads/Percona-XtraBackup-8.0/Percona-XtraBackup-${version}/source/tarball/percona-xtrabackup-${version}.tar.gz";
-    sha256 = "sha256-mxv7HM4oYGJ66+1T1i6GtV5leGnJG3FfYmwgdZtzQes=";
+    sha256 = "sha256-KhwjSX/9WQXW3CC9tagB0bi66zJF7BHtEV3uDXi3peI=";
   };
 
   nativeBuildInputs = [ bison boost cmake makeWrapper pkg-config ];


### PR DESCRIPTION
Update percona and xtrabackup to 8.0.32. Had to disable MyRocks because it fails the SSE 4.2 check and
forcing it leads to an error when compiling MyRocks. We don't use this anyway.


@flyingcircusio/release-managers

## Release process

Impact:

* Percona will be restarted

Changelog:

* percona: update to 8.0.32. Note that the MyRocks storage engine is not available with this version.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - nothing new, just a minor update 
- [x] Security requirements tested? (EVIDENCE)
  - automated test still runs, checked on a test VM with Matomo as application