### PR TITLE
statshost: fix lazy evaluation for in case the default relabel file doesn't exist.

### DIFF
--- a/nixos/roles/statshost/default.nix
+++ b/nixos/roles/statshost/default.nix
@@ -32,9 +32,12 @@ let
     } "remarshal -if yaml -of json < ${filename} > $out";
 
   relabelConfiguration = filename:
-    if pathExists filename
-    then fromJSON (readFile (customRelabelJSON filename))
-    else [];
+    let
+      # allow filtering out non-existing paths, and avoid
+      # non-lazy if/then/else
+      existing_files = builtins.filter (f: pathExists f) [ filename ];
+    in
+      map (f: fromJSON (readFile (customRelabelJSON f))) existing_files;
 
   prometheusMetricRelabel =
     cfgStats.prometheusMetricRelabel ++ customRelabelConfig;


### PR DESCRIPTION

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

no specific requirements here. trivial bug fix.

- [x] Security requirements tested? (EVIDENCE)

no tests needed.
