### PR TITLE
Add package for PHP 8.2 based LAMP stack

### DIFF
--- a/doc/src/lamp.md
+++ b/doc/src/lamp.md
@@ -200,6 +200,7 @@ Supported packages:
 - `pkgs.lamp_php74`
 - `pkgs.lamp_php80`
 - `pkgs.lamp_php81`
+- `pkgs.lamp_php82`
 
 The `lamp_php_*` packages provided by our platform include commonly used
 PHP extensions, currently:

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -192,6 +192,14 @@ in {
                 all.redis
               ]);
 
+  lamp_php82 = super.php82.withExtensions ({ enabled, all }:
+              enabled ++ [
+                all.bcmath
+                all.imagick
+                all.memcached
+                all.redis
+              ]);
+
   latencytop_nox = super.latencytop.overrideAttrs(_: {
     buildInputs = with self; [ ncurses glib ];
     makeFlags = [ "HAS_GTK_GUI=" ];

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -58,10 +58,13 @@ in {
   lampVm80_tideways = callTest ./lamp/vm-test.nix { version = "lamp_php80"; tideways = "1234"; };
   lampVm81 = callTest ./lamp/vm-test.nix { version = "lamp_php81"; };
   lampVm81_tideways = callTest ./lamp/vm-test.nix { version = "lamp_php81"; tideways = "1234"; };
+  lampVm82 = callTest ./lamp/vm-test.nix { version = "lamp_php82"; };
+  lampVm82_tideways = callTest ./lamp/vm-test.nix { version = "lamp_php82"; tideways = "1234"; };
 
   lampPackage74 = callTest ./lamp/package-test.nix { version = "lamp_php74"; };
   lampPackage80 = callTest ./lamp/package-test.nix { version = "lamp_php80"; };
   lampPackage81 = callTest ./lamp/package-test.nix { version = "lamp_php81"; };
+  lampPackage82 = callTest ./lamp/package-test.nix { version = "lamp_php82"; };
 
   locale = callTest ./locale.nix {};
   login = callTest ./login.nix {};


### PR DESCRIPTION
Add a package for a LAMP stack based on PHP 8.2.

PL-131403

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

- pkgs: add a new package `lamp_php82`, which provides a LAMP stack with PHP version 8.2 (PL-131403).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - The package should provide a correctly functioning LAMP stack, similar to the existing `lamp_php*` packages.
- [x] Security requirements tested? (EVIDENCE)
  - I've added tests for this package alongside the ones for the existing LAMP packages, and I've verified the tests manually on Hydra.