### PR TITLE
[21.05] kvm: raise netstat alerting threshold

### DIFF
--- a/nixos/roles/kvm.nix
+++ b/nixos/roles/kvm.nix
@@ -235,10 +235,18 @@ in
         }
       '';
 
-    flyingcircus.services.sensu-client.checks = {
-      qemu = {
-        notification = "Qemu health check";
-        command = "sudo ${role.package}/bin/fc-qemu check";
+    flyingcircus.services.sensu-client = {
+      checks = {
+        qemu = {
+          notification = "Qemu health check";
+          command = "sudo ${role.package}/bin/fc-qemu check";
+        };
+      };
+      # each qemu process connects directly to multiple OSD's in the
+      # ceph cluster.
+      expectedConnections = {
+        warning = 18000;
+        critical = 25000;
       };
     };
 


### PR DESCRIPTION
When accessing guest disks over RBD, qemu connects directly to the relevant OSD's in the Ceph storage pool, which causes the number of outgoing connections from the KVM host to the storage network to increase with the number of guests as well as with growth in the storage pool.

This however causes the KVM hosts to trip the `netstat_tcp` Sensu check, as the thresholds are too low for bigger KVM hosts running lots of guests. This change therefore raises the thresholds for this check for KVM hosts.

PL-131411

@flyingcircusio/release-managers

## Release process

Impact: internal

Changelog:

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Alerts should only trigger under exceptional conditions.
  - Noise in the monitoring review should be kept to a minimum.
- [x] Security requirements tested? (EVIDENCE)
  - Tested manually on a development KVM host. Opening several thousand concurrent TCP connections caused the `netstat_tcp` check to be triggered. Verified that switching to a configuration built from this branch with the raised check thresholds while keeping these TCP connections open caused this check to stop being triggered.