### PR TITLE
Use Linux 5.15

### DIFF
--- a/nixos/platform/default.nix
+++ b/nixos/platform/default.nix
@@ -210,6 +210,8 @@ in {
         "bfq"
       ];
 
+      kernelPackages = pkgs.linuxKernel.packages.linux_5_15;
+
       kernelParams = [
         # Crash management
         "panic=1"


### PR DESCRIPTION
Use Linux 5.15

We experience a known mysterious kernel bug on 6.1, in the memory
management (mm) subsystem after large folio support was introduced in
5.18. We cannot reproduce the bug and there's no idea how to fix it. We
have only seen it on VMs with postgresql and percona/mysql roles. 5.15
is a bit slower without the large folio support but the bug already
caused file system corruption and we don't want to risk that again.

PL-131574

@flyingcircusio/release-managers

## Release process

Impact:

* \[NixOS 23.05\] VMs will reboot after the update to activate the changed kernel.

Changelog:

* Move back to Linux 5.15. We experienced multiple VM crashes and slowdowns due to a known but unsolved kernel memory management bug with the 6.1 kernel branch (PL-131574).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - we change to another NixOS-supported kernel which is more stable 
- [x] Security requirements tested? (EVIDENCE)
  - checked on a test VM that Linux 5.15.137 is running