### PR TITLE
fc-branch-diff-release: self-contained dependencies via nix-shell

### DIFF
--- a/fc-branch-diff-release.sh
+++ b/fc-branch-diff-release.sh
@@ -1,4 +1,5 @@
-#!/usr/bin/env sh
+#! /usr/bin/env nix-shell
+#! nix-shell -i bash --pure -p git gh coreutils
 
 nixos_version=$(< nixos-version)
 dev="fc-${nixos_version}-dev"


### PR DESCRIPTION
@flyingcircusio/release-managers

`fc-branch-diff-release.sh` uses some external executables not always present on systems. This wraps the script in a nix-shell environment providing all required tools.
`--pure` is used to make sure that when extending the script with new executable dependencies, these are also added to the shell environment, no matter whether they are already in PATH for the author themselfs.

Other scripts in the directory are trivial enough (only use `git`) that I do not see a need to add a nix-shell wrapper to them.

## Release process

Impact:

Changelog: internal release tooling

## Security implications

none