### PR TITLE
k3s implement clean automated maintenance

### DIFF
--- a/nixos/platform/agent.nix
+++ b/nixos/platform/agent.nix
@@ -46,6 +46,14 @@ let
     }
 
     compdef _fc_slurm_completion fc-slurm
+
+    #compdef fc-kubernetes
+
+    _fc_kubernetes_completion() {
+      eval $(env _TYPER_COMPLETE_ARGS="''${words[1,$CURRENT]}" _FC_KUBERNETES_COMPLETE=complete_zsh fc-kubernetes)
+    }
+
+    compdef _fc_kubernetes_completion fc-kubernetes
   '';
 
   agentZshCompletionsPkg = pkgs.runCommand "agent-zshcomplete" {} ''

--- a/pkgs/fc/agent/fc/manage/kubernetes.py
+++ b/pkgs/fc/agent/fc/manage/kubernetes.py
@@ -1,0 +1,138 @@
+import os
+import socket
+from pathlib import Path
+from typing import NamedTuple, Optional
+
+import fc.util.kubernetes
+import structlog
+from fc.maintenance.state import EXIT_TEMPFAIL
+from fc.util.directory import directory_connection
+from fc.util.logging import init_logging
+from fc.util.typer_utils import FCTyperApp
+from rich import print
+from typer import Exit, Option, Typer
+
+
+class Context(NamedTuple):
+    logdir: Path
+    verbose: bool
+    enc_path: Path
+
+
+app = FCTyperApp("fc-kubernetes")
+context: Context
+
+
+@app.callback(no_args_is_help=True)
+def fc_kubernetes(
+    verbose: bool = Option(
+        False,
+        "--verbose",
+        "-v",
+        help="Show debug messages and code locations.",
+    ),
+    logdir: Path = Option(
+        exists=True,
+        writable=True,
+        file_okay=False,
+        default="/var/log",
+        help="Directory for log files, expects a fc-agent subdirectory there.",
+    ),
+    enc_path: Path = Option(
+        dir_okay=False,
+        default="/etc/nixos/enc.json",
+        help="Path to enc.json",
+    ),
+):
+    global context
+
+    context = Context(
+        logdir=logdir,
+        verbose=verbose,
+        enc_path=enc_path,
+    )
+
+    init_logging(verbose, logdir, syslog_identifier="fc-kubernetes")
+
+
+@app.command(
+    help="Drain this node and wait for completion",
+)
+def drain(
+    timeout: int = Option(
+        default=300, help="Timeout in seconds passed to kubectl drain."
+    ),
+    reason: str = Option(
+        default="fc-kubernetes-drain",
+        help=(
+            "Set a node label before draining. Labels can only contain "
+            "alphanumeric characters and '-', '_' or '.', and must start and "
+            "end with an alphanumeric character."
+        ),
+    ),
+    strict_state_check: Optional[bool] = False,
+):
+    log = structlog.get_logger()
+    hostname = socket.gethostname()
+    try:
+        fc.util.kubernetes.drain(
+            log, hostname, timeout, reason, strict_state_check
+        )
+    except fc.util.kubernetes.NodeDrainTimeout:
+        raise Exit(EXIT_TEMPFAIL)
+
+
+@app.command()
+def ready(
+    strict_state_check: Optional[bool] = False,
+    label_must_match: Optional[str] = Option(
+        default=None,
+        help="Only set nodes to ready which match a given label.",
+    ),
+):
+    log = structlog.get_logger()
+    hostname = socket.gethostname()
+    fc.util.kubernetes.uncordon(
+        log, hostname, strict_state_check, label_must_match
+    )
+
+
+all_nodes_app = Typer(
+    pretty_exceptions_show_locals=False,
+    help="Commands that affect all nodes in the cluster",
+    no_args_is_help=True,
+)
+app.add_typer(all_nodes_app, name="all-nodes")
+
+
+@all_nodes_app.command(
+    name="ready",
+    help="Mark nodes as ready",
+)
+def ready_all(
+    strict_state_check: Optional[bool] = False,
+    label_must_match: Optional[str] = Option(
+        default=None,
+        help="Only set nodes to ready which match a given label.",
+    ),
+    skip_nodes_in_maintenance: Optional[bool] = Option(
+        default=True,
+        help="Check maintenance state of nodes and skip when not in service.",
+    ),
+):
+    log = structlog.get_logger()
+    node_names = fc.util.kubernetes.get_all_agent_node_names()
+    with directory_connection(context.enc_path) as directory:
+        for node_name in node_names:
+            fc.util.kubernetes.uncordon(
+                log,
+                node_name,
+                strict_state_check,
+                label_must_match,
+                skip_nodes_in_maintenance,
+                directory,
+            )
+
+
+if __name__ == "__main__":
+    app()

--- a/pkgs/fc/agent/fc/util/kubernetes.py
+++ b/pkgs/fc/agent/fc/util/kubernetes.py
@@ -1,0 +1,304 @@
+import json
+import subprocess
+from enum import Enum
+from typing import NamedTuple, Optional
+
+from fc.util.directory import is_node_in_service
+from fc.util.subprocess_helper import get_popen_stdout_lines
+
+MAINT_LABEL_NAME = "fcio.net/maintenance"
+
+SERVER_TAINT = {
+    "effect": "NoSchedule",
+    "key": "node-role.kubernetes.io/server",
+    "value": "true",
+}
+
+
+class NodeStateError(Exception):
+    pass
+
+
+class NodeDrainError(Exception):
+    pass
+
+
+class NodeDrainTimeout(NodeDrainError):
+    pass
+
+
+class DrainingAction(Enum):
+    NO_OP = 0
+    DRAIN = 1
+    WAIT = 2
+
+
+def is_node_ready(node: dict):
+    spec = node["spec"]
+    return "unschedulable" not in spec or not spec["unschedulable"]
+
+
+def is_node_drained(log, node: dict):
+    spec = node["spec"]
+    metadata = node["metadata"]
+    log.debug(
+        "is-node-drained",
+        node=metadata["name"],
+        annotations=metadata["annotations"],
+    )
+    return "unschedulable" in spec and spec["unschedulable"]
+
+
+def is_agent_node(node: dict):
+    return SERVER_TAINT not in node["spec"].get("taints", [])
+
+
+def kubectl(
+    *varargs,
+    json_output=False,
+):
+    args = [
+        "k3s",
+        "kubectl",
+        "--kubeconfig",
+        "/var/lib/k3s/agent/kubelet.kubeconfig",
+        *varargs,
+    ]
+    if json_output:
+        args.extend(["-o", "json"])
+
+    return args
+
+
+def get_node(node_name) -> dict:
+    jso = subprocess.run(
+        kubectl("get", "node", node_name, json_output=True),
+        check=True,
+        text=True,
+        capture_output=True,
+    ).stdout
+    return json.loads(jso)
+
+
+def get_agent_nodes() -> list[dict]:
+    jso = subprocess.run(
+        kubectl("get", "nodes", json_output=True),
+        check=True,
+        text=True,
+        capture_output=True,
+    ).stdout
+    nodes = json.loads(jso)["items"]
+
+    return [node for node in nodes if is_agent_node(node)]
+
+
+def get_all_agent_node_names() -> list[str]:
+    return [ni["metadata"]["name"] for ni in get_agent_nodes()]
+
+
+def run_drain_pre_checks(log, node_name, strict_state_check):
+    log = log.bind(node=node_name)
+
+    node = get_node(node_name)
+
+    if not is_agent_node(node):
+        if strict_state_check:
+            log.error("drain-pre-check-state-error", reason="no agent")
+            raise NodeStateError("Node is not an agent.")
+        else:
+            log.info(
+                "drain-pre-check-no-agent",
+                _replace_msg=(
+                    "Draining a non-agent node is unnecessary. No action."
+                ),
+            )
+            return DrainingAction.NO_OP
+
+    if is_node_drained(log.bind(op="pre-check"), node):
+        if strict_state_check:
+            log.error("drain-pre-check-state-error", reason="drained")
+            raise NodeStateError("Node is already drained.")
+        else:
+            log.info(
+                "drain-pre-already-drained",
+                _replace_msg="{node} is already drained. No action.",
+            )
+            return DrainingAction.NO_OP
+
+    log.info(
+        "drain-pre-needs-draining",
+        _replace_msg="{node} needs draining.",
+    )
+
+    return DrainingAction.DRAIN
+
+
+def drain(
+    log,
+    node_name,
+    timeout: int,
+    maintenance_label: str,
+    strict_state_check: bool = False,
+):
+    log = log.bind(node=node_name)
+    log.debug(
+        "drain-start",
+        timeout=timeout,
+        maintenance_label=maintenance_label,
+        strict_state_check=strict_state_check,
+    )
+
+    drain_action = run_drain_pre_checks(log, node_name, strict_state_check)
+
+    match drain_action:
+        case DrainingAction.NO_OP:
+            return
+
+        case DrainingAction.DRAIN:
+            label = f"fcio.net/maintenance={maintenance_label}"
+            subprocess.run(
+                kubectl("label", "node", node_name, label),
+                check=True,
+            )
+        case DrainingAction.WAIT:
+            log.info(
+                "node-drain-wait",
+                _replace_msg=(
+                    "Node already has the maintenance label from a previous run "
+                    "which ran into a timeout or was interrupted. "
+                    "Waiting for the node to fully drain."
+                ),
+            )
+
+    log.debug("kubectl-drain-start")
+    proc = subprocess.Popen(
+        kubectl(
+            "drain",
+            node_name,
+            "--delete-emptydir-data",
+            "--ignore-daemonsets",
+            f"--timeout={timeout}s",
+        ),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+
+    stdout_lines = get_popen_stdout_lines(proc, log, "kubectl-drain-out")
+    stdout = "".join(stdout_lines)
+    proc.wait()
+
+    if proc.returncode == 0:
+        log.info(
+            "drain-finished",
+        )
+    elif "global timeout reached" in stdout:
+        log.error(
+            "drain-timeout",
+            _replace_msg=(
+                "{node} did not finish draining in time, waited {timeout} "
+                "seconds."
+            ),
+            timeout=timeout,
+            stdout=stdout,
+        )
+        raise NodeDrainTimeout()
+    else:
+        log.error("drain-failed", returncode=proc.returncode, stdout=stdout)
+        raise NodeDrainError()
+
+
+class ReadyPreCheckResult(NamedTuple):
+    state: str
+    action: bool
+
+
+def run_ready_pre_checks(
+    log,
+    node_name,
+    strict_state_check,
+    label_must_match,
+    skip_in_maintenance,
+    directory,
+):
+    log = log.bind(node=node_name)
+    node = get_node(node_name)
+    log.debug("ready-pre-node-state", metadata=node.get("metadata"))
+
+    if is_node_ready(node):
+        if strict_state_check:
+            log.error("ready-state-error")
+            raise NodeStateError("Node is already ready.")
+        else:
+            log.info(
+                "ready-already-reached",
+                _replace_msg="{node} is already ready. No action.",
+            )
+            return ReadyPreCheckResult("ready", action=False)
+
+    maint_label = node["metadata"]["labels"].get(MAINT_LABEL_NAME)
+
+    if label_must_match:
+        if maint_label is None or label_must_match not in maint_label:
+            log.info(
+                "ready-pre-label-not-matched",
+                _replace_msg=(
+                    "{node} cannot be set to ready because the maintenance "
+                    "label does not contain the expected string: "
+                    "expected: '{expected}', actual: '{maint_label}'"
+                ),
+                expected=label_must_match,
+                maint_label=maint_label,
+            )
+            return ReadyPreCheckResult("drained", action=False)
+
+    if skip_in_maintenance and not is_node_in_service(directory, node_name):
+        log.info(
+            "ready-pre-not-in-service",
+            node=node_name,
+            _replace_msg="{node} is still in maintenance, skipping.",
+        )
+        return ReadyPreCheckResult("drained", action=False)
+
+    log.info(
+        "ready-pre-doit",
+        _replace_msg="{node} can be set to ready.",
+    )
+    return ReadyPreCheckResult("drained", action=True)
+
+
+def uncordon(
+    log,
+    node_name,
+    strict_state_check: bool = False,
+    label_must_match: Optional[str] = None,
+    skip_in_maintenance=False,
+    directory=None,
+):
+    log = log.bind(node=node_name)
+    log.debug("ready-start")
+
+    result = run_ready_pre_checks(
+        log,
+        node_name,
+        strict_state_check,
+        label_must_match,
+        skip_in_maintenance,
+        directory,
+    )
+
+    if not result.action:
+        return
+
+    result = subprocess.run(kubectl("uncordon", node_name))
+    log.debug("node-uncordon-result", result=result)
+
+    subprocess.run(
+        kubectl("label", "node", node_name, MAINT_LABEL_NAME + "-"),
+        check=True,
+    )
+
+    log.info(
+        "ready-finished",
+        _replace_msg="{node} set to ready (uncordoned).",
+    )

--- a/pkgs/fc/agent/fc/util/tests/__init__.py
+++ b/pkgs/fc/agent/fc/util/tests/__init__.py
@@ -1,0 +1,28 @@
+class FakeCmdStream:
+    def __init__(self, content):
+        self.content = content
+        self.line_gen = (l for l in content.splitlines(keepends=True))
+
+    def readline(self):
+        try:
+            return next(self.line_gen)
+        except StopIteration:
+            return ""
+
+    def read(self):
+        return self.content
+
+
+class PollingFakePopen:
+    def __init__(
+        self, cmd, stdout="", stderr="", poll="stdout", returncode=0, pid=123
+    ):
+        self.cmd = cmd
+        self.stdout = FakeCmdStream(stdout)
+        self.stderr = FakeCmdStream(stderr)
+        self.returncode = returncode
+        self.pid = pid
+        self._poll = poll
+
+    def wait(self):
+        pass

--- a/pkgs/fc/agent/fc/util/tests/test_kubernetes.py
+++ b/pkgs/fc/agent/fc/util/tests/test_kubernetes.py
@@ -1,0 +1,150 @@
+import subprocess
+import sys
+import unittest.mock
+from unittest.mock import MagicMock, Mock
+
+from fc.util.logging import init_logging
+from fc.util.tests import PollingFakePopen
+from pytest import raises
+
+init_logging(verbose=True, syslog_identifier="kubernetes-test")
+
+import fc.util.kubernetes
+from fc.util.kubernetes import DrainingAction, NodeDrainTimeout
+
+
+def fake_metadata(name, **kwargs):
+    return {
+        "name": name,
+        "annotations": {},
+        "labels": {},
+        **kwargs,
+    }
+
+
+@unittest.mock.patch("fc.util.kubernetes.get_node")
+@unittest.mock.patch("subprocess.run")
+def test_uncordon(run: MagicMock, get_node, logger, log):
+    get_node.return_value = {
+        "spec": {"unschedulable": True},
+        "metadata": fake_metadata(
+            "test20", labels={"fcio.net/maintenance": "test"}
+        ),
+    }
+    fc.util.kubernetes.uncordon(logger, "test20", label_must_match="test")
+    run.assert_any_call(
+        [
+            "k3s",
+            "kubectl",
+            "--kubeconfig",
+            "/var/lib/k3s/agent/kubelet.kubeconfig",
+            "uncordon",
+            "test20",
+        ]
+    )
+    assert log.has("ready-pre-doit")
+    assert log.has("ready-finished")
+
+
+@unittest.mock.patch("fc.util.kubernetes.get_node")
+@unittest.mock.patch("subprocess.run")
+def test_uncordon_noop_when_already_ready(run, get_node, logger, log):
+    get_node.return_value = {
+        "spec": {},
+        "metadata": fake_metadata("test20"),
+    }
+    fc.util.kubernetes.uncordon(logger, "test20")
+    run.assert_not_called()
+    assert log.has("ready-already-reached")
+
+
+@unittest.mock.patch("fc.util.kubernetes.get_node")
+@unittest.mock.patch("subprocess.run")
+def test_uncordon_noop_when_label_not_matched(run, get_node, logger, log):
+    get_node.return_value = {
+        "spec": {"unschedulable": True},
+        "metadata": fake_metadata(
+            "test20", labels={"fcio.net/maintenance": "wronglabel"}
+        ),
+    }
+    fc.util.kubernetes.uncordon(logger, "test20", label_must_match="test")
+    run.assert_not_called()
+    assert log.has("ready-pre-label-not-matched")
+
+
+@unittest.mock.patch("fc.util.kubernetes.run_drain_pre_checks")
+@unittest.mock.patch("subprocess.run")
+def test_drain(run, run_drain_pre_checks, logger, monkeypatch):
+    run_drain_pre_checks.return_value = DrainingAction.DRAIN
+
+    kubectl_drain_fake = PollingFakePopen(
+        "drain",
+        stdout="Draining...",
+        returncode=0,
+    )
+
+    popen = Mock(return_value=kubectl_drain_fake)
+    monkeypatch.setattr("subprocess.Popen", popen)
+
+    fc.util.kubernetes.drain(logger, "test20", 3, "testdrain")
+
+    run.assert_any_call(
+        [
+            "k3s",
+            "kubectl",
+            "--kubeconfig",
+            "/var/lib/k3s/agent/kubelet.kubeconfig",
+            "label",
+            "node",
+            "test20",
+            "fcio.net/maintenance=testdrain",
+        ],
+        check=True,
+    )
+
+    popen.assert_called_with(
+        [
+            "k3s",
+            "kubectl",
+            "--kubeconfig",
+            "/var/lib/k3s/agent/kubelet.kubeconfig",
+            "drain",
+            "test20",
+            "--delete-emptydir-data",
+            "--ignore-daemonsets",
+            "--timeout=3s",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+
+
+@unittest.mock.patch("fc.util.kubernetes.get_node")
+@unittest.mock.patch("subprocess.Popen")
+def test_drain_noop(popen: MagicMock, get_node, logger):
+    get_node.return_value = {
+        "spec": {"unschedulable": True},
+        "metadata": fake_metadata("test20"),
+    }
+    fc.util.kubernetes.drain(logger, "test20", 3, "test drain")
+    popen.assert_not_called()
+
+
+@unittest.mock.patch("fc.util.kubernetes.run_drain_pre_checks")
+def test_drain_wait_timeout(run_drain_pre_checks, logger, log, monkeypatch):
+    run_drain_pre_checks.return_value = DrainingAction.WAIT
+
+    kubectl_drain_fake = PollingFakePopen(
+        "drain-timeout",
+        stdout="global timeout reached",
+        returncode=1,
+    )
+
+    popen = Mock(return_value=kubectl_drain_fake)
+    monkeypatch.setattr("subprocess.Popen", popen)
+
+    with raises(NodeDrainTimeout) as e:
+        fc.util.kubernetes.drain(logger, "test20", 2, "test drain")
+
+    assert log.has("drain-timeout")

--- a/pkgs/fc/agent/fc/util/tests/test_nixos.py
+++ b/pkgs/fc/agent/fc/util/tests/test_nixos.py
@@ -5,42 +5,13 @@ from unittest import mock
 import pytest
 import structlog
 from fc.util import nixos
+from fc.util.tests import PollingFakePopen
 
 structlog.configure(wrapper_class=structlog.BoundLogger)
 
 FC_CHANNEL = (
     "https://hydra.flyingcircus.io/build/93111/download/1/nixexprs.tar.xz"
 )
-
-
-class FakeCmdStream:
-    def __init__(self, content):
-        self.content = content
-        self.line_gen = (l for l in content.splitlines(keepends=True))
-
-    def readline(self):
-        try:
-            return next(self.line_gen)
-        except StopIteration:
-            return ""
-
-    def read(self):
-        return self.content
-
-
-class PollingFakePopen:
-    def __init__(
-        self, cmd, stdout="", stderr="", poll="stdout", returncode=0, pid=123
-    ):
-        self.cmd = cmd
-        self.stdout = FakeCmdStream(stdout)
-        self.stderr = FakeCmdStream(stderr)
-        self.returncode = returncode
-        self.pid = pid
-        self._poll = poll
-
-    def wait(self):
-        pass
 
 
 def test_get_fc_channel_build(log):

--- a/pkgs/fc/agent/setup.py
+++ b/pkgs/fc/agent/setup.py
@@ -69,6 +69,7 @@ setup(
             "fc-backy=fc.manage.backy:main",
             "fc-collect-garbage=fc.manage.collect_garbage:app",
             "fc-directory=fc.util.directory:directory_cli",
+            "fc-kubernetes=fc.manage.kubernetes:app",
             "fc-maintenance=fc.maintenance.cli:app",
             "fc-manage=fc.manage.cli:app",
             "fc-monitor=fc.manage.monitor:main",

--- a/pkgs/fc/agent/shell.nix
+++ b/pkgs/fc/agent/shell.nix
@@ -1,7 +1,7 @@
 let
-  pkgs = import <nixpkgs> {};
+  pkgs = import <fc> {};
   fcagent = pkgs.python310Packages.callPackage ./. {};
 in
-fcagent.overridePythonAttrs(_: {
+(fcagent.override { enableSlurm = true; }).overridePythonAttrs(_: {
   doCheck = true;
 })


### PR DESCRIPTION
k3s: automated maintenance

- Add fc-kubernetes agent command to be used manually and in maintenance
  enter/leave commands.
- Only allow one k3s-agent in maintenance at the same time
- Drain nodes before running maintenance requests.


@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

- k3s/kubernetes: implement clean automated maintenance. Agent nodes are drained (pods move to other nodes if possible) before executing maintenance requests and are uncordoned after maintenance is finished. Only one agent node can be in maintenance at any given time (PL-131525).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - kubernetes maintenance commands must be limited to `sudo-srv` and `admins` groups
- [x] Security requirements tested? (EVIDENCE)
  - checked on the test k3s cluster that
    - automated maintenance drains and uncordons agent nodes properly
    - drain timeouts cause an agent tempfail
    - server-only nodes cannot be drained (which makes only sense for agents)
    - sudo rules are correct
  - automated tests cover new functionality