### PR TITLE
Update nixpkgs

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "77c38c7fcc30beb3e99159c3ed3b5a8944dd20a0",
-    "sha256": "xKfqWXoGLeVqvn3nd9t3JX55nMhIGUwEXdOty6MMzzE="
+    "rev": "b73bbe5b2e29337b49d6bb6e65a8f275bcce6cc1",
+    "sha256": "EL74Imn6QJp+c/GQt3OdXVG8IEDnwXiT3kKdMPL6gqY="
   },
   "nixos-mailserver": {
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/",


### PR DESCRIPTION
Pull upstream NixOS changes, security fixes and package updates:
- element-{web,desktop}: 1.11.32 -> 1.11.33
- python38: 3.8.16 -> 3.8.17 (CVE-2023-24329)
- python39: 3.9.16 -> 3.9.17 (CVE-2023-24329)
- python312: 3.12.0b1 -> 3.12.0b2 (
- php82: 8.2.6 -> 8.2.7
- php81: 8.1.19 -> 8.1.20
- php80: 8.0.28 -> 8.0.29
- systemd: 253.3 -> 253.5
- opencv: add patches for CVE-2023-2617 & CVE-2023-2618
- openssl: 3.0.8 -> 3.0.9 (CVE-2023-2650, CVE-2023-1255, CVE-2023-0466, CVE-2023-0465 CVE-2023-0464)
- ffmpeg_4: 4.4.3 -> 4.4.4
- curl: 8.0.1 -> 8.1.1 (CVE-2023-28319, CVE-2023-28320, CVE-2023-28321, CVE-2023-28322)
- binutils: fix CVE-2023-1972

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - pull in upstream security fixes regularly
- [x] Security requirements tested? (EVIDENCE)
  -  test build on a testvm
  - automated tests still run
  - check upstream commit log for update problems and CVEs