### PR TITLE
[22.11] glibc: add patch for CVE-2023-4911 

### DIFF
--- a/pkgs/cve-2023-4911-first.patch
+++ b/pkgs/cve-2023-4911-first.patch
@@ -1,0 +1,38 @@
+X-Git-Url: https://sourceware.org/git/?p=glibc.git;a=blobdiff_plain;f=elf%2Fdl-tunables.c;h=cae67efa0aacb9984c49874dcb95f170ecd1d86d;hp=62b7332d95b61ce3428040522271f6e93e9d53ed;hb=1056e5b4c3f2d90ed2b4a55f96add28da2f4c8fa;hpb=0d5f9ea97f1b39f2a855756078771673a68497e1
+
+diff --git a/elf/dl-tunables.c b/elf/dl-tunables.c
+index 62b7332d95..cae67efa0a 100644
+--- a/elf/dl-tunables.c
++++ b/elf/dl-tunables.c
+@@ -180,11 +180,7 @@ parse_tunables (char *tunestr, char *valstring)
+       /* If we reach the end of the string before getting a valid name-value
+ 	 pair, bail out.  */
+       if (p[len] == '\0')
+-	{
+-	  if (__libc_enable_secure)
+-	    tunestr[off] = '\0';
+-	  return;
+-	}
++	break;
+ 
+       /* We did not find a valid name-value pair before encountering the
+ 	 colon.  */
+@@ -244,9 +240,16 @@ parse_tunables (char *tunestr, char *valstring)
+ 	    }
+ 	}
+ 
+-      if (p[len] != '\0')
+-	p += len + 1;
++      /* We reached the end while processing the tunable string.  */
++      if (p[len] == '\0')
++	break;
++
++      p += len + 1;
+     }
++
++  /* Terminate tunestr before we leave.  */
++  if (__libc_enable_secure)
++    tunestr[off] = '\0';
+ }
+ 
+ /* Enable the glibc.malloc.check tunable in SETUID/SETGID programs only when

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -87,6 +87,12 @@ in {
     };
   });
 
+  glibc = super.glibc.overrideAttrs (old: rec {
+    patches = old.patches ++ [
+      ./cve-2023-4911-first.patch
+    ];
+  });
+
   innotop = super.callPackage ./percona/innotop.nix { };
 
   libmodsecurity = super.callPackage ./libmodsecurity { };

--- a/release/default.nix
+++ b/release/default.nix
@@ -122,8 +122,9 @@ let
 
   includedPkgNames = [
     "calibre"
-    "gitlab-ee"
     "element-web"
+    # Unsupported on this platform version.
+    # "gitlab-ee"
   ];
 
   testPkgNames = includedPkgNames ++

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -44,7 +44,8 @@ in {
   ffmpeg = callTest ./ffmpeg.nix {};
   filebeat = callTest ./filebeat.nix {};
   collect-garbage = callTest ./collect-garbage.nix {};
-  gitlab = callTest ./gitlab.nix {};
+  # Unsupported on this platform version.
+  # gitlab = callTest ./gitlab.nix {};
   haproxy = callTest ./haproxy.nix {};
   java = callTest ./java.nix {};
   journal = callTest ./journal.nix {};

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -31,7 +31,8 @@ in {
 
   antivirus = callTest ./antivirus.nix {};
   audit = callTest ./audit.nix {};
-  backyserver = callTest ./backyserver.nix {};
+  # Not supported on this platform version.
+  # backyserver = callTest ./backyserver.nix {};
   channel = callTest ./channel.nix {};
   # XXX: ceph build failure
   # ceph = callTest ./ceph.nix {};


### PR DESCRIPTION
PL-131808

@flyingcircusio/release-managers

## Release process

Impact:

- \[NixOS 22.11\] All services will be restarted due to a core dependency change.

Changelog

- glibc: patch CVE-2023-4911 (PL-131808).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  -  use a recent version of glibc to get the latest security patches
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still run, works on a test VM. Other than that, we trust glibc to fix the issue as we cannot check it directly.