### PR TITLE
[21.05] util-physical: add fs-check script

### DIFF
--- a/pkgs/fc/util-physical/ceph-nautilus/default.nix
+++ b/pkgs/fc/util-physical/ceph-nautilus/default.nix
@@ -1,8 +1,12 @@
-{ lib, stdenv, bash, ceph,  utillinux, systemd, coreutils, gnugrep, makeWrapper, fc }:
+{
+  lib, stdenv, makeWrapper
+, bash, ceph, utillinux, systemd, coreutils, gnugrep, xfsprogs
+, fc
+}:
 
 
 stdenv.mkDerivation rec {
-  version = "0.2";
+  version = "0.3";
   name = "fc-util";
 
   src = ./.;
@@ -11,7 +15,7 @@ stdenv.mkDerivation rec {
   dontConfigure = true;
 
   buildInputs = [ makeWrapper ];
-  propagatedBuildInputs = [ bash ceph systemd fc.agent gnugrep utillinux coreutils ];
+  propagatedBuildInputs = [ bash ceph systemd fc.agent gnugrep utillinux coreutils xfsprogs ];
 
   installPhase = ''
     mkdir $out

--- a/pkgs/fc/util-physical/ceph-nautilus/fs-check.sh
+++ b/pkgs/fc/util-physical/ceph-nautilus/fs-check.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+export CEPH_ARGS="--id $HOSTNAME"
+
+FSCHECK_CMD="xfs_repair"
+
+# parse optional fscheck command arg
+while getopts ':F:' OPT; do
+    case $OPT in
+        F)
+            FSCHECK_CMD="$OPTARG"
+            ;;
+        ?)
+            echo "fs-check [-F <fsck_command>] <pool> <vm>"
+            echo "  shut down a VM, run a filesystem check on its root image, and start it again."
+            echo "  <fsck_command> defaults to \`xfs_repair\`"
+            echo "  note: <fsck_cmd> might need to be specified as an absolute path"
+            echo
+            echo "  Example: fs-check -F \"/run/current-system/sw/bin/fsck.ext4 -f -p\" rbd.hdd testgentoo"
+            exit 1
+            ;;
+    esac
+done
+
+# trim CLI parameters
+shift "$(($OPTIND -1))"
+
+pool=${1?need pool}
+vm=${2?need vm name}
+image=${vm}.root
+mountpoint=/mnt/restore/$vm
+
+echo "FS-Check (XFS!) for ${vm} ($pool) using \`$FSCHECK_CMD\`"
+echo "Ready? VM will shut down immediately."
+read
+
+echo "=== ${vm} ==="
+
+mkdir -p $mountpoint
+
+# Shutdown
+rbd-locktool -i ${pool}/${image}
+fc-directory "d.set_vm_property('${vm}', 'online', False)"
+until (rbd-locktool -i ${pool}/${image}| grep None) do echo "waiting for VM to shut down ..."; sleep 5; done
+
+device=$(rbd map ${pool}/${image})
+echo Mapped to $device
+mount ${device}p1 $mountpoint
+umount $mountpoint
+$FSCHECK_CMD ${device}p1
+
+rbd unmap $device
+
+
+echo "Start up"
+rbd-locktool -i ${pool}/${image}
+fc-directory "d.set_vm_property('${vm}', 'online', True)"
+until (rbd-locktool -i ${pool}/${image}| grep -v None) do echo "waiting for image to be locked ..."; sleep 5; done


### PR DESCRIPTION
adds a script that shuts down a VM, runs an fsck on its root disk, and starts the machine again afterwards.
Based on a script we used after an incident, but with added support for specifying alternative fsck commands.

PL-131478

@flyingcircusio/release-managers

## Release process

Impact: internal

Changelog:
- add `fs-check` to the pool of our util-physical scripts, that are present on our physical hosts

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - [x] operator tooling shall be self-documenting
  - [x] verify operations of script on different VM types
- [x] Security requirements tested? (EVIDENCE)
  - [x] script has a `--help` text
  - [x] tested the script on a NixOS and a legacy Gentoo VM in dev