### PR TITLE
gitlab-runner: fix docker executor by pinning older runner version

### DIFF
--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -50,6 +50,12 @@ in {
 
   innotop = super.callPackage ./percona/innotop.nix { };
 
+  # XXX: pinned to the latest 16.1.0 version using Go 1.20.5 (from release 2023_017)
+  # until the gitlab-runner problem with Go 1.20.6 is fixed:
+  # https://gitlab.com/gitlab-org/gitlab-runner/-/issues/36051 and
+  # https://github.com/NixOS/nixpkgs/issues/245365
+  gitlab-runner = builtins.storePath /nix/store/hfk8w6yf0zfvs6ng1swpiyrqrk5pghn5-gitlab-runner-16.1.0;
+
   libmodsecurity = super.callPackage ./libmodsecurity { };
 
   jicofo = super.jicofo.overrideAttrs(oldAttrs: rec {

--- a/release/default.nix
+++ b/release/default.nix
@@ -110,6 +110,9 @@ let
     "linuxPackages_5_4"
     # XXX: fails on 21.05, must be fixed
     "backy"
+    # This is a store path in the overlay which doesn't work in Hydra restricted mode.
+    # We don't need to test it.
+    "gitlab-runner"
   ];
 
   includedPkgNames = [


### PR DESCRIPTION
gitlab-runner doesn't work properly with Go 1.20.6. Talking to a docker daemon via UNIX socket fails with "invalid Host header". Pin our version of gitlab-runner to the one from release 2023_017 which uses the previous Go version until
https://gitlab.com/gitlab-org/gitlab-runner/-/issues/36051 is fixed in gitlab-runner.

PL-131694

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* gitlab-runner: go back to previous runner version 16.1.0 which fixes the docker executor (PL-131694).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - this version of gitlab-runner uses a Go version with security issues but we have to go back to the old version to make docker work again. The override should be removed as soon as possible when the problem is fixed upstream. 
- [x] Security requirements tested? (EVIDENCE)
  - tested on Gitlab staging VM