### PR TITLE
Fix opensearch-dashboards permissions for unlinking in startup script

### DIFF
--- a/nixos/services/opensearch_dashboards.nix
+++ b/nixos/services/opensearch_dashboards.nix
@@ -154,6 +154,9 @@ in {
       environment = { BABEL_CACHE_PATH = "${cfg.dataDir}/.babelcache.json"; };
       preStart = ''
         pkg_dir=$STATE_DIRECTORY/package
+        if [ -e $pkg_dir ]; then
+            chmod -R u+w $pkg_dir
+        fi
         rm -rf $pkg_dir
         cp -r ${cfg.package} $pkg_dir
         chmod -R u+w $pkg_dir

--- a/nixos/services/opensearch_dashboards.nix
+++ b/nixos/services/opensearch_dashboards.nix
@@ -153,6 +153,7 @@ in {
       after = [ "network.target" "elasticsearch.service" "opensearch.service" ];
       environment = { BABEL_CACHE_PATH = "${cfg.dataDir}/.babelcache.json"; };
       preStart = ''
+        set -x
         pkg_dir=$STATE_DIRECTORY/package
         if [ -e $pkg_dir ]; then
             chmod -R u+w $pkg_dir


### PR DESCRIPTION
The startup script for the opensearch-dashboards service removes the contents of the old state directory on startup, before re-copying the package contents from the Nix store. Sometimes this script fails when unlinking the contents of the old state directory because some files have become read-only. This change adjusts the permissions before attempting to unlink files to avoid this issue.

PL-131484

@flyingcircusio/release-managers

## Release process

Impact: internal

Changelog:

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - opensearch-dashboards should restart cleanly without operator intervention.
- [x] Security requirements tested? (EVIDENCE)
  - Hydra tests for opensearch-dashboards pass on this PR branch.
  - Manually tested by introducing write-only files in the opensearch-dashboards state directory, and then verifying that the service restarts correctly in spite of these read-only files.