### PR TITLE
Update nixpkgs

### DIFF
--- a/package-versions.json
+++ b/package-versions.json
@@ -105,9 +105,9 @@
     "version": "2.89"
   },
   "docker": {
-    "name": "docker-20.10.23",
+    "name": "docker-20.10.25",
     "pname": "docker",
-    "version": "20.10.23"
+    "version": "20.10.25"
   },
   "docker-compose": {
     "name": "docker-compose-2.18.1",
@@ -120,9 +120,9 @@
     "version": "2.3.20"
   },
   "element-web": {
-    "name": "element-web-1.11.34",
+    "name": "element-web-1.11.36",
     "pname": "element-web",
-    "version": "1.11.34"
+    "version": "1.11.36"
   },
   "erlang": {
     "name": "erlang-25.3.2",
@@ -180,9 +180,9 @@
     "version": "2.3.3"
   },
   "ghostscript": {
-    "name": "ghostscript-with-X-10.01.1",
+    "name": "ghostscript-with-X-10.01.2",
     "pname": "ghostscript-with-X",
-    "version": "10.01.1"
+    "version": "10.01.2"
   },
   "git": {
     "name": "git-2.40.1",
@@ -190,9 +190,9 @@
     "version": "2.40.1"
   },
   "github-runner": {
-    "name": "github-runner-2.305.0",
+    "name": "github-runner-2.306.0",
     "pname": "github-runner",
-    "version": "2.305.0"
+    "version": "2.306.0"
   },
   "gitlab": {
     "name": "gitlab-16.1.2",
@@ -215,9 +215,9 @@
     "version": "2.4.0"
   },
   "go": {
-    "name": "go-1.20.5",
+    "name": "go-1.20.6",
     "pname": "go",
-    "version": "1.20.5"
+    "version": "1.20.6"
   },
   "go_1_17": {},
   "go_1_18": {
@@ -226,9 +226,9 @@
     "version": "1.18.10"
   },
   "grafana": {
-    "name": "grafana-9.5.5",
+    "name": "grafana-9.5.6",
     "pname": "grafana",
-    "version": "9.5.5"
+    "version": "9.5.6"
   },
   "haproxy": {
     "name": "haproxy-2.7.8",
@@ -236,9 +236,9 @@
     "version": "2.7.8"
   },
   "imagemagick": {
-    "name": "imagemagick-7.1.1-12",
+    "name": "imagemagick-7.1.1-14",
     "pname": "imagemagick",
-    "version": "7.1.1-12"
+    "version": "7.1.1-14"
   },
   "imagemagick6": {
     "name": "imagemagick-6.9.12-68",
@@ -246,9 +246,9 @@
     "version": "6.9.12-68"
   },
   "imagemagick7": {
-    "name": "imagemagick-7.1.1-12",
+    "name": "imagemagick-7.1.1-14",
     "pname": "imagemagick",
-    "version": "7.1.1-12"
+    "version": "7.1.1-14"
   },
   "inetutils": {
     "name": "inetutils-2.4",
@@ -301,9 +301,9 @@
     "version": "1.26.4+k3s1"
   },
   "keycloak": {
-    "name": "keycloak-21.1.1",
+    "name": "keycloak-21.1.2",
     "pname": "keycloak",
-    "version": "21.1.1"
+    "version": "21.1.2"
   },
   "kibana6-oss": {},
   "kubernetes-helm": {
@@ -337,9 +337,9 @@
     "version": "2.10.4"
   },
   "linux": {
-    "name": "linux-6.1.37",
+    "name": "linux-6.1.41",
     "pname": "linux",
-    "version": "6.1.37"
+    "version": "6.1.41"
   },
   "logrotate": {
     "name": "logrotate-3.21.0",
@@ -357,14 +357,14 @@
     "version": "3.15"
   },
   "mariadb": {
-    "name": "mariadb-server-10.6.13",
+    "name": "mariadb-server-10.6.14",
     "pname": "mariadb-server",
-    "version": "10.6.13"
+    "version": "10.6.14"
   },
   "mastodon": {
-    "name": "mastodon-4.1.3",
+    "name": "mastodon-4.1.4",
     "pname": "mastodon",
-    "version": "4.1.3"
+    "version": "4.1.4"
   },
   "matomo": {
     "name": "matomo-4.14.2",
@@ -372,9 +372,9 @@
     "version": "4.14.2"
   },
   "matrix-synapse": {
-    "name": "matrix-synapse-1.86.0",
+    "name": "matrix-synapse-1.88.0",
     "pname": "matrix-synapse",
-    "version": "1.86.0"
+    "version": "1.88.0"
   },
   "mcpp": {
     "name": "mcpp-2.7.2.1",
@@ -392,9 +392,9 @@
     "version": "4.2.24"
   },
   "mysql": {
-    "name": "mariadb-server-10.6.13",
+    "name": "mariadb-server-10.6.14",
     "pname": "mariadb-server",
-    "version": "10.6.13"
+    "version": "10.6.14"
   },
   "mysql80": {
     "name": "mysql-8.0.33",
@@ -473,9 +473,9 @@
     "version": "2.4.58"
   },
   "openssh": {
-    "name": "openssh-9.3p1",
+    "name": "openssh-9.3p2",
     "pname": "openssh",
-    "version": "9.3p1"
+    "version": "9.3p2"
   },
   "openssl": {
     "name": "openssl-3.0.9",
@@ -653,9 +653,9 @@
     "version": "4.2.5"
   },
   "qemu": {
-    "name": "qemu-8.0.0",
+    "name": "qemu-8.0.2",
     "pname": "qemu",
-    "version": "8.0.0"
+    "version": "8.0.2"
   },
   "rabbitmq-server": {
     "name": "rabbitmq-server-3.11.10",
@@ -673,9 +673,9 @@
     "version": "3.0"
   },
   "redis": {
-    "name": "redis-7.0.11",
+    "name": "redis-7.0.12",
     "pname": "redis",
-    "version": "7.0.11"
+    "version": "7.0.12"
   },
   "roundcube": {
     "name": "roundcube-1.6.2",

--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "e42b556baad0267e44044f2c421e044e51087b74",
-    "sha256": "8SHZc1O3rPx5f8bF4rZATT/KDFi4cuzeEItGB2P34U8="
+    "rev": "63d398ecfdda47cbf3077639e370ccfb653c7841",
+    "sha256": "JHV2f6VcBYYGJzO32lA+SRHr7hSKfeIIwmG6arIvGvM="
   },
   "nixos-mailserver": {
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/",


### PR DESCRIPTION
Pull upstream NixOS changes, security fixes and package updates:

- docker: apply fix starting containers with a local connection with the CLI
- imagemagick: 7.1.1-13 -> 7.1.1-14
- linux: 6.1.39 -> 6.1.41
- openssh: 9.3p1 -> 9.3p2 (CVE-2023-38408)

 #PL-131663

@flyingcircusio/release-managers

## Release process

Impact: same as #754, as both will be in the same release.
Basically avoids shipping a broken docker in the next release by pulling in the upstream fix, together with all other changes. 

Changelog: (include changes from commit message here, merge with #754 ones)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - pull in upstream changes again within the same release cycle, to obtain fixes for known problems
- [ ] Security requirements tested? (EVIDENCE)
  - automated tests still pass
  - checked commit log for fixed CVEs
  - checked openssh changelog