### PR TITLE
Update nixpkgs (+ jupyterhub)

### DIFF
--- a/package-versions.json
+++ b/package-versions.json
@@ -120,9 +120,9 @@
     "version": "2.3.20"
   },
   "element-web": {
-    "name": "element-web-1.11.38",
+    "name": "element-web-1.11.40",
     "pname": "element-web",
-    "version": "1.11.38"
+    "version": "1.11.40"
   },
   "erlang": {
     "name": "erlang-25.3.2",
@@ -240,14 +240,14 @@
     "version": "1.20.7"
   },
   "grafana": {
-    "name": "grafana-9.5.7",
+    "name": "grafana-9.5.8",
     "pname": "grafana",
-    "version": "9.5.7"
+    "version": "9.5.8"
   },
   "haproxy": {
-    "name": "haproxy-2.7.8",
+    "name": "haproxy-2.7.10",
     "pname": "haproxy",
-    "version": "2.7.8"
+    "version": "2.7.10"
   },
   "imagemagick": {
     "name": "imagemagick-7.1.1-15",
@@ -350,9 +350,9 @@
     "version": "2.10.4"
   },
   "linux": {
-    "name": "linux-6.1.45",
+    "name": "linux-6.1.51",
     "pname": "linux",
-    "version": "6.1.45"
+    "version": "6.1.51"
   },
   "logrotate": {
     "name": "logrotate-3.21.0",
@@ -385,9 +385,9 @@
     "version": "4.14.2"
   },
   "matrix-synapse": {
-    "name": "matrix-synapse-1.90.0",
+    "name": "matrix-synapse-1.91.0",
     "pname": "matrix-synapse",
-    "version": "1.90.0"
+    "version": "1.91.0"
   },
   "mcpp": {
     "name": "mcpp-2.7.2.1",
@@ -595,9 +595,9 @@
     "version": "122"
   },
   "postfix": {
-    "name": "postfix-3.8.0",
+    "name": "postfix-3.8.2",
     "pname": "postfix",
-    "version": "3.8.0"
+    "version": "3.8.2"
   },
   "postgresql_11": {
     "name": "postgresql-11.21",
@@ -685,9 +685,9 @@
     "version": "4.2.5"
   },
   "qemu": {
-    "name": "qemu-8.0.3",
+    "name": "qemu-8.0.4",
     "pname": "qemu",
-    "version": "8.0.3"
+    "version": "8.0.4"
   },
   "rabbitmq-server": {
     "name": "rabbitmq-server-3.11.10",

--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "4060dd02cf545bb0ab61f9416d31b960ab05aa4f",
-    "sha256": "NzOtkUA81uL+/IibSZMEZ7hk4OanAwFJ7exoJl/Kd6c="
+    "rev": "6c8cb40e51867b3737298ce574a7f69ee7befd3d",
+    "sha256": "PbolqBChG9nNE3nT/uZGSqH9bMmHG4c1vkx7K6F4GLQ="
   },
   "nixos-mailserver": {
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/",


### PR DESCRIPTION
Update nixpkgs

Pull upstream NixOS changes, security fixes and package updates:

- element-web: 1.11.38 -> 1.11.40
- grafana: 9.5.7 -> 9.5.8
- haproxy: 2.7.8 -> 2.7.10 (CVE-2023-40225)
- linux: 6.1.45 -> 6.1.51
- matrix-synapse: 1.90.0 -> 1.91.0
- postfix: 3.8.0 -> 3.8.2
- qemu: 8.0.3 -> 8.0.4

PL-131738

This also adds a fix and update for jupyterhub:

- jupyterhub: 1.5.0 -> 4.0.1

PL-131716

@flyingcircusio/release-managers

## Release process

Impact:

* \[NixOS 23.05\] Machines will reboot after the update to activate the changed kernel.

Changelog:

(include commit msg from above)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - pull in upstream security fixes regularly
- [x] Security requirements tested? (EVIDENCE)
  - verified that the changed nixexprs packing code in the release job still produces the same archive content as before
  - automated tests still run, works on various test VM, including a test mail server
  - checked commit log for fixed CVEs and possible problems with updates, looked at [synapse/upgrade.md](https://github.com/matrix-org/synapse/blob/develop/docs/upgrade.md), [Postfix Announcements](http://www.postfix.org/announcements.html) and  [Grafana changelog](https://github.com/grafana/grafana/blob/main/CHANGELOG.md)
