### PR TITLE
Make Philipp Herzog admin

### DIFF
--- a/nixos/platform/static.nix
+++ b/nixos/platform/static.nix
@@ -128,6 +128,7 @@ with lib;
         nm = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDFBloz5mf4SxX0/GwvOmTD2itWTRjyrmxh13Nzc2oSP nm";
         os = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJemLKFmr09o6zBscLJSD3KcAs/dnIYBjgxYzJ59VvHx os@Olivers-MBP-3";
         molly = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAmJVyCt6/vSslsEp3dATDD/kk56kaxLggm+3ppwZWbj molly@aqueduct.local";
+        phil = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILRVZrVfZrUggrw4wNNcX7r9o7NQ0VjLHTkovVnZBmYH phil";
       };
 
     };


### PR DESCRIPTION
Re FC-27885

Please backport as far as reasonable (at least 21.05 and maybe until 22.05 or so).

@flyingcircusio/release-managers

## Release process

Impact:

none

Changelog:

- Introduce Philipp Herzog as new global admin. (FC-27885)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
    - [x] strong protections for the private key implemented (Strong passphrase, separate from all other keys, not automatically activated on session logins)
- [x] Security requirements tested? (EVIDENCE)
    - [x] reviewed setup
