### PR TITLE
roles/nfs_rg_share: support export options

### DIFF
--- a/doc/src/nfs.md
+++ b/doc/src/nfs.md
@@ -16,10 +16,18 @@ The NFS configuration is fully managed and located in
 {file}`/etc/exports` for the NFS server and {file}`/etc/fstab` for the NFS
 clients.
 
-The NFS server is set up to run in sync mode, so any system call that writes
-data to files on the NFS share causes that data to be flushed to the server
-before the system call returns control to user space. This provides greater data
-cache coherence among clients, but at a significant performance cost.
+The NFS server is by default set up to run in sync mode, so any system call that
+writes data to files on the NFS share causes that data to be flushed to the
+server before the system call returns control to user space. This provides
+greater data cache coherence among clients, but at a significant performance
+cost.
+
+**flyingcircus.roles.nfs_rg_share.clientFlags**
+
+List of strings that are applied as options for every client.
+
+Default: `["rw" "sync" "root_squash" "no_subtree_check"]`
+
 
 ## Interaction
 

--- a/nixos/roles/nfs.nix
+++ b/nixos/roles/nfs.nix
@@ -22,7 +22,7 @@ let
   # RG, regardles of the node actually being a client.
   exportToClients =
     let
-      flags = "rw,sync,root_squash,no_subtree_check";
+      flags = lib.concatStringsSep "," cfg.roles.nfs_rg_share.clientFlags;
       clientWithFlags = c: "${c.node}(${flags})";
     in
       lib.concatMapStringsSep " " clientWithFlags serviceClients;
@@ -38,6 +38,7 @@ in
       '';
       supportsContainers = fclib.mkEnableContainerSupport;
     };
+
     flyingcircus.roles.nfs_rg_share = {
       enable = mkEnableOption ''
         Enable the Flying Circus nfs server role.
@@ -45,6 +46,14 @@ in
         This exports /srv/nfs/shared.
       '';
       supportsContainers = fclib.mkEnableContainerSupport;
+      clientFlags = lib.mkOption {
+          default = ["rw" "sync" "root_squash" "no_subtree_check"];
+          type = with types; listOf str;
+          description = ''
+            Flags for each client's export rule.
+          '';
+        };
+
     };
   };
 


### PR DESCRIPTION
Some clients may want to disable the `sync` flag or switch to `no_root_squash` in some scenarios.

Fixes PL-131538

@flyingcircusio/release-managers

## Release process

Impact:

none

Changelog:

* The export options on managed NFS servers can now be customized. (PL-131538)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

The defaults are the same as before, we only allow customers to use custom options which MAY be less secure, but is a decision for the customer to make and may depend on technical requirements, like some applications not working well without e.g. `no_root_squash`.

- [x] Security requirements tested? (EVIDENCE)

Extended the functional tests to prove the option works as expected.