### PR TITLE
Update nixpkgs

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -2,9 +2,9 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "68d3f0e2ec7d290b8686be9df2455c5e25995324",
-    "sha256": "RfRXjA8FTuX2V1jqKjgcVAU/vZuLcOWIRDfKjloTgWk="
-   },
+    "rev": "638a9662300c2b287d4c09f590c1c7e6c7b5c190",
+    "sha256": "l+xzisuBt5HoZ4LcZ6sUbCvoSNbMI6npsS3yW3qTObQ="
+  },
   "nixos-mailserver": {
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/",
     "rev": "02186744a7d8309d92f5b17689ee5184d87b4f2e",


### PR DESCRIPTION
Pull upstream NixOS changes, security fixes and package updates:

- linux: 5.15.109 -> 5.15.110
- nss_latest: 3.89 -> 3.89.1
- strace: 6.2 -> 6.3

PL-131494

@flyingcircusio/release-managers

## Release process

Impact:

* \[NixOS 22.11] Machines will schedule a reboot to activate the changed kernel.

Changelog: (include changes from commit msg here)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - pull in upstream security fixes regularly
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still run, works on test VM
  - checked commit log for fixed CVEs and possible problems with updates
