### PR TITLE
[22.11] Update nixpkgs

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "ad5484e847e0e52abd904f4fe401ad39018dac14",
-    "sha256": "P2VRRznKKlKDv/oTWYlHNNWIARFxNVXHDLfIqlUNxNI="
+    "rev": "fd2c629c33c2212c4444edd8fe59d9d83276af26",
+    "sha256": "OPszqExujWZoOvjkm2bx7zNPF+qk+6y1q3sUYWIw5eo="
   },
   "nixos-mailserver": {
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/",


### PR DESCRIPTION
Pull upstream NixOS changes, security fixes and package updates:

- grafana: 9.4.9 -> 9.4.12 (CVE-2023-2183, CVE-2023-2801)
- matrix-synapse: 1.84.1 -> 1.85.1
- chromium: 113.0.5672.126 -> 114.0.5735.106 (CVE-2023-3079, CVE-2023-2929 CVE-2023-2930 CVE-2023-2931 CVE-2023-2932 CVE-2023-2933 CVE-2023-2934 CVE-2023-2935 CVE-2023-2936 CVE-2023-2937 CVE-2023-2938 CVE-2023-2939 CVE-2023-2940 CVE-2023-2941)
- imagemagick: 7.1.1-10 -> 7.1.1-11
- linux: 5.15.113 -> 5.15.114

manual backport:
- openssl_1_1: 1.1.1t -> 1.1.1u (CVE-2023-2650, CVE-2023-0466, CVE-2023-0465, CVE-2023-0464)

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - pull in upstream security fixes regularly
- [x] Security requirements tested? (EVIDENCE)
  -  test build on a testvm
  - automated tests still run
  - check upstream commit log for update problems and CVEs
  - matrix-synapse changelog was checked last week already for same release
  - manually backport openssl1_1 update to fix CVEs as well
