### PR TITLE
Enable fail2ban to mitigate impact of SSH brute force attacks

### DIFF
--- a/nixos/platform/default.nix
+++ b/nixos/platform/default.nix
@@ -322,6 +322,23 @@ in {
       # overrides it
       cron.enable = fclib.mkPlatform true;
 
+      fail2ban.enable = fclib.mkPlatform true;
+      fail2ban.ignoreIP =
+        [
+          # loopback
+          "127.0.0.1/8"
+          "::1"
+
+          # rfc1918 addresses
+          "10.0.0.0/8"
+          "172.16.0.0/12"
+          "192.168.0.0/16"
+        ] ++
+        cfg.static.firewall.trusted ++
+        (flatten
+          (builtins.map (v: builtins.attrNames v.networks)
+            (builtins.attrValues (attrByPath [ "parameters" "interfaces" ] {} cfg.enc))));
+
       nscd.enable = true;
       openssh.enable = fclib.mkPlatform true;
       openssh.settings = {


### PR DESCRIPTION
Brute force attacks on sshd can trigger the MaxStartups throttling, which in acute cases can prevent new connections from legitimate sources (e.g. sensu checks, operator access) being established. This PR enables fail2ban, to block abusive hosts in the firewall to prevent connections from trigging MaxStartups rate limiting. This also configures a list of trusted networks which will be ignored by rate limiting, to prevent automation and administrator access from being erroneously blocked from SSH access.

PL-131632

@flyingcircusio/release-managers

## Release process

Impact:

Changelog: Enable and configure fail2ban to reduce the impact of brute force attacks against SSH.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Mitigations against brute force attacks should avoid erroneously blocking legitimate traffic.
- [x] Security requirements tested? (EVIDENCE)
  - Manually verified that this change enables and correctly configures fail2ban on a test host.
  - @dpausp has manually verified that fail2ban correctly identifies and sets appropriate firewall rules to block abusive hosts.