### PR TITLE
[21.05] ceph/osds: disable autorepair again to avoid spurious repair statuses

### DIFF
--- a/nixos/roles/ceph/osd.nix
+++ b/nixos/roles/ceph/osd.nix
@@ -22,8 +22,11 @@ let
     osdCrushUpdateOnStart = false;
 
     # automatically repairing PGs at scrub mismatches is reliable due to Bluestore
-    # internal checksumming
-    osdScrubAutoRepair = true;
+    # internal checksumming…
+    # TODO: but we still keep it disabled for Nautilus because it has spurious status
+    # display issues of generally indicating a `repairing` for deep-scrubbing PGs.
+    # see PL-131662
+    osdScrubAutoRepair = false;
     # we use the default value of max. number of automatically corrected errors
     # "osd_scrub_auto_repair_num_errors": "5",
 


### PR DESCRIPTION
According to people on the mailing list, Ceph Nautilus incorrectly reports normal deep scrubs as repairs.
Disabling autorepair for 2 weeks did not surface any errors needing to be repaired, so this analsysis appears to be correct.

PL-131662

@flyingcircusio/release-managers

## Release process

Impact: internal only, might restart ceph daemons except for OSDs
manual intervention needed: reactivate all osds to make them pick up config changes 

Changelog:
- disable ceph osd autorepair

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - keep system output understandable and actionable
  - config changes need to be tested
- [x] Security requirements tested? (EVIDENCE)
  - [x] automated tests still pass
  - [x] settings had been running as injected in the cluster for 2 weeks without any issues
