### PR TITLE
Update nixpkgs + jupyterhub 4.0.1

### DIFF
--- a/package-versions.json
+++ b/package-versions.json
@@ -240,14 +240,14 @@
     "version": "1.20.7"
   },
   "grafana": {
-    "name": "grafana-9.5.7",
+    "name": "grafana-9.5.8",
     "pname": "grafana",
-    "version": "9.5.7"
+    "version": "9.5.8"
   },
   "haproxy": {
-    "name": "haproxy-2.7.8",
+    "name": "haproxy-2.7.10",
     "pname": "haproxy",
-    "version": "2.7.8"
+    "version": "2.7.10"
   },
   "imagemagick": {
     "name": "imagemagick-7.1.1-15",
@@ -350,9 +350,9 @@
     "version": "2.10.4"
   },
   "linux": {
-    "name": "linux-6.1.45",
+    "name": "linux-6.1.47",
     "pname": "linux",
-    "version": "6.1.45"
+    "version": "6.1.47"
   },
   "logrotate": {
     "name": "logrotate-3.21.0",
@@ -685,9 +685,9 @@
     "version": "4.2.5"
   },
   "qemu": {
-    "name": "qemu-8.0.3",
+    "name": "qemu-8.0.4",
     "pname": "qemu",
-    "version": "8.0.3"
+    "version": "8.0.4"
   },
   "rabbitmq-server": {
     "name": "rabbitmq-server-3.11.10",

--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "4060dd02cf545bb0ab61f9416d31b960ab05aa4f",
-    "sha256": "NzOtkUA81uL+/IibSZMEZ7hk4OanAwFJ7exoJl/Kd6c="
+    "rev": "4da0d66df53de2cdea31ab0ef897a24a38db24d9",
+    "sha256": "pyDnqH3sN16upTKqCl+9p0LeDYSTKE6rvyzllTfijyQ="
   },
   "nixos-mailserver": {
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/",


### PR DESCRIPTION
Pull upstream NixOS changes, security fixes and package updates:

- grafana: 9.5.7 -> 9.5.8
- haproxy: 2.7.8 -> 2.7.10
- linux: 6.1.45 -> 6.1.47
- qemu: 8.0.3 -> 8.0.4

This also adds a fix and update for jupyterhub:

- jupyterhub: 1.5.0 -> 4.0.1

PL-131716

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

## Security implications

- [ ] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [ ] Security requirements tested? (EVIDENCE)
