### PR TITLE
[22.05] Enable fail2ban to mitigate impact of SSH brute force attacks

### DIFF
--- a/nixos/platform/default.nix
+++ b/nixos/platform/default.nix
@@ -294,6 +294,23 @@ in {
       # overrides it
       cron.enable = fclib.mkPlatform true;
 
+      fail2ban.enable = fclib.mkPlatform true;
+      fail2ban.ignoreIP =
+        [
+          # loopback
+          "127.0.0.1/8"
+          "::1"
+
+          # rfc1918 addresses
+          "10.0.0.0/8"
+          "172.16.0.0/12"
+          "192.168.0.0/16"
+        ] ++
+        cfg.static.firewall.trusted ++
+        (flatten
+          (builtins.map (v: builtins.attrNames v.networks)
+            (builtins.attrValues (attrByPath [ "parameters" "interfaces" ] {} cfg.enc))));
+
       nscd.enable = true;
       openssh.enable = fclib.mkPlatform true;
       openssh.kbdInteractiveAuthentication = false;


### PR DESCRIPTION
Backport of #755

PL-131632

@flyingcircusio/release-managers

## Release process

Impact:

Changelog: Enable and configure fail2ban to reduce the impact of brute force attacks against SSH.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [x] Security requirements tested? (EVIDENCE)
