### PR TITLE
[21.05] Patch Inception and downfall CPU vulnerabilities

### DIFF
--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -267,14 +267,15 @@ in {
                 all.redis
               ]);
 
-  # newer linux kernel
+  # Newer linux kernel. Includes mitigations for the Inception and Downfall
+  # CPU vulnerabilities.
   linuxPackages = super.linuxPackagesFor (super.linux_5_10.override {
     argsOverride = rec {
       src = self.fetchurl {
         url = "mirror://kernel/linux/kernel/v5.x/linux-${version}.tar.xz";
-        sha256 = "sha256-4ndWLijyNONmZa4St1hflVeoOoa8So3ohAowWvYwe84=";
+        hash = "sha256-KXI98B1A/wf/bSVOqvkMez7Dxw9OvgibgPeF9G769Zc=";
       };
-      version = "5.10.175";
+      version = "5.10.190";
       modDirVersion = version;
     };
   });
@@ -293,10 +294,12 @@ in {
   mc = super.callPackage ./mc.nix { };
 
   # Use linux-firmware from 23.05 to get microcode which includes
-  # fixes for Zenbleed.
+  # fixes for Zenbleed and Inception.
   microcodeAmd = super.microcodeAmd.override {
     firmwareLinuxNonfree = nixpkgs-23_05.linux-firmware;
   };
+  # Use microcodeIntel from 23.05 to get fixes for Downfall.
+  inherit (nixpkgs-23_05) microcodeIntel;
 
   mongodb-3_6 = super.mongodb-3_6.overrideAttrs(_: rec {
     # We have set the license to null to avoid that Hydra complains about unfree

--- a/versions.json
+++ b/versions.json
@@ -14,8 +14,8 @@
   "nixpkgs-23.05": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "63d398ecfdda47cbf3077639e370ccfb653c7841",
-    "sha256": "sha256-JHV2f6VcBYYGJzO32lA+SRHr7hSKfeIIwmG6arIvGvM="
+    "rev": "9a23ab5c399dc8b4cd9f2580fad6edec2b03d151",
+    "sha256": "M++P0depmUF4gwGWxgAqvVGLLhdp6B/z4LXTbpvkQnU="
   },
   "nixos-mailserver": {
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/",


### PR DESCRIPTION
Inception affects AMD CPUs, Downfall is an Intel problem. Kernel 5.10.190 (applied in 189) includes mitigations for both. Microcode for both also had to be updated.

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

*  Mitigate Inception (AMD) and Downfall (Intel) CPU vulnerabilities on virtualization hosts (PL-131687, PL-131688).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - keep kernel and microcode up-to-date to protect against CPU vulnerabilities  
- [x] Security requirements tested? (EVIDENCE)
  - tested on a KVM host in dev, checked that nothing break (old Intel only in dev, so microcode update didn't get applied)