### PR TITLE
Update nixpkgs

### DIFF
--- a/nixpkgs-config.nix
+++ b/nixpkgs-config.nix
@@ -15,7 +15,7 @@
   permittedInsecurePackages = [
     "nodejs-14.21.3" # Needed for opensearch-dashboards.
     "nodejs-16.20.0" # Needed for discourse 3.1.0.beta4, will go away with next version.
-    "openssl-1.1.1t" # EOL 2023-09-11, needed for Percona and older PHP versions.
+    "openssl-1.1.1u" # EOL 2023-09-11, needed for Percona and older PHP versions.
     "python-2.7.18.6" # Needed for some legacy customer applications.
     "ruby-2.7.8" # EOL 2023-03-31, needed for Sensu checks
   ];

--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "1b6ee98d864cd4a7d2a330d884034d15f405930b",
-    "sha256": "se46THNWJPfahLw4Dp4oXnrE+YL3f7ccYmBRdlLSWyw="
+    "rev": "77c38c7fcc30beb3e99159c3ed3b5a8944dd20a0",
+    "sha256": "xKfqWXoGLeVqvn3nd9t3JX55nMhIGUwEXdOty6MMzzE="
   },
   "nixos-mailserver": {
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/",


### PR DESCRIPTION
Pull upstream NixOS changes, security fixes and package updates:

- gitlab: 15.11.6 -> 16.0.2
- imagemagick: 7.1.1-10 -> 7.1.1-11
- linux: 6.1.30 -> 6.1.31
- matrix-synapse: 1.84.0 -> 1.85.1
- openssl_1_1: 1.1.1t -> 1.1.1u (CVE-2023-2650, CVE-2023-0466, CVE-2023-0465, CVE-2023-0464)

PL-131551

@flyingcircusio/release-managers

## Release process

Impact:

* \[NixOS 22.11] Most services will restarted because of a core dependency change. Machines will schedule a reboot to activate the changed kernel.

Changelog:

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - pull in upstream security fixes regularly
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still run, works on test VM and gitlab staging 
  -  checked commit log for fixed CVEs and possible problems with updates, looked at [synapse/upgrade.md](https://github.com/matrix-org/synapse/blob/develop/docs/upgrade.md) 