### PR TITLE
agent: maintenance monitoring

### DIFF
--- a/nixos/platform/agent.nix
+++ b/nixos/platform/agent.nix
@@ -195,6 +195,7 @@ in
             "${pkgs.fc.agent}/bin/fc-maintenance show"
             "${pkgs.fc.agent}/bin/fc-maintenance delete"
             "${pkgs.fc.agent}/bin/fc-maintenance metrics"
+            "${pkgs.fc.agent}/bin/fc-maintenance check"
           ];
           groups = [ "admins" "sudo-srv" "service" ];
         }
@@ -398,6 +399,11 @@ in
             notification = "fc-manage check failed. System may not build and update correctly.";
             command = "sudo ${pkgs.fc.agent}/bin/fc-manage check";
             interval = 300;
+          };
+          fc-maintenance = {
+            notification = "fc-maintenance check failed.";
+            command = "sudo ${pkgs.fc.agent}/bin/fc-maintenance check";
+            interval = 180;
           };
         };
       };

--- a/pkgs/fc/agent/default.nix
+++ b/pkgs/fc/agent/default.nix
@@ -79,6 +79,8 @@ buildPythonPackage rec {
   ];
   dontStrip = true;
   doCheck = true;
-  passthru.pythonDevEnv = python.withPackages (_: checkInputs ++ propagatedBuildInputs);
+  passthru.pythonDevEnv = python.withPackages (_:
+    checkInputs ++ [ py.pytest ] ++ propagatedBuildInputs
+  );
 
 }

--- a/pkgs/fc/agent/fc/maintenance/cli.py
+++ b/pkgs/fc/agent/fc/maintenance/cli.py
@@ -347,9 +347,8 @@ def constraints(
 
 @app.command(help="Prints metrics in the telegraf JSON input format.")
 def metrics():
-    with rm:
-        rm.scan()
-        jso = json.dumps(rm.get_metrics())
+    rm.scan()
+    jso = json.dumps(rm.get_metrics())
 
     print(jso)
 

--- a/pkgs/fc/agent/fc/maintenance/cli.py
+++ b/pkgs/fc/agent/fc/maintenance/cli.py
@@ -1,4 +1,5 @@
 import json
+import traceback
 from pathlib import Path
 from typing import NamedTuple, Optional
 
@@ -343,6 +344,24 @@ def constraints(
             raise Exit(failure_exit_code)
 
     log.debug("constraints-success")
+
+
+@app.command()
+def check():
+    fc.util.logging.init_logging(
+        context.verbose, context.logdir, log_to_console=context.verbose
+    )
+    try:
+        rm.scan()
+        result = rm.check()
+    except Exception:
+        print("UNKNOWN: Exception occurred while running checks")
+        traceback.print_exc()
+        raise Exit(3)
+
+    print(result.format_output())
+    if result.exit_code:
+        raise Exit(result.exit_code)
 
 
 @app.command(help="Prints metrics in the telegraf JSON input format.")

--- a/pkgs/fc/agent/fc/maintenance/reqmanager.py
+++ b/pkgs/fc/agent/fc/maintenance/reqmanager.py
@@ -101,18 +101,8 @@ class ReqManager:
             if not d.exists():
                 os.mkdir(d)
         self.enc_path = Path(enc_path)
-        self.config_file = Path(config_file)
         self.requests = {}
-
-    def __enter__(self):
-        if self.lockfile:
-            return self
-        self.lockfile = open(p.join(self.spooldir, ".lock"), "a+")
-        fcntl.flock(self.lockfile.fileno(), fcntl.LOCK_EX)
-        self.lockfile.seek(0)
-        print(os.getpid(), file=self.lockfile)
-        self.lockfile.flush()
-        self.scan()
+        self.config_file = Path(config_file)
         self.config = configparser.ConfigParser()
         if self.config_file:
             if self.config_file.is_file():
@@ -123,6 +113,20 @@ class ReqManager:
         self.maintenance_preparation_seconds = int(
             self.config.get("maintenance", "preparation_seconds", fallback=300)
         )
+
+    def __enter__(self):
+        """
+        Sets up global request manager lock and loads active requests.
+        Used for invasive tasks that may change requests.
+        """
+        if self.lockfile:
+            return self
+        self.lockfile = open(p.join(self.spooldir, ".lock"), "a+")
+        fcntl.flock(self.lockfile.fileno(), fcntl.LOCK_EX)
+        self.lockfile.seek(0)
+        print(os.getpid(), file=self.lockfile)
+        self.lockfile.flush()
+        self.scan()
         return self
 
     def __exit__(self, exc_type, exc_value, exc_tb):

--- a/pkgs/fc/agent/fc/maintenance/request.py
+++ b/pkgs/fc/agent/fc/maintenance/request.py
@@ -42,11 +42,11 @@ class RequestMergeResult(Enum):
 class Attempt:
     """Data object to track finished activities."""
 
-    stdout = None
-    stderr = None
-    returncode = None
-    finished = None
-    duration = None
+    stdout: str | None = None
+    stderr: str | None = None
+    returncode: int | None = None
+    finished: datetime.datetime | None = None
+    duration: float | None = None
 
     def __init__(self):
         self.started = utcnow()
@@ -278,6 +278,7 @@ class Request:
         attempt = Attempt()  # sets start time
         try:
             self.state = State.running
+            self.attempts.append(attempt)
             self.save()
             with cd(self.dir):
                 try:
@@ -286,7 +287,6 @@ class Request:
                 except Exception as e:
                     attempt.returncode = 70  # EX_SOFTWARE
                     attempt.stderr = str(e)
-            self.attempts.append(attempt)
             self.state = evaluate_state(self.activity.returncode)
         except Exception:
             self.log.error(

--- a/pkgs/fc/agent/fc/maintenance/tests/test_reqmanager.py
+++ b/pkgs/fc/agent/fc/maintenance/tests/test_reqmanager.py
@@ -1,24 +1,26 @@
-import contextlib
 import datetime
 import os
 import os.path as p
 import socket
 import textwrap
 import unittest.mock
-import uuid
 from io import StringIO
 from unittest.mock import MagicMock, Mock, call
 
 import freezegun
 import pytest
 import pytz
-import shortuuid
-from fc.maintenance.activity import Activity, ActivityMergeResult, RebootType
+from fc.maintenance.activity import Activity, RebootType
 from fc.maintenance.estimate import Estimate
-from fc.maintenance.reqmanager import PostponeMaintenance, TempfailMaintenance
+from fc.maintenance.reqmanager import (
+    PostponeMaintenance,
+    ReqManager,
+    TempfailMaintenance,
+)
 from fc.maintenance.request import Attempt, Request
 from fc.maintenance.state import ARCHIVE, EXIT_POSTPONE, State
 from fc.maintenance.tests import MergeableActivity
+from fc.util.time_date import utcnow
 from rich.console import Console
 
 
@@ -217,6 +219,7 @@ def test_explicitly_deleted(connect, reqmanager):
     )
 
 
+@freezegun.freeze_time("2016-04-20 11:00:00")
 def test_enter_maintenance(log, reqmanager, monkeypatch):
     monkeypatch.setattr(
         "fc.util.directory.connect", connect_mock := MagicMock()
@@ -227,6 +230,8 @@ def test_enter_maintenance(log, reqmanager, monkeypatch):
 
     assert log.has("enter-maintenance")
     connect_mock().mark_node_service_status.assert_called_with("host", False)
+    maintenance_entered_at = reqmanager.maintenance_marker_path.read_text()
+    assert maintenance_entered_at == "2016-04-20T11:00:00+00:00"
 
 
 def test_enter_maintenance_postpone(log, reqmanager, monkeypatch):
@@ -239,6 +244,8 @@ def test_enter_maintenance_postpone(log, reqmanager, monkeypatch):
     with pytest.raises(PostponeMaintenance):
         reqmanager.enter_maintenance()
 
+    assert reqmanager.maintenance_marker_path.exists()
+
 
 def test_enter_maintenance_tempfail(log, reqmanager, monkeypatch):
     monkeypatch.setattr(
@@ -249,6 +256,8 @@ def test_enter_maintenance_tempfail(log, reqmanager, monkeypatch):
 
     with pytest.raises(TempfailMaintenance):
         reqmanager.enter_maintenance()
+
+    assert reqmanager.maintenance_marker_path.exists()
 
 
 def test_execute_postpone(log, reqmanager, monkeypatch):
@@ -612,3 +621,108 @@ def test_overdue(request_population):
 
     assert reqs[0].state == State.due
     assert reqs[1].state == State.postpone
+
+
+def test_check_no_maintenance_should_be_ok(reqmanager):
+    res = reqmanager.check()
+    print(res)
+    assert not res.warnings
+    assert not res.errors
+    assert res.ok_info
+    assert "Machine is in service" in res.ok_info[0]
+
+
+def test_check_scheduled_requests_should_show_count_and_time(
+    request_population,
+):
+    with request_population(2) as (rm, reqs):
+        reqs[0].next_due = datetime.datetime(2016, 4, 20, 11, tzinfo=pytz.UTC)
+        reqs[0].state = State.due
+        reqs[1].next_due = datetime.datetime(
+            2016, 4, 20, 11, 10, tzinfo=pytz.UTC
+        )
+        reqs[1].state = State.due
+    res = rm.check()
+    assert "2 scheduled" in res.ok_info[1]
+    assert "2016-04-20 11:00" in res.ok_info[1]
+
+
+def test_check_waiting_to_be_scheduled_requests_should_show_count(
+    request_population,
+):
+    with request_population(2) as (rm, reqs):
+        reqs[0].state = State.pending
+        reqs[1].state = State.pending
+    res = rm.check()
+    assert res.ok_info
+    assert "2 maintenance requests are waiting to be sched" in res.ok_info[1]
+
+
+def test_check_waiting_and_scheduled_requests(
+    request_population,
+):
+    with request_population(2) as (rm, reqs):
+        reqs[0].state = State.pending
+        reqs[0].next_due = datetime.datetime(2016, 4, 20, 11, tzinfo=pytz.UTC)
+        reqs[1].state = State.pending
+    res = rm.check()
+    assert res.ok_info
+    assert "A maintenance request is due at 2016-04-20 11:00" in res.ok_info[1]
+    assert "A maintenance request is waiting to be sched" in res.ok_info[2]
+
+
+@freezegun.freeze_time("2016-04-20 11:01:00")
+def test_check_recent_maintenance_running_should_be_ok(request_population):
+    with request_population(1) as (rm, reqs):
+        rm: ReqManager
+        rm.maintenance_marker_path.write_text(
+            (utcnow() - datetime.timedelta(minutes=10)).isoformat()
+        )
+        reqs[0].next_due = datetime.datetime(2016, 4, 20, 11, tzinfo=pytz.UTC)
+        reqs[0].state = State.running
+        att = Attempt()
+        att.started -= datetime.timedelta(minutes=1)
+        reqs[0].attempts = [att]
+        reqs[0].save()
+
+        res = rm.check()
+        print(res)
+        assert not res.warnings
+        assert not res.errors
+        assert res.ok_info
+        assert "activated 600 seconds ago" in res.ok_info[0]
+        assert "request started 60 seconds ago" in res.ok_info[1]
+
+
+@freezegun.freeze_time("2016-04-20 12:00:01")
+def test_check_long_maintenance_should_be_critical(request_population):
+    with request_population(1) as (rm, reqs):
+        rm: ReqManager
+        rm.maintenance_marker_path.write_text(
+            (utcnow() - datetime.timedelta(minutes=60, seconds=1)).isoformat()
+        )
+        reqs[0].next_due = datetime.datetime(2016, 4, 20, 11, tzinfo=pytz.UTC)
+        reqs[0].state = State.running
+        att = Attempt()
+        att.started -= datetime.timedelta(minutes=50)
+        reqs[0].attempts = [att]
+        reqs[0].save()
+
+        res = rm.check()
+        print(res)
+        assert res.errors
+        assert "activated 3601 seconds ago" in res.errors[0]
+        assert "request started 3000 seconds ago" in res.errors[1]
+
+
+@freezegun.freeze_time("2016-04-27 11:00:01")
+def test_check_request_stuck_in_queue_should_warn(request_population):
+    with request_population(1) as (rm, reqs):
+        reqs[0].added_at = datetime.datetime(2016, 4, 20, 11, tzinfo=pytz.UTC)
+        reqs[0].state = State.pending
+        reqs[0].save()
+
+        res = rm.check()
+        print(res)
+        assert res.warnings
+        assert "in the queue for 168 hours" in res.warnings[0]


### PR DESCRIPTION
agent: maintenance check for Sensu, more metrics

- fc-maintenance check is run by Sensu every 3 minutes.
  and can also used by sudo-srv, service and admins groups with sudo.
- Check for stuck requests (existing for more than 7 days).
- Report maintenance duration and run time of running requests.
- enter_maintenance now creates a marker file at
  /var/spool/maintenance/in_maintenance, leave_maintenance deletes it.
- Alert when maintenance mode is activated for a long time
  (warning: 30min, critical 60min)
- Attempts are now created and saved before the activity starts
  so we can use it to measure time while it is running.
- More request metrics
  - count running
  - count waiting_for_schedule (created, but not scheduled)
  - count scheduled
  - time of next due request
- Add current maintenance metrics
  - duration of maintenance
  - current request run time

agent: do not acquire lock when getting metrics

We also want metrics during a maintenance run.
It's generally safe to call ReqManager methods as long as
they don't modify request state.

__enter__ now only acquires the lock. Reading the config is
moved to __init__ so that methods can read config without
locking.

This also includes a fix to include pytest in the Python dev
environment again as the pytestCheckHook doesn't propagate pytest
itself.

There's a possibility that loading requests will lead to an error
which means that a "read-only" method might change state because
requests that failed to load are archived immediately. This should
be fixed later as it can be annoying for testing/debugging.


@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - The change is about discovering problems with automated maintenance, like maintenance mode being activated for too long or requests not being executed for a long time. These problems could affect availability (we don't send alerts when machines are in maintenance mode) and security in general when updates are not rolled out in time.
- [x] Security requirements tested? (EVIDENCE)
  - Checked metrics and verified check output on a test VM in various phases of the maintenance workflow (no requests, (multiple) request(s) waiting to be scheduled or already scheduled, running requests)