### PR TITLE
[22.11] Update nixpkgs

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "960dab25f0225cf9fd8f48922087d805ae649782",
-    "sha256": "uYN/VDlw8dsZxEKHfdwlfKaHcP14b+Euc8saf7xxA6M="
+    "rev": "2ecc5d3cb589bf2968cfc0fef4b5cb3a0c23949c",
+    "sha256": "hb5zjUzp6U9NqskRy8umsKEE3O0Ebq14VLxgUxyPUtU="
   },
   "nixos-mailserver": {
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/",


### PR DESCRIPTION
Pull upstream NixOS changes, security fixes and package updates:

- cacert: 3.86 -> 3.89.1
- curl: backport 8.1.0 security fixes (CVE-2023-28320, CVE-2023-28321, CVE-2023-28322)
- git: 2.38.4 -> 2.38.5 (CVE-2023-25652, CVE-2023-25815, CVE-2023-29007)
- gitlab: 15.11.5 -> 15.11.6
- imagemagick: 7.1.1-8 -> 7.1.1-10
- keycloak: 20.0.5 -> 21.1.1
- libcap: backport 2.69 security fixes (CVE-2023-2602, CVE-2023-2603)
- libmodsecurity: 3.0.8 -> 3.0.9
- linux: 5.15.110 -> 5.15.113
- matrix-synapse: 1.82.0 -> 1.84.1
- php81: 8.1.18 -> 8.1.19
- postgresql_11: 11.19 -> 11.20 (for all postgresql packages: CVE-2023-2454, CVE-2023-2455)
- postgresql_12: 12.14 -> 12.15
- postgresql_13: 13.10 -> 13.11
- postgresql_14: 14.7 -> 14.8
- postgresql_15: 15.2 -> 15.3
- systemd: 251.15 -> 251.16
- wget: 1.21.3 -> 1.21.4

PL-131517

@flyingcircusio/release-managers

## Release process

Impact:

* \[NixOS 22.11] Most services will restarted because of a core dependency change. Machines will schedule a reboot to activate the changed kernel.

Changelog: (include changes from commit msg here)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - pull in upstream security fixes regularly
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still run, works on test VM
  - checked commit log for fixed CVEs and possible problems with updates, looked at [synapse/upgrade.md](https://github.com/matrix-org/synapse/blob/develop/docs/upgrade.md), [PostgreSQL: Documentation: 15: E.1. Release 15.3](https://www.postgresql.org/docs/current/release-15-3.html), [PHP: PHP 8 ChangeLog](https://www.php.net/ChangeLog-8.php#8.1.19), [ModSecurity/CHANGES at v3/master · SpiderLabs/ModSecurity](https://github.com/SpiderLabs/ModSecurity/blob/v3/master/CHANGES), [Keycloak 21.0.0 released - Keycloak](https://www.keycloak.org/2023/02/keycloak-2100-released) and following keycloak release notes.