### PR TITLE
ssh: only allow strong KexAlgorithms

### DIFF
--- a/nixos/platform/default.nix
+++ b/nixos/platform/default.nix
@@ -327,6 +327,13 @@ in {
       openssh.settings = {
         KbdInteractiveAuthentication = false;
         PasswordAuthentication = false;
+        KexAlgorithms = [
+          "sntrup761x25519-sha512@openssh.com"
+          "curve25519-sha256"
+          "curve25519-sha256@libssh.org"
+          "diffie-hellman-group16-sha512"
+          "diffie-hellman-group18-sha512"
+        ];
       };
 
       telegraf.enable = mkDefault true;


### PR DESCRIPTION
The defaults include "diffie-hellman-group-exchange-sha256" which has incorrect fallback behaviour which reduces its strength and is flagged as warning by ssh-audit 3.0.

This adds "diffie-hellman-group16-sha512" and "diffie-hellman-group18-sha512" which are recommended by ssh-audit 3.0.

PL-131620

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* ssh:  remove `diffie-hellman-group-exchange-sha256` key exchange algorithm because of a bug in openssh which weakens security. The algorithm can be added again by setting `services.openssh.settings.KexAlgorithms = [ "diffie-hellman-group-exchange-sha256" ];` if old clients should require it. This also adds the `diffie-hellman-group16-sha512` and `diffie-hellman-group18-sha512 kex algorithms (PL-131620).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - use secure key exchange algorithms for SSH
- [x] Security requirements tested? (EVIDENCE)
  -  ssh-audit 3.0 returns a green test result
  - checked with a test VM that SSH login still works