### PR TITLE
nginx: add nginxLegacyCrypt package and documentation for it

### DIFF
--- a/doc/src/upgrade.md
+++ b/doc/src/upgrade.md
@@ -140,6 +140,12 @@ roles should stay on 22.11 and migrate to Opensearch before upgrading.
 before upgrading to 23.05. See our {ref}`MongoDB upgrade docs <nixos-mongodb-upgrade>`
 for details.
 
+### Webgateway/Nginx
+
+See {ref}`nixos-webgateway-nginx-legacy-crypt` if you still need algorithms
+like MD5 or SHA256 for HTTP basic auth which aren't supported anymore by the
+default `libxcrypt` used by Nginx.
+
 ## Other notable changes
 
 - NixOS now defaults to using nsncd (a non-caching reimplementation in Rust)

--- a/doc/src/webgateway.md
+++ b/doc/src/webgateway.md
@@ -275,3 +275,19 @@ nginx' error logs go to systemd's journal by default. To view them, use
 ```console
 $ journalctl --since -1h -u nginx
 ```
+
+(nixos-webgateway-nginx-legacy-crypt)=
+
+### Basic auth with legacy password hashes
+
+Starting with NixOS 23.05, nginx uses a version of `libxcrypt` which only supports algorithms marked as [`strong`](https://github.com/besser82/libxcrypt/blob/v4.4.33/lib/hashes.conf#L48). You will encounter errors when password files for HTTP basic auth use algorithms like MD5 (hash prefix`$1$`) and SHA256 (`$5$`). Password hashes using these algorithms should be replaced as soon as possible.
+
+If you still need them on 23.05, use the Nginx package which still supports all algorithms:
+
+~~~
+# /etc/local/nixos/nginx-legacy-crypt.nix
+{ pkgs, ... }:
+{
+  services.nginx.package = pkgs.nginxLegacyCrypt;
+}
+~~~

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -280,6 +280,11 @@ in {
     ];
   });
 
+  nginxLegacyCrypt = self.nginx.overrideAttrs(old: {
+    strictDeps = true;
+    buildInputs = [ self.libxcrypt-legacy ] ++ old.buildInputs;
+  });
+
   openldap_2_4 = super.callPackage ./openldap_2_4.nix {
     libxcrypt = self.libxcrypt-with-sha256;
   };


### PR DESCRIPTION
PL-131552

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* webgateway/nginx: add nginxLegacyCrypt package to optionally support older algorithms for HTTP basic auth (PL-131552).


## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - the more secure option only supporting strong algos shold be the default, but we can fall back to libxcrypt-legacy if needed for a specific machine  
- [x] Security requirements tested? (EVIDENCE)
  - tested that legacy package builds and MD5 hash works for basic auth