### PR TITLE
Improve Kubernetes monitoring and telemetry

### DIFF
--- a/nixos/roles/k3s/agent.nix
+++ b/nixos/roles/k3s/agent.nix
@@ -53,6 +53,28 @@ in
         }];
       };
 
+      flyingcircus.services.sensu-client = {
+        checks = {
+          kubelet = {
+            notification = "Kubernetes kubelet is not working";
+            command = ''
+              ${pkgs.monitoring-plugins}/bin/check_http -H localhost -p 10248 -u /healthz
+            '';
+          };
+
+          kube-proxy = {
+            notification = "Kubernetes kube-proxy is not working";
+            command = ''
+              ${pkgs.monitoring-plugins}/bin/check_http -H localhost -p 10256 -u /healthz
+            '';
+          };
+        };
+
+        systemdUnitChecks = {
+          "k3s.service" = {};
+        };
+      };
+
       flyingcircus.activationScripts.kubernetes-apitoken-node = ''
         mkdir -p /var/lib/k3s
         umask 077

--- a/nixos/roles/k3s/agent.nix
+++ b/nixos/roles/k3s/agent.nix
@@ -13,6 +13,9 @@ let
     "--flannel-iface=ethsrv"
     "--node-ip=${agentAddress}"
     "--data-dir=/var/lib/k3s"
+    # k3s disables this port by default, we re-enable it to conform to
+    # standard k8s behaviour.
+    "--kubelet-arg read-only-port=10255"
   ];
 
 in

--- a/nixos/roles/k3s/server.nix
+++ b/nixos/roles/k3s/server.nix
@@ -348,6 +348,21 @@ in {
       };
     };
 
+    flyingcircus.services.telegraf.inputs = {
+      kube_inventory = [{
+        url = "https://localhost:6443";
+        bearer_token = "/var/lib/k3s/tokens/telegraf";
+        insecure_skip_verify = true;
+        namespace = "";
+        resource_exclude = [
+          "persistentvolumes"
+          "persistentvolumeclaims"
+          "endpoints"
+          "ingress"
+        ];
+      }];
+    };
+
     networking.nameservers = lib.mkOverride 90 (lib.take 3 ([netCfg.clusterDns] ++ fcNameservers));
 
     services.k3s = let

--- a/pkgs/sensuplugins-rb/sensu-plugins-kubernetes/0001-Don-t-assume-that-private-keys-are-RSA.patch
+++ b/pkgs/sensuplugins-rb/sensu-plugins-kubernetes/0001-Don-t-assume-that-private-keys-are-RSA.patch
@@ -1,0 +1,25 @@
+From 6e468db8be31a2772c46a6f3a1333a7f8d2e7001 Mon Sep 17 00:00:00 2001
+From: Molly Miller <mm@flyingcircus.io>
+Date: Mon, 12 Jun 2023 17:19:48 +0200
+Subject: [PATCH] Don't assume that private keys are RSA.
+
+---
+ lib/sensu-plugins-kubernetes/client.rb | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/sensu-plugins-kubernetes/client.rb b/lib/sensu-plugins-kubernetes/client.rb
+index f4d0844..9eced38 100644
+--- a/lib/sensu-plugins-kubernetes/client.rb
++++ b/lib/sensu-plugins-kubernetes/client.rb
+@@ -91,7 +91,7 @@ module Sensu
+ 
+           if options[:client_key_file]
+             begin
+-              ssl_options[:client_key] = OpenSSL::PKey::RSA.new(File.read(options[:client_key_file]))
++              ssl_options[:client_key] = OpenSSL::PKey.read(File.read(options[:client_key_file]))
+             rescue StandardError => e
+               raise e, "Unable to read client key: #{e}", e.backtrace
+             end
+-- 
+2.39.2 (Apple Git-143)
+

--- a/pkgs/sensuplugins-rb/sensu-plugins-kubernetes/default.nix
+++ b/pkgs/sensuplugins-rb/sensu-plugins-kubernetes/default.nix
@@ -15,6 +15,11 @@ bundlerSensuPlugin {
   extraGemConfig = {
     sensu-plugins-kubernetes = attrs: {
       buildInputs = [  ];
+      dontBuild = false;
+      patches = [
+        # patch kept here as upstream seems to be inactive.
+        ./0001-Don-t-assume-that-private-keys-are-RSA.patch
+      ];
     };
   };
 }


### PR DESCRIPTION
We currently do not have useful telemetry or metrics for k3s nodes on our platform. This PR makes a number of changes to fix and extend the Sensu checks, and to enable the Telegraf plugins for collecting metrics from the Kubernetes control plane.

The commit messages have detailed commentary on the changes here. In summary:
- The read-only control port on the `kubelet` process has been enabled on the worker nodes to allow the Telegraf `kubernetes` plugin to work correctly.
- Sensu checks for the k3s systemd units have been added.
- Additional Sensu health checks have been added for control plane HTTP endpoints.
  - The apiserver component running on the k3s server has been configured to allow unauthenticated clients, to which  only the health check and readiness endpoints are exposed. These are used by Sensu for checking liveness of the apiserver.
- Additional Sensu checks (from `pkgs.sensu-plugins-kubernetes`) and the Telegraf `kube_inventory` plugin require access to authenticated endpoints on the apiserver. k3s supports loading of additional vendor-supplied Kubernetes manifests found in `/var/lib/k3s/server/manifests`, which is the mechanism it uses for bundling Traefik and other third-party components. This PR adds some services to add further manifests for setting up authentication roles and exporting access tokens for Sensu and Telegraf so they can access these endpoints.

PL-131009

@flyingcircusio/release-managers

## Release process

Impact: internal

Changelog:

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Telemetry for Kubernetes components should be available in order to ensure these components are functioning correctly.
  - The Kubernetes environment provided by the `k3s-server` and `k3s-agent` roles should have suitable default configuration to ensure secure operation (e.g. prevent unauthorised access, etc).
- [x] Security requirements tested? (EVIDENCE)
  - Hydra tests have been added to test the setup logic for the authentication tokens for Sensu and Telegraf.
  - Manually verified that the apiserver HTTPS endpoint is correctly firewalled on the frontend interface, and (non-exhaustively) tested that an unauthenticated client cannot access sensitive API endpoints as described in the upstream Kubernetes documentation.