### PR TITLE
Update nixpkgs

### DIFF
--- a/important_packages.json
+++ b/important_packages.json
@@ -75,6 +75,7 @@
   "lz4",
   "mailutils",
   "mariadb",
+  "mastodon",
   "matomo",
   "matrix-synapse",
   "mcpp",

--- a/package-versions.json
+++ b/package-versions.json
@@ -30,9 +30,9 @@
     "version": "5.2"
   },
   "bind": {
-    "name": "bind-9.18.14",
+    "name": "bind-9.18.16",
     "pname": "bind",
-    "version": "9.18.14"
+    "version": "9.18.16"
   },
   "binutils": {
     "name": "binutils-wrapper-2.40",
@@ -45,9 +45,9 @@
     "version": "2.4.13"
   },
   "cacert": {
-    "name": "nss-cacert-3.89.1",
+    "name": "nss-cacert-3.90",
     "pname": "nss-cacert",
-    "version": "3.89.1"
+    "version": "3.90"
   },
   "ceph": {
     "name": "ceph-17.2.5",
@@ -70,9 +70,9 @@
     "version": "3.25.3"
   },
   "consul": {
-    "name": "consul-1.15.2",
+    "name": "consul-1.15.3",
     "pname": "consul",
-    "version": "1.15.2"
+    "version": "1.15.3"
   },
   "containerd": {
     "name": "containerd-1.7.1",
@@ -120,9 +120,9 @@
     "version": "2.3.20"
   },
   "element-web": {
-    "name": "element-web-1.11.33",
+    "name": "element-web-1.11.34",
     "pname": "element-web",
-    "version": "1.11.33"
+    "version": "1.11.34"
   },
   "erlang": {
     "name": "erlang-25.3.2",
@@ -190,14 +190,14 @@
     "version": "2.40.1"
   },
   "github-runner": {
-    "name": "github-runner-2.304.0",
+    "name": "github-runner-2.305.0",
     "pname": "github-runner",
-    "version": "2.304.0"
+    "version": "2.305.0"
   },
   "gitlab": {
-    "name": "gitlab-16.0.2",
+    "name": "gitlab-16.1.2",
     "pname": "gitlab",
-    "version": "16.0.2"
+    "version": "16.1.2"
   },
   "glibc": {
     "name": "glibc-2.37-8",
@@ -215,9 +215,9 @@
     "version": "2.4.0"
   },
   "go": {
-    "name": "go-1.20.4",
+    "name": "go-1.20.5",
     "pname": "go",
-    "version": "1.20.4"
+    "version": "1.20.5"
   },
   "go_1_17": {},
   "go_1_18": {
@@ -226,9 +226,9 @@
     "version": "1.18.10"
   },
   "grafana": {
-    "name": "grafana-9.5.3",
+    "name": "grafana-9.5.5",
     "pname": "grafana",
-    "version": "9.5.3"
+    "version": "9.5.5"
   },
   "haproxy": {
     "name": "haproxy-2.7.8",
@@ -236,9 +236,9 @@
     "version": "2.7.8"
   },
   "imagemagick": {
-    "name": "imagemagick-7.1.1-11",
+    "name": "imagemagick-7.1.1-12",
     "pname": "imagemagick",
-    "version": "7.1.1-11"
+    "version": "7.1.1-12"
   },
   "imagemagick6": {
     "name": "imagemagick-6.9.12-68",
@@ -246,9 +246,9 @@
     "version": "6.9.12-68"
   },
   "imagemagick7": {
-    "name": "imagemagick-7.1.1-11",
+    "name": "imagemagick-7.1.1-12",
     "pname": "imagemagick",
-    "version": "7.1.1-11"
+    "version": "7.1.1-12"
   },
   "inetutils": {
     "name": "inetutils-2.4",
@@ -322,14 +322,14 @@
     "version": "3.0.8"
   },
   "libressl": {
-    "name": "libressl-3.7.2",
+    "name": "libressl-3.7.3",
     "pname": "libressl",
-    "version": "3.7.2"
+    "version": "3.7.3"
   },
   "libtiff": {
-    "name": "libtiff-4.5.0",
+    "name": "libtiff-4.5.1",
     "pname": "libtiff",
-    "version": "4.5.0"
+    "version": "4.5.1"
   },
   "libxml2": {
     "name": "libxml2-2.10.4",
@@ -337,9 +337,9 @@
     "version": "2.10.4"
   },
   "linux": {
-    "name": "linux-6.1.31",
+    "name": "linux-6.1.37",
     "pname": "linux",
-    "version": "6.1.31"
+    "version": "6.1.37"
   },
   "logrotate": {
     "name": "logrotate-3.21.0",
@@ -361,15 +361,20 @@
     "pname": "mariadb-server",
     "version": "10.6.13"
   },
+  "mastodon": {
+    "name": "mastodon-4.1.3",
+    "pname": "mastodon",
+    "version": "4.1.3"
+  },
   "matomo": {
     "name": "matomo-4.14.2",
     "pname": "matomo",
     "version": "4.14.2"
   },
   "matrix-synapse": {
-    "name": "matrix-synapse-1.85.1",
+    "name": "matrix-synapse-1.86.0",
     "pname": "matrix-synapse",
-    "version": "1.85.1"
+    "version": "1.86.0"
   },
   "mcpp": {
     "name": "mcpp-2.7.2.1",
@@ -432,14 +437,14 @@
     "version": "14.21.3"
   },
   "nodejs_16": {
-    "name": "nodejs-16.20.0",
+    "name": "nodejs-16.20.1",
     "pname": "nodejs",
-    "version": "16.20.0"
+    "version": "16.20.1"
   },
   "nodejs_18": {
-    "name": "nodejs-18.16.0",
+    "name": "nodejs-18.16.1",
     "pname": "nodejs",
-    "version": "18.16.0"
+    "version": "18.16.1"
   },
   "nodejs_19": {},
   "nspr": {
@@ -448,9 +453,9 @@
     "version": "4.35"
   },
   "nss_latest": {
-    "name": "nss-3.89.1",
+    "name": "nss-3.91",
     "pname": "nss",
-    "version": "3.89.1"
+    "version": "3.91"
   },
   "openjdk": {
     "name": "openjdk-19.0.2+7",
@@ -593,9 +598,9 @@
     "version": "4.7.4"
   },
   "prometheus": {
-    "name": "prometheus-2.42.0",
+    "name": "prometheus-2.44.0",
     "pname": "prometheus",
-    "version": "2.42.0"
+    "version": "2.44.0"
   },
   "prosody": {
     "name": "prosody-0.12.3",
@@ -603,19 +608,19 @@
     "version": "0.12.3"
   },
   "python3": {
-    "name": "python3-3.10.11",
+    "name": "python3-3.10.12",
     "pname": "python3",
-    "version": "3.10.11"
+    "version": "3.10.12"
   },
   "python310": {
-    "name": "python3-3.10.11",
+    "name": "python3-3.10.12",
     "pname": "python3",
-    "version": "3.10.11"
+    "version": "3.10.12"
   },
   "python311": {
-    "name": "python3-3.11.3",
+    "name": "python3-3.11.4",
     "pname": "python3",
-    "version": "3.11.3"
+    "version": "3.11.4"
   },
   "python38": {
     "name": "python3-3.8.17",
@@ -673,9 +678,9 @@
     "version": "7.0.11"
   },
   "roundcube": {
-    "name": "roundcube-1.6.1",
+    "name": "roundcube-1.6.2",
     "pname": "roundcube",
-    "version": "1.6.1"
+    "version": "1.6.2"
   },
   "rsync": {
     "name": "rsync-3.2.7",
@@ -713,9 +718,9 @@
     "version": "8.11.2"
   },
   "strace": {
-    "name": "strace-6.3",
+    "name": "strace-6.4",
     "pname": "strace",
-    "version": "6.3"
+    "version": "6.4"
   },
   "strongswan": {
     "name": "strongswan-5.9.10",
@@ -809,9 +814,9 @@
     "version": "6.2.0"
   },
   "xorg.libX11": {
-    "name": "libX11-1.8.4",
+    "name": "libX11-1.8.6",
     "pname": "libX11",
-    "version": "1.8.4"
+    "version": "1.8.6"
   },
   "zip": {
     "name": "zip-3.0",

--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "5aaa9f9509f330332792a492a8836d68f91fa743",
-    "sha256": "w3+rq9wCUUBs/1o/DTp3XErVi5xc6iG3vmQxvJaR9mU="
+    "rev": "92cb908608cc351ca88c3f3281811687cf516e04",
+    "sha256": "+OtofbjCZaXmMJjC/UOcVQnOVPNWtHVlbvddOooZ31A="
   },
   "nixos-mailserver": {
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/",


### PR DESCRIPTION
Pull upstream NixOS changes, security fixes and package updates:

- bind: 9.18.14 -> 9.18.16 (CVE-2023-2828, CVE-2023-2911, CVE-202-3094,
  CVE-2022-3736, CVE-2023-3924)
- cacert: 3.89.1 -> 3.90
- cmake: 3.25.3 -> 3.26.4
- gitlab: 16.0.5 -> 16.1.2
- imagemagick: 7.1.1-11 -> 7.1.1-12
- libtiff: 4.5.0 -> 4.5.1 (CVE-2023-25434, CVE-2023-26965)
- linux: 6.1.35 -> 6.1.37
- mastodon: 4.1.2 -> 4.1.3 (CVE-2023-36460, CVE-2023-36459)
- nss_latest: 3.90 -> 3.91
- python310: 3.10.11 -> 3.10.12 (CVE-2023-24329)
- python311: 3.11.3 -> 3.11.4 (CVE-2023-24329)
- roundcube: 1.6.1 -> 1.6.2
- strace: 6.3 -> 6.4
- systemd: fix services not stopping
- xorg.libX11: 1.8.4 → 1.8.6

PL-131621


@flyingcircusio/release-managers

## Release process

Impact:

* \[NixOS 23.05] Most services will restarted because of a core dependency change. Machines will schedule a reboot to activate the changed kernel.

Changelog:

(include commit msg from above)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - pull in upstream security fixes regularly
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still run, works on test VM
  -  checked commit log for fixed CVEs and possible problems with updates