### PR TITLE
[22.11] opensearch: auto-migrate existing elasticsearch data

### DIFF
--- a/doc/src/elasticsearch.md
+++ b/doc/src/elasticsearch.md
@@ -14,8 +14,13 @@ they expect the unfree versions of Elasticsearch. Note that *x-pack* features
 are not available in the free version.
 
 Elastic doesn't provide updates to the 7.x line anymore so 7.10.2
-will be the last available version. We are planning to move to OpenSearch
-instead which is a fork of Elasticsearch 7.10.2.
+will be the last available version.
+
+:::{warning}
+This is the last platform version that supports Elasticsearch.
+Migrate to {ref}`nixos-opensearch` which is a fork of Elasticsearch
+7.10.2.
+:::
 
 ## Interaction
 

--- a/doc/src/elasticsearch.md
+++ b/doc/src/elasticsearch.md
@@ -56,7 +56,7 @@ To see the final rendered config for Elasticsearch, use the
 {command}`elasticsearch-show-config` command as service or sudo-srv user.
 
 To activate config changes, run {command}`sudo fc-manage --build`
-(see {ref}`nixos-local` for details).
+  (see {ref}`nixos-local` for details).
 
 ### NixOS Options
 
@@ -130,6 +130,12 @@ Rolling upgrades for Elasticsearch 6 multi-node clusters to 7 are supported.
 Nodes should be upgraded one at a time to ensure continous operation of the
 cluster. Upgrading nodes is done by changing the role of the machine to
 *elasticsearch7*.
+
+### Upgrade/Migration to OpenSearch
+
+Upgrading to OpenSearch is possible when starting from ES7. All indices must
+have been (re-)indexed with ES7 before doing so. See
+{ref}`nixos-opensearch` for the upgrade process.
 
 ## Monitoring
 

--- a/doc/src/opensearch.md
+++ b/doc/src/opensearch.md
@@ -135,9 +135,38 @@ Note that the key must be quoted to stop Nix from interpreting the name
 of the setting as a path to a nested attribute.
 
 
-## Upgrades
+## Migrate/Upgrade from Elasticsearch
 
-We will offer an upgrade path from Elasticsearch 6/7 in the future.
+
+Upgrading to OpenSearch is possible when starting from ES7.
+
+:::{warning}
+All indices must have been indexed with ES7 before migrating or
+starting OpenSearch will fail! See the
+[Elasticsearch documentation](https://www.elastic.co/guide/en/elasticsearch/reference/7.10/reindex-upgrade-inplace.html)
+for instructions.
+:::
+
+Start the migration by activating the `opensearch` role and deactivating the
+`elasticsearch7` role at the same time, followed by a system rebuild with
+{command}`fc-manage switch -be` or just waiting for the next run of the fc-agent service.
+
+On OpenSearch startup, existing data from ES will be copied to the new data
+directory at {file}`/var/lib/opensearch`. This will only happen when the
+destination is empty to avoid overwriting existing OpenSearch data.
+
+The process is usually very fast regardless of the amount of data as the
+*reflink* feature of the XFS file system is used when copying the files. This
+also saves disk space as files are only copied when they have to be
+modified (*copy-on-write*).
+
+The contents of the old data directory at {file}`/srv/elasticsearch` can
+safely be removed after verifying that OpenSearch works as expected:
+
+```shell
+sudo -u opensearch rm -rf /srv/elasticsearch/*
+```
+
 
 ## Monitoring
 

--- a/nixos/services/opensearch.nix
+++ b/nixos/services/opensearch.nix
@@ -160,17 +160,16 @@ in
             migrateDataDir = ''
               set -e
               echo "Running as $(id opensearch)."
-              if ls -A /srv/opensearch/*; then
-                echo "Old data dir /srv/opensearch is not empty."
+              if ls -A /srv/elasticsearch/*; then
+                echo "Old elasticsearch data dir /srv/elasticsearch is not empty."
                 if ls -A /var/lib/opensearch/*; then
-                  echo "Not moving old data, new data dir /var/lib/opensearch already has content!"
+                  echo "Not migrating, new data dir /var/lib/opensearch already has content!"
                 else
-                  echo "Migrating existing data to /var/lib/opensearch..."
-                  mv /srv/opensearch/* /var/lib/opensearch/
-                  rm -rf /srv/opensearch
-                  ln -s /var/lib/opensearch /srv/opensearch
+                  echo "Copying existing Elasticsearch data to /var/lib/opensearch (using lightweight reflinks)..."
+                  cp -r --reflink=always /srv/elasticsearch/* /var/lib/opensearch/
+                  echo "Done. Old data dir /srv/elasticsearch can be deleted when OpenSearch starts up properly and you don't want to go back."
                 fi
-              else echo "Nothing found in old data dir.".
+              else echo "Nothing found in Elasticsearch data dir.".
               fi
 
               chown -R opensearch:opensearch ${cfgUpstream.dataDir}/


### PR DESCRIPTION
(not on 23.05 because we don't have the elasticsearch roles there anymore).

Only works when all indices have been indexed on ES 7.*
ES 6 indices need an re-index before migrating to OpenSearch.

Preserves the old ES data dir in case something goes wrong. Files are copied using reflinks so data is only duplicated when data files are changed by OS. The old dir can be deleted safely when OS is working as expected.

PL-131553

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

- opensearch: implement automated migration from ElasticSearch 7. Note that migrations from ES6 require re-indexing on ES7 before migrating to OpenSearch. See the OpenSearch role docs for details (PL-1315530).

## Security implications


- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - have safe, automated data migration where possible to avoid manual interactions with elevated privileges 
- [x] Security requirements tested? (EVIDENCE)
  - checked that migration from ES7 to OpenSearch works on a test VM and that the migration code doesn't overwrite existing data. Tried with Indices created on ES7 and indices created on ES6/re-indexed on ES7. 