### PR TITLE
Update nixpkgs for Gitlab 15.11.2

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "962bd9e48ae9fababd62bed7e023e3aa169d982b",
-    "sha256": "GvgunrWPhO476sc/aysm0WDHQ40cZNPYej/5OLjDrgs="
+    "rev": "63572e7d205027d8ae4bed36f1d5b166ae620d14",
+    "sha256": "pJ9W+jBwHog5dB3nzozejUQB2ElEGPYfecja3ejVSz8="
   },
   "nixos-mailserver": {
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/",


### PR DESCRIPTION
The nixpkgs update already had an Gitlab update, this PR bumps the minor version to get the latest security update

- gitlab: 15.11.1 -> 15.11.2

PL-131472

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? 
  -  do regular security updates for Gitlab 
- [x] Security requirements tested? (EVIDENCE)
  - automated test still runs, tested on our Gitlab staging machine