### PR TITLE
Add fd, lnav packages

### DIFF
--- a/nixos/platform/packages.nix
+++ b/nixos/platform/packages.nix
@@ -14,6 +14,7 @@
         dnsutils
         dstat
         ethtool
+        fd
         file
         fc.logcheckhelper
         fio
@@ -30,6 +31,7 @@
         latencytop_nox
         links2_nox
         lsof
+        lnav
         lynx
         magic-wormhole
         mailutils


### PR DESCRIPTION
[Lnav](https://lnav.org/) is very useful for navigating large log files, [fd](https://github.com/sharkdp/fd) is a small utility for finding files fast in nested directories

@nichmoe 

@flyingcircusio/release-managers

## Release process

Impact: Add additional packages

Changelog: lnav, fd installed by default packages on all machines

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - [x] just add two packages with no known security vulnerabilities and limited attack surface
- [x] Security requirements tested? (EVIDENCE)
  - [x] the packages can run on all VMs (x64)
  - [x] the building of packages has been tested with nix shells on several VMs


