### PR TITLE
More legacy xcrypt packages, use as defaults for LAMP and nginx

### DIFF
--- a/doc/src/upgrade.md
+++ b/doc/src/upgrade.md
@@ -116,10 +116,24 @@ following common breaking changes and role-specific notes below.
 - `libxcrypt`, the library providing the `crypt(3)` password hashing function,
   is now built without support for algorithms not flagged
   [`strong`](https://github.com/besser82/libxcrypt/blob/v4.4.33/lib/hashes.conf#L48)
-  in NixOS 23.05. We added a variant package called `libxcrypt-with-sha256`
-  which enables the `sha256` algorithm in addition to the `strong` algorithms.
-  OpenLDAP, Dovecot, Postfix, cyrus_sasl use that version by default.
-  New password hashes should use strong algorithms like `yescrypt`.
+  in NixOS 23.05.
+    - Check your applications if they still use algorithms for passwords that
+      are not `strong`.
+    - New password hashes should use strong algorithms like `yescrypt`.
+    - We added a variant package called `libxcrypt-with-sha256` which enables
+      the `sha256` algorithm in addition to the `strong` algorithms.
+    - There is also an upstream package with all old algorithms called
+      `libxcrypt-legacy`. OpenLDAP, Dovecot, Postfix and cyrus_sasl use that
+      version which might change with 23.11.
+    - The `nginx` service (also `webgateway` and `nginx` roles) and the `lamp`
+      role use `nginxLegacyCrypt` and `apacheHttpdLegacyCrypt` by default,
+      respectively. You may choose to switch to the strong algorithm variants
+      now by setting `services.nginx.package = pkgs.nginx` or
+      `services.httpd.package = pkgs.apacheHttpd`. These packages will become
+      the default on 23.11. If you want to keep the legacy variants for a
+      longer time, you can also use these options to set the legacy crypt
+      packages explicitly. 23.11 will emit a warning if they are still in
+      use.
 - `podman` now uses the `netavark` network stack. Users will need to delete
   all of their local containers, images, volumes, etc, by running `podman
   system reset --force` once before upgrading their systems.

--- a/nixos/roles/lamp.nix
+++ b/nixos/roles/lamp.nix
@@ -143,6 +143,7 @@ in {
         services.httpd.enable = true;
         services.httpd.adminAddr = "admin@flyingcircus.io";
         services.httpd.mpm = "event";
+        services.httpd.package = fclib.mkPlatform pkgs.apacheHttpdLegacyCrypt;
 
         # We always provide the PHP cli environment but we need to ensure
         # to choose the right one in case someone uses the LAMP role.

--- a/nixos/services/nginx/default.nix
+++ b/nixos/services/nginx/default.nix
@@ -358,6 +358,7 @@ in
 
       services.nginx = {
         enable = true;
+        package = fclib.mkPlatform pkgs.nginxLegacyCrypt;
         appendConfig = mainConfig;
         appendHttpConfig = ''
           ${baseHttpConfig}

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -20,6 +20,10 @@ in {
   # imports from other nixpkgs versions or local definitions
   #
 
+  apacheHttpdLegacyCrypt = self.apacheHttpd.override {
+    aprutil = self.aprutil.override { libxcrypt = self.libxcrypt-legacy; };
+  };
+
   inherit (super.callPackage ./boost { }) boost159;
 
   bundlerSensuPlugin = super.callPackage ./sensuplugins-rb/bundler-sensu-plugin.nix { };
@@ -127,15 +131,15 @@ in {
     preBuild = "rm -rf x-pack";
   });
 
-  cyrus_sasl-with-sha256 = super.cyrus_sasl.override {
-    libxcrypt = self.libxcrypt-with-sha256;
+  cyrus_sasl-legacyCrypt = super.cyrus_sasl.override {
+    libxcrypt = self.libxcrypt-legacy;
   };
 
   dovecot = (super.dovecot.override {
-    cyrus_sasl = self.cyrus_sasl-with-sha256;
+    cyrus_sasl = self.cyrus_sasl-legacyCrypt;
   }).overrideAttrs(old: {
     strictDeps = true;
-    buildInputs = [ self.libxcrypt-with-sha256 ] ++ old.buildInputs;
+    buildInputs = [ self.libxcrypt-legacy ] ++ old.buildInputs;
   });
 
   filebeat7-oss = self.filebeat7.overrideAttrs(a: a // {
@@ -286,7 +290,7 @@ in {
   });
 
   openldap_2_4 = super.callPackage ./openldap_2_4.nix {
-    libxcrypt = self.libxcrypt-with-sha256;
+    libxcrypt = self.libxcrypt-legacy;
   };
 
   opensearch = super.callPackage ./opensearch { };
@@ -329,7 +333,7 @@ in {
   pkgconfig = super.pkg-config;
 
   postfix = super.postfix.override {
-    cyrus_sasl = self.cyrus_sasl-with-sha256;
+    cyrus_sasl = self.cyrus_sasl-legacyCrypt;
   };
 
   postgis_2_5 = (super.postgresqlPackages.postgis.override {


### PR DESCRIPTION
- new packages: apacheHttpdLegacyCrypt, LAMP role uses this as default package
- modified packages:
  - nginxLegacyCrypt, nginx service uses this as default package
  - cyrus_sasl-legacyCrypt, used by postfix, dovecot
- override packages: openldap_2_4

PL-131617

@flyingcircusio/release-managers

## Release process

Impact:

Changelog: see commit description

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - we want to use `strong` algorithms for password hashing (like yescrypt) and encourage users to use them in their applications but have to support old hashes for compatibility reasons because changes may take a longer time and we don't want people to stay on old platform versions.
- [x] Security requirements tested? (EVIDENCE)
  - automated NixOS tests still run
  - checked that new packages actually use libxcrypt-legacy
  - checked on a test VM that lamp and nginx use the right default packages