### PR TITLE
[21.05] check_ceph: make log parsing resilient against encoding errors

### DIFF
--- a/pkgs/fc/check-ceph/nautilus/fc/check_ceph/ceph.py
+++ b/pkgs/fc/check-ceph/nautilus/fc/check_ceph/ceph.py
@@ -203,7 +203,7 @@ class CephLog(nagiosplugin.Resource):
         _log.info("scanning %s for slow request logs", self.logfile)
         with nagiosplugin.LogTail(self.logfile, self.cookie) as newlines:
             for line in newlines:
-                m = self.r_slow_req.search(line.decode())
+                m = self.r_slow_req.search(line.decode(errors="replace"))
                 if not m:
                     continue
                 _log.debug("slow requests: %s", line.strip())


### PR DESCRIPTION
- fixes a crash in the parsing of /var/log/ceph/ceph.log when the file contains invalid non-Unicode literals, such errors are now replaced
- decoding the output of `ceph status` is deliberately left as strict, because glitches in command output are not persistent and probably noteworthy, while encoding glitches in log files linger around until the file is being rotated

fixes PL-131612

@flyingcircusio/release-managers

## Release process

Impact:

Changelog: internal only

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - [x] keep monitoring system resilient against persistent errors
  - [x] test regression fix on the actual data causing it
- [x] Security requirements tested? (EVIDENCE)
  - [x] automated tests still pass
  - [x] manual test on dev ceph host with original problematic log file from production
