### PR TITLE
nginx: provide nginxLegacyCrypt alias for upgrading to 23.05

### DIFF
--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -282,6 +282,9 @@ in {
 
   nginx = self.nginxStable;
 
+  # for allowing upgrades to 23.05
+  nginxLegacyCrypt = self.nginx;
+
   nginxMainline = (super.nginxMainline.override {
     modules = with super.nginxModules; [
       dav


### PR DESCRIPTION
corresponding doc update is in a separate PR #737 towards fc-23.05-dev

PL-131584

@flyingcircusio/release-managers

## Release process

Impact: none

Changelog:
- simplified upgrade path from 22.11 to 23.05 for users of nginx with legacy cryptographic algorithms

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - deployments requiring the use of the `nginxLegacyCrypt` package under 23.05 must not break at (unattended) system upgrade time.
  - deployments can already be modified *before* upgrading to 23.05
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still pass
  - apart from that no manual tests, as just aliasing a package here.