### PR TITLE
fc-agent: add maintenance stats

### DIFF
--- a/nixos/platform/agent.nix
+++ b/nixos/platform/agent.nix
@@ -194,12 +194,19 @@ in
             "${pkgs.fc.agent}/bin/fc-maintenance list"
             "${pkgs.fc.agent}/bin/fc-maintenance show"
             "${pkgs.fc.agent}/bin/fc-maintenance delete"
+            "${pkgs.fc.agent}/bin/fc-maintenance metrics"
           ];
           groups = [ "admins" "sudo-srv" "service" ];
         }
         {
           commands = [ "${pkgs.fc.agent}/bin/fc-manage check" ];
           groups = [ "sensuclient" ];
+        }
+        {
+          commands = [
+            "${pkgs.fc.agent}/bin/fc-maintenance metrics"
+          ];
+          groups = [ "telegraf" ];
         }
         {
           commands = [ "${pkgs.fc.agent}/bin/fc-postgresql check-autoupgrade-unexpected-dbs" ];
@@ -384,6 +391,7 @@ in
     })
 
     {
+
       flyingcircus.services.sensu-client = {
         checks = {
           fc-agent = {
@@ -393,6 +401,16 @@ in
           };
         };
       };
+      flyingcircus.services.telegraf.inputs = {
+        exec = [{
+          commands = [ "/run/wrappers/bin/sudo ${pkgs.fc.agent}/bin/fc-maintenance metrics" ];
+          timeout = "10s";
+          data_format = "json";
+          json_name_key = "name";
+        }];
+      };
+
+
     }
   ];
 }

--- a/pkgs/fc/agent/fc/maintenance/cli.py
+++ b/pkgs/fc/agent/fc/maintenance/cli.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 from typing import NamedTuple, Optional
 
@@ -341,6 +342,15 @@ def constraints(
             raise Exit(failure_exit_code)
 
     log.debug("constraints-success")
+
+
+@app.command(help="Prints metrics in the telegraf JSON input format.")
+def metrics():
+    with rm:
+        rm.scan()
+        jso = json.dumps(rm.get_metrics())
+
+    print(jso)
 
 
 if __name__ == "__main__":

--- a/pkgs/fc/agent/fc/util/logging.py
+++ b/pkgs/fc/agent/fc/util/logging.py
@@ -630,7 +630,7 @@ def init_logging(
     # If the journal module is available and stdout is connected to journal, we
     # shouldn't log to console because output would be duplicated in the journal.
     if log_to_console and not (journal and os.environ.get("JOURNAL_STREAM")):
-        loggers["console"] = structlog.PrintLoggerFactory()
+        loggers["console"] = structlog.PrintLoggerFactory(sys.stderr)
 
     structlog.configure(
         processors=processors,


### PR DESCRIPTION
Provide various metrics about maintenance requests and the last execution of maintenance requests in the reqmanager to telegraf (and Prometheus -> Grafana from there).

`fc-maintenance metrics` prints metrics in the JSON format expected by Telegraf.

This also set the output stream for logs to stderr so commands can produce structured output while still being able to log to the console.

PL-131697

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* (not really visible for users right now)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - provide insights into what our automated maintenance is doing, collecting metrics which we be used later to detect delayed updates, for example. There's no critical security-related data collected by this change.  
- [x] Security requirements tested? (EVIDENCE)
  - checked on a test VM that metrics are collected properly and appear on a statshost