### PR TITLE
[21.05] add frequent longterm backup schedule

### DIFF
--- a/nixos/roles/backyserver.nix
+++ b/nixos/roles/backyserver.nix
@@ -104,6 +104,10 @@ in
         longterm:
           daily: {interval: 1d, keep: 30}
           monthly: {interval: 30d, keep: 12}
+        frequent_longterm:
+          hourly: {interval: 1h, keep: 25}
+          daily: {interval: 1d, keep: 30}
+          monthly: {interval: 30d, keep: 12}
     '';
 
     flyingcircus.agent.extraCommands = ''

--- a/nixos/roles/backyserver.nix
+++ b/nixos/roles/backyserver.nix
@@ -90,17 +90,17 @@ in
       schedules:
         default:
           daily: {interval: 1d, keep: 10}
-          monthly: {interval: 30d, keep: 4}
           weekly: {interval: 7d, keep: 4}
+          monthly: {interval: 30d, keep: 4}
         frequent:
-          daily: {interval: 1d, keep: 10}
           hourly: {interval: 1h, keep: 25}
-          monthly: {interval: 30d, keep: 4}
+          daily: {interval: 1d, keep: 10}
           weekly: {interval: 7d, keep: 4}
+          monthly: {interval: 30d, keep: 4}
         reduced:
           daily: {interval: 1d, keep: 8}
-          monthly: {interval: 30d, keep: 2}
           weekly: {interval: 7d, keep: 3}
+          monthly: {interval: 30d, keep: 2}
         longterm:
           daily: {interval: 1d, keep: 30}
           monthly: {interval: 30d, keep: 12}


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

None

Changelog:

* Add a new combined schedule: "frequent+longterm": hourly for a day, daily for 30 days and monthly for 12 months.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

no specific requirements, simple change

- [x] Security requirements tested? (EVIDENCE)

relying on CI/CD
