### PR TITLE
Patch for FC-Search

### DIFF
--- a/nixos/platform/auditbeat.nix
+++ b/nixos/platform/auditbeat.nix
@@ -13,7 +13,7 @@ in
       type = types.package;
       default = pkgs.auditbeat7-oss;
       defaultText = "pkgs.auditbeat7-oss";
-      example = literalExample "pkgs.auditbeat7";
+      example = literalExpression "pkgs.auditbeat7";
       description = ''
         The auditbeat package to use.
       '';

--- a/nixos/platform/filebeat.nix
+++ b/nixos/platform/filebeat.nix
@@ -125,7 +125,7 @@ in
         type = types.package;
         default = pkgs.filebeat7-oss;
         defaultText = "pkgs.filebeat7-oss";
-        example = literalExample "pkgs.filebeat7";
+        example = literalExpression "pkgs.filebeat7";
         description = ''
           The filebeat package to use.
         '';

--- a/nixos/platform/filebeat.nix
+++ b/nixos/platform/filebeat.nix
@@ -111,6 +111,7 @@ in
             extraSettings = mkOption { type = attrs; default = {}; };
           };
         });
+        defaultText = "{}";
         default = config.flyingcircus.beats.logTargets;
         description = ''
           Where filebeat should send logs from various files,

--- a/nixos/platform/journalbeat.nix
+++ b/nixos/platform/journalbeat.nix
@@ -133,7 +133,7 @@ in
           type = types.package;
           default = pkgs.filebeat7-oss;
           defaultText = "pkgs.filebeat7-oss";
-          example = literalExample "pkgs.filebeat7";
+          example = literalExpression "pkgs.filebeat7";
           description = ''
             The filebeat package to use.
           '';

--- a/nixos/platform/journalbeat.nix
+++ b/nixos/platform/journalbeat.nix
@@ -119,6 +119,7 @@ in
               extraSettings = mkOption { type = attrs; default = {}; };
             };
           });
+          defaultText = "{}";
           default = config.flyingcircus.beats.logTargets;
           description = ''
             Where filebeat should send logs from the journal,

--- a/nixos/platform/users.nix
+++ b/nixos/platform/users.nix
@@ -131,6 +131,7 @@ in
 
     userDataPath = lib.mkOption {
       default = /etc/nixos/users.json;
+      defaultText = "/etc/nixos/users.json";
       type = path;
       description = "Where to find the user json file.";
     };
@@ -142,6 +143,7 @@ in
 
     permissionsPath = lib.mkOption {
       default = /etc/nixos/permissions.json;
+      defaultText = "/etc/nixos/permissions.json";
       type = path;
       description = ''
         Where to find the permissions json file.

--- a/nixos/roles/antivirus.nix
+++ b/nixos/roles/antivirus.nix
@@ -18,6 +18,7 @@ in
         type = lib.types.listOf lib.types.str;
         default = fclib.network.lo.dualstack.addresses ++
                   fclib.network.srv.dualstack.addresses;
+        defaultText = "addresses of the interfaces `lo` and `srv` (IPv4 & IPv6)";
       };
     };
   };

--- a/nixos/roles/ceph/mon.nix
+++ b/nixos/roles/ceph/mon.nix
@@ -19,6 +19,7 @@ in
       supportsContainers = fclib.mkDisableContainerSupport;
 
       primary = lib.mkOption {
+        defaultText = "false";
         default = (first_mon == config.networking.hostName);
         description = "Primary monitors take over additional maintenance tasks.";
         type = lib.types.bool;
@@ -26,6 +27,7 @@ in
 
       config = lib.mkOption {
         type = lib.types.lines;
+        defaultText = "";
         default = (lib.concatMapStringsSep "\n" (mon:
           let id = head (lib.splitString "." mon.address);
               addr = "${head (filter fclib.isIp4 mon.ips)}:${mon_port}";

--- a/nixos/roles/ceph/rgw.nix
+++ b/nixos/roles/ceph/rgw.nix
@@ -21,6 +21,7 @@ in
       supportsContainers = fclib.mkDisableContainerSupport;
 
       primary = lib.mkOption {
+        defaultText = "false";
         default = (first_rgw == config.networking.hostName);
         description = "Primary monitors take over additional maintenance tasks.";
         type = lib.types.bool;

--- a/nixos/roles/coturn.nix
+++ b/nixos/roles/coturn.nix
@@ -50,6 +50,19 @@ in
       config = mkOption {
         description = "Platform-configured options";
         type = types.attrs;
+        defaultText = {
+          hostname = "\${cfg.hostName}";
+          alt-listening-port = 3479;
+          alt-tls-listening-port = 5350;
+          listening-ips = "the addresses of networks `lo`, `srv` and `fe` (IPv4 & IPv6)";
+          listening-port = 3478;
+          lt-cred-mech = false;
+          no-cli = true;
+          realm = "\${cfg.hostName}";
+          tls-listening-port = 5349;
+          use-auth-secret = true;
+          extraConfig = [];
+        };
         default =  {
           hostname = cfg.hostName;
           alt-listening-port = 3479;

--- a/nixos/roles/external_net/default.nix
+++ b/nixos/roles/external_net/default.nix
@@ -34,7 +34,7 @@ in
   options = {
     flyingcircus.roles.external_net = {
 
-      enable = lib.mkEnableOption { };
+      enable = lib.mkEnableOption "fcio external_net role";
       supportsContainers = fclib.mkDisableContainerSupport;
 
       vxlan4 = lib.mkOption {
@@ -60,6 +60,7 @@ in
       frontendName = lib.mkOption {
         type = lib.types.str;
         default = defaultFrontendName;
+        defaultText = "reverse name of the frontend's address";
         description = ''
           DNS host name for the external network gateway. This is also the name
           of the OpenVPN client configuration. The default is derived from the

--- a/nixos/roles/external_net/openvpn.nix
+++ b/nixos/roles/external_net/openvpn.nix
@@ -208,7 +208,7 @@ in
 {
   options = {
     flyingcircus.roles.openvpn = {
-      enable = lib.mkEnableOption { };
+      enable = lib.mkEnableOption "fcio openvpn role";
       supportsContainers = fclib.mkDisableContainerSupport;
 
       accessNets = lib.mkOption {

--- a/nixos/roles/external_net/vxlan-client.nix
+++ b/nixos/roles/external_net/vxlan-client.nix
@@ -19,6 +19,7 @@ in
       enable = lib.mkOption {
         description = "Access external networks via external_net gateway";
         type = lib.types.bool;
+        defaultText = "false";
         default = (gw != null) && (!cfg.roles.vxlan.gateway);
       };
       supportsContainers = fclib.mkDisableContainerSupport;

--- a/nixos/roles/external_net/vxlan.nix
+++ b/nixos/roles/external_net/vxlan.nix
@@ -106,7 +106,7 @@ in
 {
   options = with lib; {
     flyingcircus.roles.vxlan =  {
-      gateway = mkEnableOption { };
+      gateway = mkEnableOption "fcio vxlan gateway";
 
       supportsContainers = fclib.mkDisableContainerSupport;
 

--- a/nixos/roles/lamp.nix
+++ b/nixos/roles/lamp.nix
@@ -59,6 +59,7 @@ in {
             name = mkOption {
               type = str;
               default = "lamp-${toString config.port}";
+              defaultText = "lamp-\${port}";
             };
           };
         }));

--- a/nixos/roles/memcached.nix
+++ b/nixos/roles/memcached.nix
@@ -36,6 +36,7 @@ in
         type = lib.types.listOf lib.types.str;
         default = fclib.network.lo.dualstack.addresses ++
                   fclib.network.srv.dualstack.addresses;
+        defaultText = "the addresses of the networks `lo` and `srv` (IPv4 & IPv6)";
       };
 
     };

--- a/nixos/roles/mongodb.nix
+++ b/nixos/roles/mongodb.nix
@@ -89,7 +89,7 @@ in {
       supportsContainers = fclib.mkEnableContainerSupport;
       extraCheckArgs = with lib; mkOption {
         type = types.str;
-        default = if (lib.versionOlder majorVersion "3.6") then "" else "-h localhost -p 27017";
+        default = if (lib.versionOlder v "3.6") then "" else "-h localhost -p 27017";
         example = "-h example00.fe.rzob.fcio.net -p 27017 -t -U admin -P /etc/local/mongodb/password.txt";
         description = "Extra arguments to be passed to the check_mongodb script";
       };

--- a/nixos/roles/mysql.nix
+++ b/nixos/roles/mysql.nix
@@ -39,6 +39,7 @@ in
           type = lib.types.listOf lib.types.str;
           default = fclib.network.lo.dualstack.addresses ++
                     fclib.network.srv.dualstack.addresses;
+          defaultText = "the addresses of the networks `lo` and `srv` (IPv4 & IPv6)";
         };
 
         extraConfig = mkOption {

--- a/nixos/roles/statshost/default.nix
+++ b/nixos/roles/statshost/default.nix
@@ -192,6 +192,7 @@ in
       prometheusListenAddress = mkOption {
         type = types.str;
         default = "${head fclib.network.srv.dualstack.addressesQuoted}:9090";
+        defaultText = "\${head fclib.network.srv.dualstack.addressQuoted}:9090";
         description = "Prometheus listen address";
       };
 

--- a/nixos/roles/webproxy.nix
+++ b/nixos/roles/webproxy.nix
@@ -28,6 +28,7 @@ in
 
       listenAddresses = lib.mkOption {
         type = lib.types.listOf lib.types.str;
+        defaultText = "the addresses of the networks `lo` and `srv` (IPv4 & IPv6)";
         default = fclib.network.srv.dualstack.addressesQuoted ++
                   fclib.network.lo.dualstack.addressesQuoted;
       };

--- a/nixos/services/ceph/client.nix
+++ b/nixos/services/ceph/client.nix
@@ -21,6 +21,30 @@ in
     flyingcircus.services.ceph = {
       config = lib.mkOption {
         type = lib.types.lines;
+        defaultText = ''
+          [global]
+          pid file = /run/ceph/$type-$id.pid
+          admin socket = /run/ceph/$cluster-$name.asok
+          # Needs to correspond with daemon startup ulimit
+          max open files = 262144
+          osd pool default min size = 2
+          osd pool default size = 3
+          osd pool default pg num = 64
+          osd pool default pgp num = 64
+          setuser match path = /srv/ceph/$type/ceph-$id
+          debug filestore = 4
+          debug mon = 4
+          debug osd = 4
+          debug journal = 4
+          debug throttle = 4
+          mon compact on start = true     # Keep leveldb small
+          mon osd down out interval = 900  # Allow 15 min for reboots to happen without backfilling.
+          mon osd nearfull ratio = .9
+          mon data = /srv/ceph/mon/$cluster-$id
+          mon osd allow primary affinity = true
+          mon pg warn max per osd = 3000
+          mon pg warn max object skew = 20
+        '';
         default = ''
           [global]
           fsid = ${fs_id}

--- a/nixos/services/haproxy/config-options.nix
+++ b/nixos/services/haproxy/config-options.nix
@@ -298,7 +298,7 @@ in {
   };
   listen = mkOption {
     default = {};
-    example = literalExample ''{
+    example = literalExpression ''{
       http-in = {
         binds = [
           "127.0.0.1:8002"
@@ -325,7 +325,7 @@ in {
   };
   backend = mkOption {
     default = {};
-    example = literalExample ''{
+    example = literalExpression ''{
       be = {
         servers = [
           "localhost localhost:8080"

--- a/nixos/services/jitsi/jibri.nix
+++ b/nixos/services/jitsi/jibri.nix
@@ -162,6 +162,7 @@ in
 
     configFile = mkOption {
       type = types.path;
+      defaultText = "jibri.conf";
       default = "${pkgs.writeText "jibri.conf" (toHOCON cfg.settings)}";
       description = ''
         Jibri main config file path.
@@ -171,6 +172,7 @@ in
 
     settings = mkOption {
       type = types.attrs;
+      defaultText = {};
       default = settings;
       description = "Settings used to generate the default config file";
     };

--- a/nixos/services/jitsi/jicofo.nix
+++ b/nixos/services/jitsi/jicofo.nix
@@ -62,7 +62,7 @@ in
     config = mkOption {
       type = attrsOf str;
       default = { };
-      example = literalExample ''
+      example = literalExpression ''
         {
           "org.jitsi.jicofo.auth.URL" = "XMPP:jitsi-meet.example.com";
         }

--- a/nixos/services/jitsi/jitsi-meet.nix
+++ b/nixos/services/jitsi/jitsi-meet.nix
@@ -54,7 +54,7 @@ in
     config = mkOption {
       type = attrs;
       default = { };
-      example = literalExample ''
+      example = literalExpression ''
         {
           enableWelcomePage = false;
           defaultLang = "fi";
@@ -81,7 +81,7 @@ in
     interfaceConfig = mkOption {
       type = attrs;
       default = { };
-      example = literalExample ''
+      example = literalExpression ''
         {
           SHOW_JITSI_WATERMARK = false;
           SHOW_WATERMARK_FOR_GUESTS = false;

--- a/nixos/services/jitsi/jitsi-videobridge.nix
+++ b/nixos/services/jitsi/jitsi-videobridge.nix
@@ -57,7 +57,7 @@ in
     config = mkOption {
       type = attrs;
       default = { };
-      example = literalExample ''
+      example = literalExpression ''
         {
           videobridge = {
             ice.udp.port = 5000;
@@ -83,7 +83,7 @@ in
         See <link xlink:href="https://github.com/jitsi/jitsi-videobridge/blob/master/doc/muc.md" /> for more information.
       '';
       default = { };
-      example = literalExample ''
+      example = literalExpression ''
         {
           "localhost" = {
             hostName = "localhost";

--- a/nixos/services/jitsi/prosody.nix
+++ b/nixos/services/jitsi/prosody.nix
@@ -501,7 +501,7 @@ in
         description = "Prosody package to use";
         default = pkgs.prosody;
         defaultText = "pkgs.prosody";
-        example = literalExample ''
+        example = literalExpression ''
           pkgs.prosody.override {
             withExtraLibs = [ pkgs.luaPackages.lpty ];
             withCommunityModules = [ "auth_external" ];

--- a/nixos/services/k3s/frontend.nix
+++ b/nixos/services/k3s/frontend.nix
@@ -171,7 +171,7 @@ in
           };
 
           extraPodTemplateOptions = mkOption {
-            type = string;
+            type = lines;
             default = "";
             description = "haproxy options for the server-template directive used for the pod backends, added verbatim to the end of the generated line.";
           };
@@ -220,7 +220,7 @@ in
           };
 
           namespace = mkOption {
-            type = string;
+            type = str;
             default = "default";
             description = ''
               Kubernetes namespace the service is defined in.
@@ -231,7 +231,7 @@ in
           binds = mkOption {
             type = nullOr (listOf str);
             default = null;
-            example = map (a: "${a}:8080") fclib.network.fe.dualstack.addressesQuoted;
+            example = [ "0.0.0.0:8008" ];
             description = ''Addresses with ports haproxy is binding to,
               listening for incoming connections. Defaults to 127.0.0.1, using either `lbServicePort`
               or `podPort`, if `lbServicePort` is not set.

--- a/nixos/services/matomo.nix
+++ b/nixos/services/matomo.nix
@@ -129,7 +129,7 @@ in {
         '';
         default = pkgs.matomo;
         defaultText = literalExpression "pkgs.matomo";
-        example = literalExample "pkgs.matomo-beta";
+        example = literalExpression "pkgs.matomo-beta";
       };
 
       webServerUser = mkOption {
@@ -161,11 +161,7 @@ in {
       hostname = mkOption {
         type = types.str;
         default = "${user}.${fqdn}";
-        defaultText = literalExpression ''
-          if config.${options.networking.domain} != null
-          then "${user}.''${config.${options.networking.fqdn}}"
-          else "${user}.''${config.${options.networking.hostName}}"
-        '';
+        defaultText = literalExpression "${user}.\${fqdn}";
         example = "matomo.yourdomain.org";
         description = lib.mdDoc ''
           URL of the host, without https prefix. You may want to change it if you

--- a/nixos/services/nginx/default.nix
+++ b/nixos/services/nginx/default.nix
@@ -163,6 +163,7 @@ in
     defaultListenAddresses = lib.mkOption {
       type = lib.types.listOf lib.types.str;
       default = fclib.network.fe.dualstack.addressesQuoted;
+      defaultText = "addresses of the `fe` network (IPv4 & IPv6)";
       description = ''
         Addresses to listen on if a vhost does not specify any.
       '';
@@ -262,7 +263,7 @@ in
         };
       }));
       default = {};
-      example = literalExample ''
+      example = literalExpression ''
         {
           "hydra.example.com" = {
             forceSSL = true;

--- a/nixos/services/nginx/location-options.nix
+++ b/nixos/services/nginx/location-options.nix
@@ -14,7 +14,7 @@ with lib;
     basicAuth = mkOption {
       type = types.attrsOf types.str;
       default = {};
-      example = literalExample ''
+      example = literalExpression ''
         {
           user = "password";
         };

--- a/nixos/services/nginx/vhost-options.nix
+++ b/nixos/services/nginx/vhost-options.nix
@@ -234,7 +234,7 @@ with lib;
     basicAuth = mkOption {
       type = types.attrsOf types.str;
       default = {};
-      example = literalExample ''
+      example = literalExpression ''
         {
           user = "password";
         };
@@ -264,7 +264,7 @@ with lib;
         inherit lib;
       }));
       default = {};
-      example = literalExample ''
+      example = literalExpression ''
         {
           "/" = {
             proxyPass = "http://localhost:3000";

--- a/nixos/services/percona.nix
+++ b/nixos/services/percona.nix
@@ -102,7 +102,7 @@ in
 
       package = mkOption {
         type = types.package;
-        example = literalExample "pkgs.percona";
+        example = literalExpression "pkgs.percona";
         description = "
           Which MySQL derivation to use.
         ";
@@ -155,8 +155,8 @@ in
           to create databases on the first startup of MySQL
         '';
         example = [
-          { name = "foodatabase"; schema = literalExample "./foodatabase.sql"; }
-          { name = "bardatabase"; schema = literalExample "./bardatabase.sql"; }
+          { name = "foodatabase"; schema = literalExpression "./foodatabase.sql"; }
+          { name = "bardatabase"; schema = literalExpression "./bardatabase.sql"; }
         ];
       };
 

--- a/nixos/services/prometheus.nix
+++ b/nixos/services/prometheus.nix
@@ -74,7 +74,7 @@ let
 
   mkDefOpt = type : defaultStr : description : mkOpt type (description + ''
 
-    Defaults to <literal>${defaultStr}</literal> in prometheus
+    Defaults to <literal>${builtins.toString defaultStr}</literal> in prometheus
     when set to <literal>null</literal>.
   '');
 

--- a/nixos/services/rabbitmq/365frozen.nix
+++ b/nixos/services/rabbitmq/365frozen.nix
@@ -17,6 +17,7 @@ in
       package = mkOption {
         type = types.package;
         default = storePath /nix/store/sqap94f4a0z8pxdal5wfgsm83ncwwbbd-rabbitmq-server-3.6.5;
+        defaultText = "a frozen rabbitmq store path";
         description = ''
           Which rabbitmq package to use. Should be the same as used in `service`.
         '';

--- a/nixos/services/redis.nix
+++ b/nixos/services/redis.nix
@@ -27,6 +27,7 @@ in {
 
       listenAddresses = lib.mkOption {
         type = lib.types.listOf lib.types.str;
+        defaultText = "the addresses of the networks `lo` and `srv` (IPv4 & IPv6)";
         default = fclib.network.lo.dualstack.addresses ++
                   fclib.network.srv.dualstack.addresses;
       };

--- a/nixos/services/redis.nix
+++ b/nixos/services/redis.nix
@@ -49,6 +49,7 @@ in {
 
       maxmemory = mkOption {
         type = types.str;
+        defaultText = "100mb";
         default = "${toString ((fclib.currentMemory 1024) * cfg.memoryPercentage / 100)}mb";
         description = "Maximum memory redis is allowed to use for a dataset";
         example = "100mb";

--- a/nixos/services/sensu/client.nix
+++ b/nixos/services/sensu/client.nix
@@ -211,6 +211,7 @@ in {
       expectedLoad = {
         warning = mkOption {
           type = types.str;
+          defaultText = "$n_cores * 8, $n_cores * 5, $n_cores * 2";
           default =
             "${toString (cores * 8)},${toString (cores * 5)}," +
             "${toString (cores * 2)}";
@@ -218,6 +219,7 @@ in {
         };
         critical = mkOption {
           type = types.str;
+          defaultText = "$n_cores * 10, $n_cores * 8, $n_cores * 3";
           default =
             "${toString (cores * 10)},${toString (cores * 8)}," +
             "${toString (cores * 3)}";


### PR DESCRIPTION
this is a revamped version of https://github.com/flyingcircusio/fc-nixos/pull/713 after it was reverted in 89ef0b400b35deb5626f06dc5dae48b78647f3c7.

There are no functionality changes, these changes just make it possible to evaluate the options and generate a json from them. 

## Release process

Impact:

1. several minor adjustments to modules options, none that change functionality anywhatsoever
2. migration from literalExample -> literalExpression for options

Changelog:

Fix module option evaluation to enable the planned fc-search option discoverability and documentation service https://github.com/flyingcircusio/fc-search

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - [x] no functionality changes to the platform itself
- [x] Security requirements tested? (EVIDENCE)
  - [x] this commit evaluates + builds on a VM