### PR TITLE
roundcube: 1.6.3 -> 1.6.4

### DIFF
--- a/package-versions.json
+++ b/package-versions.json
@@ -810,9 +810,9 @@
     "version": "7.0.13"
   },
   "roundcube": {
-    "name": "roundcube-1.6.3",
+    "name": "roundcube-1.6.4",
     "pname": "roundcube",
-    "version": "1.6.3"
+    "version": "1.6.4"
   },
   "rsync": {
     "name": "rsync-3.2.7",

--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "67391dd2848d1f83b2313b2811190cd29038835d",
-    "sha256": "XzUuD6nEojqB3aF9I1Vx8Sn1ZVekOmiVns5KRZTv8uQ="
+    "rev": "23c15991cbda41508bd8c2e7e645acb0d16ac756",
+    "sha256": "zLsLU8UNqaekhorl92UJ9jCxB8wHsjkrIi7P77SeaM4="
   },
   "nixos-mailserver": {
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/",


### PR DESCRIPTION
CVE-2023-5631

PL-131869

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

- roundcube: 1.6.3 -> 1.6.4 (CVE-2023-5631) (PL-131869).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - keep roundcube up-to-date, here we are patching a CVE which is about stored XSS 
- [x] Security requirements tested? (EVIDENCE)
  - checked on test mail server that roundcube still works