### PR TITLE
Fix deeplinks for documentation on VM to point to 23.05

### DIFF
--- a/nixos/platform/firewall.nix
+++ b/nixos/platform/firewall.nix
@@ -74,7 +74,7 @@ in
       - nixos-nat-pre: prerouting rules, e.g. port redirects (-t nat)
       - nixos-nat-post: postrouting rules, e.g. masquerading (-t nat)
 
-      See also https://doc.flyingcircus.io/roles/fc-22.05-production/firewall.html
+      See also https://doc.flyingcircus.io/roles/fc-23.05-production/firewall.html
     '';
 
     flyingcircus.services.sensu-client.checks = {

--- a/nixos/roles/mysql.nix
+++ b/nixos/roles/mysql.nix
@@ -307,7 +307,7 @@ in
       `sudo systemctl restart mysql`
 
       For more information, see our documentation at
-      https://doc.flyingcircus.io/roles/fc-22.05-production/mysql.html
+      https://doc.flyingcircus.io/roles/fc-23.05-production/mysql.html
     '';
 
     systemd.services.fc-mysql-post-init = {

--- a/nixos/services/mail/README
+++ b/nixos/services/mail/README
@@ -7,7 +7,7 @@ It uses Postfix for mail delivery, Dovecot as IMAP access server, and Roundcube 
 
 Refer to the platform documentation for detailed information on how to configure this:
 
-https://doc.flyingcircus.io/roles/fc-22.05-production/mailserver.html
+https://doc.flyingcircus.io/roles/fc-23.05-production/mailserver.html
 
 
 Role Settings

--- a/nixos/services/mail/stub.nix
+++ b/nixos/services/mail/stub.nix
@@ -39,7 +39,7 @@ let
 
     This role shares some configuration options which the 'mailserver' role:
     mailHost, rootAlias, smtpBind[46], explicitSmtpBind. Refer to
-    https://doc.flyingcircus.io/roles/fc-22.05-production/mailserver.html for
+    https://doc.flyingcircus.io/roles/fc-23.05-production/mailserver.html for
     explanation.
   '';
 

--- a/nixos/services/nginx/README.txt
+++ b/nixos/services/nginx/README.txt
@@ -3,7 +3,7 @@ Nginx is enabled on this machine.
 The recommended method is structured configuration via Nix code in `/etc/local/nixos`.
 You can also find an example at `/etc/local/nixos/nginx.nix.example`.
 Refer to the webgateway role documentation at
-https://doc.flyingcircus.io/roles/fc-22.05-production/webgateway.html for more info.
+https://doc.flyingcircus.io/roles/fc-23.05-production/webgateway.html for more info.
 
 
 Old configuration methods

--- a/nixos/services/postgresql.nix
+++ b/nixos/services/postgresql.nix
@@ -54,7 +54,7 @@ let
   legacyConfigWarning =
     ''Plain PostgreSQL configuration found in ${toString localConfigPath}.
     This does not work properly anymore and must be migrated to NixOS configuration.
-    See https://doc.flyingcircus.io/roles/fc-22.05-production/postgresql.html for details.'';
+    See https://doc.flyingcircus.io/roles/fc-23.05-production/postgresql.html for details.'';
 
   localConfig =
     if legacyConfigFiles != []
@@ -206,7 +206,7 @@ in {
 
         See the platform documentation for more details:
 
-        https://doc.flyingcircus.io/roles/fc-22.05-production/postgresql.html
+        https://doc.flyingcircus.io/roles/fc-23.05-production/postgresql.html
       '';
 
       flyingcircus.infrastructure.preferNoneSchedulerOnSsd = true;


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

Changelog:
* Fix some deeplinks for documentation

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [ ] Security requirements tested? (EVIDENCE)
