### PR TITLE
agent: resume interrupted requests, other related improvements

### DIFF
--- a/pkgs/fc/agent/fc/maintenance/activity/tests/test_reboot.py
+++ b/pkgs/fc/agent/fc/maintenance/activity/tests/test_reboot.py
@@ -1,3 +1,4 @@
+import fc.maintenance.state
 import pytest
 import yaml
 from fc.maintenance.activity import Activity, RebootType
@@ -97,7 +98,12 @@ def test_reboot_activity_serialize(warm):
     assert serialized == SERIALIZED_ACTIVITY
 
 
-def test_update_activity_deserialize(warm, logger):
+def test_reboot_activity_deserialize(warm, logger):
     deserialized = yaml.load(SERIALIZED_ACTIVITY, Loader=yaml.UnsafeLoader)
     deserialized.set_up_logging(logger)
     assert deserialized.__getstate__() == warm.__getstate__()
+
+
+def test_reboot_should_be_not_resumable(warm):
+    warm.resume()
+    assert warm.returncode == fc.maintenance.state.EXIT_INTERRUPTED

--- a/pkgs/fc/agent/fc/maintenance/activity/tests/test_update.py
+++ b/pkgs/fc/agent/fc/maintenance/activity/tests/test_update.py
@@ -1,6 +1,6 @@
 import textwrap
 from io import StringIO
-from unittest.mock import create_autospec
+from unittest.mock import Mock, create_autospec
 
 import responses
 import yaml
@@ -464,3 +464,10 @@ def test_rich_print(activity):
         "fc.maintenance.activity.update.UpdateActivity (warm reboot needed)\n"
         == str_output
     )
+
+
+def test_update_should_run_on_resume(activity, monkeypatch):
+    run_mock = Mock()
+    monkeypatch.setattr(activity, "run", run_mock)
+    activity.resume()
+    assert run_mock.called

--- a/pkgs/fc/agent/fc/maintenance/activity/tests/test_vm_change.py
+++ b/pkgs/fc/agent/fc/maintenance/activity/tests/test_vm_change.py
@@ -1,4 +1,5 @@
 from io import StringIO
+from unittest.mock import Mock
 
 import yaml
 from fc.maintenance.activity import Activity, RebootType
@@ -108,3 +109,10 @@ def test_rich_print(activity):
         "fc.maintenance.activity.vm_change.VMChangeActivity (cold reboot needed)\n"
         == str_output
     )
+
+
+def test_vm_change_should_run_on_resume(activity, monkeypatch):
+    run_mock = Mock()
+    monkeypatch.setattr(activity, "run", run_mock)
+    activity.resume()
+    assert run_mock.called

--- a/pkgs/fc/agent/fc/maintenance/activity/update.py
+++ b/pkgs/fc/agent/fc/maintenance/activity/update.py
@@ -267,6 +267,10 @@ class UpdateActivity(Activity):
             next_release=self.next_release,
         )
 
+    def resume(self):
+        """It's safe to resume an interrupted update, just run it again."""
+        self.run()
+
     def run(self):
         """Do the update"""
         try:

--- a/pkgs/fc/agent/fc/maintenance/activity/vm_change.py
+++ b/pkgs/fc/agent/fc/maintenance/activity/vm_change.py
@@ -182,3 +182,7 @@ class VMChangeActivity(Activity):
 
     # Running an VMChangeActivity is not needed, so no run method.
     # The request manager handles the reboot required by this activity.
+
+    def resume(self):
+        # There's nothing to do so we can safely "retry" this activity.
+        self.run()

--- a/pkgs/fc/agent/fc/maintenance/activity/vm_change.py
+++ b/pkgs/fc/agent/fc/maintenance/activity/vm_change.py
@@ -114,6 +114,9 @@ class VMChangeActivity(Activity):
         return False
 
     def _need_poweroff_for_memory(self):
+        if self.wanted_memory is None:
+            return False
+
         actual_memory = fc.util.dmi_memory.main()
         if self.current_memory != actual_memory:
             self.log.debug(
@@ -134,10 +137,15 @@ class VMChangeActivity(Activity):
             self.log.debug(
                 "poweroff-mem-needed",
                 msg="Power-off needed to activate new memory size.",
+                actual_memory=actual_memory,
+                wanted_memory=self.wanted_memory,
             )
             return True
 
     def _need_poweroff_for_cores(self):
+        if self.wanted_cores is None:
+            return False
+
         actual_cores = fc.util.vm.count_cores()
         if self.current_cores != actual_cores:
             self.log.debug(
@@ -158,6 +166,8 @@ class VMChangeActivity(Activity):
             self.log.debug(
                 "poweroff-cores-needed",
                 msg="Power-off needed to activate new cores count.",
+                actual_cores=actual_cores,
+                wanted_cores=self.wanted_cores,
             )
             return True
 

--- a/pkgs/fc/agent/fc/maintenance/cli.py
+++ b/pkgs/fc/agent/fc/maintenance/cli.py
@@ -155,6 +155,11 @@ def run(run_all_now: bool = False, force_run: bool = False):
     If you still want to execute requests even if a maintenance enter command returned
     with EXIT_TEMPFAIL or EXIT_POSTPONE, add the --force-run flag.
 
+    WARNING: ignoring the result of enter commands can be dangerous!
+
+    The --force-run flag also runs requests in state 'success' again when they are still
+    in the queue after a recent system reboot.
+
     After executing all runnable requests, requests that want to be postponed
     are postponed (they get a new execution time) and finished requests
     (successful or failed permanently) moved from the current request to the

--- a/pkgs/fc/agent/fc/maintenance/lib/reboot.py
+++ b/pkgs/fc/agent/fc/maintenance/lib/reboot.py
@@ -1,98 +1,18 @@
-"""Scheduled machine reboot.
-
-This activity does nothing if the machine has been booted for another reason in
-the time between creation and execution.
-"""
-
 import subprocess
 import time
 
-from ..activity import Activity
+import fc.maintenance.activity.reboot
+from fc.maintenance.activity import Activity, RebootType
 
 
-class RebootActivity(Activity):
-    def __init__(self, action="reboot"):
-        super().__init__()
-        assert action in ["reboot", "poweroff"]
-        self.action = action
-        self.coldboot = action == "poweroff"
-        # small allowance for VM clock skew
-        self.initial_boottime = self.boottime() + 1
+class RebootActivity(fc.maintenance.activity.reboot.RebootActivity):
+    """Load legacy reboot activities created with previous fc-agent versions."""
 
-    @staticmethod
-    def boottime():
-        with open("/proc/uptime") as f:
-            uptime = float(f.read().split()[0])
-        return time.time() - uptime
+    coldboot: bool
 
-    def boom(self):
-        with open("starttime", "w") as f:
-            print(time.time(), file=f)
-        if self.coldboot:
-            subprocess.check_call(["poweroff"])
-        else:
-            subprocess.check_call(["reboot"])
-        self.finish(
-            "shutdown at {}".format(
-                time.strftime(
-                    "%Y-%m-%d %H:%M:%S UTC", time.gmtime(time.time() + 60)
-                )
-            )
+    def load(self):
+        # We only need to determine the reboot type on load. Everything
+        # else works like the current RebootActivity.
+        self.reboot_needed = (
+            RebootType.COLD if self.coldboot else RebootType.WARM
         )
-        self.request.save()
-        time.sleep(120)  # `shutdown` waits 1min until kicking off action
-
-    def finish(self, message):
-        """Signal to ReqManager that we are done."""
-        self.stdout = message
-        self.returncode = 0
-
-    def other_coldboot(self):
-        """Checks if there is another pending cold boot.
-
-        Given that there are two reboot requests, one warm reboot and a
-        cold reboot, the warm reboot will trigger and update boottime.
-        Thus, the following cold reboot will not be performed (boottime
-        > initial_boottime). But some setups require that the cold
-        reboot must win regardless of issue order (e.g. Qemu), so we
-        must skip warm reboots if a cold reboot is present.
-
-        Returns cold boot request on success.
-        """
-        try:
-            for req in self.request.other_requests():
-                if (
-                    isinstance(req.activity, RebootActivity)
-                    and req.activity.coldboot
-                ):
-                    return req
-        except AttributeError:  # self.request has not been set
-            pass
-        return
-
-    def run(self):
-        if not self.coldboot:
-            coldboot_req = self.other_coldboot()
-            if coldboot_req:
-                return self.finish(
-                    "cold boot pending ({}), skipped".format(coldboot_req.id)
-                )
-        boottime = self.boottime()
-        if not boottime > self.initial_boottime:
-            self.boom()
-            return
-        try:
-            with open("starttime") as f:
-                started = float(f.read().strip())
-                self.duration = time.time() - started
-        except (IOError, ValueError):
-            pass
-        self.finish(
-            "booted at {} UTC".format(time.asctime(time.gmtime(boottime)))
-        )
-
-    def __rich__(self):
-        if self.coldboot:
-            return "Cold reboot"
-        else:
-            return "Warm reboot"

--- a/pkgs/fc/agent/fc/maintenance/lib/reboot.py
+++ b/pkgs/fc/agent/fc/maintenance/lib/reboot.py
@@ -16,3 +16,15 @@ class RebootActivity(fc.maintenance.activity.reboot.RebootActivity):
         self.reboot_needed = (
             RebootType.COLD if self.coldboot else RebootType.WARM
         )
+
+    def resume(self):
+        self.log.info(
+            "legacy-reboot-activity-noop",
+            _replace_msg=(
+                "Finalizing a legacy reboot activity which has been created by an "
+                "earlier version of fc-agent and is still in 'running' state. "
+                "Doing nothing as the reboot likely has already happened. "
+            ),
+        )
+        self.reboot_needed = None
+        self.returncode = 0

--- a/pkgs/fc/agent/fc/maintenance/lib/tests/test_legacy_reboot.py
+++ b/pkgs/fc/agent/fc/maintenance/lib/tests/test_legacy_reboot.py
@@ -1,3 +1,4 @@
+import fc.maintenance.lib.reboot
 from fc.maintenance import Request
 from fc.maintenance.activity import RebootType
 
@@ -34,3 +35,10 @@ def test_legacy_reboot_activity_loading_serialization_should_work(
     activity = request.activity
     assert activity.reboot_needed == RebootType.COLD
     assert activity.__rich__()
+
+
+def test_legacy_reboot_should_be_noop_success_when_already_running():
+    activity = fc.maintenance.lib.reboot.RebootActivity()
+    activity.resume()
+    assert activity.reboot_needed is None
+    assert activity.returncode == 0

--- a/pkgs/fc/agent/fc/maintenance/lib/tests/test_reboot.py
+++ b/pkgs/fc/agent/fc/maintenance/lib/tests/test_reboot.py
@@ -1,0 +1,36 @@
+from fc.maintenance import Request
+from fc.maintenance.activity import RebootType
+
+SERIALIZED_REQUEST = """
+!!python/object:fc.maintenance.request.Request
+_comment: null
+_estimate: null
+_reqid: RqZnZSVRD6d3ojcmhpaCmv
+_reqmanager: null
+activity: !!python/object:fc.maintenance.lib.reboot.RebootActivity
+  action: reboot
+  coldboot: true
+  initial_boottime: 1695578792.5227735
+added_at: 2023-09-29 22:23:34.623081+00:00
+attempts: []
+comment: Reboot to activate changed kernel (5.15.119 to 6.1.51)
+dir: /var/spool/maintenance/requests/RqZnZSVRD6d3ojcmhpaCmv
+estimate: !!python/object:fc.maintenance.estimate.Estimate
+  value: 600.0
+last_scheduled_at: 2023-09-29 22:34:11.155626+00:00
+next_due: 2023-09-30 07:30:00+00:00
+state: !!python/object/apply:fc.maintenance.state.State
+- '='
+updated_at: null
+"""
+
+
+def test_legacy_reboot_activity_loading_serialization_should_work(
+    logger, tmp_path
+):
+    request_path = tmp_path / "request.yaml"
+    request_path.write_text(SERIALIZED_REQUEST)
+    request = Request.load(tmp_path, logger)
+    activity = request.activity
+    assert activity.reboot_needed == RebootType.COLD
+    assert activity.__rich__()

--- a/pkgs/fc/agent/fc/maintenance/lib/tests/test_shellscript.py
+++ b/pkgs/fc/agent/fc/maintenance/lib/tests/test_shellscript.py
@@ -1,5 +1,6 @@
 import os
 
+import fc.maintenance.state
 import pytest
 from fc.maintenance.lib.shellscript import ShellScriptActivity
 
@@ -32,3 +33,9 @@ sys.exit(5)
     assert a.stdout == "hello\n"
     assert a.stderr == "world\n"
     assert a.returncode == 5
+
+
+def test_shellscript_should_be_not_resumable():
+    activity = ShellScriptActivity("true")
+    activity.resume()
+    assert activity.returncode == fc.maintenance.state.EXIT_INTERRUPTED

--- a/pkgs/fc/agent/fc/maintenance/reqmanager.py
+++ b/pkgs/fc/agent/fc/maintenance/reqmanager.py
@@ -426,12 +426,14 @@ class ReqManager:
             runnable_requests = sorted(
                 r
                 for r in self.requests.values()
-                if r.state in (State.pending, State.due)
+                if r.state in (State.pending, State.due, State.running)
             )
         else:
             # Normal operation
             runnable_requests = sorted(
-                r for r in self.requests.values() if r.state == State.due
+                r
+                for r in self.requests.values()
+                if r.state in (State.due, State.running)
             )
 
         if not runnable_requests:

--- a/pkgs/fc/agent/fc/maintenance/reqmanager.py
+++ b/pkgs/fc/agent/fc/maintenance/reqmanager.py
@@ -405,18 +405,31 @@ class ReqManager:
                 {key: {"result": "deleted"} for key in disappeared}
             )
 
-    def runnable(self, run_all_now=False):
+    def runnable(self, run_all_now=False, force_run=False):
         """Generate due Requests in running order."""
-        if run_all_now:
+        if run_all_now and force_run:
             self.log.warn(
-                "execute-all-requests-now",
+                "execute-all-requests-now-force",
                 _replace_msg=(
-                    "Run all mode requested, treating all requests as runnable."
+                    "Run-all mode with force requested. "
+                    "Treating all requests as runnable."
                 ),
             )
             runnable_requests = sorted(self.requests.values())
-
+        elif run_all_now:
+            self.log.warn(
+                "execute-all-requests-now",
+                _replace_msg=(
+                    "Run all mode requested, treating pending requests as runnable."
+                ),
+            )
+            runnable_requests = sorted(
+                r
+                for r in self.requests.values()
+                if r.state in (State.pending, State.due)
+            )
         else:
+            # Normal operation
             runnable_requests = sorted(
                 r for r in self.requests.values() if r.state == State.due
             )
@@ -701,10 +714,11 @@ class ReqManager:
         are still respected so requests may actually not run.
 
         When `force_run` is given, postpone and tempfail from maintenance enter command
-        are ignored and requests are run regardless. WARNING: this can be dangerous!
+        are ignored and requests are run regardless. This also runs requests in state
+        'success' again when they are still in the queue after a recent system reboot.
         """
 
-        runnable_requests = self.runnable(run_all_now)
+        runnable_requests = self.runnable(run_all_now, force_run)
         if not runnable_requests:
             self.leave_maintenance()
             self._write_stats_for_execute()

--- a/pkgs/fc/agent/fc/maintenance/request.py
+++ b/pkgs/fc/agent/fc/maintenance/request.py
@@ -277,12 +277,16 @@ class Request:
         )
         attempt = Attempt()  # sets start time
         try:
+            resuming = self.state == State.running
             self.state = State.running
             self.attempts.append(attempt)
             self.save()
             with cd(self.dir):
                 try:
-                    self.activity.run()
+                    if resuming:
+                        self.activity.resume()
+                    else:
+                        self.activity.run()
                     attempt.record(self.activity)
                 except Exception as e:
                     attempt.returncode = 70  # EX_SOFTWARE

--- a/pkgs/fc/agent/fc/maintenance/state.py
+++ b/pkgs/fc/agent/fc/maintenance/state.py
@@ -35,6 +35,7 @@ ARCHIVE = {State.success, State.error, State.deleted}
 EXIT_SUCCESS = 0
 EXIT_POSTPONE = 69
 EXIT_TEMPFAIL = 75
+EXIT_INTERRUPTED = 80
 
 
 def evaluate_state(returncode):

--- a/pkgs/fc/agent/fc/maintenance/tests/test_reqmanager.py
+++ b/pkgs/fc/agent/fc/maintenance/tests/test_reqmanager.py
@@ -268,7 +268,7 @@ def test_execute_postpone(log, reqmanager, monkeypatch):
     def enter_maintenance_postpone():
         raise PostponeMaintenance()
 
-    reqmanager.runnable = lambda r: [req]
+    reqmanager.runnable = lambda run_all_now, force_run: [req]
     reqmanager.enter_maintenance = enter_maintenance_postpone
     reqmanager.leave_maintenance = Mock()
     reqmanager.execute()
@@ -286,7 +286,7 @@ def test_execute_tempfail(log, reqmanager, monkeypatch):
     def enter_maintenance_tempfail():
         raise TempfailMaintenance()
 
-    reqmanager.runnable = lambda r: [req]
+    reqmanager.runnable = lambda run_all_now, force_run: [req]
     reqmanager.enter_maintenance = enter_maintenance_tempfail
     reqmanager.leave_maintenance = MagicMock()
     reqmanager.execute()
@@ -300,7 +300,7 @@ def test_execute_tempfail(log, reqmanager, monkeypatch):
 @unittest.mock.patch("fc.util.directory.connect")
 def test_execute_activity_no_reboot(connect, run, reqmanager, log):
     req = reqmanager.add(Request(Activity(), 1))
-    reqmanager.runnable = lambda r: [req]
+    reqmanager.runnable = lambda run_all_now, force_run: [req]
     reqmanager.execute()
     run.assert_has_calls(
         [


### PR DESCRIPTION
agent: implement resuming interrupted requests

Before, requests that had been persisted in state "running" were just
ignored by the ReqManager and had to be cleaned up manually.

Now, the default behaviour defined in Activity.resume() is to put the
activity into an error state (special value EXT_INTERRUPTED = 80) to
avoid re-running non-idempotent activity that could be unsafe to run
again.

Idempotent acivities (UpdateActivity, VMChangeActivity) are just
run again.

The legacy reboot activity is a special case: it was usually interrupted
by the planned reboot triggered in activity.run() so we just mark it
as successful to clean it up.

agent: handle legacy reboot activities properly

Old reboot activities rebooted during activity execution which we don't
want to do anymore with the new ReqManager design. It's possible that
they have been created before switching to new agent code which tries to
execute them, leading to an unexpected reboot. Instead, we now use the
new implementation which is basically a no-op and defers rebooting to
the ReqManager.

VMChangeActivity: do not check for reboot when value is None

Avoids unneccessary work and log messages that make no sense.

agent: make fc-maintenance --run-all-now safer

Before, "run all" really meant this, so even finished requests executed
when `--run-all-now` was given. The flag is now interpreted to include
pending requests into the runnable request list but not more. If you
really want every request to run (which is dangerous because requests
might not be idempotent when they succeeded, for example), add
--force-run which also ignores postpone and tempfail situations caused
by maintenance enter commands.

PL-131849

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

- (internal, I guess)

## Security implications

Mostly changes to automated actions, no new capabilities for normal users.

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - reduce risk of unintended, possibly dangerous behaviour when special flags like --run-all-now are used   
  - avoid cluttering monitoring and logs with things that could be cleaned up automatically  
- [x] Security requirements tested? (EVIDENCE)
  - checked on a test VM that --run-all-now and --force-run work as expected (tried with an ShellScriptActivity which was already in State.success. --run-all-now didn't run it again, but --force-run did)
  - checked on a test VM that running, non-idempotent activites are put in a failure state (tried with an ShellScriptActivity in State.running) and that legacy reboot requests are a no-op now.
  - automated tests cove resuming behaviour of activities and general execution of requests