### PR TITLE
Update nixpkgs for glibc CVE-2023-4911 fix

### DIFF
--- a/package-versions.json
+++ b/package-versions.json
@@ -205,7 +205,7 @@
     "version": "3.84.0"
   },
   "glibc": {
-    "name": "glibc-2.37-8",
+    "name": "glibc-2.37-45",
     "pname": "glibc",
     "version": "2.37"
   },

--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "fb0f12654d587e09b217efeb9d64f50ea236d269",
-    "sha256": "NLmPlG8jT97hLqHyMKKVbPYuUEQ3JHldfh6asgkO48g="
+    "rev": "7899ff5f912ab691346382fc4c75957f3e33096d",
+    "sha256": "f6Psp0SJuFLLCWHa3VIwOcTUoeoSff9pKALHge/PVxQ="
   },
   "nixos-mailserver": {
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/",


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

- glibc: update to 2.37-45 to get the fix for CVE-2023-4911 (PL-131808).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  -  use a recent version of glibc to get the latest security patches
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still run, works on a test VM. Other than that, we trust glibc to fix the issue as we cannot check it directly.