### PR TITLE
Fix race condition between network interface renaming and network sysctls

### DIFF
--- a/nixos/platform/network.nix
+++ b/nixos/platform/network.nix
@@ -59,6 +59,11 @@ in
         then cfg.static.nameservers.${location}
         else [];
 
+      # Using SLAAC/privacy addresses will cause firewalls to block us
+      # internally and also have customers get problems with outgoing
+      # connections.
+      tempAddresses = "disabled";
+
       # data structure for all configured interfaces with their IP addresses:
       # { ethfe = { ... }; ethsrv = { }; ... }
       interfaces = listToAttrs (map (interface:
@@ -86,11 +91,6 @@ in
               defaultRoutes ++ additionalRoutes;
 
           ipv6.addresses = interface.v6.attrs;
-
-          # Using SLAAC/privacy addresses will cause firewalls to block
-          # us internally and also have customers get problems with
-          # outgoing connections.
-          tempAddress = "disabled";
 
           ipv6.routes =
             let

--- a/nixos/platform/network.nix
+++ b/nixos/platform/network.nix
@@ -161,7 +161,7 @@ in
 
     };
 
-    services.udev.extraRules = lib.concatMapStrings
+    boot.initrd.services.udev.rules = lib.concatMapStrings
       (interface: ''
         SUBSYSTEM=="net" , ATTR{address}=="${interface.mac}", NAME="${interface.physicalDevice}"
         '') interfaces;

--- a/release/vm-image.nix
+++ b/release/vm-image.nix
@@ -18,7 +18,7 @@ in
 {
   config = {
 
-    services.udev.extraRules = ''
+    boot.initrd.services.udev.rules = ''
         # static/bootstrap fallback rules for VMs
         SUBSYSTEM=="net", ATTR{address}=="02:00:00:02:??:??", NAME="ethfe"
         SUBSYSTEM=="net", ATTR{address}=="02:00:00:03:??:??", NAME="ethsrv"


### PR DESCRIPTION
There is a race condition where systemd will start `systemd-sysctl` to apply sysctl configuration before the network interfaces have been renamed from their default names to `ethfe` or `ethsrv` by udev. This means that per-interface sysctls are possibly not set correctly, if the interfaces do not yet exist under the expected name.

We use udev rules set in `system.udev.extraRules` for renaming the network interfaces, by matching on MAC address. However, the NixOS manual says [the following](https://nixos.org/manual/nixos/stable/index.html#sec-rename-ifs) on this topic:

> **Warning**
> 
> The rule must be installed in the initrd using `services.udev.initrdRules`, not the usual `services.udev.extraRules` option. This is to avoid race conditions with other programs controlling the interface.

(It seems that `services.udev.initrdRules` is a typo of `boot.initrd.services.udev.rules`, from a quick scan of the NixOS options search.)

This change moves the udev configuration for renaming interfaces from the stage 2 udev configuration to the stage 1 udev configuration, which means that the interfaces will be renamed in the initramfs, and guarantees that this happens before sysctl configuration is applied.

Additionally, we also disable IPv6 privacy addresses, however the udev rules generated by the NixOS networking module for setting this configuration at runtime would also run out of order with respect to the interface renaming rules, due to how udev handles the order of rule evaluation and command execution. The above change to the interface renaming configuration also fixes this problem, however this PR additionally moves from the per-interface configuration option for this behaviour to the global `networking.tempAddresses` option, to ensure that system-wide default behaviour is set appropriately (and as a side effect and implementation detail reduces the number of udev rules generated by the networking module).

PL-131498

@flyingcircusio/release-managers

## Release process

Impact: internal

Changelog:

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Network interface configuration should be applied correctly and without errors, to ensure network behaviour is as expected and desired.
- [x] Security requirements tested? (EVIDENCE)
  - Tested manually by booting a host with this configuration applied, and verifying that:
    - the errors previously observed in the system journal at boot time are no longer present with this modified configuration.
    - network interfaces are named correctly.
    - network sysctls defined in `/etc/sysctl.d/60-nixos.conf` are applied correctly.
    - in particular, IPv6 privacy addresses are disabled, both globally and per-interface.