### PR TITLE
[21.05] ceph-nautilus: Raise log level for informational messages

### DIFF
--- a/pkgs/ceph/nautilus/rgw-reduce-log-verbosity.patch
+++ b/pkgs/ceph/nautilus/rgw-reduce-log-verbosity.patch
@@ -20,3 +20,88 @@ index ad43b5d33d6..c9550742171 100644
  	  << " op status=" << op_ret
  	  << " http_status=" << s->err.http_ret
  	  << " latency=" << s->time_elapsed()
+--- a/src/cls/rgw/cls_rgw.cc
++++ b/src/cls/rgw/cls_rgw.cc
+@@ -688,7 +688,7 @@ int rgw_bucket_prepare_op(cls_method_context_t hctx, bufferlist *in, bufferlist
+     return -EINVAL;
+   }
+ 
+-  CLS_LOG(1, "rgw_bucket_prepare_op(): request: op=%d name=%s instance=%s tag=%s\n",
++  CLS_LOG(2, "rgw_bucket_prepare_op(): request: op=%d name=%s instance=%s tag=%s\n",
+           op.op, op.key.name.c_str(), op.key.instance.c_str(), op.tag.c_str());
+ 
+   // get on-disk state
+@@ -755,14 +755,14 @@ static void unaccount_entry(rgw_bucket_dir_header& header,
+ 
+ static void log_entry(const char *func, const char *str, rgw_bucket_dir_entry *entry)
+ {
+-  CLS_LOG(1, "%s(): %s: ver=%ld:%llu name=%s instance=%s locator=%s\n", func, str,
++  CLS_LOG(2, "%s(): %s: ver=%ld:%llu name=%s instance=%s locator=%s\n", func, str,
+           (long)entry->ver.pool, (unsigned long long)entry->ver.epoch,
+           entry->key.name.c_str(), entry->key.instance.c_str(), entry->locator.c_str());
+ }
+ 
+ static void log_entry(const char *func, const char *str, rgw_bucket_olh_entry *entry)
+ {
+-  CLS_LOG(1, "%s(): %s: epoch=%llu name=%s instance=%s tag=%s\n", func, str,
++  CLS_LOG(2, "%s(): %s: epoch=%llu name=%s instance=%s tag=%s\n", func, str,
+           (unsigned long long)entry->epoch, entry->key.name.c_str(), entry->key.instance.c_str(),
+           entry->tag.c_str());
+ }
+@@ -843,7 +843,7 @@ int rgw_bucket_complete_op(cls_method_context_t hctx, bufferlist *in, bufferlist
+     CLS_LOG(1, "ERROR: rgw_bucket_complete_op(): failed to decode request\n");
+     return -EINVAL;
+   }
+-  CLS_LOG(1, "rgw_bucket_complete_op(): request: op=%d name=%s instance=%s ver=%lu:%llu tag=%s\n",
++  CLS_LOG(2, "rgw_bucket_complete_op(): request: op=%d name=%s instance=%s ver=%lu:%llu tag=%s\n",
+           op.op, op.key.name.c_str(), op.key.instance.c_str(),
+           (unsigned long)op.ver.pool, (unsigned long long)op.ver.epoch,
+           op.tag.c_str());
+@@ -976,17 +976,17 @@ int rgw_bucket_complete_op(cls_method_context_t hctx, bufferlist *in, bufferlist
+   CLS_LOG(20, "rgw_bucket_complete_op(): remove_objs.size()=%d\n", (int)op.remove_objs.size());
+   for (remove_iter = op.remove_objs.begin(); remove_iter != op.remove_objs.end(); ++remove_iter) {
+     cls_rgw_obj_key& remove_key = *remove_iter;
+-    CLS_LOG(1, "rgw_bucket_complete_op(): removing entries, read_index_entry name=%s instance=%s\n",
++    CLS_LOG(2, "rgw_bucket_complete_op(): removing entries, read_index_entry name=%s instance=%s\n",
+             remove_key.name.c_str(), remove_key.instance.c_str());
+     rgw_bucket_dir_entry remove_entry;
+     string k;
+     int ret = read_key_entry(hctx, remove_key, &k, &remove_entry);
+     if (ret < 0) {
+-      CLS_LOG(1, "rgw_bucket_complete_op(): removing entries, read_index_entry name=%s instance=%s ret=%d\n",
++      CLS_LOG(2, "rgw_bucket_complete_op(): removing entries, read_index_entry name=%s instance=%s ret=%d\n",
+             remove_key.name.c_str(), remove_key.instance.c_str(), ret);
+       continue;
+     }
+-    CLS_LOG(0,
++    CLS_LOG(2,
+ 	    "rgw_bucket_complete_op(): entry.name=%s entry.instance=%s entry.meta.category=%d\n",
+             remove_entry.key.name.c_str(),
+ 	    remove_entry.key.instance.c_str(),
+@@ -1003,7 +1003,7 @@ int rgw_bucket_complete_op(cls_method_context_t hctx, bufferlist *in, bufferlist
+ 
+     ret = cls_cxx_map_remove_key(hctx, k);
+     if (ret < 0) {
+-      CLS_LOG(1, "rgw_bucket_complete_op(): cls_cxx_map_remove_key, failed to remove entry, name=%s instance=%s read_index_entry ret=%d\n", remove_key.name.c_str(), remove_key.instance.c_str(), rc);
++      CLS_LOG(2, "rgw_bucket_complete_op(): cls_cxx_map_remove_key, failed to remove entry, name=%s instance=%s read_index_entry ret=%d\n", remove_key.name.c_str(), remove_key.instance.c_str(), rc);
+       continue;
+     }
+   }
+@@ -1925,7 +1925,7 @@ static int rgw_bucket_clear_olh(cls_method_context_t hctx, bufferlist *in, buffe
+ int rgw_dir_suggest_changes(cls_method_context_t hctx,
+ 			    bufferlist *in, bufferlist *out)
+ {
+-  CLS_LOG(1, "rgw_dir_suggest_changes()");
++  CLS_LOG(2, "rgw_dir_suggest_changes()");
+ 
+   bufferlist header_bl;
+   rgw_bucket_dir_header header;
+@@ -3949,7 +3949,7 @@ static int rgw_get_bucket_resharding(cls_method_context_t hctx,
+ 
+ CLS_INIT(rgw)
+ {
+-  CLS_LOG(1, "Loaded rgw class!");
++  CLS_LOG(2, "Loaded rgw class!");
+ 
+   cls_handle_t h_class;
+   cls_method_handle_t h_rgw_bucket_init_index;


### PR DESCRIPTION
For getting an RGW access log, we need to set "debug rgw" to at least a level of 1. Unfortunately, this also gives us a large number of informational or notice logs in OSD logs.
For all RGW-class log messages not clearly related to errors or cancellations, I increased the required log level to 2. This helps differentiationg between an error-like and info-like log.

Note: some of the messages now ignored had the format
`read_index_entry(): existing entry:`

I hereby decide that (already) existing bucket entries are not relevant for error-like logs.

@flyingcircusio/release-managers

## Release process

Impact: internal

Changelog:
- reduce log verbosity of some RGW-class messages that appear not to be directly related to errors

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - [x] default production log verbosity needs to be bearable
  - [x] by default, we mainly want to log errors, but the affected log messages can reappear when we increase the log level for debugging purposes
- [x] Security requirements tested? (EVIDENCE)
  - [x] automated tests still pass
  - [x] verify in real-world cluster that offending messages are not logged anymore 
