### PR TITLE
agent: reduce directory errors, easier debugging, various improvements

### DIFF
--- a/nixos/platform/agent.nix
+++ b/nixos/platform/agent.nix
@@ -191,23 +191,14 @@ in
           commands = [
             "${pkgs.fc.agent}/bin/fc-collect-garbage"
             "${pkgs.fc.agent}/bin/fc-manage"
-            "${pkgs.fc.agent}/bin/fc-maintenance list"
-            "${pkgs.fc.agent}/bin/fc-maintenance show"
             "${pkgs.fc.agent}/bin/fc-maintenance delete"
-            "${pkgs.fc.agent}/bin/fc-maintenance metrics"
-            "${pkgs.fc.agent}/bin/fc-maintenance check"
+            "${pkgs.fc.agent}/bin/fc-maintenance -v delete"
           ];
           groups = [ "admins" "sudo-srv" "service" ];
         }
         {
           commands = [ "${pkgs.fc.agent}/bin/fc-manage check" ];
-          groups = [ "sensuclient" ];
-        }
-        {
-          commands = [
-            "${pkgs.fc.agent}/bin/fc-maintenance metrics"
-          ];
-          groups = [ "telegraf" ];
+          users = [ "sensuclient" ];
         }
         {
           commands = [ "${pkgs.fc.agent}/bin/fc-postgresql check-autoupgrade-unexpected-dbs" ];
@@ -218,6 +209,10 @@ in
           commands = [
             "${pkgs.fc.agent}/bin/fc-maintenance run"
             "${pkgs.fc.agent}/bin/fc-maintenance run --run-all-now"
+            "${pkgs.fc.agent}/bin/fc-maintenance schedule"
+            "${pkgs.fc.agent}/bin/fc-maintenance -v run"
+            "${pkgs.fc.agent}/bin/fc-maintenance -v run --run-all-now"
+            "${pkgs.fc.agent}/bin/fc-maintenance -v schedule"
           ];
           groups = [ "admins" ];
         }
@@ -402,14 +397,14 @@ in
           };
           fc-maintenance = {
             notification = "fc-maintenance check failed.";
-            command = "sudo ${pkgs.fc.agent}/bin/fc-maintenance check";
+            command = "${pkgs.fc.agent}/bin/fc-maintenance check";
             interval = 180;
           };
         };
       };
       flyingcircus.services.telegraf.inputs = {
         exec = [{
-          commands = [ "/run/wrappers/bin/sudo ${pkgs.fc.agent}/bin/fc-maintenance metrics" ];
+          commands = [ "${pkgs.fc.agent}/bin/fc-maintenance metrics" ];
           timeout = "10s";
           data_format = "json";
           json_name_key = "name";

--- a/pkgs/fc/agent/default.nix
+++ b/pkgs/fc/agent/default.nix
@@ -35,6 +35,20 @@ let
     buildInputs = [ pytest structlog ];
   };
 
+  stamina = py.buildPythonPackage rec {
+    pname = "stamina";
+    version = "23.1.0";
+    format = "pyproject";
+
+    src = fetchPypi {
+      inherit pname version;
+      hash = "sha256-sWzj1S1liqdduBP8amZht3Cr/qkV9yzaSOMl8qeFR4Y=";
+    };
+
+    nativeBuildInputs = with py; [ hatchling hatch-vcs hatch-fancy-pypi-readme ];
+    propagatedBuildInputs = with py; [ structlog tenacity typing-extensions ];
+  };
+
 in
 buildPythonPackage rec {
   name = "fc-agent-${version}";
@@ -68,6 +82,7 @@ buildPythonPackage rec {
     py.structlog
     py.typer
     py.pyyaml
+    stamina
     util-linux
   ] ++ lib.optionals stdenv.isLinux [
     dmidecode

--- a/pkgs/fc/agent/default.nix
+++ b/pkgs/fc/agent/default.nix
@@ -15,6 +15,7 @@
 , xfsprogs
 , pytest
 , structlog
+, enableSlurm ? stdenv.isLinux
 }:
 
 let
@@ -72,10 +73,11 @@ buildPythonPackage rec {
     dmidecode
     gptfdisk
     multipath-tools
-    py.pyslurm
     py.pystemd
     py.systemd
     xfsprogs
+  ] ++ lib.optionals enableSlurm [
+    py.pyslurm
   ];
   dontStrip = true;
   doCheck = true;

--- a/pkgs/fc/agent/fc/maintenance/activity/update.py
+++ b/pkgs/fc/agent/fc/maintenance/activity/update.py
@@ -10,6 +10,7 @@ import structlog
 from fc.maintenance import state
 from fc.maintenance.estimate import Estimate
 from fc.util import nixos
+from fc.util.logging import init_command_logging
 from fc.util.nixos import UnitChanges
 
 from ...util.channel import Channel
@@ -281,6 +282,8 @@ class UpdateActivity(Activity):
                 self.returncode = 0
                 return
 
+            init_command_logging(self.log)
+
             system_path = nixos.build_system(
                 self.next_channel_url, log=self.log
             )
@@ -304,6 +307,9 @@ class UpdateActivity(Activity):
             next_version=self.next_version,
             next_environment=self.next_environment,
         )
+
+        # No clean up of the command log file needed as we initialized
+        # logging only after checking that the activity changes the system.
 
         self.returncode = 0
 

--- a/pkgs/fc/agent/fc/maintenance/activity/vm_change.py
+++ b/pkgs/fc/agent/fc/maintenance/activity/vm_change.py
@@ -177,12 +177,11 @@ class VMChangeActivity(Activity):
         else:
             self.reboot_needed = None
 
-    def load(self):
+    def run(self):
         self._update_reboot_needed()
-
-    # Running an VMChangeActivity is not needed, so no run method.
-    # The request manager handles the reboot required by this activity.
+        self.returncode = 0
 
     def resume(self):
-        # There's nothing to do so we can safely "retry" this activity.
+        # run() just checks if the reboot is needed at the moment so we can safely
+        # retry this activity.
         self.run()

--- a/pkgs/fc/agent/fc/maintenance/cli.py
+++ b/pkgs/fc/agent/fc/maintenance/cli.py
@@ -31,9 +31,10 @@ from fc.util.logging import (
     init_command_logging,
     init_logging,
 )
-from typer import Argument, Exit, Option, Typer
+from fc.util.typer_utils import FCTyperApp
+from typer import Argument, Exit, Option
 
-app = Typer(pretty_exceptions_show_locals=False)
+app = FCTyperApp("fc-maintenance")
 log = structlog.get_logger()
 
 
@@ -52,7 +53,7 @@ rm: ReqManager
 
 
 @app.callback(no_args_is_help=True)
-def main(
+def fc_maintenance(
     verbose: bool = Option(
         False,
         "--verbose",

--- a/pkgs/fc/agent/fc/maintenance/lib/shellscript.py
+++ b/pkgs/fc/agent/fc/maintenance/lib/shellscript.py
@@ -8,6 +8,7 @@ file, it is executed with /bin/sh.
 import os
 import subprocess
 
+import rich.console
 import rich.syntax
 import rich.text
 
@@ -38,5 +39,8 @@ class ShellScriptActivity(Activity):
         self.returncode = p.returncode
 
     def __rich__(self):
-        syntax = rich.syntax.Syntax(self.script, "shell", line_numbers=True)
-        return syntax
+        lines = self.script.splitlines()
+        syntax = rich.syntax.Syntax(
+            self.script, "shell", line_numbers=len(lines) > 2
+        )
+        return rich.console.Group("Execute script:\n", syntax)

--- a/pkgs/fc/agent/fc/maintenance/reqmanager.py
+++ b/pkgs/fc/agent/fc/maintenance/reqmanager.py
@@ -351,7 +351,7 @@ class ReqManager:
     @require_lock
     @require_directory
     def schedule(self):
-        """Triggers request scheduling on server."""
+        """Gets (updated) start times for pending requests from the directory."""
         self.log.debug("schedule-start")
 
         schedule_maintenance = {
@@ -360,6 +360,7 @@ class ReqManager:
                 "comment": req.comment,
             }
             for reqid, req in self.requests.items()
+            if req.state == State.pending
         }
         if schedule_maintenance:
             self.log.debug(

--- a/pkgs/fc/agent/fc/maintenance/reqmanager.py
+++ b/pkgs/fc/agent/fc/maintenance/reqmanager.py
@@ -10,13 +10,12 @@ import socket
 import subprocess
 import sys
 import time
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import NamedTuple
 
 import fc.maintenance.state
 import fc.util.directory
-import pytz
 import rich
 import rich.syntax
 import structlog
@@ -964,7 +963,8 @@ class ReqManager:
         if name_matches:
             return sorted(
                 [Request.load(name, self.log) for name in name_matches],
-                key=lambda r: r.added_at or datetime.fromtimestamp(0),
+                key=lambda r: r.added_at
+                or datetime.fromtimestamp(0, tz=timezone.utc),
             )
         return []
 
@@ -977,7 +977,8 @@ class ReqManager:
         if name_matches:
             return sorted(
                 [Request.load(name, self.log) for name in name_matches],
-                key=lambda r: r.added_at or datetime.fromtimestamp(0),
+                key=lambda r: r.added_at
+                or datetime.fromtimestamp(0, tz=timezone.utc),
             )
         return []
 
@@ -1139,7 +1140,7 @@ class ReqManager:
         if num_scheduled := metrics["requests_scheduled"]:
             next_due = format_datetime(
                 datetime.fromtimestamp(
-                    metrics["request_next_due_at"], tz=pytz.utc
+                    metrics["request_next_due_at"], tz=timezone.utc
                 )
             )
             if num_scheduled == 1:

--- a/pkgs/fc/agent/fc/maintenance/reqmanager.py
+++ b/pkgs/fc/agent/fc/maintenance/reqmanager.py
@@ -21,9 +21,11 @@ import rich.syntax
 import structlog
 from fc.maintenance.activity import RebootType
 from fc.util.checks import CheckResult
+from fc.util.subprocess_helper import get_popen_stdout_lines
 from fc.util.time_date import format_datetime, utcnow
 from rich.table import Table
 
+from . import state
 from .request import Request, RequestMergeResult
 from .state import ARCHIVE, EXIT_POSTPONE, EXIT_TEMPFAIL, State
 
@@ -560,24 +562,50 @@ class ReqManager:
         for name, command in self.config["maintenance-enter"].items():
             if not command.strip():
                 continue
-            self.log.info(
-                "enter-maintenance-subsystem", subsystem=name, command=command
+
+            log = self.log.bind(
+                subsystem=name,
             )
-            try:
-                # XXX: capture output
-                subprocess.run(command, shell=True, check=True)
-            except subprocess.CalledProcessError as e:
-                if e.returncode == EXIT_POSTPONE:
-                    self.log.info(
+
+            proc = subprocess.Popen(
+                command,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                shell=True,
+                text=True,
+            )
+            log.info(
+                "enter-maintenance-cmd",
+                _replace_msg=(
+                    "{subsystem}: Maintenance enter command started with PID "
+                    "{cmd_pid}: `{command}`"
+                ),
+                command=command,
+                cmd_pid=proc.pid,
+            )
+
+            stdout_lines = get_popen_stdout_lines(
+                proc, log, "enter-maintenance-out"
+            )
+            stdout = "".join(stdout_lines)
+            proc.wait()
+
+            match proc.returncode:
+                case 0:
+                    log.debug("enter-maintenance-cmd-success")
+                case state.EXIT_POSTPONE:
+                    log.info(
                         "enter-maintenance-postpone",
                         command=command,
                         _replace_msg=(
-                            "Command `{command}` requested to postpone all requests."
+                            "Command `{command}` requested to postpone all "
+                            "requests."
                         ),
                     )
+                    log.debug("enter-maintenance-postpone-out", stdout=stdout)
                     postpone_seen = True
-                elif e.returncode == EXIT_TEMPFAIL:
-                    self.log.info(
+                case state.EXIT_TEMPFAIL:
+                    log.info(
                         "enter-maintenance-tempfail",
                         command=command,
                         _replace_msg=(
@@ -585,9 +613,15 @@ class ReqManager:
                             "Requests should be tried again next time."
                         ),
                     )
+                    log.debug("enter-maintenance-tempfail-out", stdout=stdout)
                     tempfail_seen = True
-                else:
-                    raise
+                case error:
+                    log.error(
+                        "enter-maintenance-fail",
+                        command=command,
+                        exit_code=error,
+                    )
+                    raise subprocess.CalledProcessError(error, command, stdout)
 
         if postpone_seen:
             raise PostponeMaintenance()
@@ -749,8 +783,8 @@ class ReqManager:
             self.log.warn(
                 "execute-requests-force",
                 _replace_msg=(
-                    "Due requests will be executed regardless of the temporary failure "
-                    "of a maintenance enter command."
+                    "Due requests will be executed regardless of the "
+                    "(temporary) failure of a maintenance enter command."
                 ),
             )
             return HandleEnterExceptionResult()
@@ -760,8 +794,8 @@ class ReqManager:
                 "run-all-now-force",
                 _replace_msg=(
                     "Run all mode requested and force mode activated: "
-                    "All requests will be executed now regardless of the temporary "
-                    "failure of a maintenance enter command."
+                    "All requests will be executed now regardless of the "
+                    "(temporary) failure of a maintenance enter command."
                 ),
             )
             return HandleEnterExceptionResult()
@@ -847,6 +881,9 @@ class ReqManager:
         are ignored and requests are run regardless. This also runs requests in state
         'success' again when they are still in the queue after a recent system reboot.
         """
+        self.log.debug(
+            "execute-start", run_all_now=run_all_now, force_run=force_run
+        )
 
         runnable_requests = self._runnable(run_all_now, force_run)
         if not runnable_requests:
@@ -871,7 +908,21 @@ class ReqManager:
         except TempfailMaintenance:
             res = self._handle_enter_tempfail(run_all_now, force_run)
             if res.exit:
-                # Stay in maintenance mode.
+                # Stay in maintenance mode as we expect the temporary failure
+                # to go away on the next agent run.
+                self._write_stats_for_execute()
+                return
+
+        except Exception:
+            # Other exceptions are similar to tempfail, just with additional
+            # logging. Could an error from a enter command, from the directory
+            # or an internal one.
+            self.log.error("execute-enter-maintenance-failed", exc_info=True)
+            res = self._handle_enter_tempfail(run_all_now, force_run)
+            if res.exit:
+                # Might already be in maintenance or not, depending on where
+                # _enter_maintenance failed. That's ok, the next agent
+                # run can continue in either case.
                 self._write_stats_for_execute()
                 return
 

--- a/pkgs/fc/agent/fc/maintenance/request.py
+++ b/pkgs/fc/agent/fc/maintenance/request.py
@@ -64,6 +64,27 @@ class Attempt:
         elif self.started and not self.duration:
             self.duration = (self.finished - self.started).total_seconds()
 
+    def __rich__(self):
+        table = rich.table.Table(show_header=False, show_edge=False)
+        table.add_column()
+        table.add_column()
+        table.add_row("Started", format_datetime(self.started) or "-")
+        table.add_row("Finished", format_datetime(self.finished) or "-")
+        table.add_row(
+            "Duration",
+            f"{self.duration:.4}s" if self.duration is not None else "-",
+        )
+
+        table.add_row(
+            "Exit code",
+            str(self.returncode) if self.returncode is not None else "-",
+        )
+        if self.stdout:
+            table.add_row("Stdout", self.stdout)
+        if self.stderr:
+            table.add_row("Stderr", self.stderr)
+        return table
+
 
 class Request:
     MAX_RETRIES = 48
@@ -140,22 +161,20 @@ class Request:
 
     def __rich_repr__(self):
         yield "ID", self._reqid
-        yield "state", str(self.state)
+        yield "State", str(self.state)
         if self.next_due:
-            yield "next_due", format_datetime(self.next_due)
+            yield "Due at", format_datetime(self.next_due)
         if self.added_at:
-            yield "added_at", format_datetime(self.added_at)
+            yield "Added at", format_datetime(self.added_at)
         if self.updated_at:
-            yield "updated_at", format_datetime(self.updated_at)
+            yield "Updated at", format_datetime(self.updated_at)
         if self.last_scheduled_at:
-            yield "last_scheduled_at", format_datetime(self.last_scheduled_at)
-        yield "estimate", str(self.estimate)
-        yield "comment", self.comment
-        yield "activity", self.activity
-        yield "attempts", ", ".join(
-            f"{format_datetime(a.finished)} (exit {a.returncode})"
-            for a in self.attempts
-        )
+            yield "Scheduled at", format_datetime(self.last_scheduled_at)
+        yield "Estimate", str(self.estimate)
+        yield "Comment", self.comment
+        yield "Activity", self.activity
+        for pos, attempt in enumerate(self.attempts):
+            yield (f"Attempt {pos}", attempt)
 
     def set_up_logging(self, log):
         log = log.bind(request=self.id)

--- a/pkgs/fc/agent/fc/maintenance/tests/test_cli.py
+++ b/pkgs/fc/agent/fc/maintenance/tests/test_cli.py
@@ -43,10 +43,10 @@ def app_main_args(tmp_path, agent_maintenance_config):
 
 
 @pytest.fixture
-def invoke_app(app_main_args):
-    runner = typer.testing.CliRunner()
+def _invoke_app(app_main_args, monkeypatch):
+    def _invoke_app_wrapper(*args, exit_code=0):
+        runner = typer.testing.CliRunner()
 
-    def _invoke_app(*args, exit_code=0):
         with unittest.mock.patch("fc.maintenance.cli.ReqManager"):
             result = runner.invoke(
                 fc.maintenance.cli.app, app_main_args + args
@@ -55,66 +55,101 @@ def invoke_app(app_main_args):
                 result.exit_code == exit_code
             ), f"unexpected exit code {result.exit_code}, output: {result.output}"
 
+    return _invoke_app_wrapper
+
+
+@pytest.fixture
+def invoke_app_as_root(_invoke_app, monkeypatch):
+    monkeypatch.setattr("os.getuid", lambda: 0)
     return _invoke_app
 
 
-def test_invoke_run(invoke_app):
-    invoke_app("run")
+@pytest.fixture
+def invoke_app_as_normal_user(_invoke_app, monkeypatch):
+    monkeypatch.setattr("os.getuid", lambda: 1000)
+    return _invoke_app
+
+
+def test_invoke_schedule(invoke_app_as_root):
+    invoke_app_as_root("schedule")
+    fc.maintenance.cli.rm.schedule.assert_called_once()
+
+
+def test_invoke_run(invoke_app_as_root):
+    invoke_app_as_root("run")
     fc.maintenance.cli.rm.execute.assert_called_once_with(False, False)
     fc.maintenance.cli.rm.postpone.assert_called_once()
     fc.maintenance.cli.rm.archive.assert_called_once()
 
 
-def test_invoke_run_all_now(invoke_app):
-    invoke_app("run", "--run-all-now")
+def test_invoke_run_as_normal_user_should_fail(invoke_app_as_normal_user):
+    invoke_app_as_normal_user("run", exit_code=77)
+
+
+def test_invoke_run_all_now(invoke_app_as_root):
+    invoke_app_as_root("run", "--run-all-now")
     fc.maintenance.cli.rm.execute.assert_called_once_with(True, False)
 
 
-def test_invoke_run_all_now_force_run(invoke_app):
-    invoke_app("run", "--run-all-now", "--force-run")
+def test_invoke_run_all_now_force_run(invoke_app_as_root):
+    invoke_app_as_root("run", "--run-all-now", "--force-run")
     fc.maintenance.cli.rm.execute.assert_called_once_with(True, True)
 
 
-def test_invoke_list(invoke_app):
-    invoke_app("list")
-    fc.maintenance.cli.rm.list.assert_called_once()
-
-
-def test_invoke_show(invoke_app):
-    invoke_app("show")
-    fc.maintenance.cli.rm.show.assert_called_once()
-
-
-def test_invoke_show_request_id_dump_yaml(invoke_app):
-    invoke_app("show", "123abc", "--dump-yaml")
-    fc.maintenance.cli.rm.show.assert_called_once_with("123abc", True)
-
-
-def test_invoke_delete(invoke_app):
-    invoke_app("delete", "123abc")
+def test_invoke_delete(invoke_app_as_root):
+    invoke_app_as_root("delete", "123abc")
     fc.maintenance.cli.rm.delete.assert_called_once_with("123abc")
 
 
-def test_invoke_schedule(invoke_app):
-    invoke_app("schedule")
-    fc.maintenance.cli.rm.schedule.assert_called_once()
+@pytest.mark.parametrize(
+    "args",
+    [
+        ["schedule"],
+        ["run"],
+        ["delete", "123abc"],
+        ["request", "script", "comment", "true"],
+        ["request", "reboot"],
+        ["request", "update"],
+        ["request", "system-properties"],
+    ],
+)
+def test_invoke_root_cmds_as_normal_user_should_fail(
+    args,
+    invoke_app_as_normal_user,
+):
+    invoke_app_as_normal_user(*args, exit_code=77)
 
 
-def test_invoke_request_run_script(invoke_app):
-    invoke_app("request", "script", "comment", "true")
+def test_invoke_list(invoke_app_as_normal_user):
+    invoke_app_as_normal_user("list")
+    fc.maintenance.cli.rm.list_requests.assert_called_once()
+
+
+def test_invoke_show(invoke_app_as_normal_user):
+    invoke_app_as_normal_user("show")
+    fc.maintenance.cli.rm.show_request.assert_called_once()
+
+
+def test_invoke_show_request_id_dump_yaml(invoke_app_as_normal_user):
+    invoke_app_as_normal_user("show", "123abc", "--dump-yaml")
+    fc.maintenance.cli.rm.show_request.assert_called_once_with("123abc", True)
+
+
+def test_invoke_request_run_script(invoke_app_as_root):
+    invoke_app_as_root("request", "script", "comment", "true")
     fc.maintenance.cli.rm.add.assert_called_once()
 
 
 @unittest.mock.patch("fc.maintenance.cli.RebootActivity")
-def test_invoke_request_warm_reboot(activity, invoke_app):
-    invoke_app("request", "reboot")
+def test_invoke_request_warm_reboot(activity, invoke_app_as_root):
+    invoke_app_as_root("request", "reboot")
     activity.assert_called_once_with("reboot")
     fc.maintenance.cli.rm.add.assert_called_once()
 
 
 @unittest.mock.patch("fc.maintenance.cli.RebootActivity")
-def test_invoke_request_cold_reboot(activity, invoke_app):
-    invoke_app("request", "reboot", "--cold-reboot")
+def test_invoke_request_cold_reboot(activity, invoke_app_as_root):
+    invoke_app_as_root("request", "reboot", "--cold-reboot")
     activity.assert_called_once_with("poweroff")
     fc.maintenance.cli.rm.add.assert_called_once()
 
@@ -124,9 +159,9 @@ def test_invoke_request_cold_reboot(activity, invoke_app):
 @unittest.mock.patch("fc.maintenance.cli.request_reboot_for_cpu")
 @unittest.mock.patch("fc.maintenance.cli.request_reboot_for_memory")
 def test_invoke_request_system_properties_virtual(
-    memory, cpu, qemu, kernel, invoke_app
+    memory, cpu, qemu, kernel, invoke_app_as_root
 ):
-    invoke_app("request", "system-properties")
+    invoke_app_as_root("request", "system-properties")
     memory.assert_called_once()
     cpu.assert_called_once()
     qemu.assert_called_once()
@@ -138,14 +173,14 @@ def test_invoke_request_system_properties_virtual(
 @unittest.mock.patch("fc.maintenance.cli.request_reboot_for_cpu")
 @unittest.mock.patch("fc.maintenance.cli.request_reboot_for_memory")
 def test_invoke_request_system_properties_virtual(
-    memory, cpu, qemu, kernel, tmpdir, invoke_app
+    memory, cpu, qemu, kernel, tmpdir, invoke_app_as_root
 ):
     enc_file = tmpdir / "enc.json"
     enc = ENC.copy()
     enc["parameters"]["machine"] = "physical"
     enc_file.write_text(json.dumps(enc), encoding="utf8")
 
-    invoke_app("request", "system-properties")
+    invoke_app_as_root("request", "system-properties")
     memory.assert_not_called()
     cpu.assert_not_called()
     qemu.assert_not_called()
@@ -154,17 +189,19 @@ def test_invoke_request_system_properties_virtual(
 
 @unittest.mock.patch("fc.maintenance.cli.request_update")
 @unittest.mock.patch("fc.maintenance.cli.load_enc")
-def test_invoke_request_update(load_enc, request_update, invoke_app):
-    invoke_app("request", "update")
+def test_invoke_request_update(load_enc, request_update, invoke_app_as_root):
+    invoke_app_as_root("request", "update")
     load_enc.assert_called_once()
     request_update.assert_called_once()
     fc.maintenance.cli.rm.add.assert_called_once()
 
 
 @unittest.mock.patch("fc.util.directory.is_node_in_service")
-def test_invoke_constraints(is_node_in_service, monkeypatch, invoke_app, log):
+def test_invoke_constraints(
+    is_node_in_service, monkeypatch, invoke_app_as_root, log
+):
     monkeypatch.setattr("fc.util.directory.connect", MagicMock())
-    invoke_app("constraints", "--in-service", "test01")
+    invoke_app_as_root("constraints", "--in-service", "test01")
     is_node_in_service.assert_called_with(unittest.mock.ANY, "test01")
     assert log.debug("constraints-check-in-service", machine="test01")
     assert log.debug("constraints-success")
@@ -172,11 +209,11 @@ def test_invoke_constraints(is_node_in_service, monkeypatch, invoke_app, log):
 
 @unittest.mock.patch("fc.util.directory.is_node_in_service")
 def test_invoke_constraints_not_met(
-    is_node_in_service, monkeypatch, invoke_app, log
+    is_node_in_service, monkeypatch, invoke_app_as_root, log
 ):
     monkeypatch.setattr("fc.util.directory.connect", MagicMock())
     is_node_in_service.return_value = False
-    invoke_app("constraints", "--in-service", "test01", exit_code=69)
+    invoke_app_as_root("constraints", "--in-service", "test01", exit_code=69)
     assert log.info("constraints-failure")
 
 

--- a/pkgs/fc/agent/fc/maintenance/tests/test_reqmanager.py
+++ b/pkgs/fc/agent/fc/maintenance/tests/test_reqmanager.py
@@ -175,13 +175,17 @@ def test_list_other_requests(reqmanager):
 
 @unittest.mock.patch("fc.util.directory.connect")
 def test_schedule_requests(connect, reqmanager):
-    req = reqmanager.add(Request(Activity(), 320, "comment"))
+    req = reqmanager.add(Request(Activity(), 320, "schedule"))
+    req_success = reqmanager.add(
+        Request(Activity(), 320, "done, do not schedule this")
+    )
+    req_success.state = State.success
     rpccall = connect().schedule_maintenance
     rpccall.return_value = {req.id: {"time": "2016-04-20T15:12:40.9+00:00"}}
     reqmanager.schedule()
-    #
+    # The estimate is expected to be 900 (15 min) which is the minimum.
     rpccall.assert_called_once_with(
-        {req.id: {"estimate": 900, "comment": "comment"}}
+        {req.id: {"estimate": 900, "comment": "schedule"}}
     )
     assert req.next_due == datetime.datetime(
         2016, 4, 20, 15, 12, 40, 900000, tzinfo=pytz.UTC

--- a/pkgs/fc/agent/fc/manage/cli.py
+++ b/pkgs/fc/agent/fc/manage/cli.py
@@ -1,5 +1,4 @@
 import os
-import sys
 import traceback
 from pathlib import Path
 from typing import NamedTuple
@@ -8,10 +7,10 @@ import fc.manage.manage
 import fc.util.enc
 import fc.util.logging
 import structlog
-import typer
 from fc.util import nixos
 from fc.util.lock import locked
-from typer import Argument, Exit, Option, Typer
+from fc.util.typer_utils import FCTyperApp
+from typer import Argument, Exit, Option
 
 
 class Context(NamedTuple):
@@ -27,7 +26,7 @@ class Context(NamedTuple):
 context: Context
 
 
-app = Typer(pretty_exceptions_show_locals=False)
+app = FCTyperApp("fc-manage")
 
 
 @app.command()
@@ -302,11 +301,5 @@ def fc_manage(
     log.info("fc-manage-succeeded", legacy_call=True)
 
 
-def main():
-    command = typer.main.get_command(app)
-    result = command(standalone_mode=False)
-    sys.exit(result)
-
-
 if __name__ == "__main__":
-    main()
+    app()

--- a/pkgs/fc/agent/fc/util/logging.py
+++ b/pkgs/fc/agent/fc/util/logging.py
@@ -221,6 +221,10 @@ class ConsoleFileRenderer:
         )
 
     def __call__(self, logger, method_name, event_dict):
+        log_settings = event_dict.pop("_log_settings", {})
+        if log_settings.get("console_ignore", False):
+            return
+
         console_io = io.StringIO()
         log_io = io.StringIO()
 
@@ -423,6 +427,9 @@ class SystemdJournalRenderer:
     def __call__(self, logger, method_name, event_dict):
         if method_name == "trace":
             return {}
+
+        # Unused
+        event_dict.pop("_log_settings", None)
 
         kv_renderer = structlog.processors.KeyValueRenderer(sort_keys=True)
         event_dict["message"] = event_dict["event"]
@@ -672,3 +679,8 @@ def init_logging(
             raise ValueError("A logdir is required for command logging.")
 
         init_command_logging(log, logdir)
+
+
+def logging_initialized():
+    logger_factory = structlog.get_config()["logger_factory"]
+    return isinstance(logger_factory, MultiOptimisticLoggerFactory)

--- a/pkgs/fc/agent/fc/util/logging.py
+++ b/pkgs/fc/agent/fc/util/logging.py
@@ -83,7 +83,8 @@ class PartialFormatter(string.Formatter):
 
 
 class MultiOptimisticLoggerFactory:
-    def __init__(self, **factories):
+    def __init__(self, context, factories):
+        self.context = context
         self.factories = factories
 
     def __call__(self, *args):
@@ -525,7 +526,7 @@ def format_exc_info(logger, name, event_dict):
     return event_dict
 
 
-def init_command_logging(log, logdir):
+def init_command_logging(log, logdir=None):
     """
     Adds a cmd_output_file logger factory to an already configured
     MultiOptimisticLoggerFactory, used for logging Nix command output to a
@@ -538,6 +539,19 @@ def init_command_logging(log, logdir):
     logger_factory = structlog.get_config()["logger_factory"]
 
     if not isinstance(logger_factory, MultiOptimisticLoggerFactory):
+        return
+
+    if logdir is None:
+        logdir = logger_factory.context.get("logdir")
+
+    if logdir is None:
+        log.warn(
+            "logging-cmd-output-no-logdir",
+            _replace_msg=(
+                "Cannot set up command logging: "
+                "No logdir given and factory context has no logdir either."
+            ),
+        )
         return
 
     # The invocation ID is normally set by systemd when the script is called
@@ -626,11 +640,17 @@ def init_logging(
         multi_renderer,
     ]
 
+    context = {}
     loggers = {}
 
     if logdir is not None:
-        main_log_file = open(logdir / f"{syslog_identifier}.log", "a")
-        loggers["file"] = structlog.PrintLoggerFactory(main_log_file)
+        try:
+            main_log_file = open(logdir / f"{syslog_identifier}.log", "a")
+        except PermissionError:
+            pass
+        else:
+            loggers["file"] = structlog.PrintLoggerFactory(main_log_file)
+            context["logdir"] = logdir
     if journal:
         loggers["journal"] = JournalLoggerFactory()
 
@@ -642,7 +662,7 @@ def init_logging(
     structlog.configure(
         processors=processors,
         wrapper_class=structlog.BoundLogger,
-        logger_factory=MultiOptimisticLoggerFactory(**loggers),
+        logger_factory=MultiOptimisticLoggerFactory(context, loggers),
     )
 
     log = structlog.get_logger()
@@ -651,4 +671,4 @@ def init_logging(
         if not logdir:
             raise ValueError("A logdir is required for command logging.")
 
-        return init_command_logging(log, logdir)
+        init_command_logging(log, logdir)

--- a/pkgs/fc/agent/fc/util/tests/test_nixos.py
+++ b/pkgs/fc/agent/fc/util/tests/test_nixos.py
@@ -343,6 +343,23 @@ def test_find_nix_build_error_failed_assertion():
     assert nixos.find_nix_build_error(stderr) == expected
 
 
+def test_find_nix_build_error_oneline():
+    stderr = textwrap.dedent(
+        """
+        copying path '/nix/store/24lrf2pp03i902sfpx2wfsxvv7xclcxc-bind-9.18.19-man' from 'https://s3.whq.fcio.net/hydra'...
+        copying path '/nix/store/hx1mzy0d8kx3a8fzncz42m8ij06pm0s1-bc-1.07.1' from 'https://s3.whq.fcio.net/hydra'...
+        error: opening directory '/nix/store/v04xnxah48g4m9lp4151xw70yr2dlcc9-unit-script-acme-selfsigned-test-start': Too many open files
+        """
+    )
+    expected = textwrap.dedent(
+        """
+        opening directory '/nix/store/v04xnxah48g4m9lp4151xw70yr2dlcc9-unit-script-acme-selfsigned-test-start': Too many open files
+        """
+    ).strip()
+
+    assert nixos.find_nix_build_error(stderr) == expected
+
+
 @pytest.fixture
 def dirsetup(tmpdir):
     drv = tmpdir.mkdir("abcdef-linux-4.4.27")

--- a/pkgs/fc/agent/fc/util/typer_utils.py
+++ b/pkgs/fc/agent/fc/util/typer_utils.py
@@ -1,0 +1,44 @@
+import os
+
+import fc.util.logging
+import structlog
+import typer
+
+
+class FCTyperApp(typer.Typer):
+    def __init__(self, command_name):
+        # Showing local variables may leak secrets, don't do it in production!
+        super().__init__(pretty_exceptions_show_locals=False)
+        self.command_name = command_name
+
+    def __call__(self):
+        try:
+            super().__call__()
+        except Exception as e:
+            if fc.util.logging.logging_initialized():
+                try:
+                    log = structlog.get_logger()
+                    log.error(
+                        "unhandled-exception",
+                        exc_info=True,
+                        command=self.command_name,
+                        _log_settings=dict(console_ignore=True),
+                    )
+                except:
+                    # Raise the original exception when logging fails.
+                    print("WARNING: logging an unhandled exception failed.")
+                    raise e
+            else:
+                # Raise the original exception when our logging is not
+                # initialized.
+                print(
+                    "WARNING: could not log an unhandled exception because "
+                    "structured logging has not been initialized."
+                )
+                raise e
+
+            # Always raise the original exception if we are not running in a
+            # systemd unit. The exception hook installed by typer will take
+            # care of it and pretty-print the exception for interactive use.
+            if not os.environ.get("INVOCATION_ID"):
+                raise e

--- a/pkgs/fc/agent/setup.py
+++ b/pkgs/fc/agent/setup.py
@@ -53,6 +53,7 @@ setup(
         "requests",
         "rich",
         "shortuuid",
+        "stamina",
         "structlog",
         "typer",
     ],

--- a/pkgs/fc/agent/setup.py
+++ b/pkgs/fc/agent/setup.py
@@ -69,7 +69,7 @@ setup(
             "fc-collect-garbage=fc.manage.collect_garbage:app",
             "fc-directory=fc.util.directory:directory_cli",
             "fc-maintenance=fc.maintenance.cli:app",
-            "fc-manage=fc.manage.cli:main",
+            "fc-manage=fc.manage.cli:app",
             "fc-monitor=fc.manage.monitor:main",
             "fc-resize-disk=fc.manage.resize_disk:app",
             "fc-postgresql=fc.manage.postgresql:app",


### PR DESCRIPTION
A collection of commits to reduce the need for sudo for non-invasive fc-maintenance commands, improve error handling, logging, avoiding unneccessary directory API calls and retrying failed calls. See commit messages for details.

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

 * `fc-maintenance` commands for viewing requests (`show` and `list`) can now be used without sudo by all users. The same applies to the commands used for monitoring and telemetry (`check` and `metrics`).
 * `fc-maintenance show <request ID prefix>`: now has improved output and also works for archived maintenance requests while active requests are preferred when there are multiple matches.
 * Command output generated during execution of an update activity is now logged to separate files in `/var/log/fc-agent`, like for `fc-manage` calls.
* Unhandled errors in `fc-manage` and `fc-maintenance` are now logged properly to the system journal and can be viewed with `journalctl SYSLOG_IDENTIFIER=fc-agent`.

## Security implications

This change affects sudo rules for fc-maintenance commands but the set of commands that can be run and the allowed groups have not been extended.

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - reduce need to use sudo for commands that only access data readable by any user  
  - make sure that invasive commands cannot be run by normal users without sudo and that sudo permissions are limited properly (admin, sudo-srv and service may only run fc-maintenance (-v) delete without password)
- [x] Security requirements tested? (EVIDENCE)
  - checked on a test VM that fc-maintenance commands work as intended, checked sudo rules, checked logs
  - automated test have been extended