### PR TITLE
Flake-Info patches

### DIFF
--- a/doc/src/mailserver.md
+++ b/doc/src/mailserver.md
@@ -257,7 +257,7 @@ HELO name
 
 Frontend IP addresses
 
-: Public IPv4 and/or IPv6 adresses. **A** and **AAAA** queries of the HELO name
+: Public IPv4 and/or IPv6 addresses. **A** and **AAAA** queries of the HELO name
   must resolve to the frontend IP addresses. Each address must have a **PTR**
   record which must resolve exactly to the HELO name.
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,7 @@
+{
+  "nodes": {
+    "root": {}
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,86 @@
+{
+  outputs = { self, ...}: let
+    versions = builtins.fromJSON (builtins.readFile ./versions.json);
+    nixpkgs = let
+      inherit (versions.nixpkgs) owner repo rev;
+    in builtins.getFlake "github:${owner}/${repo}/${rev}";
+
+    inherit (nixpkgs) lib;
+    nixpkgsConfig = import ./nixpkgs-config.nix;
+
+    pkgsFor = system: import nixpkgs {
+      inherit system;
+      overlays = [ self.overlays.default ];
+      config = {
+        inherit (nixpkgsConfig) permittedInsecurePackages;
+      };
+    };
+
+    forAllSystems = lib.genAttrs lib.systems.flakeExposed;
+  in {
+    overlays.default = import ./pkgs/overlay.nix;
+    nixosModules.default = import ./nixos/default.nix;
+
+    legacyPackages = forAllSystems (system: import ./. {
+      inherit nixpkgs system;
+      overlays = [ self.overlays.default ];
+      config = {
+        inherit (nixpkgsConfig) permittedInsecurePackages;
+      };
+    });
+
+    packages = forAllSystems (system: let
+      pkgs = pkgsFor system;
+    in {
+      options = let
+        testConfigFor = system: let
+          pkgs = pkgsFor system;
+          versions = import ./versions.nix { inherit pkgs; };
+          testlib = import ./tests/testlib.nix { inherit  (pkgs) lib; };
+        in lib.nixosSystem {
+          inherit pkgs system;
+          specialArgs.nixos-mailserver = versions.nixos-mailserver;
+
+          modules = [
+            {
+              options.virtualisation.vlans = lib.mkOption {
+                type = lib.types.anything;
+                default = [];
+              };
+
+              config.networking.domain = "test.fcio.net";
+
+              imports = [
+                (testlib.fcConfig {
+                  id = 1;
+                  net.fe = true;
+                  extraEncParameters.environment_url = "test.fcio.net";
+                })
+              ];
+            }
+          ];
+        };
+
+        rawOpts = lib.optionAttrSetToDocList (testConfigFor system).options;
+
+        substSpecial = x:
+          if lib.isDerivation x then { _type = "derivation"; name = x.name; }
+          else if builtins.isAttrs x then lib.mapAttrs (name: substSpecial) x
+          else if builtins.isList x then map substSpecial x
+          else if lib.isFunction x then "<function>"
+          else x;
+
+        filteredOpts = lib.filter (opt: opt.visible && !opt.internal) rawOpts;
+        optionsList = lib.flip map filteredOpts
+          (opt: opt
+            // lib.optionalAttrs (opt ? example) { example = substSpecial opt.example; }
+            // lib.optionalAttrs (opt ? default) { default = substSpecial opt.default; }
+            // lib.optionalAttrs (opt ? type) { type = substSpecial opt.type; }
+          );
+
+        optionsNix = builtins.listToAttrs (map (o: { name = o.name; value = removeAttrs o ["name" "visible" "internal"]; }) optionsList);
+        finalOptions = lib.mapAttrsToList (name: option: option // { inherit name; }) optionsNix;
+      in pkgs.writeText "options.json" (builtins.unsafeDiscardStringContext (builtins.toJSON finalOptions));
+    });
+  };
+}

--- a/nixos/platform/auditbeat.nix
+++ b/nixos/platform/auditbeat.nix
@@ -13,7 +13,7 @@ in
       type = types.package;
       default = pkgs.auditbeat7-oss;
       defaultText = "pkgs.auditbeat7-oss";
-      example = literalExample "pkgs.auditbeat7";
+      example = literalExpression "pkgs.auditbeat7";
       description = ''
         The auditbeat package to use.
       '';

--- a/nixos/platform/default.nix
+++ b/nixos/platform/default.nix
@@ -82,6 +82,7 @@ in {
     };
 
     flyingcircus.enc_services_path = mkOption {
+      defaultText = "/etc/nixos/services.json";
       default = /etc/nixos/services.json;
       type = path;
       description = "Where to find the ENC services json file.";
@@ -168,7 +169,7 @@ in {
       '';
       type = types.path;
       default = "/etc/local";
-      example = ./test_cfg;
+      example = "./test_cfg";
     };
 
     flyingcircus.platform = {

--- a/nixos/platform/enc.nix
+++ b/nixos/platform/enc.nix
@@ -35,6 +35,7 @@ with lib;
     };
 
     encAddressesPath = mkOption {
+      defaultText = "/etc/nixos/addresses_srv.json";
       default = /etc/nixos/addresses_srv.json;
       type = path;
       description = "Where to find the address list json file.";
@@ -46,6 +47,7 @@ with lib;
     };
 
     encServicesPath = mkOption {
+      defaultText = "/etc/nixos/services.json";
       default = /etc/nixos/services.json;
       type = path;
       description = "Where to find the ENC services json file.";
@@ -59,12 +61,14 @@ with lib;
     };
 
     encServiceClientsPath = mkOption {
+      defaultText = "/etc/nixos/service_clients.json";
       default = /etc/nixos/service_clients.json;
       type = path;
       description = "Where to find the ENC service clients json file.";
     };
 
     systemStatePath = mkOption {
+      defaultText = "/etc/nixos/system_state.json";
       default = /etc/nixos/system_state.json;
       type = path;
       description = "Where to find the system state json file.";

--- a/nixos/platform/filebeat.nix
+++ b/nixos/platform/filebeat.nix
@@ -118,7 +118,7 @@ in
         type = types.package;
         default = pkgs.filebeat7-oss;
         defaultText = "pkgs.filebeat7-oss";
-        example = literalExample "pkgs.filebeat7";
+        example = literalExpression "pkgs.filebeat7";
         description = ''
           The filebeat package to use.
         '';

--- a/nixos/platform/journalbeat.nix
+++ b/nixos/platform/journalbeat.nix
@@ -125,7 +125,7 @@ in
           type = types.package;
           default = pkgs.filebeat7-oss;
           defaultText = "pkgs.filebeat7-oss";
-          example = literalExample "pkgs.filebeat7";
+          example = literalExpression "pkgs.filebeat7";
           description = ''
             The filebeat package to use.
           '';

--- a/nixos/platform/static.nix
+++ b/nixos/platform/static.nix
@@ -21,6 +21,7 @@ with lib;
       };
 
       ceph.fsids = {
+        "testloc"."testrg" = "7d3bdc42-1d8e-4fcd-952d-e968d4f0cde4";
         # These are needed once per cluster.
         # Generate a new one via: `uuidgen -t` and record
         # it here with the ${location}.${resourcegroup} key

--- a/nixos/platform/users.nix
+++ b/nixos/platform/users.nix
@@ -126,6 +126,7 @@ in
     };
 
     userDataPath = lib.mkOption {
+      defaultText = "/etc/nixos/users.json";
       default = /etc/nixos/users.json;
       type = path;
       description = "Where to find the user json file.";
@@ -137,6 +138,7 @@ in
     };
 
     permissionsPath = lib.mkOption {
+      defaultText = "/etc/nixos/permissions.json";
       default = /etc/nixos/permissions.json;
       type = path;
       description = ''

--- a/nixos/roles/antivirus.nix
+++ b/nixos/roles/antivirus.nix
@@ -16,6 +16,7 @@ in
 
       listenAddresses = lib.mkOption {
         type = lib.types.listOf lib.types.str;
+        defaultText = "addresses of the interfaces `lo` and `srv`";
         default = fclib.network.lo.dualstack.addresses ++
                   fclib.network.srv.dualstack.addresses;
       };

--- a/nixos/roles/coturn.nix
+++ b/nixos/roles/coturn.nix
@@ -50,7 +50,20 @@ in
       config = mkOption {
         description = "Platform-configured options";
         type = types.attrs;
-        default =  {
+        defaultText = {
+          hostname = "\${cfg.hostName}";
+          alt-listening-port = 3479;
+          alt-tls-listening-port = 5350;
+          listening-ips = "the addresses of networks `lo`, `srv` and `fe`";
+          listening-port = 3478;
+          lt-cred-mech = false;
+          no-cli = true;
+          realm = "\${cfg.hostName}";
+          tls-listening-port = 5349;
+          use-auth-secret = true;
+          extraConfig = [];
+        };
+        default = {
           hostname = cfg.hostName;
           alt-listening-port = 3479;
           alt-tls-listening-port = 5350;

--- a/nixos/roles/external_net/default.nix
+++ b/nixos/roles/external_net/default.nix
@@ -34,7 +34,7 @@ in
   options = {
     flyingcircus.roles.external_net = {
 
-      enable = lib.mkEnableOption { };
+      enable = lib.mkEnableOption "fcio external_net role";
       supportsContainers = fclib.mkDisableContainerSupport;
 
       vxlan4 = lib.mkOption {
@@ -59,6 +59,7 @@ in
 
       frontendName = lib.mkOption {
         type = lib.types.str;
+        defaultText = "reverse name of the frontend's address";
         default = defaultFrontendName;
         description = ''
           DNS host name for the external network gateway. This is also the name

--- a/nixos/roles/external_net/openvpn.nix
+++ b/nixos/roles/external_net/openvpn.nix
@@ -208,7 +208,7 @@ in
 {
   options = {
     flyingcircus.roles.openvpn = {
-      enable = lib.mkEnableOption { };
+      enable = lib.mkEnableOption "fcio openvpn role";
       supportsContainers = fclib.mkDisableContainerSupport;
 
       accessNets = lib.mkOption {

--- a/nixos/roles/external_net/vxlan.nix
+++ b/nixos/roles/external_net/vxlan.nix
@@ -106,7 +106,7 @@ in
 {
   options = with lib; {
     flyingcircus.roles.vxlan =  {
-      gateway = mkEnableOption { };
+      gateway = mkEnableOption "fcio vxlan gateway";
 
       supportsContainers = fclib.mkDisableContainerSupport;
 

--- a/nixos/roles/mailserver.nix
+++ b/nixos/roles/mailserver.nix
@@ -26,7 +26,7 @@ let
         then "${hostName}.fe.${params.location}.${domain}"
         else if domain != null then "${hostName}.${domain}" else hostName;
       description = ''
-        FQDN of the mail server's frontend address. IP adresses and
+        FQDN of the mail server's frontend address. IP addresses and
         forward/reverse DNS must match exactly.
       '';
       example = "mail.example.com";

--- a/nixos/roles/memcached.nix
+++ b/nixos/roles/memcached.nix
@@ -34,6 +34,7 @@ in
 
       listenAddresses = lib.mkOption {
         type = lib.types.listOf lib.types.str;
+        defaultText = "the addresses of the networks `lo` and `srv`";
         default = fclib.network.lo.dualstack.addresses ++
                   fclib.network.srv.dualstack.addresses;
       };

--- a/nixos/roles/mysql.nix
+++ b/nixos/roles/mysql.nix
@@ -37,6 +37,7 @@ in
 
         listenAddresses = lib.mkOption {
           type = lib.types.listOf lib.types.str;
+          defaultText = "the addresses of the networks `lo` and `srv`";
           default = fclib.network.lo.dualstack.addresses ++
                     fclib.network.srv.dualstack.addresses;
         };

--- a/nixos/roles/statshost/default.nix
+++ b/nixos/roles/statshost/default.nix
@@ -191,6 +191,7 @@ in
 
       prometheusListenAddress = mkOption {
         type = types.str;
+        defaultText = "\${head fclib.network.srv.dualstack.addressQuoted}:9090";
         default = "${head fclib.network.srv.dualstack.addressesQuoted}:9090";
         description = "Prometheus listen address";
       };

--- a/nixos/roles/webproxy.nix
+++ b/nixos/roles/webproxy.nix
@@ -48,6 +48,7 @@ in
 
       listenAddresses = lib.mkOption {
         type = lib.types.listOf lib.types.str;
+        defaultText = "the addresses of the networks `srv` and `lo`";
         default = fclib.network.srv.dualstack.addressesQuoted ++
                   fclib.network.lo.dualstack.addressesQuoted;
       };

--- a/nixos/services/ceph/client.nix
+++ b/nixos/services/ceph/client.nix
@@ -21,6 +21,37 @@ in
     flyingcircus.services.ceph = {
       config = lib.mkOption {
         type = lib.types.lines;
+        defaultText = ''
+          [global]
+          pid file = /run/ceph/$type-$id.pid
+          admin socket = /run/ceph/$cluster-$name.asok
+
+          # Needs to correspond with daemon startup ulimit
+          max open files = 262144
+
+          osd pool default min size = 2
+          osd pool default size = 3
+
+          osd pool default pg num = 64
+          osd pool default pgp num = 64
+
+          setuser match path = /srv/ceph/$type/ceph-$id
+
+          debug filestore = 4
+          debug mon = 4
+          debug osd = 4
+          debug journal = 4
+          debug throttle = 4
+
+          mon compact on start = true     # Keep leveldb small
+          mon osd down out interval = 900  # Allow 15 min for reboots to happen without backfilling.
+          mon osd nearfull ratio = .9
+
+          mon data = /srv/ceph/mon/$cluster-$id
+          mon osd allow primary affinity = true
+          mon pg warn max per osd = 3000
+          mon pg warn max object skew = 20
+        '';
         default = ''
           [global]
           fsid = ${fs_id}

--- a/nixos/services/haproxy/config-options.nix
+++ b/nixos/services/haproxy/config-options.nix
@@ -298,7 +298,7 @@ in {
   };
   listen = mkOption {
     default = {};
-    example = literalExample ''{
+    example = literalExpression ''{
       http-in = {
         binds = [
           "127.0.0.1:8002"
@@ -325,7 +325,7 @@ in {
   };
   backend = mkOption {
     default = {};
-    example = literalExample ''{
+    example = literalExpression ''{
       be = {
         servers = [
           "localhost localhost:8080"

--- a/nixos/services/jitsi/jibri.nix
+++ b/nixos/services/jitsi/jibri.nix
@@ -162,6 +162,7 @@ in
 
     configFile = mkOption {
       type = types.path;
+      defaultText = "jibri.conf";
       default = "${pkgs.writeText "jibri.conf" (toHOCON cfg.settings)}";
       description = ''
         Jibri main config file path.
@@ -171,6 +172,7 @@ in
 
     settings = mkOption {
       type = types.attrs;
+      defaultText = {};
       default = settings;
       description = "Settings used to generate the default config file";
     };

--- a/nixos/services/jitsi/jicofo.nix
+++ b/nixos/services/jitsi/jicofo.nix
@@ -62,7 +62,7 @@ in
     config = mkOption {
       type = attrsOf str;
       default = { };
-      example = literalExample ''
+      example = literalExpression ''
         {
           "org.jitsi.jicofo.auth.URL" = "XMPP:jitsi-meet.example.com";
         }

--- a/nixos/services/jitsi/jitsi-meet.nix
+++ b/nixos/services/jitsi/jitsi-meet.nix
@@ -54,7 +54,7 @@ in
     config = mkOption {
       type = attrs;
       default = { };
-      example = literalExample ''
+      example = literalExpression ''
         {
           enableWelcomePage = false;
           defaultLang = "fi";
@@ -81,7 +81,7 @@ in
     interfaceConfig = mkOption {
       type = attrs;
       default = { };
-      example = literalExample ''
+      example = literalExpression ''
         {
           SHOW_JITSI_WATERMARK = false;
           SHOW_WATERMARK_FOR_GUESTS = false;

--- a/nixos/services/jitsi/jitsi-videobridge.nix
+++ b/nixos/services/jitsi/jitsi-videobridge.nix
@@ -57,7 +57,7 @@ in
     config = mkOption {
       type = attrs;
       default = { };
-      example = literalExample ''
+      example = literalExpression ''
         {
           videobridge = {
             ice.udp.port = 5000;
@@ -83,7 +83,7 @@ in
         See <link xlink:href="https://github.com/jitsi/jitsi-videobridge/blob/master/doc/muc.md" /> for more information.
       '';
       default = { };
-      example = literalExample ''
+      example = literalExpression ''
         {
           "localhost" = {
             hostName = "localhost";

--- a/nixos/services/jitsi/prosody.nix
+++ b/nixos/services/jitsi/prosody.nix
@@ -501,7 +501,7 @@ in
         description = "Prosody package to use";
         default = pkgs.prosody;
         defaultText = "pkgs.prosody";
-        example = literalExample ''
+        example = literalExpression ''
           pkgs.prosody.override {
             withExtraLibs = [ pkgs.luaPackages.lpty ];
             withCommunityModules = [ "auth_external" ];

--- a/nixos/services/k3s/frontend.nix
+++ b/nixos/services/k3s/frontend.nix
@@ -78,9 +78,10 @@ let
         (lib.optionalString (conf.haproxyExtraConfig != "") conf.haproxyExtraConfig)
       ];
   }) frontendCfg;
+
 in
 {
-  options = with lib; {
+  options = {
 
     flyingcircus.services.k3s-frontend.enable = mkEnableOption "Enable k3s (Kubernetes) Frontend";
 
@@ -171,7 +172,7 @@ in
           };
 
           extraPodTemplateOptions = mkOption {
-            type = string;
+            type = lines;
             default = "";
             description = "haproxy options for the server-template directive used for the pod backends, added verbatim to the end of the generated line.";
           };
@@ -195,7 +196,7 @@ in
           };
 
           serviceName = mkOption {
-            type = nullOr string;
+            type = nullOr str;
             default = null;
             description = ''
               Name of the Kubernetes service we want to proxy.
@@ -220,7 +221,7 @@ in
           };
 
           namespace = mkOption {
-            type = string;
+            type = str;
             default = "default";
             description = ''
               Kubernetes namespace the service is defined in.
@@ -231,7 +232,7 @@ in
           binds = mkOption {
             type = nullOr (listOf str);
             default = null;
-            example = map (a: "${a}:8080") fclib.network.fe.dualstack.addressesQuoted;
+            example = [ "0.0.0.0:8008" ];
             description = ''Addresses with ports haproxy is binding to,
               listening for incoming connections. Defaults to 127.0.0.1, using either `lbServicePort`
               or `podPort`, if `lbServicePort` is not set.

--- a/nixos/services/mail/default.nix
+++ b/nixos/services/mail/default.nix
@@ -1,4 +1,8 @@
-{ config, lib, pkgs, ... }:
+{ config
+, lib
+, pkgs
+, nixos-mailserver ? (import ../../../versions.nix {}).nixos-mailserver
+, ... }:
 
 with builtins;
 with lib;
@@ -11,8 +15,6 @@ with lib;
 # - domains: list of mail domains for which regular mail accounts exist
 
 let
-  inherit (import ../../../versions.nix { }) nixos-mailserver;
-
   role = config.flyingcircus.roles.mailserver;
   svc = config.flyingcircus.services.mail;
   fclib = config.fclib;

--- a/nixos/services/matomo.nix
+++ b/nixos/services/matomo.nix
@@ -162,11 +162,7 @@ in {
       hostname = mkOption {
         type = types.str;
         default = "${user}.${fqdn}";
-        defaultText = literalExpression ''
-          if config.${options.networking.domain} != null
-          then "${user}.''${config.${options.networking.fqdn}}"
-          else "${user}.''${config.${options.networking.hostName}}"
-        '';
+        defaultText = literalExpression "${user}.\${fqdn}";
         example = "matomo.yourdomain.org";
         description = lib.mdDoc ''
           URL of the host, without https prefix. You may want to change it if you

--- a/nixos/services/nginx/default.nix
+++ b/nixos/services/nginx/default.nix
@@ -147,6 +147,7 @@ in
 
     defaultListenAddresses = lib.mkOption {
       type = lib.types.listOf lib.types.str;
+      defaultText = "addresses of the `fe` network";
       default = fclib.network.fe.dualstack.addressesQuoted;
       description = ''
         Addresses to listen on if a vhost does not specify any.
@@ -239,7 +240,7 @@ in
         };
       }));
       default = {};
-      example = literalExample ''
+      example = literalExpression ''
         {
           "hydra.example.com" = {
             forceSSL = true;

--- a/nixos/services/nginx/location-options.nix
+++ b/nixos/services/nginx/location-options.nix
@@ -14,7 +14,7 @@ with lib;
     basicAuth = mkOption {
       type = types.attrsOf types.str;
       default = {};
-      example = literalExample ''
+      example = literalExpression ''
         {
           user = "password";
         };

--- a/nixos/services/nginx/vhost-options.nix
+++ b/nixos/services/nginx/vhost-options.nix
@@ -234,7 +234,7 @@ with lib;
     basicAuth = mkOption {
       type = types.attrsOf types.str;
       default = {};
-      example = literalExample ''
+      example = literalExpression ''
         {
           user = "password";
         };
@@ -264,7 +264,7 @@ with lib;
         inherit lib;
       }));
       default = {};
-      example = literalExample ''
+      example = literalExpression ''
         {
           "/" = {
             proxyPass = "http://localhost:3000";

--- a/nixos/services/percona.nix
+++ b/nixos/services/percona.nix
@@ -102,7 +102,7 @@ in
 
       package = mkOption {
         type = types.package;
-        example = literalExample "pkgs.percona";
+        example = literalExpression "pkgs.percona";
         description = "
           Which MySQL derivation to use.
         ";
@@ -155,8 +155,8 @@ in
           to create databases on the first startup of MySQL
         '';
         example = [
-          { name = "foodatabase"; schema = literalExample "./foodatabase.sql"; }
-          { name = "bardatabase"; schema = literalExample "./bardatabase.sql"; }
+          { name = "foodatabase"; schema = literalExpression "./foodatabase.sql"; }
+          { name = "bardatabase"; schema = literalExpression "./bardatabase.sql"; }
         ];
       };
 

--- a/nixos/services/prometheus.nix
+++ b/nixos/services/prometheus.nix
@@ -73,8 +73,7 @@ let
     else x;
 
   mkDefOpt = type : defaultStr : description : mkOpt type (description + ''
-
-    Defaults to <literal>${defaultStr}</literal> in prometheus
+    Defaults to <literal>${builtins.toString defaultStr}</literal> in prometheus
     when set to <literal>null</literal>.
   '');
 

--- a/nixos/services/redis.nix
+++ b/nixos/services/redis.nix
@@ -27,6 +27,7 @@ in {
 
       listenAddresses = lib.mkOption {
         type = lib.types.listOf lib.types.str;
+        defaultText = "the addresses of the networks `lo` and `srv`";
         default = fclib.network.lo.dualstack.addresses ++
                   fclib.network.srv.dualstack.addresses;
       };

--- a/release/default.nix
+++ b/release/default.nix
@@ -308,6 +308,9 @@ let
     # VM image for the Flying Circus infrastructure.
     fc = lib.hydraJob (import "${nixpkgs_}/nixos/lib/eval-config.nix" {
       inherit system;
+      specialArgs = {
+        inherit (import ../versions.nix { inherit pkgs; }) nixos-mailserver;
+      };
       modules = [
         (import ./vm-image.nix imgArgs)
         (import version_nix {})

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -11,7 +11,7 @@ let
     inherit system;
   } // args);
 
-  callTest = fn: args: hydraJob (importTest fn args system).test;
+  callTest = fn: args: hydraJob (importTest fn args system);
 
   callSubTests = fn: args: let
     discover = attrs: let

--- a/tests/lamp/package-test.nix
+++ b/tests/lamp/package-test.nix
@@ -1,23 +1,20 @@
 { version ? "lamp_php74", pkgs ? import ./../.. {}, ... }:
 let
   php = pkgs.${version};
-  pcreTestPackage = import ./pcre-test-package.nix { pkgs = pkgs; php = php; };
-in
-{
-  test = pkgs.runCommand "php-pcre-test-${version}" {} ''
-    set -eo pipefail
+  pcreTestPackage = import ./pcre-test-package.nix { inherit pkgs php; };
+in pkgs.runCommand "php-pcre-test-${version}" {} ''
+  set -eo pipefail
 
-    # run ${pcreTestPackage}/testPcre.sh and save output as variable
-    output=$(${pcreTestPackage}/testPcre.sh)
+  # run ${pcreTestPackage}/testPcre.sh and save output as variable
+  output=$(${pcreTestPackage}/testPcre.sh)
 
-    # remove the first line of the output, which just roughly shows the command that was run
-    output=$(echo "''${output}" | tail -n +2)
+  # remove the first line of the output, which just roughly shows the command that was run
+  output=$(echo "''${output}" | tail -n +2)
 
-    # if output contains "doesnotwork", exit with error
-    if echo "$output" | grep "doesnotwork"; then
-      echo "PCRE test failed with output: $output"
-      exit 1
-    fi
-    >$out
-  '';
-}
+  # if output contains "doesnotwork", exit with error
+  if echo "$output" | grep "doesnotwork"; then
+    echo "PCRE test failed with output: $output"
+    exit 1
+  fi
+  >$out
+''


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

The gist of this patch will have to be applied to all release branches in order to index them with https://github.com/flyingcircusio/fc-search

Impact:

Changelog:

## Security implications

- [ ] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [ ] Security requirements tested? (EVIDENCE)

As part of the adoption of nixos-search for the custom flyingcircus nixos module several changes had to be made. Generally these were limited to very small changes or adding a default text for options to prevent it from evaling deeper-nested configs that rely on hardware-specific configuration and cannot be generalized very well.

I also took the liberty of adjusting the way the mail module imports nixos-mailserver to allow for a pure evaluation of the options-json generating package.

There is still a small bug on flyingcircus-managed vms that leads to a permission error:

```
phil@test21 ~/fc-nixos $ nix build
error: flake output attribute 'packages.x86_64-linux.default' is not a derivation

phil@test21 ~/fc-nixos $ nix repl
Welcome to Nix 2.11.1. Type :? for help.

nix-repl> :lf .
Added 15 variables.

nix-repl> :b packages.x86_64-linux.default
error: opening file '/etc/nixos/services.json': Permission denied

nix-repl>
```

However, when building on a machine without this file the error is not triggered:

```
fc-nixos on branch flake
λ ❱ nix build

fc-nixos on branch flake (took 2s)
λ ❱
```

I presume this is a nix bug when evaluating options, not sure how to work around it.

EDIT: this error can be resolved by using a newer version of nix on the VM:

```
phil@test21 ~ $ nix shell nixpkgs#nix
                                                                                                                                                                                                                                                             
phil@test21 ~ $ nix --version
nix (Nix) 2.13.3
                                                                                                                                                                                                                                                             
phil@test21 ~ $ nix build github:philtaken/fc-nixos/flake
                                                                                                                                                                                                                                                             
phil@test21 ~ $
```