### PR TITLE
[22.11] Update nixpkgs for gitlab version 15.11.8

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "2ecc5d3cb589bf2968cfc0fef4b5cb3a0c23949c",
-    "sha256": "hb5zjUzp6U9NqskRy8umsKEE3O0Ebq14VLxgUxyPUtU="
+    "rev": "ad5484e847e0e52abd904f4fe401ad39018dac14",
+    "sha256": "P2VRRznKKlKDv/oTWYlHNNWIARFxNVXHDLfIqlUNxNI="
   },
   "nixos-mailserver": {
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/",


### PR DESCRIPTION
PL-131536

@flyingcircusio/release-managers

## Release process

Impact:

* \[NixOS 22.11\] Gitlab will be restarted.

Changelog:

* Gitlab: 15.11.6 -> 15.11.8 (PL-131536).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? 
  -  do regular security updates for Gitlab 
- [x] Security requirements tested? (EVIDENCE)
  - automated test still runs, tested on our Gitlab staging machine