### PR TITLE
agent: handle postpone/tempfail in maintenance enter commands

### DIFF
--- a/pkgs/fc/agent/default.nix
+++ b/pkgs/fc/agent/default.nix
@@ -22,13 +22,13 @@ let
 
   pytest-structlog = py.buildPythonPackage rec {
     pname = "pytest-structlog";
-    version = "0.4";
+    version = "0.6";
 
     src = fetchFromGitHub {
       owner = "wimglenn";
       repo = "pytest-structlog";
-      rev = "b71518015109b292bc6584b8637264939b44af62";
-      sha256 = "00g2ivgj4y398d0y60lk710zz62pj80r9ya3b4iqijkp4j8nh4gp";
+      rev = "cb82f00cfc47696a36797a6eeb9f65ad6e727f19";
+      hash = "sha256-ktLsdEtxfiWhCTTaKowBoAAijOF9640m5XV/rdahpl0=";
     };
 
     buildInputs = [ pytest structlog ];
@@ -41,14 +41,15 @@ buildPythonPackage rec {
   namePrefix = "";
   src = ./.;
   checkInputs = [
-    py.pytestCheckHook
     py.freezegun
     py.pytest-cov
     py.responses
-    py.pytest
     py.pytest-mock
     py.pytest-subprocess
     pytest-structlog
+  ];
+  nativeCheckInputs = [
+    py.pytestCheckHook
   ];
   propagatedBuildInputs = [
     gitMinimal
@@ -77,6 +78,7 @@ buildPythonPackage rec {
     xfsprogs
   ];
   dontStrip = true;
+  doCheck = true;
   passthru.pythonDevEnv = python.withPackages (_: checkInputs ++ propagatedBuildInputs);
 
 }

--- a/pkgs/fc/agent/fc/maintenance/tests/test_cli.py
+++ b/pkgs/fc/agent/fc/maintenance/tests/test_cli.py
@@ -54,14 +54,19 @@ def invoke_app(tmpdir, agent_maintenance_config):
 
 def test_invoke_run(invoke_app):
     invoke_app("run")
-    fc.maintenance.cli.rm.execute.assert_called_once_with(False)
+    fc.maintenance.cli.rm.execute.assert_called_once_with(False, False)
     fc.maintenance.cli.rm.postpone.assert_called_once()
     fc.maintenance.cli.rm.archive.assert_called_once()
 
 
 def test_invoke_run_all_now(invoke_app):
     invoke_app("run", "--run-all-now")
-    fc.maintenance.cli.rm.execute.assert_called_once_with(True)
+    fc.maintenance.cli.rm.execute.assert_called_once_with(True, False)
+
+
+def test_invoke_run_all_now_force_run(invoke_app):
+    invoke_app("run", "--run-all-now", "--force-run")
+    fc.maintenance.cli.rm.execute.assert_called_once_with(True, True)
 
 
 def test_invoke_list(invoke_app):


### PR DESCRIPTION
agent: handle postpone/tempfail in maintenance enter commands

The postpone/tempfail protocol is now properly handled by the
RequestManager.

Maintenance enter commands can return EXIT_POSTPONE (69) or
EXIT_TEMPFAIL (75) to stop execution before maintenance requests
are run, typically when pre-conditions are not met.

The important difference is that temporary failures are expected
to go away with the next agent run, so the machine stays in maintenance
mode and just tries again (until the retry limit is hit).

Postponing is for conditions that will likely not be met within minutes,
so a new execution time for activities is requested from the directory
and the node is put back in service for now.

Tempfail and postpone can be ignored with the `force_run` flag if
needed for manual cleanup.

Dev env changes:

I had to move pytestCheckHook to nativeCheckInputs to make nix-shell
add `bin/pytest` to PATH.

doCheck is not explictly set to true (which is the default) to make
switching off checks during development easier.

Updates pytest-structlog to the current version.

PL-130625

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

- agent: handle special exit codes of maintenance enter commands (defined by `flyingcircus.agent.maintenance.enter.*`) correctly. They can now use EXIT_POSTPONE (69) or EXIT_TEMPFAIL (75) to stop execution before maintenance requests
are run, typically when pre-conditions are not met. This is currently not used by platform code but will be useful to prevent redundant machines from having service interruptions caused by automated maintenance at the same time (PL-130625). 

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - nothing new, just affects handling of maintenance enter commands, no relevant additional attack surface 
- [x] Security requirements tested? (EVIDENCE)
  - checked on a test VM that postpone and tempfail enter commands work, Python tests cover new functionality