### PR TITLE
varnish: simple multihost configuration

### DIFF
--- a/doc/src/webproxy.md
+++ b/doc/src/webproxy.md
@@ -26,16 +26,16 @@ and how you are used to configure, start, stop and maintain these packages.
 
 ### Role configuration
 
-The role currently supports two different ways to configure varnish.
+The role currently supports two different ways to configure Varnish.
 Please note that all configuration has to be performed as a service user.
 
 The recommended way is to use Nix. For an overview of the available configuration
 options, see the Varnish module in our [infrastructure repository](https://github.com/flyingcircusio/fc-nixos).
-As with all nixos modules, put your configuration into an appropriately named file
+As with all NixOS modules, put your configuration into an appropriately named file
 in the {file}`/etc/local/nixos` directory, e.g. {file}`/etc/local/nixos/varnish.nix`.
 
-You can also put your verbatim varnish configuration into {file}`/etc/local/varnish/default.vcl`.
-Please note that this way of configuring varnish is deprecated and will likely
+You can also put your verbatim Varnish configuration into {file}`/etc/local/varnish/default.vcl`.
+Please note that this way of configuring Varnish is deprecated and will likely
 be removed in the future.
 
 ### Monitoring

--- a/doc/src/webproxy.md
+++ b/doc/src/webproxy.md
@@ -12,7 +12,7 @@ and how you are used to configure, start, stop and maintain these packages.
 - **configuration file locations:**
 
   Since we use NixOS, configuration files have to be edited in
-  {file}`/etc/local/varnish`, followed by a NixOS rebuild which copies them into
+  {file}`/etc/local/nixos`, followed by a NixOS rebuild which copies them into
   the Nix store and activates the new configuration. To do so, run the command
   {command}`sudo fc-manage --build`.
 
@@ -26,9 +26,17 @@ and how you are used to configure, start, stop and maintain these packages.
 
 ### Role configuration
 
-Your custom configuration goes to
-{file}`/etc/local/varnish/default.vcl`. Please note that all
-configuration has to be performed as a service user.
+The role currently supports two different ways to configure varnish.
+Please note that all configuration has to be performed as a service user.
+
+The recommended way is to use Nix. For an overview of the available configuration
+options, see the Varnish module in our [infrastructure repository](https://github.com/flyingcircusio/fc-nixos).
+As with all nixos modules, put your configuration into an appropriately named file
+in the {file}`/etc/local/nixos` directory, e.g. {file}`/etc/local/nixos/varnish.nix`.
+
+You can also put your verbatim varnish configuration into {file}`/etc/local/varnish/default.vcl`.
+Please note that this way of configuring varnish is deprecated and will likely
+be removed in the future.
 
 ### Monitoring
 

--- a/nixos/roles/webproxy.nix
+++ b/nixos/roles/webproxy.nix
@@ -5,37 +5,15 @@ let
   fccfg = config.flyingcircus.roles.webproxy;
   fclib = config.fclib;
 
-  vclExample = ''
-    vcl 4.0;
-    backend test {
-      .host = "127.0.0.1";
-      .port = "8080";
-    }
-  '';
-
-  varnishCfg = fclib.configFromFile /etc/local/varnish/default.vcl vclExample;
-  configFile = pkgs.writeText "default.vcl" varnishCfg;
-
   cacheMemory = (fclib.currentMemory 256) / 100 * fccfg.mallocMemoryPercentage;
 
-  varnishCmd =
-    "${cfg.package}/sbin/varnishd -a ${cfg.http_address}" +
-    " -f /etc/current-config/varnish.vcl -n ${cfg.stateDir}" +
-    " -s malloc,${toString cacheMemory}M" +
-    lib.optionalString
-      (cfg.extraCommandLine != "")
-      " ${cfg.extraCommandLine}" +
-    lib.optionalString
-      (cfg.extraModules != [])
-      " -p vmod_path='${lib.makeSearchPathOutput "lib" "lib/varnish/vmods" ([cfg.package] ++ cfg.extraModules)}' -r vmod_path" +
-    " -F";
-
   kill = "${pkgs.coreutils}/bin/kill";
+
+  # if there is a default.vcl file, use that instead of the nixos varnish configuration
+  varnishCfg = fclib.configFromFile /etc/local/varnish/default.vcl null;
 in
 {
-
   options = with lib; {
-
     flyingcircus.roles.webproxy = {
       enable = mkEnableOption "Flying Circus varnish server role";
       supportsContainers = fclib.mkEnableContainerSupport;
@@ -57,6 +35,14 @@ in
 
   config = lib.mkMerge [
     (lib.mkIf fccfg.enable {
+      warnings = lib.optional (varnishCfg != null) "Configuring varnish via /etc/local/varnish/default.vcl is deprecated, please migrate your Configuration to Nix";
+
+      assertions = [{
+        assertion = !((config.flyingcircus.services.varnish.virtualHosts != {}) && (varnishCfg != null));
+        message  = ''
+          Please remove the file `/etc/local/varnish/default.vcl` if you want to specify your Varnish configuration in Nix code.
+        '';
+      }];
 
       environment.etc = {
         "local/varnish/README.txt".text = ''
@@ -64,16 +50,14 @@ in
 
           Varnish is listening on: ${cfg.http_address}
 
-          Put your configuration into `default.vcl`.
+          Configure varnish via Nix or put your configuration into `default.vcl` (deprecated, please transition to a Nix config).
         '';
-        "local/varnish/default.vcl.example".text = vclExample;
-        "current-config/varnish.vcl".source = configFile;
       };
 
       flyingcircus.services.sensu-client.checks = {
         varnish_status = {
           notification = "varnishadm status reports errors";
-          command = "${cfg.package}/bin/varnishadm -n ${cfg.stateDir} status";
+          command = "${cfg.package}/bin/varnishadm";
           timeout = 180;
         };
         varnish_http = {
@@ -98,44 +82,15 @@ in
         };
       };
 
-      services.varnish = {
+      flyingcircus.services.varnish = {
         enable = true;
+        extraCommandLine = "-s malloc,${toString cacheMemory}M";
         http_address = lib.concatMapStringsSep " -a "
           (addr: "${addr}:8008") fccfg.listenAddresses;
         config = varnishCfg;
       };
 
       systemd.services = {
-        varnish = {
-          stopIfChanged = false;
-          path = with pkgs; [ varnish procps gawk ];
-          reloadIfChanged = true;
-          restartTriggers = [ configFile ];
-          reload = ''
-            if pgrep -a varnish | grep  -Fq '${varnishCmd}'
-            then
-              config=$(readlink -e /etc/current-config/varnish.vcl)
-              # Varnish doesn't like slashes and numbers in config names.
-              name=$(tr -dc 'a-z' <<< $config)
-              varnishadm -n ${cfg.stateDir} vcl.list | grep -q $name && echo "Config unchanged." && exit
-              varnishadm -n ${cfg.stateDir} vcl.load $name $config && varnishadm -n ${cfg.stateDir} vcl.use $name
-
-              for vcl in $(varnishadm -n ${cfg.stateDir} vcl.list | grep ^available | awk {'print $5'});
-              do
-                varnishadm -n ${cfg.stateDir} vcl.discard $vcl
-              done
-            else
-              echo "Binary or parameters changed. Restarting."
-              systemctl restart varnish
-            fi
-          '';
-
-          serviceConfig = {
-            ExecStart = lib.mkOverride 90 varnishCmd;
-            RestartSec = lib.mkOverride 90 "10s";
-          };
-
-        };
         varnishncsa = rec {
           after = [ "varnish.service" ];
           requires = after;
@@ -149,7 +104,7 @@ in
             PIDFile = "/run/varnish/varnishncsa.pid";
             User = "varnish";
             Group = "varnish";
-            ExecStart = "${cfg.package}/bin/varnishncsa -D -a -w /var/log/varnish.log -P /run/varnish/varnishncsa.pid -n ${cfg.stateDir}";
+            ExecStart = "${cfg.package}/bin/varnishncsa -D -a -w /var/log/varnish.log -P /run/varnish/varnishncsa.pid";
             ExecReload = "${kill} -HUP $MAINPID";
           };
         };
@@ -200,6 +155,5 @@ in
         }
       ];
     }
-
   ];
 }

--- a/nixos/roles/webproxy.nix
+++ b/nixos/roles/webproxy.nix
@@ -9,13 +9,13 @@ let
 
   kill = "${pkgs.coreutils}/bin/kill";
 
-  # if there is a default.vcl file, use that instead of the nixos varnish configuration
+  # if there is a default.vcl file, use that instead of the NixOS Varnish configuration
   varnishCfg = fclib.configFromFile /etc/local/varnish/default.vcl null;
 in
 {
   options = with lib; {
     flyingcircus.roles.webproxy = {
-      enable = mkEnableOption "Flying Circus varnish server role";
+      enable = mkEnableOption "Flying Circus Varnish server role";
       supportsContainers = fclib.mkEnableContainerSupport;
 
       mallocMemoryPercentage = mkOption {
@@ -57,7 +57,7 @@ in
       flyingcircus.services.sensu-client.checks = {
         varnish_status = {
           notification = "varnishadm status reports errors";
-          command = "${cfg.package}/bin/varnishadm";
+          command = "${cfg.package}/bin/varnishadm status";
           timeout = 180;
         };
         varnish_http = {

--- a/nixos/services/default.nix
+++ b/nixos/services/default.nix
@@ -41,6 +41,7 @@ in {
     ./sensu/client.nix
     ./solr.nix
     ./telegraf
+    ./varnish
 
     (mkRemovedOptionModule [ "flyingcircus" "services" "percona" "rootPassword" ] "Change the root password via MySQL and modify secret files")
   ];

--- a/nixos/services/varnish/default.nix
+++ b/nixos/services/varnish/default.nix
@@ -7,16 +7,26 @@
 
   mkHostSelection = hcfg: let
     includefile = if (builtins.isPath hcfg.config) then hcfg.config else (pkgs.writeText "${hcfg.host}.vcl" hcfg.config);
-    # vcl_hash-${hcfg.host} -> has to change with the file's contents
+    # Varnish uses a two-step approach with config names and labels, that we
+    # leverage in this way:
+    # 1. Every vhost received a config file that is written as a VCL config
+    #    in the nix store, so every vhost's config file name changes when
+    #    the config changes. We reflect this change in the config name within
+    #    Varnish so that we can load multiple configs for the same vhost
+    #    at the same time to facilitate graceful switchover.
+    # 2. The label for every vhost stays the same, independent of any changes
+    #    in the config. The label is then pointed to a new (versioned) name
+    #    from step 1 to perform the switch-over.
     name = mkVclName includefile;
-    # has to stay the same when only the file's the content changes, such that a reload only "moves" the label over to the new config
     label = "label-${sanitizeConfigName hcfg.host}";
   in {
+    # This is the VCL snippet that will be embedded into the main VCL config.
     config = ''
       if (${hcfg.condition}) {
         return(vcl(${label}));
       }
     '';
+    # These are the commands to activate new config (both at startup and reload.)
     command = ''
       vcl.load ${name} ${includefile}
       vcl.label ${label} ${name}
@@ -27,6 +37,8 @@
     vcl 4.0;
     import std;
 
+    # An (invalid) backend that will never be used but is needed
+    # to created a syntactically valid config.
     backend default {
       .host = "0.0.0.0";
       .port = "80";
@@ -41,14 +53,20 @@
 
   vhosts = map mkHostSelection (builtins.attrValues cfg.virtualHosts);
   virtualHostSelection = lib.concatStringsSep "else" (map (x: x.config) vhosts);
-  commandsfile = pkgs.writeText "varnishd-commands" (lib.concatStringsSep "\n" ((map (x: x.command) vhosts) ++ (let
-    name = mkVclName mainConfig;
-  in [''
-    vcl.load ${name} ${mainConfig}
-    vcl.use ${name}
-  ''])));
 
-  extraCommandLine = cfg.extraCommandLine + (lib.optionalString (cfg.extraCommandLine != "") " ") + lib.optionalString (cfg.config == null) "-I ${commandsfile}";
+  vhostActivationCommands = lib.concatStringsSep "\n" (map (x: x.command) vhosts);
+  mainActivationCommands = ''
+    vcl.load ${name} ${mkVclName mainConfig}
+    vcl.use ${name}
+  '';
+
+  commandsfile = pkgs.writeText "varnishd-commands" ''
+    ${vhostActivationCommands}
+    ${mainActivationCommands}
+    '';
+
+  # Only activate the NixOS module config if there is no legacy config.
+  commandsFileArg = lib.optionalString (cfg.config == null) "-I ${commandsfile})";
 in {
   options.flyingcircus.services.varnish = {
     enable = mkEnableOption "varnish";
@@ -89,7 +107,7 @@ in {
     services.varnish = {
       enable = true;
       enableConfigCheck = false;
-      inherit extraCommandLine;
+      extraCommandLine = lib.concatStringsSep [ cfg.extraCommandLine commandsFileArg ];
       inherit (cfg) http_address;
       config = if cfg.config == null then ''
         vcl 4.0;

--- a/nixos/services/varnish/default.nix
+++ b/nixos/services/varnish/default.nix
@@ -1,0 +1,130 @@
+{ pkgs, lib, config, ... }: let
+  cfg = config.flyingcircus.services.varnish;
+  inherit (lib) mkOption mkEnableOption types;
+
+  sanitizeConfigName = name: builtins.replaceStrings ["."] ["-"] (lib.strings.sanitizeDerivationName name);
+  mkVclName = file: "vcl_${builtins.head (lib.splitString "." (builtins.baseNameOf file))}";
+
+  mkHostSelection = hcfg: let
+    includefile = if (builtins.isPath hcfg.config) then hcfg.config else (pkgs.writeText "${hcfg.host}.vcl" hcfg.config);
+    # vcl_hash-${hcfg.host} -> has to change with the file's contents
+    name = mkVclName includefile;
+    # has to stay the same when only the file's the content changes, such that a reload only "moves" the label over to the new config
+    label = "label-${sanitizeConfigName hcfg.host}";
+  in {
+    config = ''
+      if (${hcfg.condition}) {
+        return(vcl(${label}));
+      }
+    '';
+    command = ''
+      vcl.load ${name} ${includefile}
+      vcl.label ${label} ${name}
+    '';
+  };
+
+  mainConfig = pkgs.writeText "main-config" ''
+    vcl 4.0;
+    import std;
+
+    backend default {
+      .host = "0.0.0.0";
+      .port = "80";
+    }
+
+    sub vcl_recv {
+      ${virtualHostSelection}
+
+      return (synth(503, "Internal Error"));
+    }
+  '';
+
+  vhosts = map mkHostSelection (builtins.attrValues cfg.virtualHosts);
+  virtualHostSelection = lib.concatStringsSep "else" (map (x: x.config) vhosts);
+  commandsfile = pkgs.writeText "varnishd-commands" (lib.concatStringsSep "\n" ((map (x: x.command) vhosts) ++ (let
+    name = mkVclName mainConfig;
+  in [''
+    vcl.load ${name} ${mainConfig}
+    vcl.use ${name}
+  ''])));
+
+  extraCommandLine = cfg.extraCommandLine + (lib.optionalString (cfg.extraCommandLine != "") " ") + lib.optionalString (cfg.config == null) "-I ${commandsfile}";
+in {
+  options.flyingcircus.services.varnish = {
+    enable = mkEnableOption "varnish";
+    config = mkOption {
+      type = types.nullOr types.str;
+    };
+    extraCommandLine = mkOption {
+      type = types.str;
+      default = "";
+    };
+    http_address = mkOption {
+      type = types.str;
+      default = "*:8008";
+    };
+    virtualHosts = mkOption {
+      type = types.attrsOf (types.submodule ({ name, config, ... }: {
+        options = {
+          host = mkOption {
+            type = types.str;
+            default = name;
+          };
+
+          config = mkOption {
+            type = types.lines;
+          };
+
+          condition = mkOption {
+            type = types.str;
+            default = ''req.http.Host == "${config.host}"'';
+          };
+        };
+      }));
+      default = {};
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    services.varnish = {
+      enable = true;
+      enableConfigCheck = false;
+      inherit extraCommandLine;
+      inherit (cfg) http_address;
+      config = if cfg.config == null then ''
+        vcl 4.0;
+        import std;
+
+        backend default {
+          .host = "0.0.0.0";
+          .port = "80";
+        }
+
+        sub vcl_recv {
+          return (synth(503, "Varnish is starting up"));
+        }
+      '' else cfg.config;
+    };
+
+    systemd.services.varnish = let
+      vcfg = config.services.varnish;
+    in {
+      reloadIfChanged = true;
+      restartTriggers = [ cfg.extraCommandLine vcfg.package cfg.http_address cfg.config ];
+      reload = ''
+        vadm="${vcfg.package}/bin/varnishadm -n ${vcfg.stateDir}"
+        cat ${commandsfile} | $vadm
+
+        coldvcls=$($vadm vcl.list | grep " cold " | ${pkgs.gawk}/bin/awk {'print $5'})
+
+        if [ ! -z "$coldvcls" ]; then
+          for vcl in "$coldvcls"; do
+            $vadm vcl.discard $vcl
+          done
+        fi
+      '';
+
+      serviceConfig.RestartSec = lib.mkOverride 90 "10s";
+    };
+  };
+}


### PR DESCRIPTION
@flyingcircusio/release-managers

A simple multihost configuration for varnish that separates the configuration into host-specific modules that are being loaded during startup and can be hot-reloaded if the configuration changes.

For backwards-compatibility reasons, the /etc/local/varnish/default.vcl will be used as the varnish config if it exists and there is no conflicting nix configuration. 

If both a /etc/local/varnish/default.vcl and flyingcircus.services.varnish.virtualHost Nix configurations are found, the rebuild will fail with an appropriate error message. 

## Release process

Impact:  

* Varnish will be restarted, so caches will be cold.

Changelog: Added multi-host functionality to the webproxy role via `flyincircus.services.varnish` 

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

The defaults work the same, specific host configuration is not affected since the only relevant change the configuration being split up into multiple files.

- [x] Security requirements tested? (EVIDENCE)

The tests have been adjusted to test the relevant configuration changes.