### PR TITLE
[22.11] Build Python 2.7 with libxcrypt to enable crypt module

### DIFF
--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -348,6 +348,15 @@ in {
 
   prometheus-elasticsearch-exporter = super.callPackage ./prometheus-elasticsearch-exporter.nix { };
 
+  python27 = super.python27.overrideAttrs (prev: {
+    buildInputs = prev.buildInputs ++ [ super.libxcrypt ];
+    NIX_LDFLAGS = "-lcrypt";
+    configureFlags = [
+      "CFLAGS=-I${super.libxcrypt}/include"
+      "LIBS=-L${super.libxcrypt}/lib"
+    ];
+  });
+
   # This was renamed in NixOS 22.11, nixos-mailserver still refers to the old name.
   pypolicyd-spf = self.spf-engine;
 


### PR DESCRIPTION
Backport of #752.

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:
- Re-enable the `crypt` module for obsolete Python version 2.7 to fix compatibility with legacy applications.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - The platform should maintain compatibility in application runtimes between different platform versions.
- [x] Security requirements tested? (EVIDENCE)
  - Verified manually that ./result/bin/python27 -c "import crypt" exits with an error before this change is applied, and without an error after this change is applied.
