### PR TITLE
gitlab: ensure service is restarted again after dependency restarts

### DIFF
--- a/nixos/roles/gitlab.nix
+++ b/nixos/roles/gitlab.nix
@@ -218,6 +218,12 @@ in
     # Needed for Git via SSH.
     users.users.gitlab.extraGroups = [ "login" ];
 
+    # ensure that gitlab is restarted again, when stopped due to a dependency
+    # (e.g. postgresql) being stopped and started again
+    systemd.services.gitlab = {
+      wantedBy = lib.mkForce [];
+      requiredBy = [ "gitlab.target" ];
+    };
   })
 
   (lib.mkIf (cfg.enable && cfg.extraSecrets != []) {


### PR DESCRIPTION
When a dependency, like postgresql.service or redis-gitlab.service, had been stopped and started at switch-to-configuration time, gitlab.service and its helper units had been stopped but not had been started again. This commit fixes this by upgrading the dependy relationship of gitlab.service towards gitlab.target from a "Wants" to a "Requires". It should be enough to do this for this single unit part of gitlab.target only, as all other units wantedBy gitlab.target are pulled in by gitlab.service as well.

fixes PL-131286

@flyingcircusio/release-managers

## Release process

Impact: none, no service restarts triggered

Changelog:
- fixes a scenario, where gitlab was stopped and never started again after one of its dependencies had been upgraded

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - [x] must not introduce new known regressions
  - [x] reproduce issue first
  - [x] then verify that this reproduced issue is fixed 
- [x] Security requirements tested? (EVIDENCE)
  - [x] NixOS tests still pass
  - [x] verified in a testvm that this upgrade causes no service restarts
  - [x] reproduced the issue by enforcing the restart of `postgresql.service` and `redis-gitlab.service` during system upgrade with restartTriggers
  - [x] verified that these enforced dependency restarts also cause gitlab.service to stop, but also make it start up again now
