### PR TITLE
Extend our list of things we build manually to reduce local builds on…

### DIFF
--- a/release/default.nix
+++ b/release/default.nix
@@ -115,6 +115,7 @@ let
     "gitlab-runner"
   ];
 
+  # XXX overcome force push hydra blockade.
   includedPkgNames = [
     "binutils"
     "calibre"

--- a/release/default.nix
+++ b/release/default.nix
@@ -116,9 +116,26 @@ let
   ];
 
   includedPkgNames = [
+    "binutils"
     "calibre"
-    "gitlab-ee"
+    "chromedriver"
+    "chromium"
+    "cyrus_sasl"
     "element-web"
+    "gitlab-ee"
+    "glibc"
+    "libffi"
+    "libjpeg"
+    "libmysqlclient"
+    "libxml2"
+    "libxslt"
+    "libyaml"
+    "openldap"
+    "openssl"
+    "postgresql"
+    "python38"
+    "zlib"
+    "zstd"
   ];
 
   testPkgNames = includedPkgNames ++


### PR DESCRIPTION
… VMs.

For example our directory relies on our channel and it started building LLVM etc. after the last glibc update. :(

@flyingcircusio/release-managers

## Release process

Impact:

none

Changelog:

none

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

no specific requirements

- [x] Security requirements tested? (EVIDENCE)

nothing to test