### PR TITLE
[23.05] mailserver tests: recreate the password hashes for test users.

### DIFF
--- a/tests/mail/default.nix
+++ b/tests/mail/default.nix
@@ -70,12 +70,12 @@ in
             mailserver.loginAccounts = lib.mkForce {
               "user1@example.local" = {
                 # User1User1
-                hashedPassword = "$5$ld7g3N1MtrZl$PisX9yQsemPEwVNUqQVToe07MaP9qDesXMh5mAwWTR6";
+                hashedPassword = "$6$bJ15li3x3hoWc6av$HREqV9DGuHOgO26M6GQrjoA8.p5kAqzY2hTy.yipNZ6s32EHnHLaw0kop6mMmfxN.LvePsm/1sShrSXJLWotm.";
                 aliases = [ "alias1@example.local" ];
               };
               "user2@example.local" = {
                 # User2USer2
-                hashedPassword = "$5$YF.qhP4xh$N.hX/1SMxmjqjYZqmrtTClzzSLOR/scz.TTmz4KAFX2";
+                hashedPassword = "$6$ubISDRB4Pr3IV0CO$n5tZuntp4EG9l6euyyzuR3GQHKcjpzN5f4HRIQrhykuI3H8/6A7H8mS7AFtOR5KZyWeJNX1BGkbetLCZM6A02/";
               };
             };
 


### PR DESCRIPTION
The passwords for the test users in the mail server test were hashed with SHA256, however support for this password hash algorithm has been dropped from NixOS upstream as of 23.05, which caused our tests to fail. Recreating the password hashes using SHA512 fixes the tests, which now run correctly again.

@flyingcircusio/release-managers

## Release process

Impact: internal

Changelog:

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Fix tests to ensure that any later regressions in functionality are detected correctly.
- [x] Security requirements tested? (EVIDENCE)
  - Tested manually with `nix-build ./tests/mail`, the test now runs to completion without any errors.