### PR TITLE
agent: add missing UpdateActivity attributes on deserialization

### DIFF
--- a/pkgs/fc/agent/fc/maintenance/activity/tests/test_update.py
+++ b/pkgs/fc/agent/fc/maintenance/activity/tests/test_update.py
@@ -4,6 +4,7 @@ from unittest.mock import create_autospec
 
 import responses
 import yaml
+from fc.maintenance import Request
 from fc.maintenance.activity import Activity, RebootType
 from fc.maintenance.activity.update import UpdateActivity
 from fc.util.channel import Channel
@@ -56,6 +57,43 @@ SUMMARY = textwrap.dedent(
     Build number: {CURRENT_BUILD} -> {NEXT_BUILD}
     Channel URL: {NEXT_CHANNEL_URL}"""
 )
+
+OUTDATED_SERIALIZED_REQUEST = f"""\
+!!python/object:fc.maintenance.request.Request
+_comment: null
+_estimate: null
+_reqid: ZXutH76zLeQ9XmpDvW3axh
+_reqmanager: null
+activity: !!python/object:fc.maintenance.activity.update.UpdateActivity
+  current_channel_url: https://hydra.flyingcircus.io/build/93111/download/1/nixexprs.tar.xz
+  current_environment: fc-21.05-production
+  current_kernel: 5.10.45
+  current_system: {CURRENT_SYSTEM_PATH}
+  current_version: 21.05.1233.a9cc58d
+  next_channel_url: https://hydra.flyingcircus.io/build/93222/download/1/nixexprs.tar.xz
+  next_environment: fc-21.05-production
+  next_kernel: 5.10.50
+  next_system: {NEXT_SYSTEM_PATH}
+  next_version: 21.05.1235.bacc11d
+  reboot_needed: !!python/object/apply:fc.maintenance.activity.RebootType
+  - reboot
+  unit_changes:
+    reload:
+    - nginx.service
+    restart:
+    - telegraf.service
+    start:
+    - postgresql.service
+    stop:
+    - postgresql.services
+added_at: 2023-07-11 18:38:59.850059+00:00
+dir: /var/spool/maintenance/requests/testid
+last_scheduled_at: null
+next_due: null
+state: !!python/object/apply:fc.maintenance.state.State
+- d
+updated_at: null
+"""
 
 SERIALIZED_ACTIVITY = f"""\
 !!python/object:fc.maintenance.activity.update.UpdateActivity
@@ -240,6 +278,20 @@ def test_update_activity_deserialize(activity, logger):
     deserialized = yaml.load(SERIALIZED_ACTIVITY, Loader=yaml.UnsafeLoader)
     deserialized.set_up_logging(logger)
     assert deserialized.__getstate__() == activity.__getstate__()
+
+
+def test_update_activity_loading_outdated_serialization_should_work(
+    logger, tmp_path
+):
+    request_path = tmp_path / "request.yaml"
+    request_path.write_text(OUTDATED_SERIALIZED_REQUEST)
+    request = Request.load(tmp_path, logger)
+    activity = request.activity
+    assert activity.changelog_url is None
+    assert activity.current_release is None
+    assert activity.next_release is None
+    assert activity.summary
+    assert activity.__rich__()
 
 
 def test_update_activity_prepare(log, logger, tmp_path, activity, nixos_mock):

--- a/pkgs/fc/agent/fc/maintenance/activity/update.py
+++ b/pkgs/fc/agent/fc/maintenance/activity/update.py
@@ -120,6 +120,16 @@ class UpdateActivity(Activity):
             return False
         return True
 
+    def load(self):
+        # Add attributes after deserialization if needed to stay compatible
+        # with older persisted instances of UpdateActivity.
+        if not hasattr(self, "current_release"):
+            self.current_release = None
+        if not hasattr(self, "next_release"):
+            self.next_release = None
+        if not hasattr(self, "changelog_url"):
+            self.changelog_url = None
+
     def prepare(self, dry_run=False):
         self.log.debug(
             "update-prepare-start",


### PR DESCRIPTION
We added some attributes to UpdateActivity which may cause exceptions when old serialized instances are loaded by newer agent code and the new code expects them to be present.

Often, this isn't triggered as UpdateActivities are archived after the update and not touched again but as these activities can do reboots or may fail (typically on the system switch), they might hang around for a longer time and be loaded again by updated agent code.

This also acts as an on-disk "schema migration" of old activities as requests are loaded and saved back by the reqmanager if something changes.

PL-131774

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

(internal)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - reduce journal noise and confusing errors  
- [x] Security requirements tested? (EVIDENCE)
  - automated test checks that old serialized actitvity can still be loaded and used, checked manually on a test VM that new attributes are added and serialized back to disk on changes