### PR TITLE
userscan: ignore more nixpkgs stuff

### DIFF
--- a/nixos/platform/collect-garbage-userscan.exclude
+++ b/nixos/platform/collect-garbage-userscan.exclude
@@ -10,7 +10,11 @@
 **/journal/
 **/lucene/
 **/solr/data/
-**/nixpkgs-*/
+# Very big, has misleading store paths which shouldn't be registered.
+**/nixpkgs*/
+# If we missed a nixpkgs directory: test files from this directory trip
+# userscan over as they contain store paths which are too long on purpose.
+**/pkgs/test/make-binary-wrapper/*
 # Files in sub-directories to ignore (anywhere in the home directory)
 **/.local/share/fish/fish_history
 **/diagnostic.data/metrics.*


### PR DESCRIPTION
We missed some nixpkgs dirs with the current regex which is now extended to any dir starting with `nixpkgs`. If we still missed a nixpkgs dir, `pkgs/test/make-binary-wrapper` is now explicitly ignored because userscan dies when scanning it.

PL-131439

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

- fc-userscan/garbage collect: ignore all dirs starting with `nixpkgs` because scanning them takes a long time and yields false positives. In addition to that, `pkgs/test/make-binary-wrapper` from nixpkgs is ignored explicitly because it crashes userscan at the moment (PL-131439).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - save scanning time and avoid breaking the GC service
- [x] Security requirements tested? (EVIDENCE)
  - checked on a test VM that fc-userscan runs and nixpkgs is ignored as expected