### PR TITLE
[21.05] ceph_rgw: re-enable access logs for Nautilus+

### DIFF
--- a/nixos/roles/ceph/rgw.nix
+++ b/nixos/roles/ceph/rgw.nix
@@ -23,15 +23,15 @@ let
     rgwData = "/srv/ceph/radosgw/ceph-$id";
     rgwEnableOpsLog = false;
     rgwMimeTypesFile = "${pkgs.mime-types}/etc/mime.types";
-    debugRgw = "0 5";
     debugRados = "1 5";
   } // (if releaseAtLeast "nautilus" role.cephRelease
     then {
       rgwFrontends = "beast port=80";
-      debugBeast = "1 5";
+      debugRgw = "1 5";
     } else {
       rgwFrontends = "civetweb port=80";
       debugCivetweb = "1 5";
+      debugRgw = "0 5";
     });
 in
 {

--- a/pkgs/ceph/nautilus/default.nix
+++ b/pkgs/ceph/nautilus/default.nix
@@ -111,6 +111,7 @@ in rec {
     patches = [
       ./0000-fix-SPDK-build-env.patch
       ./0001-fix-iterator.patch
+      ./rgw-reduce-log-verbosity.patch
     ];
 
     nativeBuildInputs = [

--- a/pkgs/ceph/nautilus/rgw-reduce-log-verbosity.patch
+++ b/pkgs/ceph/nautilus/rgw-reduce-log-verbosity.patch
@@ -1,0 +1,22 @@
+diff --git a/src/rgw/rgw_process.cc b/src/rgw/rgw_process.cc
+index ad43b5d33d6..c9550742171 100644
+--- a/src/rgw/rgw_process.cc
++++ b/src/rgw/rgw_process.cc
+@@ -179,7 +179,7 @@ int process_request(RGWRados* const store,
+ {
+   int ret = client_io->init(g_ceph_context);
+ 
+-  dout(1) << "====== starting new request req=" << hex << req << dec
++  dout(2) << "====== starting new request req=" << hex << req << dec
+ 	  << " =====" << dendl;
+   perfcounter->inc(l_rgw_req);
+ 
+@@ -312,7 +312,7 @@ done:
+     handler->put_op(op);
+   rest->put_handler(handler);
+ 
+-  dout(1) << "====== req done req=" << hex << req << dec
++  dout(2) << "====== req done req=" << hex << req << dec
+ 	  << " op status=" << op_ret
+ 	  << " http_status=" << s->err.http_ret
+ 	  << " latency=" << s->time_elapsed()


### PR DESCRIPTION
With the switch to the beast frontend for radosgw in Nautilus, I had accidentally disabled access logs.
The reason: there is no dedicated debug setting for the beast frontend anymore ("debug beast"), logging is now controlled by the subsystem-level "debug rgw".

Note that the acces log format in /var/log/ceph/client.radosgw.log changes slightly, but the major difference has been patched out.

@flyingcircusio/release-managers

## Release process

Impact: internal only

Changelog:
- re-enables access log for radosgw

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - [x] must not introduce new known regressions
  - [x] fix discovered (non-functional) unintended regression in logging, that might impact debugging and incident triage
- [x] Security requirements tested? (EVIDENCE)
  - [x] NixOS tests still pass
  - [x] tried out the option changes on a dev host
