### PR TITLE
[21.05] fix swap deactivation

### DIFF
--- a/nixos/infrastructure/flyingcircus-physical.nix
+++ b/nixos/infrastructure/flyingcircus-physical.nix
@@ -41,6 +41,7 @@ mkIf (cfg.infrastructureModule == "flyingcircus-physical") {
         wipefs -af /dev/disk/by-label/swap || true
       '';
     };
+    systemd.targets.swap.enable = false;  # implicitly mask the unit to prevent pulling in existing `*.swap` units
 
     environment.systemPackages = with pkgs; [
       fc.ledtool


### PR DESCRIPTION
@flyingcircusio/release-managers

follow-up to #779 

## Release process

Impact: disables swap, fixes system activation in dev

Changelog:

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - switching to this target state needs to work in 3 szenarios:
    - [x] hosts running a pre-#779 release with existing swap volumes
    - [x] hosts running a post-#779 release with wiped swap volumes, that have failed swap units
    - [x] hosts after a reboot with no autogenerated swap units anymore 
- [x] Security requirements tested? (EVIDENCE)
  - [x] automated tests still pass
  - [x] tested all 3 applicable szenarios on physical hosts
