### PR TITLE
Fix kubeconfig generation script for recent Kubernetes versions.

### DIFF
--- a/nixos/roles/k3s/server.nix
+++ b/nixos/roles/k3s/server.nix
@@ -49,6 +49,17 @@ let
           --clusterrole=cluster-admin --serviceaccount=default:$name \
           > /dev/null
 
+    ${kc} get secret $name-token &> /dev/null \
+      || ${kc} apply -f - <<EOF > /dev/null
+    apiVersion: v1
+    kind: Secret
+    type: kubernetes.io/service-account-token
+    metadata:
+      name: $name-token
+      annotations:
+        kubernetes.io/service-account.name: $name
+    EOF
+
     token=$(${kc} describe secret $name-token | grep token: | cut -c 13-)
 
     ${remarshal} $src_config -if yaml -of json | \

--- a/nixos/roles/k3s/server.nix
+++ b/nixos/roles/k3s/server.nix
@@ -63,7 +63,8 @@ let
     token=$(${kc} describe secret $name-token | grep token: | cut -c 13-)
 
     ${remarshal} $src_config -if yaml -of json | \
-      jq --arg token "$token" '.users[0].user.token = $token' \
+      jq --arg token "$token" \
+      '.users[0].user |= (del(."client-key-data", ."client-certificate-data") | .token = $token)' \
       > /tmp/$name.kubeconfig
 
     KUBECONFIG=/tmp/$name.kubeconfig ${kc} config view --flatten

--- a/nixos/roles/k3s/single-node.nix
+++ b/nixos/roles/k3s/single-node.nix
@@ -40,6 +40,17 @@ let
           --clusterrole=cluster-admin --serviceaccount=default:$name \
           > /dev/null
 
+    ${kc} get secret $name-token &> /dev/null \
+      || ${kc} apply -f - <<EOF > /dev/null
+    apiVersion: v1
+    kind: Secret
+    type: kubernetes.io/service-account-token
+    metadata:
+      name: $name-token
+      annotations:
+        kubernetes.io/service-account.name: $name
+    EOF
+
     token=$(${kc} describe secret $name-token | grep token: | cut -c 13-)
 
     ${remarshal} $src_config -if yaml -of json | \

--- a/nixos/roles/k3s/single-node.nix
+++ b/nixos/roles/k3s/single-node.nix
@@ -54,7 +54,8 @@ let
     token=$(${kc} describe secret $name-token | grep token: | cut -c 13-)
 
     ${remarshal} $src_config -if yaml -of json | \
-      jq --arg token "$token" '.users[0].user.token = $token' \
+      jq --arg token "$token" \
+      '.users[0].user |= (del(."client-key-data", ."client-certificate-data") | .token = $token)' \
       > /tmp/$name.kubeconfig
 
     KUBECONFIG=/tmp/$name.kubeconfig ${kc} config view --flatten


### PR DESCRIPTION
Starting with Kubernetes v1.22, when new ServiceAccounts are created, the control plane no longer automatically creates Secrets containing the corresponding ServiceAccounts authentication token. This means that `kubernetes-make-config` generates kubeconfig files with an empty token, which breaks applications which depend on bearer tokens for authentication, such as the dashboard.

Additionally, the script uses the default cluster admin kubeconfig (created during cluster bootstrapping) as a template, which includes the default cluster admin's TLS client certificate. This certificate is used preferentially over the token by some clients, including kubectl -- the Hydra test suite didn't catch this issue because it uses kubectl -- which means these clients are authenticating as the default cluster admin instead of the created ServiceAccount. 

This change extends the script to create the Secret which will be populated with the ServiceAccount's authentication token, and also removes the client certificates from the generated kubeconfig to ensure that clients authenticate as the correct user.

PL-131534

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:
- The `kubernetes-make-kubeconfig` script included with the `k3s-server` role has been updated to function correctly with recent Kubernetes versions (PL-131534).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - The script should generate a configuration which works correctly with the dashboard (and other client software) as described in our public documentation.
  - Client software using the generated configuration should be authenticated as the correct user, and not use the default cluster admin role.
- [x] Security requirements tested? (EVIDENCE)
  - The Hydra tests for k3s pass with these changes applied to the script.
  - Tested manually to verify that the dashboard works correctly with a configuration file generated with these changes.