### PR TITLE
Update nixpkgs

### DIFF
--- a/nixpkgs-config.nix
+++ b/nixpkgs-config.nix
@@ -16,7 +16,7 @@
     "imagemagick-6.9.12-68" # Legacy, but gets updates. Customer still needs it.
     "nodejs-14.21.3" # Needed for opensearch-dashboards.
     "nodejs-16.20.2" # EOL 2023-09-11, needed for discourse and some customers.
-    "openssl-1.1.1v" # EOL 2023-09-11, needed for Percona and older PHP versions.
+    "openssl-1.1.1w" # EOL 2023-09-11, needed for Percona and older PHP versions.
     "python-2.7.18.6" # Needed for some legacy customer applications.
     "ruby-2.7.8" # EOL 2023-03-31, needed for Sensu checks
   ];

--- a/package-versions.json
+++ b/package-versions.json
@@ -120,9 +120,9 @@
     "version": "2.3.21"
   },
   "element-web": {
-    "name": "element-web-1.11.43",
+    "name": "element-web-1.11.45",
     "pname": "element-web",
-    "version": "1.11.43"
+    "version": "1.11.45"
   },
   "erlang": {
     "name": "erlang-25.3.2",
@@ -195,14 +195,14 @@
     "version": "2.309.0"
   },
   "gitlab": {
-    "name": "gitlab-16.3.4",
+    "name": "gitlab-16.4.1",
     "pname": "gitlab",
-    "version": "16.3.4"
+    "version": "16.4.1"
   },
   "gitlab-container-registry": {
-    "name": "gitlab-container-registry-3.82.0",
+    "name": "gitlab-container-registry-3.84.0",
     "pname": "gitlab-container-registry",
-    "version": "3.82.0"
+    "version": "3.84.0"
   },
   "glibc": {
     "name": "glibc-2.37-8",
@@ -385,9 +385,9 @@
     "version": "4.14.2"
   },
   "matrix-synapse": {
-    "name": "matrix-synapse-1.92.1",
+    "name": "matrix-synapse-1.93.0",
     "pname": "matrix-synapse",
-    "version": "1.92.1"
+    "version": "1.93.0"
   },
   "mcpp": {
     "name": "mcpp-2.7.2.1",
@@ -504,6 +504,11 @@
     "pname": "openssl",
     "version": "3.0.10"
   },
+  "openssl_1_1": {
+    "name": "openssl-1.1.1w",
+    "pname": "openssl",
+    "version": "1.1.1w"
+  },
   "openssl_3": {
     "name": "openssl-3.0.10",
     "pname": "openssl",
@@ -560,14 +565,14 @@
     "version": "8.0.29"
   },
   "php81": {
-    "name": "php-with-extensions-8.1.23",
+    "name": "php-with-extensions-8.1.24",
     "pname": "php-with-extensions",
-    "version": "8.1.23"
+    "version": "8.1.24"
   },
   "php82": {
-    "name": "php-with-extensions-8.2.10",
+    "name": "php-with-extensions-8.2.11",
     "pname": "php-with-extensions",
-    "version": "8.2.10"
+    "version": "8.2.11"
   },
   "phpPackages.composer": {
     "name": "php-composer-2.5.5",

--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "3f37c21c632290e564ab531ffc57a0e452b3822f",
-    "sha256": "c0TldiiMRGamP7M2eKh4KRHuOBail7t+AqV2JmfTw4I="
+    "rev": "fb0f12654d587e09b217efeb9d64f50ea236d269",
+    "sha256": "NLmPlG8jT97hLqHyMKKVbPYuUEQ3JHldfh6asgkO48g="
   },
   "nixos-mailserver": {
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/",


### PR DESCRIPTION
Pull upstream NixOS changes, security fixes and package updates:

- element-web: 1.11.43 -> 1.11.45
- gitlab: 16.3.4 -> 16.4.1
- matrix-synapse: 1.92.1 -> 1.93.0 (CVE-2023-41335, CVE-2023-42453)
- openssl_1_1: 1.1.1v -> 1.1.1w
- php81: 8.1.23 -> 8.1.24
- php82: 8.2.10 -> 8.2.11

PL-131805

@flyingcircusio/release-managers

## Release process

Impact

- \[NixOS 23.05\] Gitlab and matrix-synapse will be restarted.

Changelog:

(include changed packages from commit msg)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - pull in upstream security fixes regularly
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still run, works on a test VM; validated update checklist for staging Gitlab
  - checked commit log for fixed CVEs and possible problems with updates, looked at [synapse/upgrade.md](https://github.com/matrix-org/synapse/blob/develop/docs/upgrade.md) and [GitLab 16 changes](https://docs.gitlab.com/ee/update/versions/gitlab_16_changes.html)