### PR TITLE
Update motd with ChangeLog URL and release name if available inside enc

### DIFF
--- a/nixos/platform/shell.nix
+++ b/nixos/platform/shell.nix
@@ -63,12 +63,16 @@ in
       )
     );
 
-    users.motd = ''
+    users.motd = let
+      has_release_name = enc.parameters ? release_name;
+    in
+    ''
       Welcome to the Flying Circus!
 
       Status:     https://status.flyingcircus.io/
-      Docs:       https://flyingcircus.io/doc/
-      Release:    ${config.system.nixos.label}
+      Docs:       https://doc.flyingcircus.io/
+      ${ opt (enc.parameters ? release_changelog ) ("ChangeLog:  " + enc.parameters.release_changelog)}
+      Release:    ${ opt has_release_name "${enc.parameters.release_name} (" + config.system.nixos.label + opt has_release_name ")"}
 
     '' +
     (opt (enc ? name && parameters ? location && parameters ? environment)


### PR DESCRIPTION
This MR adds more detailed information about current running release and where to get a ChangeLog if maintained via enc / directory 

It also updates the link to general documentation to doc.flyingcircus.io 

DIR-766

@flyingcircusio/release-managers

## Release process

Impact: 

Changelog:
* motd shows now more detailed information about current running version and link to ChangeLog

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [x] Security requirements tested? (EVIDENCE)
