### PR TITLE
[22.11] Update nixpkgs

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "be9a23f6691a4a53e567fb26e2a7a0e8b49ae3d8",
-    "sha256": "sha256-X0uGWRHwDKVUcgfAVZPErC3VDrH0g+TyOH3tbaJLJPg="
+    "rev": "4cf8b50a06192ea109461575bb6f0f89d6c4d902",
+    "sha256": "kXdBQ5NznBiEpAJtmu64dR/7ft6FD3HV9mEAUEVr2xA="
   },
   "nixos-mailserver": {
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/",


### PR DESCRIPTION
Pull upstream NixOS changes, security fixes and package updates:

- imagemagick: 7.1.1-11 -> 7.1.1-12
- linux: 5.15.118 -> 5.15.119

@flyingcircusio/release-managers

## Release process

Impact:

* \[NixOS 22.11] Multiple network-related services will be restarted. Machines will schedule a reboot to activate the changed kernel.

Changelog:

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - pull in upstream security fixes regularly
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still run, works on test VM and gitlab staging 
  -  checked commit log for fixed CVEs and possible problems with updates