### PR TITLE
[21.05] Fix swap deactivation

### DIFF
--- a/nixos/infrastructure/flyingcircus-physical.nix
+++ b/nixos/infrastructure/flyingcircus-physical.nix
@@ -38,6 +38,7 @@ mkIf (cfg.infrastructureModule == "flyingcircus-physical") {
     flyingcircus.activationScripts = {
       disableSwap = ''
         swapoff -a
+        wipefs -af /dev/disk/by-label/swap || true
       '';
     };
 

--- a/release/netboot-installer.nix
+++ b/release/netboot-installer.nix
@@ -83,7 +83,13 @@ sgdisk $root_disk -a 2048 \
 udevadm settle
 
 mkfs -t ext4 -q -E stride=16 -m 1 -F -L boot ''${root_disk}2
-mkswap -L swap ''${root_disk}3
+# We disabled swap in hardware, because it's basically detrimental to
+# continuous operation.
+# We keep the partition (see above) to be able to respond if we want it again,
+# but creating a swap signature here will cause systemd to automatically
+# activate it. I'm keeping this commented out here for future assistance of
+# whoever may need to tackle this again.
+# mkswap -L swap ''${root_disk}3
 
 pvcreate -ffy -Z y ''${root_disk}4
 vgcreate -fy --dataalignment 64k vgsys ''${root_disk}4


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

none

Changelog:

* Fix swap deactivation for physical machines that we introduced last year but that only worked partially due to systemd automations. (PL-130935)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
no specific requirements
- [x] Security requirements tested? (EVIDENCE)
nothing security specific to test
