### PR TITLE
Set home dir ownership based on user names

### DIFF
--- a/nixos/platform/users.nix
+++ b/nixos/platform/users.nix
@@ -80,9 +80,13 @@ let
           })
           permissions));
 
+  # Set ownership by user name (uid is a bit confusing here).
+  # The UID can differ between ENC and passwd. The value from passwd is
+  # the one we want here. This activation script runs after the NixOS
+  # `users` script so using the name is safe here.
   homeDirPermissions = userdata:
     map (user: ''
-      install -d -o ${toString user.id} -g ${primaryGroup user} -m 0755 ${user.home_directory}
+      install -d -o ${user.uid} -g ${primaryGroup user} -m 0755 ${user.home_directory}
     '')
     userdata;
 


### PR DESCRIPTION
NixOS keeps track of user name-id mappings and refuses to change uids automatically so the state on the system can diverge from ENC information. Home dir permissions are set according to ENC so they might be owned by the wrong user ID which could be unknown or even another user.

PL-131881

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

- adjust home dir permissions for service users correctly when machines see a different UID at a later time. Ownership is now set for the (service) user name, not the UID (PL-131881).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - make sure service home dirs have correct permissions 
- [x] Security requirements tested? (EVIDENCE)
  - checked on a test VM that permissions are set correctly for new and existing service user home dirs.  
