### PR TITLE
percona: 8.0.32-24 -> 8.0.34-26

### DIFF
--- a/nixos/roles/mysql.nix
+++ b/nixos/roles/mysql.nix
@@ -194,7 +194,6 @@ in
           else
           "expire_logs_days = ${toString cfg.binlogExpireDays}"
         }
-
         log_slow_verbosity = 'full'
         slow_query_log = ON
         long_query_time = 0.1
@@ -234,14 +233,16 @@ in
           # too many non 8.0 client libs out there, which cannot
           # connect otherwise.
           lib.optionalString
-          (lib.versionAtLeast package.version "8.0")
-          "default_authentication_plugin = mysql_native_password"}
+          (lib.versionAtLeast package.version "8.0") ''
+            default_authentication_plugin = mysql_native_password
+            log_error_suppression_list = MY-013360
+          ''}
 
         ${# Query cache is gone in 8.0
           # https://mysqlserverteam.com/mysql-8-0-retiring-support-for-the-query-cache/
           lib.optionalString
-          (lib.versionOlder package.version "8.0")
-          ''query_cache_type           = 1
+          (lib.versionOlder package.version "8.0") ''
+            query_cache_type           = 1
             query_cache_min_res_unit   = 2k
             query_cache_size           = 80M
           ''}

--- a/pkgs/percona/8.0.nix
+++ b/pkgs/percona/8.0.nix
@@ -9,11 +9,11 @@
 
 stdenv.mkDerivation rec {
   pname = "percona";
-  version = "8.0.32-24";
+  version = "8.0.34-26";
 
   src = fetchurl {
     url = "https://www.percona.com/downloads/Percona-Server-8.0/Percona-Server-${version}/source/tarball/percona-server-${version}.tar.gz";
-    sha256 = "sha256-KGdwbpFFl8s6UWF1FXPFRjyvg0NoTtfur8rR648tCB4=";
+    sha256 = "sha256-xOaXfnh/lg/TutanwGt+EmxG4UA8oTPdil2nvU3NZXQ=";
   };
 
   preConfigure = lib.optional stdenv.isDarwin ''


### PR DESCRIPTION
PL-131639

@flyingcircusio/release-managers

## Release process

Impact:

* \[NixOS 23.05\] Percona will be restarted.

Changelog:

* percona: 8.0.32-24 -> 8.0.34-26

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - keep percona up-to-date 
- [x] Security requirements tested? (EVIDENCE)
  - checked changelogs [Percona Server for MySQL 8.0.34-26 (2023-09-26) - Percona Server for MySQL](https://docs.percona.com/percona-server/8.0/release-notes/8.0.34-26.html) [Percona Server for MySQL 8.0.33-25 (2023-06-15) - Percona Server for MySQL](https://docs.percona.com/percona-server/8.0/release-notes/8.0.33-25.html) and the linked MySQL changelogs for important and security-relevant changes
  - automated test covers basic functionality
  - checked on a test VM that mysqld runs, xtrabackup --backup works and basic interaction with the mysql client works 
