### PR TITLE
Fix various issues with release info handling

### DIFF
--- a/nixos/platform/shell.nix
+++ b/nixos/platform/shell.nix
@@ -76,7 +76,7 @@ in
       Status:     https://status.flyingcircus.io/
       Docs:       https://doc.flyingcircus.io/
       Release:    ${opt isStableRelease "${release.release_name} (" + config.system.nixos.label + opt isStableRelease ")"}
-      ${opt isStableRelease ("ChangeLog:  " + release.release_changelog)}
+      ${opt isStableRelease ("ChangeLog:  " + release.release_changelog or "https://doc.flyingcircus.io/platform/changes/index.html")}
 
     '' +
     (opt (enc ? name && parameters ? location && parameters ? environment)

--- a/pkgs/fc/agent/fc/util/tests/test_enc.py
+++ b/pkgs/fc/agent/fc/util/tests/test_enc.py
@@ -43,6 +43,7 @@ def test_initialize_enc_should_not_crash_when_initial_data_missing(
     assert log.has("initialize-enc-initial-data-not-found")
 
 
+@unittest.mock.patch("fc.util.enc.write_release_info")
 @unittest.mock.patch("fc.util.enc.write_system_state")
 @unittest.mock.patch("fc.util.enc.update_enc_nixos_config")
 @unittest.mock.patch("fc.util.enc.update_inventory")
@@ -52,6 +53,7 @@ def test_update_enc(
     update_inventory,
     update_enc_nixos_config,
     write_system_state,
+    write_release_info,
     log,
     logger,
     tmp_path,
@@ -67,3 +69,4 @@ def test_update_enc(
     update_inventory.assert_called_with(logger, enc_data)
     update_enc_nixos_config.assert_called_with(logger, enc_data, enc_path)
     write_system_state.assert_called_with(logger)
+    write_release_info.assert_called_with(logger, enc_data)


### PR DESCRIPTION
- Don't break system build when release changelog is missing for a stable release, use the changelog overview page as fallback value.
- Update release info from fresh ENC data, not previous ENC data loaded from disk.
- Handle null/None values for `release_changelog` in ENC parameters and treat them as empty string.

PL-131852

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [x] Security requirements tested? (EVIDENCE)
  - tested on a VM with dev checkout, rolling release channel and production channel