### PR TITLE
agent: fix request merging when comment is missing

### DIFF
--- a/pkgs/fc/agent/fc/maintenance/request.py
+++ b/pkgs/fc/agent/fc/maintenance/request.py
@@ -363,10 +363,16 @@ class Request:
         self.activity = activity_merge_result.merged
 
         # XXX: get rid of request estimate?
-        if self._estimate is not None and other._estimate is not None:
-            self._estimate = max(self._estimate, other._estimate)
-        if other._comment is not None and self._comment != other._comment:
-            self._comment += " " + other._comment
+        if other._estimate:
+            if not self._estimate:
+                self._estimate = other._estimate
+            else:
+                self._estimate = max(self._estimate, other._estimate)
+        if other._comment:
+            if not self._comment:
+                self._comment = other._comment
+            elif self._comment != other._comment:
+                self._comment += "\n\n" + other._comment
 
         if not activity_merge_result.is_effective:
             return RequestMergeResult.REMOVE

--- a/pkgs/fc/agent/fc/maintenance/tests/__init__.py
+++ b/pkgs/fc/agent/fc/maintenance/tests/__init__.py
@@ -1,0 +1,29 @@
+from fc.maintenance.activity import Activity, ActivityMergeResult
+from fc.maintenance.estimate import Estimate
+
+
+class MergeableActivity(Activity):
+    estimate = Estimate("10")
+
+    def __init__(self, value="test", significant=True):
+        super().__init__()
+        self.value = value
+        self.significant = significant
+
+    @property
+    def comment(self):
+        return self.value
+
+    def merge(self, other):
+        if not isinstance(other, MergeableActivity):
+            return ActivityMergeResult()
+
+        # Simulate merging an activity that reverts this activity, resulting
+        # in a no-op situation.
+        if other.value == "inverse":
+            return ActivityMergeResult(self, is_effective=False)
+
+        self.value = other.value
+        return ActivityMergeResult(
+            self, is_effective=True, is_significant=self.significant
+        )

--- a/pkgs/fc/agent/fc/maintenance/tests/test_reqmanager.py
+++ b/pkgs/fc/agent/fc/maintenance/tests/test_reqmanager.py
@@ -18,34 +18,8 @@ from fc.maintenance.estimate import Estimate
 from fc.maintenance.reqmanager import PostponeMaintenance, TempfailMaintenance
 from fc.maintenance.request import Attempt, Request
 from fc.maintenance.state import ARCHIVE, EXIT_POSTPONE, State
+from fc.maintenance.tests import MergeableActivity
 from rich.console import Console
-
-
-class MergeableActivity(Activity):
-    estimate = Estimate("10")
-
-    def __init__(self, value, significant=True):
-        super().__init__()
-        self.value = value
-        self.significant = significant
-
-    @property
-    def comment(self):
-        return self.value
-
-    def merge(self, other):
-        if not isinstance(other, MergeableActivity):
-            return ActivityMergeResult()
-
-        # Simulate merging an activity that reverts this activity, resulting
-        # in a no-op situation.
-        if other.value == "inverse":
-            return ActivityMergeResult(self, is_effective=False)
-
-        self.value = other.value
-        return ActivityMergeResult(
-            self, is_effective=True, is_significant=self.significant
-        )
 
 
 @pytest.fixture


### PR DESCRIPTION
Don't fail merging when the first request doesn't have an explicity set comment. Also put newlines between merged comments.

PL-131698

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* (not relevant)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - nothing new, just a fix for manually-created maintenance requests. 
- [x] Security requirements tested? (EVIDENCE)
  - checked merging on test system, Python tests cover merging requests now