### PR TITLE
Build python 2.7 with libxcrypt to enable crypt module

### DIFF
--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -342,6 +342,15 @@ in {
 
   prometheus-elasticsearch-exporter = super.callPackage ./prometheus-elasticsearch-exporter.nix { };
 
+  python27 = super.python27.overrideAttrs (prev: {
+    buildInputs = prev.buildInputs ++ [ super.libxcrypt-legacy ];
+    NIX_LDFLAGS = "-lcrypt";
+    configureFlags = [
+      "CFLAGS=-I${super.libxcrypt-legacy}/include"
+      "LIBS=-L${super.libxcrypt-legacy}/lib"
+    ];
+  });
+
   pythonPackagesExtensions = super.pythonPackagesExtensions ++ [
     (python-final: python-prev: {
       pyslurm = python-prev.pyslurm.overridePythonAttrs(_: {


### PR DESCRIPTION
Python 2.7 does not have the `crypt` module enabled in 23.05 as the build does not pick up libxcrypt. This breaks old applications which use Python 2.7 which require this module, as this was available in previous versions of the platform.

This PR adds an override to our overlay so that Python 2.7 build system has the necessary compiler and linker flags to detect libxcrypt as a suitable `crypt.h` implementation and enable the `crypt` module. The libxcrypt-legacy flavour is used here as old Python 2.7 applications are much more likely to encounter old password hashing schemes.

PL-131527

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:
- Re-enable the `crypt` module for obsolete Python version 2.7 to fix compatibility with legacy applications.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - The platform should maintain compatibility in application runtimes between different platform versions.
- [x] Security requirements tested? (EVIDENCE)
  - Verified manually that `./result/bin/python27 -c "import crypt"` exits with an error before this change is applied, and *without* an error after this change is applied.
  - Verified manually that the crypt module under Python 2.7 produces matching output to the crypt module running under Python 3.
  - automated tests still pass