### PR TITLE
slurm: improve maintenance resilience: munge key setup, wait after ready_all

### DIFF
--- a/nixos/roles/slurm/fc-set-munge-key.py
+++ b/nixos/roles/slurm/fc-set-munge-key.py
@@ -1,0 +1,77 @@
+import filecmp
+import hashlib
+import json
+import os
+import shutil
+import sys
+from pathlib import Path
+
+import pystemd.systemd1
+from rich import print
+
+required_env_vars = {"encServicesPath", "mungeKeyFile"}
+missing_env_vars = required_env_vars - os.environ.keys()
+
+os.umask(0o0266)
+
+if missing_env_vars:
+    print(f"error: missing environment variables: {missing_env_vars}")
+    sys.exit(1)
+
+enc_services_path = Path(os.environ["encServicesPath"])
+if not enc_services_path.exists():
+    print(f"error: services files at {enc_services_path} is missing")
+    sys.exit(2)
+
+munge_key_path = Path(os.environ["mungeKeyFile"])
+
+with open(enc_services_path) as f:
+    enc_services = json.load(f)
+
+controller_service = [
+    s for s in enc_services if s["service"] == "slurm-controller-controller"
+]
+
+if not controller_service:
+    print("error: service not found, is the slurm-controller role enabled?")
+    sys.exit(3)
+
+service_pw = controller_service[0]["password"] + "\n"
+munge_key = hashlib.sha256(service_pw.encode()).hexdigest()[:64]
+
+key_dir = munge_key_path.parent
+if not key_dir.exists():
+    print(f"init: creating key dir at {key_dir}")
+    key_dir.mkdir()
+
+tmp_key = key_dir / "tmp-set-munge-key"
+tmp_key.unlink(missing_ok=True)
+with open(tmp_key, "w") as wf:
+    wf.write(munge_key)
+    wf.flush()
+    os.fsync(wf)
+
+shutil.chown(tmp_key, "munge", "munge")
+
+munged_unit = pystemd.systemd1.Unit("munged.service")
+munged_unit.load()
+print(f"munged.service state: {munged_unit.Unit.ActiveState}")
+
+if not munge_key_path.exists():
+    print(f"init: no previous munge key found at {munge_key_path}")
+    os.replace(tmp_key, munge_key_path)
+    print("init: new key set")
+
+elif not filecmp.cmp(tmp_key, munge_key_path, shallow=False):
+    print(f"change: key in {munge_key_path} differs from expected key")
+    os.replace(tmp_key, munge_key_path)
+    print("change: key updated")
+
+    if munged_unit.Unit.ActiveState == b"active":
+        print("change: munged is running, restarting to pick up the new key")
+        munged_unit.Unit.Restart(b"replace")
+else:
+    print("skip: key is already up-to-date.")
+    tmp_key.unlink()
+
+print("fc-set-munge-key finished")

--- a/pkgs/fc/agent/fc/manage/slurm.py
+++ b/pkgs/fc/agent/fc/manage/slurm.py
@@ -1,6 +1,7 @@
 import json
 import os
 import socket
+import time
 import traceback
 from pathlib import Path
 from typing import NamedTuple, Optional
@@ -233,6 +234,18 @@ def ready_all(
                 skip_nodes_in_maintenance,
                 directory,
             )
+
+    # XXX: Give slurmctld a bit more time to settle.
+    # The change to "ready" should be almost instantaneous. However, we experienced an
+    # alert when the Sensu check ran some milliseconds after this command finished and
+    # still saw all nodes as "down" even after slurmctld said that nodes are responding.
+    # This will be replaced by a proper wait loop like drain_many.
+    # See PL-131739 "Slurm maintenance causes alert".
+    log.info(
+        "ready-all-finished",
+        _replace_msg="Finished, waiting 2 seconds for slurmctld to settle.",
+    )
+    time.sleep(2)
 
 
 @all_nodes_app.command()


### PR DESCRIPTION
slurm: improve munged key setup, Restart=always

- fc-set-munge-key rewritten in Python with additional checks and atomic
  key update, done only if needed instead of overwriting it all the
  time.
  We experienced a failure caused by a race condition between
  munge reading the key and the key service running at the same time
  which used a naive shell script. The script used `>` to overwrite the
  existing key which left the file empty for a short amount of time,
  causing munged to fail on startup.
- Add key service to multi-user.target to start it on system switch.
- munged.service dependency on the key service is relaxed to "wants"
  because munged might still be able to start when the key is already
  correct.
- munged.service now uses Restart=always. Without munge, slurm doesn't
  work at all, better to try keeping it up at all times.

- wait 3 seconds after ready_all

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

 - slurm: make maintenance and munge key setup more resilient. We have experienced slurm downtime requiring manual intervention and later a false alarm once after a system update (PL-131740).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- availability: make sure that munged doesn't fail on startup and stays active as much as possible
- key security: must only be readable by the munge service
- [x] Security requirements tested? (EVIDENCE)
  - manual tests on test slurm cluster that key initialization and updating works. When munge is already running, munge is restarted by the key service.
  - checked munged.service if Restart=always is set.
  - checked that fc-slurm all-nodes ready still works and waits at the end