### PR TITLE
[21.05] Fix race conditions in network interface renaming.

### DIFF
--- a/nixos/infrastructure/flyingcircus-physical.nix
+++ b/nixos/infrastructure/flyingcircus-physical.nix
@@ -13,6 +13,19 @@ mkIf (cfg.infrastructureModule == "flyingcircus-physical") {
     flyingcircus.raid.enable = true;
 
     boot = {
+      initrd.availableKernelModules = [
+        # assorted network drivers, for hardware discovery during
+        # stage 1.
+        "e1000e"
+        "i40e"
+        "mlxfw"
+        "tg3"
+        "mlx5_core"
+        "bnxt_en"
+        "igb"
+        "ixgbe"
+        "bnx2"
+      ];
 
       kernelParams = [
         # Drivers

--- a/nixos/platform/network.nix
+++ b/nixos/platform/network.nix
@@ -33,6 +33,10 @@ let
         ((filter (a: fclib.isIp6 a.ip) encAddresses) ++
          (filter (a: fclib.isIp4 a.ip) encAddresses));
 
+  interfaceRules = lib.concatMapStrings
+    (interface: ''
+      SUBSYSTEM=="net" , ATTR{address}=="${interface.mac}", NAME="${interface.physicalDevice}"
+      '') interfaces;
 in
 {
 
@@ -163,10 +167,8 @@ in
 
     };
 
-    services.udev.extraRules = lib.concatMapStrings
-      (interface: ''
-        SUBSYSTEM=="net" , ATTR{address}=="${interface.mac}", NAME="${interface.physicalDevice}"
-        '') interfaces;
+    services.udev.initrdRules = interfaceRules;
+    services.udev.extraRules = interfaceRules;
 
     systemd.services =
       let startStopScript = fclib.simpleRouting;

--- a/release/vm-image.nix
+++ b/release/vm-image.nix
@@ -18,7 +18,7 @@ in
 {
   config = {
 
-    services.udev.extraRules = ''
+    services.udev.initrdRules = ''
         # static/bootstrap fallback rules for VMs
         SUBSYSTEM=="net", ATTR{address}=="02:00:00:02:??:??", NAME="ethfe"
         SUBSYSTEM=="net", ATTR{address}=="02:00:00:03:??:??", NAME="ethsrv"


### PR DESCRIPTION
This is based on a backport of #735, as we're observing a similar issue on older versions of NixOS where the network interface renaming races with other processes configuring the interface.

However, some extra steps are required to handle physical hosts correctly. Physical network cards require drivers which we were not previously including in the initramfs for physical hosts, which meant that the network cards would only be discovered after entering the stage 2 (post-initramfs) boot step, and the renaming rules in the initramfs would never be triggered. I've surveyed our existing hardware and included all the relevant network drivers in the list of modules copied to the initramfs. As a graceful fallback mechanism, the udev rules are also present in the stage 2 udev configuration, so that if drivers for new network hardware are missing in the future, then the interface will still eventually be renamed properly later in the boot process instead of being left totally unconfigured.

PL-131741

@flyingcircusio/release-managers

## Release process

Impact: internal

Changelog:

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - From the original PR: network interface configuration should be applied correctly and without errors, to ensure network behaviour is as expected and desired.
- [x] Security requirements tested? (EVIDENCE)
  - Tested and manually verified with a development KVM host. Applying this change and then rebooting the host results in the network interfaces being configured correctly, and systemd units applying interface configuration exit without failures.