### PR TITLE
[22.11] Update nixpkgs for gitlab 15.11.11

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "8f618a6abeb34cfe698e7f0f015e8607244b36a1",
-    "sha256": "envhsad5sIbEpXfWPLUt0JdZhb2wYicXdcHkjq9FvRs="
+    "rev": "be9a23f6691a4a53e567fb26e2a7a0e8b49ae3d8",
+    "sha256": "sha256-X0uGWRHwDKVUcgfAVZPErC3VDrH0g+TyOH3tbaJLJPg="
   },
   "nixos-mailserver": {
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/",


### PR DESCRIPTION
- gitlab: 15.11.9 -> 15.11.11

PL-131615

@flyingcircusio/release-managers

## Release process

Impact:

* \[NixOS 22.11\] Gitlab will be restarted.

Changelog:

* Gitlab: 15.11.8 -> 15.11.11 (PL-131615).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? 
  -  do regular security updates for Gitlab 
- [x] Security requirements tested? (EVIDENCE)
  - automated test still runs. Cannot test on the staging machine because it's already on 22.11 but it's just a minor update. 