### PR TITLE
Fix redis configuration warnings, use instanced server configuration

### DIFF
--- a/doc/src/redis.md
+++ b/doc/src/redis.md
@@ -20,8 +20,9 @@ In previous versions, custom redis configuration could be set
 via {file}`/etc/local/redis/custom.conf` which is not supported anymore.
 
 If you need to change the behaviour of Redis, you define your redis
-configuration with the NixOS option `services.redis.settings`. See the
-NixOS manual for further information.
+configuration with the NixOS option
+`services.redis.servers."".settings`. See the NixOS manual for further
+information.
 
 Regarding setting the redis password, see the section on redis [passwords](#password).
 
@@ -31,7 +32,7 @@ The following NixOS module adds some modules to be loaded by Redis:
 # /etc/local/nixos/redis.nix
 { ... }:
 {
-    services.redis.settings = {
+    services.redis.server."".settings = {
         loadmodule = [ "/path/to/my_module.so" "/path/to/other_module.so" ];
     };
 }

--- a/doc/src/redis.md
+++ b/doc/src/redis.md
@@ -21,8 +21,10 @@ via {file}`/etc/local/redis/custom.conf` which is not supported anymore.
 
 If you need to change the behaviour of Redis, you define your redis
 configuration with the NixOS option
-`services.redis.servers."".settings`. See the NixOS manual for further
-information.
+`services.redis.servers."".settings`. NixOS supports multiple
+instances of Redis on a single host, so this option sets configuration
+for the default instance with an empty instance name. See the NixOS
+manual for further information.
 
 Regarding setting the redis password, see the section on redis [passwords](#password).
 

--- a/nixos/infrastructure/container.nix
+++ b/nixos/infrastructure/container.nix
@@ -103,7 +103,7 @@ in
         innodb_log_files_in_group       = 2
       '';
 
-      services.redis.bind = lib.mkForce "0.0.0.0 ::";
+      services.redis.servers."".bind = lib.mkForce "0.0.0.0 ::";
 
       # This is the insecure key pair to allow bootstrapping containers.
       # -----BEGIN OPENSSH PRIVATE KEY-----

--- a/nixos/roles/gitlab.nix
+++ b/nixos/roles/gitlab.nix
@@ -105,7 +105,7 @@ in
       databaseCreateLocally = fclib.mkPlatform true;
       databasePasswordFile = "${cfg.secretsDir}/db_password";
       initialRootPasswordFile = "${cfg.secretsDir}/root_password";
-      redisUrl = "redis://:${config.services.redis.requirePass}@localhost:6379/";
+      redisUrl = "redis://:${config.services.redis.servers."".requirePass}@localhost:6379/";
       statePath = "/srv/gitlab/state";
       https = true;
       port = 443;

--- a/nixos/services/redis.nix
+++ b/nixos/services/redis.nix
@@ -92,7 +92,7 @@ in {
             assertion = extraConfig == "";
             message = ''
               Config via /etc/local/redis/custom.conf is not supported anymore.
-              Please use a NixOS module with the option services.redis.settings instead
+              Please use a NixOS module with the option services.redis.servers."".settings instead
             '';
           }
         ];
@@ -175,7 +175,7 @@ in {
         the redis password by changing the `password` file.
 
         Changing the config via custom.conf is not supported anymore. Please use a NixOS module
-        with the option `services.redis.settings` instead.
+        with the option `services.redis.servers."".settings` instead.
       '';
 
       # We want a fixed uid that is compatible with older releases.

--- a/tests/gitlab.nix
+++ b/tests/gitlab.nix
@@ -33,7 +33,7 @@ import ./make-test-python.nix ({ pkgs, lib, testlib, ...} : with lib; {
 
       flyingcircus.roles.postgresql14.enable = true;
 
-      services.redis.requirePass = lib.mkForce "test";
+      services.redis.servers."".requirePass = lib.mkForce "test";
 
       services.gitlab = lib.mkForce {
         databasePasswordFile = pkgs.writeText "dbPassword" dbPassword;


### PR DESCRIPTION
The NixOS module for Redis at some point gained support for multiple server instances, and the old options for configuration of a single global instance have been renamed. We still use the old options, which causes warnings when evaluating host configurations. This change updates our use of the Redis module to use the instanced configuration for the default (nameless) server instance.

PL-131437

@flyingcircusio/release-managers

## Release process

Impact: internal.

Changelog:

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Redis configuration should not use renamed/deprecated module options, to ensure the platform continues to function correctly in the future.
- [x] Security requirements tested? (EVIDENCE)
  - Hydra tests for Redis pass on this PR branch.
  - Hydra tests for Gitlab (as a consumer of the Redis module) pass on this PR branch.