### PR TITLE
Update nixpkgs

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "92cb908608cc351ca88c3f3281811687cf516e04",
-    "sha256": "+OtofbjCZaXmMJjC/UOcVQnOVPNWtHVlbvddOooZ31A="
+    "rev": "e42b556baad0267e44044f2c421e044e51087b74",
+    "sha256": "8SHZc1O3rPx5f8bF4rZATT/KDFi4cuzeEItGB2P34U8="
   },
   "nixos-mailserver": {
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/",


### PR DESCRIPTION
Update nixpkgs

Pull upstream NixOS changes, security fixes and package updates:

- asterisk: apply patch for pjsip (CVE-2023-27585)
- docker: 20.10.23 -> 20.10.25 (CVE-2023-28841, CVE-2023-28840, CVE-2023-28842)
- docker: fix starting containers with a local connection
- element-web: 1.11.35 -> 1.11.36 (CVE-2023-37259)
- ghostscript: 10.01.1 -> 10.01.2 (CVE-2023-36664)
- github-runner: 2.305.0 -> 2.306.0
- grafana: 9.5.5 -> 9.5.6
- imagemagick: 7.1.1-12 -> 7.1.1-13
- iperf: 3.13 -> 3.14 (CVE-2023-38403)
- keycloak: 21.1.1 -> 21.1.2
- linux: 6.1.37 -> 6.1.39
- mastodon: 4.1.3 -> 4.1.4
- matrix-synapse: 1.86.0 -> 1.88.0
- qemu: 8.0.0 -> 8.0.2
- redis: 7.0.11 -> 7.0.12 (CVE-2022-24834, CVE-2023-36824)

PL-131648

@flyingcircusio/release-managers

## Release process

Impact:

* \[NixOS 23.05] Most services will restarted because of a core dependency change. Machines will schedule a reboot to activate the changed kernel.

Changelog: (include changes from commit msg here)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - pull in upstream security fixes regularly
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still run, works on test VM
  - checked commit log for fixed CVEs and possible problems with updates, looked at [synapse/upgrade.md](https://github.com/matrix-org/synapse/blob/develop/docs/upgrade.md), [Grafana changelog](https://github.com/grafana/grafana/blob/main/CHANGELOG.md), [Releases · redis/redis](https://github.com/redis/redis/releases) and [Releases · moby/moby (docker)](https://github.com/moby/moby/releases)