### PR TITLE
Save release ENC metadata, use it in motd

### DIFF
--- a/nixos/platform/default.nix
+++ b/nixos/platform/default.nix
@@ -292,6 +292,7 @@ in {
     '';
 
     environment.etc."fcio_environment_name".text = config.flyingcircus.enc.parameters.environment or "";
+    environment.etc."fcio_release".text = config.flyingcircus.platform.release.release_name or "pre";
 
     flyingcircus = {
       enc_services = enc_services;

--- a/nixos/platform/enc.nix
+++ b/nixos/platform/enc.nix
@@ -64,6 +64,12 @@ with lib;
       description = "Where to find the ENC service clients json file.";
     };
 
+    releasesPath = mkOption {
+      default = /etc/nixos/releases.json;
+      defaultText = "/etc/nixos/releases.json";
+      type = path;
+      description = "Where to find the releases json file.";
+    };
     systemStatePath = mkOption {
       default = /etc/nixos/system_state.json;
       type = path;
@@ -84,6 +90,20 @@ with lib;
       '';
     };
 
+    platform = {
+      release = mkOption {
+        readOnly = true;
+        default = (config.flyingcircus.platform.knownReleases.${config.system.nixos.label} or {});
+        defaultText = "Platform release metadata loaded from the file at `releasesPath`";
+      };
+
+      knownReleases = mkOption {
+        internal = true;
+        readOnly = true;
+        default = fclib.jsonFromFile cfg.releasesPath "{}";
+        defaultText = "Metadata for all known releases from the file at `releasesPath`";
+      };
+    };
   };
 
   config = {

--- a/nixos/platform/shell.nix
+++ b/nixos/platform/shell.nix
@@ -12,6 +12,9 @@ let
 in
 {
   config = {
+
+    environment.etc.motd.text = config.users.motd;
+
     environment.interactiveShellInit = ''
       export TMOUT=43200
     '';
@@ -64,15 +67,16 @@ in
     );
 
     users.motd = let
-      has_release_name = parameters ? release_name;
+      inherit (config.flyingcircus.platform) release;
+      isStableRelease = release != {};
     in
     ''
       Welcome to the Flying Circus!
 
       Status:     https://status.flyingcircus.io/
       Docs:       https://doc.flyingcircus.io/
-      ${ opt (parameters ? release_changelog ) ("ChangeLog:  " + parameters.release_changelog)}
-      Release:    ${ opt has_release_name "${parameters.release_name} (" + config.system.nixos.label + opt has_release_name ")"}
+      Release:    ${opt isStableRelease "${release.release_name} (" + config.system.nixos.label + opt isStableRelease ")"}
+      ${opt isStableRelease ("ChangeLog:  " + release.release_changelog)}
 
     '' +
     (opt (enc ? name && parameters ? location && parameters ? environment)

--- a/pkgs/fc/agent/fc/maintenance/activity/update.py
+++ b/pkgs/fc/agent/fc/maintenance/activity/update.py
@@ -36,9 +36,12 @@ class UpdateActivity(Activity):
         super().__init__()
         self.next_environment = next_environment
         self.next_channel_url = next_channel_url
+        self.changelog_url = None
         self.current_system = None
         self.next_system = None
         self.current_channel_url = None
+        self.current_release = None
+        self.next_release = None
         self.current_version = None
         self.next_version = None
         self.current_environment = None
@@ -249,7 +252,7 @@ class UpdateActivity(Activity):
         self.returncode = 0
 
     @property
-    def changelog(self):
+    def summary(self):
         """
         A human-readable summary of what will be changed by this update.
         Includes possible reboots, significant unit state changes (start, stop,
@@ -270,6 +273,13 @@ class UpdateActivity(Activity):
         if unit_change_lines:
             msg.extend(unit_change_lines)
             msg.append("")
+
+        if self.next_release:
+            msg.append(
+                f"Release: {self.current_release} -> {self.next_release}"
+            )
+        if self.changelog_url:
+            msg.append(f"ChangeLog: {self.changelog_url}")
 
         if self.current_environment != self.next_environment:
             msg.append(
@@ -293,7 +303,7 @@ class UpdateActivity(Activity):
 
     @property
     def comment(self):
-        return self.changelog
+        return self.summary
 
     def merge(self, other: Activity) -> ActivityMergeResult:
         if not isinstance(other, UpdateActivity):

--- a/pkgs/fc/agent/fc/maintenance/maintenance.py
+++ b/pkgs/fc/agent/fc/maintenance/maintenance.py
@@ -187,7 +187,7 @@ def request_update(log, enc, current_requests) -> Optional[Request]:
                 "Update preparation was successful. This update will apply "
                 "changes to the system."
             ),
-            _output=activity.changelog,
+            _output=activity.summary,
             current_channel=activity.current_channel_url,
             next_channel=activity.next_channel_url,
         )


### PR DESCRIPTION
Release metadata is now read from enc.json and written to releases.json,
with the version label as key. The data can then be accessed via a
read-only NixOS option flyingcircus.platform.release which is used to
add the proper changelog URL and release name to the motd file. This
file can now also be accessed at /etc/motd.

This also adds the changelog URL and release name to the summary for
an UpdateActivity, which is used as maintenance request comment.

PL-131736

@flyingcircusio/release-managers

## Release process

Impact:

Changelog: none

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - known releases file should be owned by root and readable by anyone (contained metadata is known anyway), other ENC files should only be readable by root
- [x] Security requirements tested? (EVIDENCE)
  - checked on a test VM that motd is rendered correctly with a known release and that it doesn't break with local dev checkouts; checked file permissions in /etc/nixos