### PR TITLE
slurm: wait for all nodes being ready

### DIFF
--- a/pkgs/fc/agent/fc/manage/slurm.py
+++ b/pkgs/fc/agent/fc/manage/slurm.py
@@ -189,6 +189,9 @@ def ready_all(
             "will be set to ready."
         ),
     ),
+    timeout: int = Option(
+        default=30, help="Wait for seconds for nodes to become ready."
+    ),
     strict_state_check: Optional[bool] = False,
     reason_must_match: Optional[str] = Option(
         default=None,
@@ -225,27 +228,17 @@ def ready_all(
                 return
 
     with directory_connection(context.enc_path) as directory:
-        for node_name in node_names:
-            fc.util.slurm.ready(
-                log,
-                node_name,
-                strict_state_check,
-                reason_must_match,
-                skip_nodes_in_maintenance,
-                directory,
-            )
+        fc.util.slurm.ready_many(
+            log,
+            node_names,
+            timeout,
+            strict_state_check,
+            reason_must_match,
+            skip_nodes_in_maintenance,
+            directory,
+        )
 
-    # XXX: Give slurmctld a bit more time to settle.
-    # The change to "ready" should be almost instantaneous. However, we experienced an
-    # alert when the Sensu check ran some milliseconds after this command finished and
-    # still saw all nodes as "down" even after slurmctld said that nodes are responding.
-    # This will be replaced by a proper wait loop like drain_many.
-    # See PL-131739 "Slurm maintenance causes alert".
-    log.info(
-        "ready-all-finished",
-        _replace_msg="Finished, waiting 2 seconds for slurmctld to settle.",
-    )
-    time.sleep(2)
+    log.info("ready-all-finished")
 
 
 @all_nodes_app.command()


### PR DESCRIPTION
Implement ready_many similar to drain_many which waits until the desired state is reached, with a configurable timeout. If nodes failed to become ready, they are reported in the timeout exception. Usually we expect the nodes to become ready almost immediately so there shouldn't be a noticeable waiting period.

ready_many is now used by the `all-nodes ready` subcommand.

PL-131739

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

- slurm: the `fc-slurm all-nodes ready` command which is used by our automated maintenance system now waits for the nodes to actually become ready by checking their reported state (PL-131739).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  -  availability: make sure that the node state reported by slurm matches the expected state
- [x] Security requirements tested? (EVIDENCE)
  - checked in the test slurm cluster that `ready all` terminates properly when nodes are ready 
  - automated test checks normal execution and timeout