### PR TITLE
[21.05] Improve kvm log cleanup

### DIFF
--- a/nixos/roles/kvm.nix
+++ b/nixos/roles/kvm.nix
@@ -195,6 +195,30 @@ in
 
     };
 
+
+    systemd.services.fc-qemu-clean-logs = let
+      fcQemuCleanLogScript = (
+        pkgs.writers.writePython3Bin "fc-qemu-clean-logs"
+        {} (builtins.readFile ../../pkgs/fc/qemu/clean-logs.py));
+    in {
+      description = "Clean orphaned fc.qemu logs.";
+
+      path = [ pkgs.python3 pkgs.lsof ];
+
+      serviceConfig = {
+        Type = "oneshot";
+        ExecStart = "${fcQemuCleanLogScript}/bin/fc-qemu-clean-logs";
+       };
+    };
+
+    systemd.timers.fc-qemu-clean-logs = {
+      wantedBy = [ "timers.target" ];
+      timerConfig = {
+        OnCalendar = "daily";
+        Persistent = true;
+      };
+    };
+
     systemd.services.fc-qemu-report-cpus = {
       description = "Report supported Qemu CPU models to the directory.";
 

--- a/pkgs/fc/qemu/clean-logs.py
+++ b/pkgs/fc/qemu/clean-logs.py
@@ -1,0 +1,67 @@
+"""
+A helper to clean up log files from fc.qemu.
+
+The logrotate targets aren't smart enough because we have VMs that move around
+and thus would end up with missing files, but `missingok` doesn't help if the
+pattern doesn't match any more.
+
+In addition we may have files that have not been written to for a long time but
+do correspond to a VM still running here.
+
+So this script deletes log files, iff:
+
+1. the file is not open, AND
+2. it is older than 14 days.
+
+"""
+import datetime
+import pathlib
+import re
+import subprocess
+import time
+
+MAX_AGE = datetime.timedelta(days=14)
+VM_LOG_DIR = pathlib.Path("/var/log/vm")
+VM_LOG_NAME_PATTERN = re.compile(r"[0-9a-zA-Z]+\.log")
+
+# Find logs of running VMs
+
+print("Checking open files ...")
+
+lsof = subprocess.run(
+    ["lsof", "-F", "n", "+D", VM_LOG_DIR], capture_output=True
+)
+# Expected output:
+# $ lsof +D /var/log/vm -F n
+# p23052
+# n/var/log/vm/release2305dev01.log
+# p319664
+# n/var/log/vm/mailstubtest01.log
+# p321165
+# n/var/log/vm/services34.log
+# p332886
+# n/var/log/vm/services08.log
+# p333454
+
+open_files = set()
+
+for open_file in lsof.stdout.decode("ascii").splitlines():
+    prefix, path = open_file[0], open_file[1:]
+    if prefix != "n":
+        continue
+    open_files.add(path)
+
+print("Checking for files to unlink...")
+
+mtime_cutoff = time.time() - MAX_AGE.total_seconds()
+for logfile in VM_LOG_DIR.glob("*"):
+    is_in_use = str(logfile) in open_files
+    is_old = logfile.stat().st_mtime < mtime_cutoff
+    is_empty = not logfile.stat().st_size
+    if is_in_use:
+        continue
+    if is_old or is_empty:
+        print(logfile.name, logfile.stat().st_size, logfile.stat().st_mtime)
+        logfile.unlink(missing_ok=True)
+
+# Clean up all old fc.qemu rotated logs (14 days is sufficient)

--- a/release/netboot-installer.nix
+++ b/release/netboot-installer.nix
@@ -90,7 +90,7 @@ vgcreate -fy --dataalignment 64k vgsys ''${root_disk}4
 vgchange -ay
 
 udevadm settle
-lvcreate -ay -L 40G -n root vgsys <<<y
+lvcreate -ay -L 80G -n root vgsys <<<y
 lvcreate -L 16G -n tmp vgsys <<<y
 
 udevadm settle

--- a/tests/physical-installer.nix
+++ b/tests/physical-installer.nix
@@ -4,7 +4,7 @@ import ./make-test-python.nix ({ nixpkgs, ... }:
   machine =
     { pkgs, ... }:
     {
-      virtualisation.emptyDiskImages = [ 70000 100 ];
+      virtualisation.emptyDiskImages = [ 120000 100 ];
       imports = [
         "${nixpkgs}/nixos/modules/installer/netboot/netboot-minimal.nix"
         ../release/netboot-installer.nix


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

none

Changelog:

* Safely improve log file cleanup on KVM hosts for orphaned log files due to live migration. (PL-131715)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  * [x] we do not want to accidentally loose current logs
  * [x] owasp should fit (unfortunately we need root as the log files are root owned)
  * [x] quoting for potential user input (happens automatically by pathlib)
- [x] Security requirements tested? (EVIDENCE)
  * tested manually, multiple times with real data on kyle08 (by archiving the current logs and using a separate work directory from the actual log directory)
