### PR TITLE
Allow k3s node kubelets to read DaemonSets

### DIFF
--- a/nixos/roles/k3s/server.nix
+++ b/nixos/roles/k3s/server.nix
@@ -150,7 +150,7 @@ let
           ];
       })
       (clusterRoleBinding {
-        metadata.name = "flyingcircus.telegraf:viewer";
+        metadata.name = "flyingcircus:telegraf:viewer";
         roleRef = {
           apiGroup = "rbac.authorization.k8s.io";
           kind = "ClusterRole";
@@ -160,6 +160,27 @@ let
           kind = "ServiceAccount";
           name = "io.flyingcircus.service.telegraf";
           namespace = "kube-system";
+        }];
+      })
+      (clusterRole {
+        metadata.name = "flyingcircus:daemonset:viewer";
+        rules = [{
+          apiGroups = ["apps"];
+          resources = ["daemonsets"];
+          verbs = ["get"];
+        }];
+      })
+      (clusterRoleBinding {
+        metadata.name = "flyingcircus:nodes";
+        roleRef = {
+          apiGroup = "rbac.authorization.k8s.io";
+          kind = "ClusterRole";
+          name = "flyingcircus:daemonset:viewer";
+        };
+        subjects = [{
+          apiGroup = "rbac.authorization.k8s.io";
+          kind = "Group";
+          name = "system:nodes";
         }];
       })
     ];


### PR DESCRIPTION
Before going into maintenance, k3s worker nodes should drain themselves of active workloads to prevent service interruptions. However, distributing suitable credentials to the nodes to grant the required API access is difficult, and would require runtime coordination between the nodes and the server. The kubelet process which runs on each worker node has nearly all of the required permissions to perform a drain operation, lacking only the permission to read DaemonSets. This PR adds this permission through an additional vendor manifest, which allows the kubelet's credentials to be used for requesting node drain operations.

PL-131525

@flyingcircusio/release-managers

## Release process

Impact: internal.

Changelog:

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Nodes should be appropriately configured to allow non-disruptive automated maintenance where possible.
- [x] Security requirements tested? (EVIDENCE)
  - Tested manually to verify that with this change applied nodes may drain themselves using the kubelet's configuration file and credentials.
