### PR TITLE
[21.05] fc-ceph: improve osd safety check UX

### DIFF
--- a/pkgs/fc/ceph/src/fc/ceph/main.py
+++ b/pkgs/fc/ceph/src/fc/ceph/main.py
@@ -125,6 +125,20 @@ def main(args=sys.argv[1:]):
         help="IDs of OSD to deactivate. "
         "Use `all` to deactivate all local OSDs.",
     )
+    parser_deactivate.add_argument(
+        "--no-safety-check",
+        action="store_true",
+        help="Skip the check whether an OSD is safe to stop without "
+        "reducing data redundancy below the point of cluster availability. "
+        "WARNING: This can result in data loss or cluster failure!!",
+    )
+    parser_deactivate.add_argument(
+        "--strict-safety-check",
+        action="store_true",
+        help="Stricter check whether stopping of the OSD reduces "
+        "the data availability at all, even when it is not below the point of "
+        "cluster availability.",
+    )
     parser_deactivate.set_defaults(action="deactivate")
 
     parser_reactivate = osd_sub.add_parser(

--- a/pkgs/fc/ceph/src/fc/ceph/main.py
+++ b/pkgs/fc/ceph/src/fc/ceph/main.py
@@ -51,7 +51,15 @@ def main(args=sys.argv[1:]):
         "--unsafe-destroy",
         action="store_true",
         help="Skip the check whether an OSD is safe to destroy without "
-        "affecting data redundancy. This can result in data loss or cluster failure!!",
+        "reducing data redundancy below the point of cluster availability. "
+        "WARNING: This can result in data loss or cluster failure!!",
+    )
+    parser_destroy.add_argument(
+        "--strict-safety-check",
+        action="store_true",
+        help="Stricter check whether destruction/stopping of the OSD reduces "
+        "the data availability at all, even when it is not below the point of "
+        "cluster availability.",
     )
     parser_destroy.set_defaults(action="destroy")
 
@@ -149,7 +157,15 @@ def main(args=sys.argv[1:]):
         "--unsafe-destroy",
         action="store_true",
         help="Skip the check whether an OSD is safe to destroy without "
-        "affecting data redundancy. This can result in data loss or cluster failure!!",
+        "reducing data redundancy below the point of cluster availability. "
+        "WARNING: This can result in data loss or cluster failure!!",
+    )
+    parser_rebuild.add_argument(
+        "--strict-safety-check",
+        action="store_true",
+        help="Stricter check whether destruction/stopping of the OSD reduces "
+        "the data availability at all, even when it is not below the point of "
+        "cluster availability.",
     )
     parser_rebuild.add_argument(
         "ids",

--- a/pkgs/fc/ceph/src/fc/ceph/main.py
+++ b/pkgs/fc/ceph/src/fc/ceph/main.py
@@ -48,7 +48,7 @@ def main(args=sys.argv[1:]):
         "instead of autodetecting it.",
     )
     parser_destroy.add_argument(
-        "--unsafe-destroy",
+        "--no-safety-check",
         action="store_true",
         help="Skip the check whether an OSD is safe to destroy without "
         "reducing data redundancy below the point of cluster availability. "
@@ -154,7 +154,7 @@ def main(args=sys.argv[1:]):
         "objectstore type.\nThe current type is detected automatically.",
     )
     parser_rebuild.add_argument(
-        "--unsafe-destroy",
+        "--no-safety-check",
         action="store_true",
         help="Skip the check whether an OSD is safe to destroy without "
         "reducing data redundancy below the point of cluster availability. "

--- a/pkgs/fc/ceph/src/fc/ceph/osd/nautilus.py
+++ b/pkgs/fc/ceph/src/fc/ceph/osd/nautilus.py
@@ -184,7 +184,8 @@ class OSDManager(object):
                     thread = threading.Thread(
                         target=lambda: self._deactivate_single(
                             osd, as_systemd_unit, flush
-                        )
+                        ),
+                        name=id_,
                     )
                     thread.start()
                     threads.append(thread)
@@ -193,6 +194,9 @@ class OSDManager(object):
 
             for thread in threads:
                 thread.join()
+
+            deactivated_osds = ", ".join([str(t.name) for t in threads])
+            print("Successfully deactivated OSDs", deactivated_osds)
 
     def _deactivate_single(
         self,
@@ -492,7 +496,7 @@ class GenericOSD(object):
                 print(
                     # fmt: off
                     "OSD not safe to destroy:", e.stderr,
-                    "\nTo override this check, remove th `--strict-safety-check` flag. "
+                    "\nTo override this check, remove the `--strict-safety-check` flag. "
                     "This can lead to reduced data redundancy, still within safety margins."
                     # fmt: on
                 )

--- a/tests/ceph-nautilus.nix
+++ b/tests/ceph-nautilus.nix
@@ -376,6 +376,7 @@ in
       assert_clean_cluster(host3, 3, 3, 3, 320)
 
     with subtest("Deactivate and activate single OSD on host 1"):
+      host1.fail('fc-ceph osd deactivate --strict-safety-check 0')
       host1.succeed('fc-ceph osd deactivate 0')
       host1.succeed('fc-ceph osd activate 0')
       status = show(host2, 'ceph -s')
@@ -385,7 +386,7 @@ in
       host2.succeed('fc-ceph osd destroy all > /dev/kmsg 2>&1')
       wait_for_cluster_status(host3, "PG_DEGRADED")
       host3.fail('fc-ceph osd destroy all > /dev/kmsg 2>&1')
-      host3.succeed('fc-ceph osd destroy --unsafe-destroy all > /dev/kmsg 2>&1')
+      host3.succeed('fc-ceph osd destroy --no-safety-check all > /dev/kmsg 2>&1')
       # now the cluster should block I/O due to being on only 1/3 redundancy
       wait_for_cluster_status(host3, "PG_AVAILABILITY")
       host3.succeed('ceph health | grep "Reduced data availability" > /dev/kmsg 2>&1')


### PR DESCRIPTION
In accordance to everyday operations usage, reduce the strictness of the
default safety check when destroying OSDs. By default, we use
`ok-to-stop` which allows degraded data redundancy as long as the
cluster stays IO-operational.
The old `safe-to-destroy` check behaviour is available under the new
flag `--strict-safety-check`.

This overall increases the UX safety of common operations tasks, as we accept temporarily degrading the redundancy for rebuilds as long as data stays available. Previously, we had to disable safety checks altogether, now the default safety check allows these operations but still prevents us from breaking availability.

The check mechanism has also been added to `fc-ceph osd deactivate`. The `reactivate` operation does its own checking anyways and is not affected.


@flyingcircusio/release-managers

## Release process

Impact: internal only

Changelog:
- fc-ceph:
  - reduce strictness of default osd destruction safety checks
  - rename flags `--unsafe-destroy` -> `--no-safety-check`
  - add safety checks for deactivate

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - The UX of our tooling should be designed along our common operation actions. Safety checks should support the operator from accidentally entering dangerous states, while not influenceing common operations too much. 
  - no new (known) regressions must be introduced
- [x] Security requirements tested? (EVIDENCE)
  - [x] extended test cases to cover new functionality
  - [x] automated tests still pass
  - [x] manually tested in dev cluster