### PR TITLE
update nixpkgs for new gitlab version 15.11.5

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "638a9662300c2b287d4c09f590c1c7e6c7b5c190",
-    "sha256": "l+xzisuBt5HoZ4LcZ6sUbCvoSNbMI6npsS3yW3qTObQ="
+    "rev": "960dab25f0225cf9fd8f48922087d805ae649782",
+    "sha256": "uYN/VDlw8dsZxEKHfdwlfKaHcP14b+Euc8saf7xxA6M="
   },
   "nixos-mailserver": {
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/",


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

* \[NixOS 22.11\] Gitlab will be restarted.

Changelog:

* Gitlab: 15.11.3 -> 15.11.5 (PL-131506).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? 
  -  do regular security updates for Gitlab 
- [x] Security requirements tested? (EVIDENCE)
  - automated test still runs, tested on our Gitlab staging machine