### PR TITLE
Ensure postfix queue permission setup script is launched at startup

### DIFF
--- a/nixos/services/mail/default.nix
+++ b/nixos/services/mail/default.nix
@@ -393,8 +393,9 @@ in {
       let
         dirs = "/var/lib/postfix/queue/{active,hold,incoming,deferred,maildrop}";
       in rec {
-        partOf = [ "postfix.service" ];
-        after = [ "postfix.service" ];
+        after = [ "postfix-setup.service" ];    # Ordering
+        wantedBy = [ "postfix-setup.service" ]; # Startup, without failure propagation
+        partOf = [ "postfix-setup.service" ];   # Restart, without failure propagation
         path = with pkgs; [ acl ];
         script = ''
           setfacl -Rm u:telegraf:rX ${dirs}


### PR DESCRIPTION
When both mail server role and metrics collection are enabled Telegraf requires access to Postfix's queue directories in order to read queue statistics. However, on startup the Postfix service sets restrictive permissions on the queue directory, which prevents this access. We have a fixup script which sets an ACL to allow the Telegraf user to read this directory, however this does not seem to be triggered properly upon system boot.

The systemd unit for the fixup script needs an additional `WantedBy` constraint in order to be triggered on system startup correctly, and not only when the Postfix service is restarted.

PL-129873

@flyingcircusio/release-managers

## Release process

Impact: internal

Changelog:

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Ensure that Telegraf has the appropriate permissions to read the Postfix queue directory, in order to provide visibility into mail server queue state.
- [x] Security requirements tested? (EVIDENCE)
  - Tested manually on a development mail server, verified that filesystem permissions are set correctly on the Postfix queue directory after a reboot.