### PR TITLE
gdb: remove as a default system package

### DIFF
--- a/nixos/platform/packages.nix
+++ b/nixos/platform/packages.nix
@@ -18,7 +18,6 @@
         fc.logcheckhelper
         fio
         gcc
-        gdb
         gitPatched
         gnumake
         gnupg


### PR DESCRIPTION
We've decided that gdb can be removed from defaults. There's no immediate need for it in cases where networking is broken, and in all other cases it can just be installed.
This saves us quite some space in disk images and during upgrades.

@flyingcircusio/release-managers

## Release process

Impact:
- removes gdb from default system packages. Scripts cannot rely on it being in PATH by default

Changelog:

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - [x] must not introduce known regressions
  - [x] common tasks that rely on gdb still need to work with modifications
- [x] Security requirements tested? (EVIDENCE)
  - [x] automated tests still pass
  - [x] manually verified on a testvm that `coredumpctl debug` still works from within a `nix-shell -p gdb`
