### PR TITLE
[21.05] Update 22.11 channel to 23.05 for Zenbleed microcode

### DIFF
--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -10,6 +10,7 @@ let
     {} super;
 
   nixpkgs-22_11 = import versions.nixpkgs-22_11 {};
+  nixpkgs-23_05 = import versions.nixpkgs-23_05 {};
 
   inherit (super) fetchpatch fetchurl lib;
 
@@ -290,6 +291,12 @@ in {
   });
 
   mc = super.callPackage ./mc.nix { };
+
+  # Use linux-firmware from 23.05 to get microcode which includes
+  # fixes for Zenbleed.
+  microcodeAmd = super.microcodeAmd.override {
+    firmwareLinuxNonfree = nixpkgs-23_05.linux-firmware;
+  };
 
   mongodb-3_6 = super.mongodb-3_6.overrideAttrs(_: rec {
     # We have set the license to null to avoid that Hydra complains about unfree

--- a/versions.json
+++ b/versions.json
@@ -11,6 +11,12 @@
     "rev": "6a70ea11060b8acf6ec3867d4db3d078e745a377",
     "sha256": "sha256-g01dOC/P8QedWBkLp4fevIIsJrjV5FdFdK3n6OUADs8="
   },
+  "nixpkgs-23.05": {
+    "owner": "flyingcircusio",
+    "repo": "nixpkgs",
+    "rev": "63d398ecfdda47cbf3077639e370ccfb653c7841",
+    "sha256": "sha256-JHV2f6VcBYYGJzO32lA+SRHr7hSKfeIIwmG6arIvGvM="
+  },
   "nixos-mailserver": {
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/",
     "rev": "32c90985be7ae42736716044f00c28435492a462",


### PR DESCRIPTION
We have hosts which are affected by CVE-2023-20593 "Zenbleed" ([original writeup](https://lock.cmpxchg8b.com/zenbleed.html), [vendor advisory](https://www.amd.com/en/resources/product-security/bulletin/amd-sb-7008.html#mitigation)), and the recommended mitigation is to apply a microcode update. This microcode is already available in Nixpkgs 23.05.

This PR adds a 23.05 channel alongside the existing 22.11 channel on this platform branch, and overrides the AMD microcode package to use the firmware versions provided in 23.05. Hosts which have the relevant NixOS option enabled to update microcode at boot time should then automatically pick up the updated microcode.

PL-131656

@flyingcircusio/release-managers

## Release process

Impact: internal.

Changelog:

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - The platform should include known mitigations for security-relevant hardware defects.
- [ ] Security requirements tested? (EVIDENCE)
  - Manually verified that system configurations based on this branch build correctly.