### PR TITLE
Update nixpkgs for gitlab 15.11.3

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -2,9 +2,9 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "63572e7d205027d8ae4bed36f1d5b166ae620d14",
-    "sha256": "pJ9W+jBwHog5dB3nzozejUQB2ElEGPYfecja3ejVSz8="
-  },
+    "rev": "68d3f0e2ec7d290b8686be9df2455c5e25995324",
+    "sha256": "RfRXjA8FTuX2V1jqKjgcVAU/vZuLcOWIRDfKjloTgWk="
+   },
   "nixos-mailserver": {
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/",
     "rev": "02186744a7d8309d92f5b17689ee5184d87b4f2e",


### PR DESCRIPTION
- gitlab: 15.11.2 -> 15.11.3

PL-131490

@flyingcircusio/release-managers

## Release process

Impact:

* \[NixOS 22.11\] Gitlab will be restarted.

Changelog:

* Gitlab: 15.11.2 -> 15.11.3 (PL-131490).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? 
  -  do regular security updates for Gitlab 
- [x] Security requirements tested? (EVIDENCE)
  - automated test still runs, tested on our Gitlab staging machine