### PR TITLE
nginxLegacyCrypt: upgrade docs from 22.11

### DIFF
--- a/doc/src/webgateway.md
+++ b/doc/src/webgateway.md
@@ -291,3 +291,5 @@ If you still need them on 23.05, use the Nginx package which still supports all 
   services.nginx.package = pkgs.nginxLegacyCrypt;
 }
 ~~~
+
+A package alias under the name `nginxLegacyCrypt` is already available in our NixOS 22.11 release, enabling seamless platform upgrades with the same configuration.


### PR DESCRIPTION
PL-131584
documentation for #736

@flyingcircusio/release-managers

## Release process

Impact: none

Changelog: simplify upgrade path from 22.11 to 23.05 for users of nginx with legacy cryptographic algorithms

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - suggested upgrade path has documentation
- [x] Security requirements tested? (EVIDENCE)
  -  automated tests still pass
  - looked at build result of docs
