### PR TITLE
[21.05] move backy to nixpkgs-23.05

### DIFF
--- a/nixos/roles/backyserver.nix
+++ b/nixos/roles/backyserver.nix
@@ -7,7 +7,7 @@ let
   role = config.flyingcircus.roles.backyserver;
   enc = config.flyingcircus.enc;
 
-  backy = pkgs.callPackage ../../pkgs/backy/default.nix { };
+  backy = pkgs.backy;
 
   backyExtract = let
     src = pkgs.fetchFromGitHub {

--- a/pkgs/backy/default.nix
+++ b/pkgs/backy/default.nix
@@ -1,54 +1,21 @@
 {
-  poetry2nix,
   fetchFromGitHub,
+  poetry2nix,
   lzo,
-  python310
-}:
+  python310,
+  mkShellNoCC,
+  poetry,
+  runCommand,
+}@inputs:
 let
-  #src = /home/os/backy;
   src = fetchFromGitHub {
     owner = "flyingcircusio";
     repo = "backy";
-    rev = "5fa55f0c512e557bea3802f0be10e997e6f33f03";
-    hash = "sha256-n3q8xr7o/REiftxHc2LYRvKnhu7Ab2MuQ+OfhSniOhk=";
+    rev = "e37a7f6570b6b9194cb3a27d8db2951eb5c992ce";
+    hash = "sha256-s7FazUx/o68VY0gaSfzSMQI4XX8o1qqKf6IEoynM4nQ=";
   };
 
-in poetry2nix.mkPoetryApplication {
-    projectDir = src;
-    src = src;
-    doCheck = true;
-    python = python310;
-    extras = [];
-    overrides = poetry2nix.overrides.withDefaults (self: super: {
-      python-lzo = super.python-lzo.overrideAttrs (old: {
-        buildInputs = [ lzo ];
-      });
-      telnetlib3 = super.telnetlib3.overrideAttrs (old: {
-        buildInputs = [ super.setuptools ];
-      });
-      pytest-flake8 = super.pytest-flake8.overrideAttrs (old: {
-        buildInputs = [ super.setuptools ];
-      });
-      filelock = super.iniconfig.overrideAttrs (old: {
-        buildInputs = [ super.hatchling super.hatch-vcs ];
-      });
-      iniconfig = super.iniconfig.overrideAttrs (old: {
-        buildInputs = [ super.hatchling super.hatch-vcs ];
-      });
-      humanize = super.humanize.overrideAttrs (old: {
-        buildInputs = [ super.hatchling super.hatch-vcs ];
-      });
-      prettytable = super.prettytable.overrideAttrs (old: {
-        buildInputs = [ super.hatchling super.hatch-vcs ];
-      });
-      # dirty workaround, as the virtualenv-20.17.1 extracted via poetry2nix did not
-      # find its `filelock` dependency
-      virtualenv = python310.pkgs.virtualenv;
-      #virtualenv = super.virtualenv.overrideAttrs (old: {
-      #  buildInputs = [ self.distlib self.filelock self.platformdirs ];
-      #});
-      consulate-fc-nix-test = super.consulate-fc-nix-test.overrideAttrs (old: {
-        buildInputs = [ super.setuptools super.setuptools-scm ];
-      });
-    });
-}
+  lib = import "${src}/lib.nix" inputs;
+
+in
+lib.packages.default

--- a/pkgs/backy/default.nix
+++ b/pkgs/backy/default.nix
@@ -11,8 +11,8 @@ let
   src = fetchFromGitHub {
     owner = "flyingcircusio";
     repo = "backy";
-    rev = "e37a7f6570b6b9194cb3a27d8db2951eb5c992ce";
-    hash = "sha256-s7FazUx/o68VY0gaSfzSMQI4XX8o1qqKf6IEoynM4nQ=";
+    rev = "2.5.1";
+    hash = "sha256-w83Q7d3vJmh5dLiL7iI7K8YbMvWKQtr9pTsL9u7jAEg=";
   };
 
   lib = import "${src}/lib.nix" inputs;

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -9,7 +9,6 @@ let
   phps = (import ../nix-phps/pkgs/phps.nix) (../nix-phps)
     {} super;
 
-  nixpkgs-22_11 = import versions.nixpkgs-22_11 {};
   nixpkgs-23_05 = import versions.nixpkgs-23_05 {};
 
   inherit (super) fetchpatch fetchurl lib;
@@ -25,6 +24,8 @@ in {
     # We use 23.05 here after back-porting agent code from 23.05.
     pythonPackages = nixpkgs-23_05.python310Packages;
   });
+
+  backy = super.callPackage ./backy { inherit (nixpkgs-23_05) poetry2nix python310 mkShellNoCC;};
 
   #
   # imports from other nixpkgs versions or local definitions
@@ -448,12 +449,6 @@ in {
       })
     ];
   });
-
-  poetry = nixpkgs-22_11.poetry;
-  poetry2nix = nixpkgs-22_11.poetry2nix;
-
-  python310 = nixpkgs-22_11.python310;
-  python310Packages = nixpkgs-22_11.python310Packages;
 
   postgis_2_5 = super.postgis.overrideAttrs(_: rec {
     version = "2.5.5";

--- a/versions.json
+++ b/versions.json
@@ -5,12 +5,6 @@
     "rev": "0f5fbc131671be14b6e76daa8125284b5111b33b",
     "sha256": "mL+pG1NIg8kKthDRz3zWgo+lzinSauslAxgxLZZmxX8="
   },
-  "nixpkgs-22.11": {
-    "owner": "flyingcircusio",
-    "repo": "nixpkgs",
-    "rev": "6a70ea11060b8acf6ec3867d4db3d078e745a377",
-    "sha256": "sha256-g01dOC/P8QedWBkLp4fevIIsJrjV5FdFdK3n6OUADs8="
-  },
   "nixpkgs-23.05": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",


### PR DESCRIPTION
removes nixpkgs-22.11
depends on flyingcircusio/backy#54
backy diff: https://github.com/flyingcircusio/backy/compare/5fa55f0c512e557bea3802f0be10e997e6f33f03..e37a7f6570b6b9194cb3a27d8db2951eb5c992ce

PL-131758, PL-131607
@flyingcircusio/release-managers

## Release process

Impact: internal

Changelog:

* A number of bugfixes and improvements to our backup utility (backy)

  * consistency check improvements (automatic distrust on verification failures, improved lock handling, quarantining of inconsistent chunks)
  * fix service reload inconsistencies and crashes
  * remove outdated, unused code and features
  * fix a crash when parent pointers were incomplete and the immediate parent was missing its snapshot
  * Add nix flake support

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - [x] keep software up to date 
- [x] Security requirements tested? (EVIDENCE)
  - [x] verify this builds and backups still work in dev environment
  - [x] automated hydra tests still pass
