### PR TITLE
[21.05] flyingcircus-physical: make nvme-cli a default package

### DIFF
--- a/nixos/infrastructure/flyingcircus-physical.nix
+++ b/nixos/infrastructure/flyingcircus-physical.nix
@@ -47,6 +47,7 @@ mkIf (cfg.infrastructureModule == "flyingcircus-physical") {
       mstflint
       pciutils
       smartmontools
+      nvme-cli
       # ensure that `rbd-locktool` uses the correct ceph tooling version
       config.fclib.ceph.releasePkgs.${cfg.services.ceph.client.cephRelease}.utilPhysical
     ];


### PR DESCRIPTION
We are using nvme disks more and more commonly in our physical infra, not just in storage servers. This requires dedicated tooling for listing and querying information previously available e.g. via smartctl.

@flyingcircusio/release-managers

## Release process

Impact: none

Changelog:
- [internal, physical infra only] add `nvme` to packages available by default

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - None, package had already been used in `nix-shell` when needed; does not automatically start a service
- [x] Security requirements tested? (EVIDENCE)
  - [x] automated tests still pass
