### PR TITLE
Implement mechanism to avoid simultaneous maintenance of machines

### DIFF
--- a/doc/src/index.md
+++ b/doc/src/index.md
@@ -7,6 +7,7 @@ Platform & roles documentation for Flying Circus [NixOS] edition
 :titlesonly: true
 
 upgrade
+maintenance
 base
 user_profile
 local

--- a/doc/src/maintenance.md
+++ b/doc/src/maintenance.md
@@ -1,0 +1,63 @@
+(nixos-maintenance)=
+
+# Automated Maintenance
+
+VMs perform automated maintenance activities in announced maintenance windows.
+Typical activities are system updates and reboots necessary to activate VM
+property changes like memory size and the number of CPUs.
+
+When new activities are scheduled by our central VM directory, a mail is sent
+out to technical contacts with information about what's happening and when.
+
+Activities can be merged into existing activities, updating them. For
+significant changes, like additional service restarts, a mail is sent again
+and the activity might get rescheduled to a later time. For small changes
+and cancelled activities, no mail is being sent currently.
+
+The `fc-agent` service executes due activities which happens every 10 minutes.
+Some activities require a reboot which is done at the end of an agent run
+after executing all activities.
+
+Activities that are overdue (more than 30 minutes after planned time) are
+postponed for at least 8 hours and scheduled again.
+
+Before executing activities, the machine is put into *maintenance mode*
+(it's *not in service*) to prevent triggering false alarms for expected
+service interruptions during maintenance.
+
+Maintenance is scheduled in a way so activities on different VMs shouldn't run
+at the same time but this is not enforced by default. The execution of activities
+can be delayed for various reasons so activities on different VMs may overlap.
+
+
+## Additional Maintenance Constraints
+
+To make sure that VMs don't execute activities at the same time, possibly affecting
+availability of a redundant system, the NixOS option
+`flyingcircus.agent.maintenanceConstraints.machinesInService` can be used.
+
+This means that the specified machines from the same resource group have to
+be *in service* (*not in maintenance mode*) when the machine tries to enter
+maintenance mode. The constraint is checked shortly after entering
+maintenance mode, before executing activities. If it's not met, due
+activities are postponed to a later time and the machines leaves maintenance
+mode immediately.
+
+For the following example, assume that the VMs `example10`, `example11` and
+`example12` are running redundant instances of an application and we want at
+least two of the instances *in service* at any time.
+
+This is enforced by this config, which has to be placed on each machine:
+```nix
+# /etc/local/nixos/maintenance_settings.nix
+{ config, ... }:
+{
+  flyingcircus.agent.maintenanceConstraints.machinesInService = [
+    "example10"
+    "example11"
+    "example12"
+  ];
+}
+```
+
+The name of the current machine is ignored, so the config can be the same on all machines.

--- a/nixos/platform/agent.nix
+++ b/nixos/platform/agent.nix
@@ -77,6 +77,21 @@ in
         type = types.bool;
       };
 
+      maintenanceConstraints = {
+        machinesInService = mkOption {
+          default = [];
+          type = with types; listOf str;
+          description = ''
+            Machines that must not be in maintenance mode at the same time.
+            After entering maintenance mode, the agent will check if a listed
+            machine is also in maintenance and leave maintenance if it finds
+            one. Due maintenance activities will be postponed in that case.
+            The name of the current machine is ignored here so you can use the same
+            value for this option on all affected machines.
+          '';
+        };
+      };
+
       updateInMaintenance = mkOption {
         default = attrByPath [ "parameters" "production" ] false cfg.enc;
         description = "Perform channel updates in scheduled maintenance. Default: all production VMs";
@@ -157,6 +172,19 @@ in
         pkgs.fc.agent
         agentZshCompletionsPkg
       ];
+
+      flyingcircus.agent.maintenance =
+      let
+        machines =
+          filter
+            (m: m != config.networking.hostName)
+            cfg.agent.maintenanceConstraints.machinesInService;
+      in
+        lib.optionalAttrs (machines != []) {
+          other-machines-not-in-maintenance.enter =
+              "${pkgs.fc.agent}/bin/fc-maintenance constraints"
+              + (lib.concatMapStrings (u: " --in-service ${u}") machines);
+        };
 
       flyingcircus.passwordlessSudoRules = [
         {

--- a/pkgs/fc/agent/default.nix
+++ b/pkgs/fc/agent/default.nix
@@ -22,7 +22,7 @@ let
 
   pytest-structlog = py.buildPythonPackage rec {
     pname = "pytest-structlog";
-    version = "0.6";
+    version = "0.6-cb82f00";
 
     src = fetchFromGitHub {
       owner = "wimglenn";

--- a/pkgs/fc/agent/fc/maintenance/reqmanager.py
+++ b/pkgs/fc/agent/fc/maintenance/reqmanager.py
@@ -597,7 +597,7 @@ class ReqManager:
                 "execute-requests-force",
                 _replace_msg=(
                     "Due requests will be executed regardless of the temporary failure "
-                    "which occurred when running maintenance enter commands."
+                    "of a maintenance enter command."
                 ),
             )
             return HandleEnterExceptionResult()
@@ -608,7 +608,7 @@ class ReqManager:
                 _replace_msg=(
                     "Run all mode requested and force mode activated: "
                     "All requests will be executed now regardless of the temporary "
-                    "failure which occurred when running maintenance enter commands."
+                    "failure of a maintenance enter command."
                 ),
             )
             return HandleEnterExceptionResult()


### PR DESCRIPTION
Add a new NixOS option
`flyingcircus.agent.maintenanceConstraints.machinesInService` which is used to specify other machines that are not allowed to be in maintenance mode at the same time when a machine is trying to enter maintenance.

This is implemented by`fc-maintenance constraints` which takes multiple `--in-service` arguments to ask the directory API about the "in service" status of the given machines, returning EXIT_POSTPONE any condition is not met. The command is configured by the NixOS option to run as maintenance enter command.

This adds basic user documentation about our maintenance system which also shows how to use the new option.

PL-131290

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

- Document how automated maintenance works and how to avoid simultaneous maintenance of machines using the new NixOS option `flyingcircus.agent.maintenanceConstraints.machinesInService` (PL-131290).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - nothing new, this is just a convenient way to specify a maintenance enter command which checks the state of other machines. 
- [x] Security requirements tested? (EVIDENCE)
  - checked on a test VM that the constraint is enforced correctly and maintenance works when conditions are met. 
  - Python tests cover the new `fc-maintenance constraints` command.  
