### PR TITLE
Replace text-based dnsmasq config with structured config.

### DIFF
--- a/nixos/roles/external_net/openvpn.nix
+++ b/nixos/roles/external_net/openvpn.nix
@@ -277,13 +277,12 @@ in
 
     services.dnsmasq = {
       enable = true;
-      extraConfig = ''
+      settings = {
         # OpenVPN specific configuration
-        bind-dynamic
-        interface=lo
-        listen-address=${addrs.ip4}
-        listen-address=${addrs.ip6}
-      '';
+        bind-dynamic = true;
+        interface = "lo";
+        listen-address = [ addrs.ip4 addrs.ip6 ];
+      };
     };
 
     services.openvpn.servers.access.config = serverConfig;

--- a/tests/mail/default.nix
+++ b/tests/mail/default.nix
@@ -4,16 +4,20 @@ let
     networking.domain = "example.local";
     networking.nameservers = [ "127.0.0.1" ];
     services.dnsmasq.enable = true;
-    services.dnsmasq.extraConfig = ''
-      mx-host=example.local,mail.example.local
-      mx-host=external.local,ext.example.local
-      no-resolv
-      server=/local/127.0.0.1
-      server=/net/
-      server=/org/
-      server=/com/
-      address=/webmail.example.local/192.168.1.3
-    '';
+    services.dnsmasq.settings = {
+      mx-host = [
+        "example.local,mail.example.local"
+        "external.local,ext.example.local"
+      ];
+      no-resolv = true;
+      server= [
+        "/local/127.0.0.1"
+        "/net/"
+        "/org/"
+        "/com/"
+      ];
+      address = "/webmail.example.local/192.168.1.3";
+    };
     services.haveged.enable = true;
   };
 in


### PR DESCRIPTION
As detailed in the [NixOS 23.05 release notes](https://nixos.org/manual/nixos/stable/release-notes.html#sec-release-23.05), text-based `extraConfig` in the dnsmasq module is deprecated and due to be removed. This change converts our uses of the dnsmasq module (`external_net` role, mailserver tests) to use the new structured configuration options.

PL-131556

@flyingcircusio/release-managers

## Release process

Impact: internal

Changelog:

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - dnsmasq configuration should not use deprecated options, to ensure that the platform continues to function correctly.
- [x] Security requirements tested? (EVIDENCE)
  - Verified that the dnsmasq configuration deprecation warnings are no longer printed when building system configurations with the `external_net` role enabled.
  - Manually verified that the dnsmasq configuration file generated for both the OpenVPN and VXLAN gateway roles contains the same configuration options before and after this change.
  - Verified that the Hydra mailserver tests pass on this feature branch.