### PR TITLE
agent: treat UpdateActivity switch problems as temporary failure

### DIFF
--- a/pkgs/fc/agent/fc/maintenance/activity/tests/test_update.py
+++ b/pkgs/fc/agent/fc/maintenance/activity/tests/test_update.py
@@ -4,7 +4,7 @@ from unittest.mock import create_autospec
 
 import responses
 import yaml
-from fc.maintenance import Request
+from fc.maintenance import Request, state
 from fc.maintenance.activity import Activity, RebootType
 from fc.maintenance.activity.update import UpdateActivity
 from fc.util.channel import Channel
@@ -364,7 +364,7 @@ def test_update_activity_run_update_system_channel_fails(
     activity.run()
 
     assert activity.returncode == 1
-    assert log.has("update-run-failed", returncode=1)
+    assert log.has("update-run-error", returncode=1)
 
 
 def test_update_activity_build_system_fails(log, nixos_mock, activity):
@@ -375,7 +375,7 @@ def test_update_activity_build_system_fails(log, nixos_mock, activity):
     activity.run()
 
     assert activity.returncode == 2
-    assert log.has("update-run-failed", returncode=2)
+    assert log.has("update-run-error", returncode=2)
 
 
 def test_update_activity_register_system_profile_fails(
@@ -388,7 +388,7 @@ def test_update_activity_register_system_profile_fails(
     activity.run()
 
     assert activity.returncode == 3
-    assert log.has("update-run-failed", returncode=3)
+    assert log.has("update-run-error", returncode=3)
 
 
 def test_update_activity_switch_to_system_fails(log, nixos_mock, activity):
@@ -396,8 +396,8 @@ def test_update_activity_switch_to_system_fails(log, nixos_mock, activity):
 
     activity.run()
 
-    assert activity.returncode == 4
-    assert log.has("update-run-failed", returncode=4)
+    assert activity.returncode == state.EXIT_TEMPFAIL
+    assert log.has("update-run-tempfail", returncode=state.EXIT_TEMPFAIL)
 
 
 def test_update_activity_from_enc(

--- a/pkgs/fc/agent/fc/maintenance/activity/update.py
+++ b/pkgs/fc/agent/fc/maintenance/activity/update.py
@@ -7,6 +7,7 @@ import os.path as p
 from typing import Optional
 
 import structlog
+from fc.maintenance import state
 from fc.maintenance.estimate import Estimate
 from fc.util import nixos
 from fc.util.nixos import UnitChanges
@@ -212,41 +213,81 @@ class UpdateActivity(Activity):
 
         return False
 
+    def _handle_channel_exception(
+        self,
+        exc: nixos.ChannelException,
+    ):
+        match exc:
+            case nixos.ChannelUpdateFailed():
+                returncode = 1
+                event = "update-run-error"
+                msg = (
+                    "Update error: setting {next_channel} ({next_version}) "
+                    "as system channel failed."
+                )
+            case nixos.BuildFailed():
+                returncode = 2
+                event = "update-run-error"
+                msg = (
+                    "Update error: building {next_channel} ({next_version}) "
+                    "failed."
+                )
+            case nixos.RegisterFailed():
+                returncode = 3
+                event = "update-run-error"
+                msg = (
+                    "Update error: registering system {next_system} for "
+                    "version {next_version} failed."
+                )
+            case nixos.SwitchFailed():
+                returncode = state.EXIT_TEMPFAIL
+                event = "update-run-tempfail"
+                msg = (
+                    "Temporary failure when switching to the new system, "
+                    "trying again."
+                )
+            case _:
+                return
+
+        self.stdout = exc.stdout
+        self.stderr = exc.stderr
+        self.returncode = returncode
+        self.log.error(
+            event,
+            _replace_msg=msg,
+            returncode=self.returncode,
+            current_version=self.current_version,
+            current_channel_url=self.current_channel_url,
+            current_system=self.current_system,
+            current_environment=self.current_environment,
+            next_channel=self.next_channel_url,
+            next_system=self.next_system,
+            next_version=self.next_version,
+            next_environment=self.next_environment,
+            next_release=self.next_release,
+        )
+
     def run(self):
         """Do the update"""
-        step = 1
         try:
             self.update_system_channel()
 
             if self.identical_to_current_system:
+                # Nothing to do here, always a success.
                 self.returncode = 0
                 return
 
-            step = 2
             system_path = nixos.build_system(
                 self.next_channel_url, log=self.log
             )
-            step = 3
+            # System path may have changed since preparing the system because of
+            # configuration changes, so update it here.
+            self.next_system = system_path
             nixos.register_system_profile(system_path, log=self.log)
-            step = 4
             nixos.switch_to_system(system_path, lazy=False, log=self.log)
-        except nixos.ChannelException as e:
-            self.stdout = e.stdout
-            self.stderr = e.stderr
-            self.returncode = step
-            self.log.error(
-                "update-run-failed",
-                _replace_msg="Update to {next_version} failed!",
-                returncode=step,
-                current_version=self.current_version,
-                current_channel_url=self.current_channel_url,
-                current_environment=self.current_environment,
-                next_channel=self.next_channel_url,
-                next_version=self.next_version,
-                next_environment=self.next_environment,
-                exc_info=True,
-            )
 
+        except nixos.ChannelException as e:
+            self._handle_channel_exception(e)
             return
 
         self.log.info(

--- a/pkgs/fc/agent/fc/maintenance/cli.py
+++ b/pkgs/fc/agent/fc/maintenance/cli.py
@@ -253,13 +253,14 @@ def system_properties():
 
     with rm:
         rm.scan()
+        current_requests = rm.requests.values()
 
         if enc["parameters"]["machine"] == "virtual":
             rm.add(request_reboot_for_memory(log, enc))
             rm.add(request_reboot_for_cpu(log, enc))
             rm.add(request_reboot_for_qemu(log))
 
-        rm.add(request_reboot_for_kernel(log))
+        rm.add(request_reboot_for_kernel(log, current_requests))
         log.info("fc-maintenance-system-properties-finished")
 
 

--- a/pkgs/fc/agent/fc/maintenance/request.py
+++ b/pkgs/fc/agent/fc/maintenance/request.py
@@ -12,6 +12,7 @@ import rich.table
 import shortuuid
 import structlog
 import yaml
+from fc.maintenance import state
 from fc.util.time_date import ensure_timezone_present, format_datetime, utcnow
 
 from .activity import Activity, ActivityMergeResult
@@ -190,6 +191,10 @@ class Request:
         if not self.not_after:
             return False
         return utcnow() > self.not_after
+
+    @property
+    def tempfail(self):
+        return self.state not in state.ARCHIVE and self.attempts
 
     @classmethod
     def load(cls, dir, log):


### PR DESCRIPTION
agent: treat UpdateActivity switch problems as temporary failure

As we treat every error when running an update activity as permanent,
we often get maintenance error notifications for updates when the first
switch fails. The second try usually succeeds when fc-manage runs the
next time but the error mail is already sent.

Switch errors are now treated as temporary failures which are retried on
the next maintenance run.

This change also addresses unwanted behaviour when an update needs a
reboot because of a changed kernel and then fails in the switch phase.

Activity failure prevents the system from rebooting immediately, so
there's difference between running and wanted kernel.

Before, the next `fc-maintenance request` run would then schedule a
reboot which is now unneccessary as the update activity is still present.
The activity will trigger the reboot when the retry succeeds.

PL-131769


@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

(internal)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - reduce noise from errors that fix themselves on the next agent run, avoid announcing unneccessary reboots
- [x] Security requirements tested? (EVIDENCE)
  - automated tests check that reboot requests are not scheduled when there's a tempfail update request which would reboot  and that update run errors are handled/reported properly
  - checked on a test VM that an update request is retried when the switch fails temporarily