### PR TITLE
[21.05] agent backport, part 3

### DIFF
--- a/nixos/platform/agent.nix
+++ b/nixos/platform/agent.nix
@@ -208,11 +208,8 @@ in
         {
           commands = [
             "${pkgs.fc.agent}/bin/fc-manage"
-            "${pkgs.fc.agent}/bin/fc-maintenance list"
-            "${pkgs.fc.agent}/bin/fc-maintenance show"
             "${pkgs.fc.agent}/bin/fc-maintenance delete"
-            "${pkgs.fc.agent}/bin/fc-maintenance metrics"
-            "${pkgs.fc.agent}/bin/fc-maintenance check"
+            "${pkgs.fc.agent}/bin/fc-maintenance -v delete"
           ];
           groups = [ "admins" "sudo-srv" "service" ];
         }
@@ -230,6 +227,10 @@ in
           commands = [
             "${pkgs.fc.agent}/bin/fc-maintenance run"
             "${pkgs.fc.agent}/bin/fc-maintenance run --run-all-now"
+            "${pkgs.fc.agent}/bin/fc-maintenance schedule"
+            "${pkgs.fc.agent}/bin/fc-maintenance -v run"
+            "${pkgs.fc.agent}/bin/fc-maintenance -v run --run-all-now"
+            "${pkgs.fc.agent}/bin/fc-maintenance -v schedule"
           ];
           groups = [ "admins" ];
         }
@@ -403,14 +404,14 @@ in
           };
           fc-maintenance = {
             notification = "fc-maintenance check failed.";
-            command = "sudo ${pkgs.fc.agent}/bin/fc-maintenance check";
+            command = "${pkgs.fc.agent}/bin/fc-maintenance check";
             interval = 180;
           };
         };
       };
       flyingcircus.services.telegraf.inputs = {
         exec = [{
-          commands = [ "/run/wrappers/bin/sudo ${pkgs.fc.agent}/bin/fc-maintenance metrics" ];
+          commands = [ "${pkgs.fc.agent}/bin/fc-maintenance metrics" ];
           timeout = "10s";
           data_format = "json";
           json_name_key = "name";

--- a/nixos/platform/agent.nix
+++ b/nixos/platform/agent.nix
@@ -214,6 +214,12 @@ in
           groups = [ "admins" "sudo-srv" "service" ];
         }
         {
+          commands = [
+            "${pkgs.fc.agent}/bin/fc-maintenance request reboot"
+          ];
+          groups = [ "admins" ];
+        }
+        {
           commands = [ "${pkgs.fc.agent}/bin/fc-manage check" ];
           groups = [ "sensuclient" ];
         }

--- a/pkgs/fc/agent/default.nix
+++ b/pkgs/fc/agent/default.nix
@@ -34,6 +34,20 @@ let
     buildInputs = [ pytest structlog ];
   };
 
+  stamina = py.buildPythonPackage rec {
+    pname = "stamina";
+    version = "23.1.0";
+    format = "pyproject";
+
+    src = fetchPypi {
+      inherit pname version;
+      hash = "sha256-sWzj1S1liqdduBP8amZht3Cr/qkV9yzaSOMl8qeFR4Y=";
+    };
+
+    nativeBuildInputs = with py; [ hatchling hatch-vcs hatch-fancy-pypi-readme ];
+    propagatedBuildInputs = with py; [ structlog tenacity typing-extensions ];
+  };
+
 in
 buildPythonPackage rec {
   name = "fc-agent-${version}";
@@ -67,6 +81,7 @@ buildPythonPackage rec {
     py.structlog
     py.typer
     py.pyyaml
+    stamina
     util-linux
   ] ++ lib.optionals stdenv.isLinux [
     dmidecode

--- a/pkgs/fc/agent/fc/maintenance/activity/update.py
+++ b/pkgs/fc/agent/fc/maintenance/activity/update.py
@@ -10,6 +10,7 @@ import structlog
 from fc.maintenance import state
 from fc.maintenance.estimate import Estimate
 from fc.util import nixos
+from fc.util.logging import init_command_logging
 from fc.util.nixos import UnitChanges
 
 from ...util.channel import Channel
@@ -266,6 +267,8 @@ class UpdateActivity(Activity):
                 self.returncode = 0
                 return
 
+            init_command_logging(self.log)
+
             system_path = nixos.build_system(
                 self.next_channel_url, log=self.log
             )
@@ -289,6 +292,9 @@ class UpdateActivity(Activity):
             next_version=self.next_version,
             next_environment=self.next_environment,
         )
+
+        # No clean up of the command log file needed as we initialized
+        # logging only after checking that the activity changes the system.
 
         self.returncode = 0
 

--- a/pkgs/fc/agent/fc/maintenance/activity/vm_change.py
+++ b/pkgs/fc/agent/fc/maintenance/activity/vm_change.py
@@ -167,12 +167,11 @@ class VMChangeActivity(Activity):
         else:
             self.reboot_needed = None
 
-    def load(self):
+    def run(self):
         self._update_reboot_needed()
-
-    # Running an VMChangeActivity is not needed, so no run method.
-    # The request manager handles the reboot required by this activity.
+        self.returncode = 0
 
     def resume(self):
-        # There's nothing to do so we can safely "retry" this activity.
+        # run() just checks if the reboot is needed at the moment so we can safely
+        # retry this activity.
         self.run()

--- a/pkgs/fc/agent/fc/maintenance/cli.py
+++ b/pkgs/fc/agent/fc/maintenance/cli.py
@@ -31,9 +31,10 @@ from fc.util.logging import (
     init_command_logging,
     init_logging,
 )
-from typer import Argument, Exit, Option, Typer
+from fc.util.typer_utils import FCTyperApp
+from typer import Argument, Exit, Option
 
-app = Typer(pretty_exceptions_show_locals=False)
+app = FCTyperApp("fc-maintenance")
 log = structlog.get_logger()
 
 
@@ -52,7 +53,7 @@ rm: ReqManager
 
 
 @app.callback(no_args_is_help=True)
-def main(
+def fc_maintenance(
     verbose: bool = Option(
         False,
         "--verbose",

--- a/pkgs/fc/agent/fc/maintenance/lib/shellscript.py
+++ b/pkgs/fc/agent/fc/maintenance/lib/shellscript.py
@@ -8,6 +8,7 @@ file, it is executed with /bin/sh.
 import os
 import subprocess
 
+import rich.console
 import rich.syntax
 import rich.text
 
@@ -38,5 +39,8 @@ class ShellScriptActivity(Activity):
         self.returncode = p.returncode
 
     def __rich__(self):
-        syntax = rich.syntax.Syntax(self.script, "shell", line_numbers=True)
-        return syntax
+        lines = self.script.splitlines()
+        syntax = rich.syntax.Syntax(
+            self.script, "shell", line_numbers=len(lines) > 2
+        )
+        return rich.console.Group("Execute script:\n", syntax)

--- a/pkgs/fc/agent/fc/maintenance/reqmanager.py
+++ b/pkgs/fc/agent/fc/maintenance/reqmanager.py
@@ -1020,7 +1020,9 @@ class ReqManager:
         if name_matches:
             return sorted(
                 [
-                    Request.load(name, self.log, self.request_runnable_for_seconds)
+                    Request.load(
+                        name, self.log, self.request_runnable_for_seconds
+                    )
                     for name in name_matches
                 ],
                 key=lambda r: r.added_at
@@ -1037,7 +1039,9 @@ class ReqManager:
         if name_matches:
             return sorted(
                 [
-                    Request.load(name, self.log, self.request_runnable_for_seconds)
+                    Request.load(
+                        name, self.log, self.request_runnable_for_seconds
+                    )
                     for name in name_matches
                 ],
                 key=lambda r: r.added_at

--- a/pkgs/fc/agent/fc/maintenance/reqmanager.py
+++ b/pkgs/fc/agent/fc/maintenance/reqmanager.py
@@ -359,7 +359,7 @@ class ReqManager:
     @require_lock
     @require_directory
     def schedule(self):
-        """Triggers request scheduling on server."""
+        """Gets (updated) start times for pending requests from the directory."""
         self.log.debug("schedule-start")
 
         schedule_maintenance = {
@@ -368,6 +368,7 @@ class ReqManager:
                 "comment": req.comment,
             }
             for reqid, req in self.requests.items()
+            if req.state == State.pending
         }
         if schedule_maintenance:
             self.log.debug(

--- a/pkgs/fc/agent/fc/maintenance/reqmanager.py
+++ b/pkgs/fc/agent/fc/maintenance/reqmanager.py
@@ -59,6 +59,14 @@ def require_directory(func):
     return with_directory_connection
 
 
+class RequestsNotLoaded(Exception):
+    def __init__(self):
+        super().__init__(
+            "Accessing requests is not possible because ReqManager has not been "
+            "initialized."
+        )
+
+
 class PostponeMaintenance(Exception):
     pass
 
@@ -73,11 +81,52 @@ class HandleEnterExceptionResult(NamedTuple):
 
 
 class ReqManager:
-    """Container for Requests."""
+    """
+    Manage maintenance requests.
+    The basic phases in the life of a request are:
+    add, schedule, execute, archive.
+
+    Requests may be merged when they are compatible with existing requests
+    or postponed when they cannot be executed at the moment and should run at
+    a later time.
+
+    *Invasive* methods use `self.requests` and are allowed to make changes to
+    requests. To use them, requests must be loaded and the global request
+    manager lock must be held.
+
+    These methods are typically used like this to handle locking and request
+    loading:
+    ```
+    rm = ReqManager()
+    with rm:
+        rm.invasive_method()
+    ```
+
+    Invasive methods are:
+
+    * scan
+    * add
+    * delete
+    * schedule
+    * update_states
+    * execute
+    * postpone
+    * archive
+
+    For non-invasive tasks, ReqManager methods can be used immediately. These
+    include:
+
+    * list_requests
+    * show_request
+    * check
+    * get_metrics
+
+    They also work with non-privileged users.
+    """
 
     directory = None
     lockfile = None
-    requests: dict[str, Request]
+    _requests: dict[str, Request] | None
     min_estimate_seconds: int = 900
 
     def __init__(
@@ -93,26 +142,27 @@ class ReqManager:
             "reqmanager-init",
             spooldir=str(spooldir),
             enc_path=str(enc_path),
-            config_file=str(config_file),
         )
         self.spooldir = Path(spooldir)
         self.requestsdir = self.spooldir / "requests"
         self.archivedir = self.spooldir / "archive"
         self.last_run_stats_path = self.spooldir / "last_run.json"
         self.maintenance_marker_path = self.spooldir / "in_maintenance"
-        for d in (self.spooldir, self.requestsdir, self.archivedir):
-            if not d.exists():
-                os.mkdir(d)
         self.enc_path = Path(enc_path)
-        self.requests = {}
         self.config_file = Path(config_file)
         self.config = configparser.ConfigParser()
         if self.config_file:
             if self.config_file.is_file():
-                self.log.debug("reqmanager-enter-read-config")
+                self.log.debug(
+                    "reqmanager-enter-read-config",
+                    config_file=str(config_file),
+                )
                 self.config.read(self.config_file)
             else:
-                self.log.warn("reqmanager-enter-config-not-found")
+                self.log.warn(
+                    "reqmanager-enter-config-not-found",
+                    config_file=str(config_file),
+                )
         self.maintenance_preparation_seconds = int(
             self.config.get("maintenance", "preparation_seconds", fallback=300)
         )
@@ -124,9 +174,21 @@ class ReqManager:
 
     def __enter__(self):
         """
-        Sets up global request manager lock and loads active requests.
-        Used for invasive tasks that may change requests.
+        Acquires global request manager lock and loads active requests.
+        Must be called before using invasive methods that use
+        `self.requests` and make changes to requests.
+
+        Typically used like this:
+        ```
+        rm = ReqManager()
+        with rm:
+            rm.invasive_method()
+        ```
         """
+        for d in (self.spooldir, self.requestsdir, self.archivedir):
+            if not d.exists():
+                os.mkdir(d)
+
         if self.lockfile:
             return self
         self.lockfile = open(p.join(self.spooldir, ".lock"), "a+")
@@ -144,6 +206,7 @@ class ReqManager:
         self.lockfile = None
 
     def __rich__(self):
+        requests = self._active_requests()
         table = Table(
             show_header=True,
             title="Maintenance requests",
@@ -151,7 +214,7 @@ class ReqManager:
             title_style="bold",
         )
 
-        if not self.requests:
+        if not requests:
             return "[bold]No maintenance requests at the moment.[/bold]"
 
         table.add_column("State")
@@ -162,7 +225,7 @@ class ReqManager:
         table.add_column("Added")
         table.add_column("Updated")
         table.add_column("Scheduled")
-        for req in sorted(self.requests.values()):
+        for req in sorted(requests):
             if req.next_due:
                 exec_interval = (
                     format_datetime(req.next_due)
@@ -190,12 +253,20 @@ class ReqManager:
 
         return table
 
-    def dir(self, request):
-        """Return file system path for request identified by `reqid`."""
+    def _request_directory(self, request):
+        """Return file system path for an active request."""
         return p.realpath(p.join(self.requestsdir, request.id))
 
+    @property
+    def requests(self):
+        if self._requests is None:
+            raise RequestsNotLoaded()
+
+        return self._requests
+
+    @require_lock
     def scan(self):
-        self.requests = {}
+        self._requests = {}
         for d in glob.glob(p.join(self.requestsdir, "*")):
             if not p.isdir(d):
                 continue
@@ -221,7 +292,7 @@ class ReqManager:
 
     def _add_request(self, request: Request):
         self.requests[request.id] = request
-        request.dir = self.dir(request)
+        request.dir = self._request_directory(request)
         request._reqmanager = self
         request.added_at = utcnow()
         request.runnable_for_seconds = self.request_runnable_for_seconds
@@ -307,6 +378,7 @@ class ReqManager:
 
         return merge_result
 
+    @require_lock
     def add(self, request: Request | None, add_always=False) -> Request | None:
         """Adds a Request object to the local queue.
         New request is merged with existing requests. If the merge results
@@ -354,6 +426,33 @@ class ReqManager:
         return max(
             self.min_estimate_seconds,
             int(request.estimate) + self.maintenance_preparation_seconds,
+        )
+
+    @require_lock
+    def delete(self, reqid):
+        """
+        Deletes an active request from the queue.
+        `reqid` can be a full request ID or a prefix.
+        """
+        self.log.debug("delete-start", request=reqid)
+        req = None
+        for i in self.requests:
+            if i.startswith(reqid):
+                req = self.requests[i]
+                break
+        if not req:
+            self.log.warning(
+                "delete-skip-missing",
+                _replace_msg="Cannot locate request {request}, skipping.",
+                request=reqid,
+            )
+            return
+        req.state = State.deleted
+        req.save()
+        self.log.info(
+            "delete-finished",
+            _replace_msg="Marked request {request} as deleted.",
+            request=req.id,
         )
 
     @require_lock
@@ -414,7 +513,128 @@ class ReqManager:
                 {key: {"result": "deleted"} for key in disappeared}
             )
 
-    def runnable(self, run_all_now=False, force_run=False):
+    @require_lock
+    def update_states(self):
+        """
+        Updates all request states.
+
+        We want to run continuously scheduled requests in one go to reduce overall
+        maintenance time and reboots.
+
+        A Request is considered "due" if its start time is in the past or is
+        scheduled directly after a previous due request.
+
+        In other words: if there's a due request, following requests can be run even if
+        their start time is not reached, yet.
+        """
+        due_dt = utcnow()
+        requests = self.requests.values()
+        self.log.debug("update-states-start", request_count=len(requests))
+        for request in sorted(requests):
+            request.update_state(due_dt)
+            request.save()
+            if request.state == State.due and request.next_due:
+                delta = timedelta(
+                    seconds=self._estimated_request_duration(request) + 60
+                )
+                due_dt = max(utcnow(), request.next_due + delta)
+
+    @require_directory
+    def _enter_maintenance(self):
+        """Enters maintenance mode which tells the directory to mark the machine
+        as 'not in service'. The main reason is to avoid false alarms during expected
+        service interruptions as the machine reboots or services are restarted.
+        """
+        self.log.debug("enter-maintenance")
+        self.log.debug("mark-node-out-of-service")
+        self.directory.mark_node_service_status(socket.gethostname(), False)
+
+        if self.maintenance_marker_path.exists():
+            previous_maintenance_entered_at = (
+                self.maintenance_marker_path.read_text()
+            )
+            self.log.info(
+                "enter-maintenance-marker-present",
+                _replace_msg=(
+                    "Maintenance marker is already present, likely from an "
+                    "unfinished maintenance run. Keeping the old one from "
+                    "{previous_maintenance_entered_at} and continuing."
+                ),
+                previous_maintenance_entered_at=previous_maintenance_entered_at,
+            )
+        else:
+            self.maintenance_marker_path.write_text(utcnow().isoformat())
+        postpone_seen = False
+        tempfail_seen = False
+        for name, command in self.config["maintenance-enter"].items():
+            if not command.strip():
+                continue
+            self.log.info(
+                "enter-maintenance-subsystem", subsystem=name, command=command
+            )
+            try:
+                # XXX: capture output
+                subprocess.run(command, shell=True, check=True)
+            except subprocess.CalledProcessError as e:
+                if e.returncode == EXIT_POSTPONE:
+                    self.log.info(
+                        "enter-maintenance-postpone",
+                        command=command,
+                        _replace_msg=(
+                            "Command `{command}` requested to postpone all requests."
+                        ),
+                    )
+                    postpone_seen = True
+                elif e.returncode == EXIT_TEMPFAIL:
+                    self.log.info(
+                        "enter-maintenance-tempfail",
+                        command=command,
+                        _replace_msg=(
+                            "Command `{command}` failed temporarily. "
+                            "Requests should be tried again next time."
+                        ),
+                    )
+                    tempfail_seen = True
+                else:
+                    raise
+
+        if postpone_seen:
+            raise PostponeMaintenance()
+
+        if tempfail_seen:
+            raise TempfailMaintenance()
+
+    @require_directory
+    def _leave_maintenance(self):
+        """
+        Tells the directory to mark the machine 'in service'.
+        It's ok to call this method even when the machine is already in service.
+        """
+        self.log.debug("leave-maintenance")
+        for name, command in self.config["maintenance-leave"].items():
+            if not command.strip():
+                continue
+            self.log.info(
+                "leave-maintenance-subsystem", subsystem=name, command=command
+            )
+            subprocess.run(command, shell=True, check=True)
+        self.log.debug("mark-node-in-service")
+        self.directory.mark_node_service_status(socket.gethostname(), True)
+        if self.maintenance_marker_path.exists():
+            maintenance_entered_at = self.maintenance_marker_path.read_text()
+            self.log.debug(
+                "remove-maintenance-marker",
+                maintenance_entered_at=maintenance_entered_at,
+            )
+            self.maintenance_marker_path.unlink()
+        else:
+            # Expected when `enter_maintenance` has not been called before.
+            self.log.debug(
+                "no-maintenance-marker",
+                maintenance_marker_path=self.maintenance_marker_path,
+            )
+
+    def _runnable(self, run_all_now=False, force_run=False):
         """Generate due Requests in running order."""
         if run_all_now and force_run:
             self.log.warn(
@@ -466,127 +686,6 @@ class ReqManager:
         )
 
         return runnable_requests
-
-    @require_lock
-    @require_directory
-    def enter_maintenance(self):
-        """Enters maintenance mode which tells the directory to mark the machine
-        as 'not in service'. The main reason is to avoid false alarms during expected
-        service interruptions as the machine reboots or services are restarted.
-        """
-        self.log.debug("enter-maintenance")
-        self.log.debug("mark-node-out-of-service")
-        self.directory.mark_node_service_status(socket.gethostname(), False)
-
-        if self.maintenance_marker_path.exists():
-            previous_maintenance_entered_at = (
-                self.maintenance_marker_path.read_text()
-            )
-            self.log.info(
-                "enter-maintenance-marker-present",
-                _replace_msg=(
-                    "Maintenance marker is already present, likely from an "
-                    "unfinished maintenance run. Keeping the old one from "
-                    "{previous_maintenance_entered_at} and continuing."
-                ),
-                previous_maintenance_entered_at=previous_maintenance_entered_at,
-            )
-        else:
-            self.maintenance_marker_path.write_text(utcnow().isoformat())
-        postpone_seen = False
-        tempfail_seen = False
-        for name, command in self.config["maintenance-enter"].items():
-            if not command.strip():
-                continue
-            self.log.info(
-                "enter-maintenance-subsystem", subsystem=name, command=command
-            )
-            try:
-                subprocess.run(command, shell=True, check=True)
-            except subprocess.CalledProcessError as e:
-                if e.returncode == EXIT_POSTPONE:
-                    self.log.info(
-                        "enter-maintenance-postpone",
-                        command=command,
-                        _replace_msg=(
-                            "Command `{command}` requested to postpone all requests."
-                        ),
-                    )
-                    postpone_seen = True
-                elif e.returncode == EXIT_TEMPFAIL:
-                    self.log.info(
-                        "enter-maintenance-tempfail",
-                        command=command,
-                        _replace_msg=(
-                            "Command `{command}` failed temporarily."
-                            "Requests should be tried again next time."
-                        ),
-                    )
-                    tempfail_seen = True
-                else:
-                    raise
-
-        if postpone_seen:
-            raise PostponeMaintenance()
-
-        if tempfail_seen:
-            raise TempfailMaintenance()
-
-    @require_lock
-    @require_directory
-    def leave_maintenance(self):
-        """
-        Tells the directory to mark the machine 'in service'.
-        It's ok to call this method even when the machine is already in service.
-        """
-        self.log.debug("leave-maintenance")
-        for name, command in self.config["maintenance-leave"].items():
-            if not command.strip():
-                continue
-            self.log.info(
-                "leave-maintenance-subsystem", subsystem=name, command=command
-            )
-            subprocess.run(command, shell=True, check=True)
-        self.log.debug("mark-node-in-service")
-        self.directory.mark_node_service_status(socket.gethostname(), True)
-        if self.maintenance_marker_path.exists():
-            maintenance_entered_at = self.maintenance_marker_path.read_text()
-            self.log.debug(
-                "remove-maintenance-marker",
-                maintenance_entered_at=maintenance_entered_at,
-            )
-            self.maintenance_marker_path.unlink()
-        else:
-            # Expected when `enter_maintenance` has not been called before.
-            self.log.debug(
-                "no-maintenance-marker",
-                maintenance_marker_path=self.maintenance_marker_path,
-            )
-
-    def update_states(self):
-        """
-        Updates all request states.
-
-        We want to run continuously scheduled requests in one go to reduce overall
-        maintenance time and reboots.
-
-        A Request is considered "due" if its start time is in the past or is
-        scheduled directly after a previous due request.
-
-        In other words: if there's a due request, following requests can be run even if
-        their start time is not reached, yet.
-        """
-        due_dt = utcnow()
-        requests = self.requests.values()
-        self.log.debug("update-states-start", request_count=len(requests))
-        for request in sorted(requests):
-            request.update_state(due_dt)
-            request.save()
-            if request.state == State.due and request.next_due:
-                delta = timedelta(
-                    seconds=self._estimated_request_duration(request) + 60
-                )
-                due_dt = max(utcnow(), request.next_due + delta)
 
     def _handle_enter_postpone(
         self, run_all_now: bool, force_run: bool
@@ -649,7 +748,7 @@ class ReqManager:
                 "run-all-now-tempfail",
                 _replace_msg=(
                     "Run all mode requested but a maintenance enter "
-                    "command had a temporary failure."
+                    "command had a (temporary) failure. "
                     "Doing nothing unless --force-run is given, too."
                 ),
             )
@@ -705,6 +804,33 @@ class ReqManager:
         with open(self.last_run_stats_path, "w") as wf:
             json.dump(stats, wf, indent=4)
 
+    def _reboot_and_exit(self, requested_reboots):
+        if RebootType.COLD in requested_reboots:
+            self.log.info(
+                "maintenance-poweroff",
+                _replace_msg=(
+                    "Doing a cold boot in five seconds to finish maintenance "
+                    "activities."
+                ),
+            )
+            time.sleep(5)
+            subprocess.run(
+                "poweroff", check=True, capture_output=True, text=True
+            )
+            sys.exit(0)
+
+        elif RebootType.WARM in requested_reboots:
+            self.log.info(
+                "maintenance-reboot",
+                _replace_msg=(
+                    "Rebooting in five seconds to finish maintenance "
+                    "activities."
+                ),
+            )
+            time.sleep(5)
+            subprocess.run("reboot", check=True, capture_output=True, text=True)
+            sys.exit(0)
+
     @require_directory
     @require_lock
     def execute(self, run_all_now: bool = False, force_run: bool = False):
@@ -729,15 +855,15 @@ class ReqManager:
         'success' again when they are still in the queue after a recent system reboot.
         """
 
-        runnable_requests = self.runnable(run_all_now, force_run)
+        runnable_requests = self._runnable(run_all_now, force_run)
         if not runnable_requests:
-            self.leave_maintenance()
+            self._leave_maintenance()
             self._write_stats_for_execute()
             return
 
         prepare_dt = utcnow()
         try:
-            self.enter_maintenance()
+            self._enter_maintenance()
         except PostponeMaintenance:
             res = self._handle_enter_postpone(run_all_now, force_run)
             if res.postpone:
@@ -745,7 +871,7 @@ class ReqManager:
                     self.log.debug("execute-requests-postpone", request=req.id)
                     req.state = State.postpone
             if res.exit:
-                self.leave_maintenance()
+                self._leave_maintenance()
                 self._write_stats_for_execute()
                 return
 
@@ -769,11 +895,11 @@ class ReqManager:
         )
 
         # Execute any reboots while still in maintenance mode.
-        self.reboot_and_exit(requested_reboots)
+        self._reboot_and_exit(requested_reboots)
 
         # When we are still here, no reboot happened. We can leave maintenance now.
         self.log.debug("no-reboot-requested")
-        self.leave_maintenance()
+        self._leave_maintenance()
 
     @require_lock
     @require_directory
@@ -835,41 +961,99 @@ class ReqManager:
             req.dir = dest
             req.save()
 
-    @require_lock
-    def list(self):
-        rich.print(self)
-
-    @require_lock
-    def show(self, request_id=None, dump_yaml=False):
-        if not self.requests:
-            rich.print("[bold]No maintenance requests at the moment.[/bold]")
-            return
-
-        if request_id is None:
-            requests = list(self.requests.values())
-            if len(self.requests) == 1:
-                rich.print("[bold]There's only one at the moment:[/bold]\n")
-        else:
-            requests = sorted(
+    def _active_requests(self, req_id_prefix: str = "") -> list[Request]:
+        """
+        Loads active requests. Optionally, a request ID prefix can be passed
+        for filtering.
+        """
+        name_matches = self.requestsdir.glob(req_id_prefix + "*")
+        if name_matches:
+            return sorted(
                 [
-                    req
-                    for key, req in self.requests.items()
-                    if key.startswith(request_id)
+                    Request.load(name, self.log, self.request_runnable_for_seconds)
+                    for name in name_matches
                 ],
                 key=lambda r: r.added_at or datetime.fromtimestamp(0),
             )
+        return []
+
+    def _archived_requests(self, req_id_prefix: str = "") -> list[Request]:
+        """
+        Loads archived requests by an request ID prefix. Optionally, a request
+        ID prefix can be passed for filtering.
+        """
+        name_matches = self.archivedir.glob(req_id_prefix + "*")
+        if name_matches:
+            return sorted(
+                [
+                    Request.load(name, self.log, self.request_runnable_for_seconds)
+                    for name in name_matches
+                ],
+                key=lambda r: r.added_at or datetime.fromtimestamp(0),
+            )
+        return []
+
+    def list_requests(self):
+        rich.print(self)
+
+    def show_request(self, request_id=None, dump_yaml=False):
+        request_id_prefix = "" if request_id is None else request_id
+        active_requests = self._active_requests(request_id_prefix)
+
+        print()
+
+        if request_id is None:
+            # We only check active requests when no request ID was given.
+            if not active_requests:
+                rich.print(
+                    "[bold]No active maintenance requests at the moment.[/bold]"
+                )
+                return
+
+            if len(active_requests) == 1:
+                rich.print(
+                    "[bold]There's only one active request at the moment:[/bold]\n"
+                )
+            else:
+                rich.print(
+                    "[bold blue]Notice:[/bold blue] [bold]There are multiple "
+                    "active requests, showing the newest one:[/bold]\n"
+                )
+            requests = active_requests
+        else:
+            # Request ID (prefix) was given. First, check active requests for
+            # matches and use them, if present.
+            if active_requests:
+                if len(active_requests) > 1:
+                    rich.print(
+                        "[bold blue]Notice:[/bold blue] [bold]Found multiple "
+                        f"active requests for prefix '{request_id}', showing "
+                        "the newest:[/bold]\n"
+                    )
+                requests = active_requests
+            else:
+                # Nothing found in active requests, check archived requests.
+                archived_requests = self._archived_requests(request_id_prefix)
+                if len(archived_requests) == 1:
+                    rich.print(
+                        "[bold blue]Notice:[/bold blue] [bold]Found one "
+                        f"archived request for prefix '{request_id}'\n"
+                    )
+                elif archived_requests:
+                    rich.print(
+                        "[bold blue]Notice:[/bold blue] [bold]Found multiple "
+                        f"archived requests for prefix '{request_id}', showing "
+                        "the newest:[/bold]\n"
+                    )
+
+                requests = archived_requests
+
             if not requests:
                 rich.print(
                     f"[bold red]Error:[/bold red] [bold]Cannot locate any "
                     f"request with prefix '{request_id}'![/bold]"
                 )
                 return
-
-        if len(requests) > 1:
-            rich.print(
-                "[bold blue]Notice:[/bold blue] [bold]Multiple requests "
-                "found, showing the newest:[/bold]\n"
-            )
 
         req = requests[-1]
 
@@ -880,55 +1064,17 @@ class ReqManager:
         else:
             rich.print(req)
 
-    @require_lock
-    def delete(self, reqid):
-        self.log.debug("delete-start", request=reqid)
-        req = None
-        for i in self.requests:
-            if i.startswith(reqid):
-                req = self.requests[i]
-                break
-        if not req:
-            self.log.warning(
-                "delete-skip-missing",
-                _replace_msg="Cannot locate request {request}, skipping.",
-                request=reqid,
-            )
-            return
-        req.state = State.deleted
-        req.save()
-        self.log.info(
-            "delete-finished",
-            _replace_msg="Marked request {request} as deleted.",
-            request=req.id,
-        )
-
-    def reboot_and_exit(self, requested_reboots):
-        if RebootType.COLD in requested_reboots:
-            self.log.info(
-                "maintenance-poweroff",
-                _replace_msg=(
-                    "Doing a cold boot in five seconds to finish maintenance "
-                    "activities."
-                ),
-            )
-            time.sleep(5)
-            subprocess.run(
-                "poweroff", check=True, capture_output=True, text=True
-            )
-            sys.exit(0)
-
-        elif RebootType.WARM in requested_reboots:
-            self.log.info(
-                "maintenance-reboot",
-                _replace_msg=(
-                    "Rebooting in five seconds to finish maintenance "
-                    "activities."
-                ),
-            )
-            time.sleep(5)
-            subprocess.run("reboot", check=True, capture_output=True, text=True)
-            sys.exit(0)
+        if len(requests) > 1:
+            other = ", ".join(req.id for req in requests[:-1])
+            if request_id:
+                rich.print(
+                    "\n[bold blue]Notice:[/bold blue] Other matches with prefix "
+                    f"'{request_id}': {other}"
+                )
+            else:
+                rich.print(
+                    f"\n[bold blue]Notice:[/bold blue] Other requests: {other}"
+                )
 
     def check(self) -> CheckResult:
         errors = []
@@ -1030,8 +1176,10 @@ class ReqManager:
         return CheckResult(errors, warnings, ok_info)
 
     def get_metrics(self) -> dict:
-        requests = sorted(self.requests.values())
-        runnable = self.runnable()
+        requests = self._active_requests()
+        runnable = [
+            r for r in requests if r.state in (State.due, State.running)
+        ]
 
         metrics = {
             "name": "fc_maintenance",

--- a/pkgs/fc/agent/fc/maintenance/reqmanager.py
+++ b/pkgs/fc/agent/fc/maintenance/reqmanager.py
@@ -10,13 +10,12 @@ import socket
 import subprocess
 import sys
 import time
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import NamedTuple
 
 import fc.maintenance.state
 import fc.util.directory
-import pytz
 import rich
 import rich.syntax
 import structlog
@@ -973,7 +972,8 @@ class ReqManager:
                     Request.load(name, self.log, self.request_runnable_for_seconds)
                     for name in name_matches
                 ],
-                key=lambda r: r.added_at or datetime.fromtimestamp(0),
+                key=lambda r: r.added_at
+                or datetime.fromtimestamp(0, tz=timezone.utc),
             )
         return []
 
@@ -989,7 +989,8 @@ class ReqManager:
                     Request.load(name, self.log, self.request_runnable_for_seconds)
                     for name in name_matches
                 ],
-                key=lambda r: r.added_at or datetime.fromtimestamp(0),
+                key=lambda r: r.added_at
+                or datetime.fromtimestamp(0, tz=timezone.utc),
             )
         return []
 
@@ -1151,7 +1152,7 @@ class ReqManager:
         if num_scheduled := metrics["requests_scheduled"]:
             next_due = format_datetime(
                 datetime.fromtimestamp(
-                    metrics["request_next_due_at"], tz=pytz.utc
+                    metrics["request_next_due_at"], tz=timezone.utc
                 )
             )
             if num_scheduled == 1:

--- a/pkgs/fc/agent/fc/maintenance/request.py
+++ b/pkgs/fc/agent/fc/maintenance/request.py
@@ -431,7 +431,7 @@ class Request:
         if other._comment:
             if not self._comment:
                 self._comment = other._comment
-            elif self._comment != other._comment:
+            elif other._comment not in self._comment:
                 self._comment += "\n\n" + other._comment
 
         if not activity_merge_result.is_effective:

--- a/pkgs/fc/agent/fc/maintenance/request.py
+++ b/pkgs/fc/agent/fc/maintenance/request.py
@@ -64,6 +64,27 @@ class Attempt:
         elif self.started and not self.duration:
             self.duration = (self.finished - self.started).total_seconds()
 
+    def __rich__(self):
+        table = rich.table.Table(show_header=False, show_edge=False)
+        table.add_column()
+        table.add_column()
+        table.add_row("Started", format_datetime(self.started) or "-")
+        table.add_row("Finished", format_datetime(self.finished) or "-")
+        table.add_row(
+            "Duration",
+            f"{self.duration:.4}s" if self.duration is not None else "-",
+        )
+
+        table.add_row(
+            "Exit code",
+            str(self.returncode) if self.returncode is not None else "-",
+        )
+        if self.stdout:
+            table.add_row("Stdout", self.stdout)
+        if self.stderr:
+            table.add_row("Stderr", self.stderr)
+        return table
+
 
 class Request:
     MAX_RETRIES = 48
@@ -142,22 +163,20 @@ class Request:
 
     def __rich_repr__(self):
         yield "ID", self._reqid
-        yield "state", str(self.state)
+        yield "State", str(self.state)
         if self.next_due:
-            yield "next_due", format_datetime(self.next_due)
+            yield "Due at", format_datetime(self.next_due)
         if self.added_at:
-            yield "added_at", format_datetime(self.added_at)
+            yield "Added at", format_datetime(self.added_at)
         if self.updated_at:
-            yield "updated_at", format_datetime(self.updated_at)
+            yield "Updated at", format_datetime(self.updated_at)
         if self.last_scheduled_at:
-            yield "last_scheduled_at", format_datetime(self.last_scheduled_at)
-        yield "estimate", str(self.estimate)
-        yield "comment", self.comment
-        yield "activity", self.activity
-        yield "attempts", ", ".join(
-            f"{format_datetime(a.finished)} (exit {a.returncode})"
-            for a in self.attempts
-        )
+            yield "Scheduled at", format_datetime(self.last_scheduled_at)
+        yield "Estimate", str(self.estimate)
+        yield "Comment", self.comment
+        yield "Activity", self.activity
+        for pos, attempt in enumerate(self.attempts):
+            yield (f"Attempt {pos}", attempt)
 
     def set_up_logging(self, log):
         log = log.bind(request=self.id)

--- a/pkgs/fc/agent/fc/maintenance/tests/test_cli.py
+++ b/pkgs/fc/agent/fc/maintenance/tests/test_cli.py
@@ -43,76 +43,111 @@ def app_main_args(tmp_path, agent_maintenance_config):
 
 
 @pytest.fixture
-def invoke_app(app_main_args):
-    runner = typer.testing.CliRunner()
+def _invoke_app(app_main_args, monkeypatch):
+    def _invoke_app_wrapper(*args, exit_code=0):
+        runner = typer.testing.CliRunner()
 
-    def _invoke_app(*args, exit_code=0):
         with unittest.mock.patch("fc.maintenance.cli.ReqManager"):
             result = runner.invoke(fc.maintenance.cli.app, app_main_args + args)
             assert (
                 result.exit_code == exit_code
             ), f"unexpected exit code {result.exit_code}, output: {result.output}"
 
+    return _invoke_app_wrapper
+
+
+@pytest.fixture
+def invoke_app_as_root(_invoke_app, monkeypatch):
+    monkeypatch.setattr("os.getuid", lambda: 0)
     return _invoke_app
 
 
-def test_invoke_run(invoke_app):
-    invoke_app("run")
+@pytest.fixture
+def invoke_app_as_normal_user(_invoke_app, monkeypatch):
+    monkeypatch.setattr("os.getuid", lambda: 1000)
+    return _invoke_app
+
+
+def test_invoke_schedule(invoke_app_as_root):
+    invoke_app_as_root("schedule")
+    fc.maintenance.cli.rm.schedule.assert_called_once()
+
+
+def test_invoke_run(invoke_app_as_root):
+    invoke_app_as_root("run")
     fc.maintenance.cli.rm.execute.assert_called_once_with(False, False)
     fc.maintenance.cli.rm.postpone.assert_called_once()
     fc.maintenance.cli.rm.archive.assert_called_once()
 
 
-def test_invoke_run_all_now(invoke_app):
-    invoke_app("run", "--run-all-now")
+def test_invoke_run_as_normal_user_should_fail(invoke_app_as_normal_user):
+    invoke_app_as_normal_user("run", exit_code=77)
+
+
+def test_invoke_run_all_now(invoke_app_as_root):
+    invoke_app_as_root("run", "--run-all-now")
     fc.maintenance.cli.rm.execute.assert_called_once_with(True, False)
 
 
-def test_invoke_run_all_now_force_run(invoke_app):
-    invoke_app("run", "--run-all-now", "--force-run")
+def test_invoke_run_all_now_force_run(invoke_app_as_root):
+    invoke_app_as_root("run", "--run-all-now", "--force-run")
     fc.maintenance.cli.rm.execute.assert_called_once_with(True, True)
 
 
-def test_invoke_list(invoke_app):
-    invoke_app("list")
-    fc.maintenance.cli.rm.list.assert_called_once()
-
-
-def test_invoke_show(invoke_app):
-    invoke_app("show")
-    fc.maintenance.cli.rm.show.assert_called_once()
-
-
-def test_invoke_show_request_id_dump_yaml(invoke_app):
-    invoke_app("show", "123abc", "--dump-yaml")
-    fc.maintenance.cli.rm.show.assert_called_once_with("123abc", True)
-
-
-def test_invoke_delete(invoke_app):
-    invoke_app("delete", "123abc")
+def test_invoke_delete(invoke_app_as_root):
+    invoke_app_as_root("delete", "123abc")
     fc.maintenance.cli.rm.delete.assert_called_once_with("123abc")
 
 
-def test_invoke_schedule(invoke_app):
-    invoke_app("schedule")
-    fc.maintenance.cli.rm.schedule.assert_called_once()
+@pytest.mark.parametrize(
+    "args",
+    [
+        ["schedule"],
+        ["run"],
+        ["delete", "123abc"],
+        ["request", "script", "comment", "true"],
+        ["request", "reboot"],
+        ["request", "update"],
+        ["request", "system-properties"],
+    ],
+)
+def test_invoke_root_cmds_as_normal_user_should_fail(
+    args,
+    invoke_app_as_normal_user,
+):
+    invoke_app_as_normal_user(*args, exit_code=77)
 
 
-def test_invoke_request_run_script(invoke_app):
-    invoke_app("request", "script", "comment", "true")
+def test_invoke_list(invoke_app_as_normal_user):
+    invoke_app_as_normal_user("list")
+    fc.maintenance.cli.rm.list_requests.assert_called_once()
+
+
+def test_invoke_show(invoke_app_as_normal_user):
+    invoke_app_as_normal_user("show")
+    fc.maintenance.cli.rm.show_request.assert_called_once()
+
+
+def test_invoke_show_request_id_dump_yaml(invoke_app_as_normal_user):
+    invoke_app_as_normal_user("show", "123abc", "--dump-yaml")
+    fc.maintenance.cli.rm.show_request.assert_called_once_with("123abc", True)
+
+
+def test_invoke_request_run_script(invoke_app_as_root):
+    invoke_app_as_root("request", "script", "comment", "true")
     fc.maintenance.cli.rm.add.assert_called_once()
 
 
 @unittest.mock.patch("fc.maintenance.cli.RebootActivity")
-def test_invoke_request_warm_reboot(activity, invoke_app):
-    invoke_app("request", "reboot")
+def test_invoke_request_warm_reboot(activity, invoke_app_as_root):
+    invoke_app_as_root("request", "reboot")
     activity.assert_called_once_with("reboot")
     fc.maintenance.cli.rm.add.assert_called_once()
 
 
 @unittest.mock.patch("fc.maintenance.cli.RebootActivity")
-def test_invoke_request_cold_reboot(activity, invoke_app):
-    invoke_app("request", "reboot", "--cold-reboot")
+def test_invoke_request_cold_reboot(activity, invoke_app_as_root):
+    invoke_app_as_root("request", "reboot", "--cold-reboot")
     activity.assert_called_once_with("poweroff")
     fc.maintenance.cli.rm.add.assert_called_once()
 
@@ -122,9 +157,9 @@ def test_invoke_request_cold_reboot(activity, invoke_app):
 @unittest.mock.patch("fc.maintenance.cli.request_reboot_for_cpu")
 @unittest.mock.patch("fc.maintenance.cli.request_reboot_for_memory")
 def test_invoke_request_system_properties_virtual(
-    memory, cpu, qemu, kernel, invoke_app
+    memory, cpu, qemu, kernel, invoke_app_as_root
 ):
-    invoke_app("request", "system-properties")
+    invoke_app_as_root("request", "system-properties")
     memory.assert_called_once()
     cpu.assert_called_once()
     qemu.assert_called_once()
@@ -136,14 +171,14 @@ def test_invoke_request_system_properties_virtual(
 @unittest.mock.patch("fc.maintenance.cli.request_reboot_for_cpu")
 @unittest.mock.patch("fc.maintenance.cli.request_reboot_for_memory")
 def test_invoke_request_system_properties_virtual(
-    memory, cpu, qemu, kernel, tmpdir, invoke_app
+    memory, cpu, qemu, kernel, tmpdir, invoke_app_as_root
 ):
     enc_file = tmpdir / "enc.json"
     enc = ENC.copy()
     enc["parameters"]["machine"] = "physical"
     enc_file.write_text(json.dumps(enc), encoding="utf8")
 
-    invoke_app("request", "system-properties")
+    invoke_app_as_root("request", "system-properties")
     memory.assert_not_called()
     cpu.assert_not_called()
     qemu.assert_not_called()
@@ -152,17 +187,19 @@ def test_invoke_request_system_properties_virtual(
 
 @unittest.mock.patch("fc.maintenance.cli.request_update")
 @unittest.mock.patch("fc.maintenance.cli.load_enc")
-def test_invoke_request_update(load_enc, request_update, invoke_app):
-    invoke_app("request", "update")
+def test_invoke_request_update(load_enc, request_update, invoke_app_as_root):
+    invoke_app_as_root("request", "update")
     load_enc.assert_called_once()
     request_update.assert_called_once()
     fc.maintenance.cli.rm.add.assert_called_once()
 
 
 @unittest.mock.patch("fc.util.directory.is_node_in_service")
-def test_invoke_constraints(is_node_in_service, monkeypatch, invoke_app, log):
+def test_invoke_constraints(
+    is_node_in_service, monkeypatch, invoke_app_as_root, log
+):
     monkeypatch.setattr("fc.util.directory.connect", MagicMock())
-    invoke_app("constraints", "--in-service", "test01")
+    invoke_app_as_root("constraints", "--in-service", "test01")
     is_node_in_service.assert_called_with(unittest.mock.ANY, "test01")
     assert log.debug("constraints-check-in-service", machine="test01")
     assert log.debug("constraints-success")
@@ -170,11 +207,11 @@ def test_invoke_constraints(is_node_in_service, monkeypatch, invoke_app, log):
 
 @unittest.mock.patch("fc.util.directory.is_node_in_service")
 def test_invoke_constraints_not_met(
-    is_node_in_service, monkeypatch, invoke_app, log
+    is_node_in_service, monkeypatch, invoke_app_as_root, log
 ):
     monkeypatch.setattr("fc.util.directory.connect", MagicMock())
     is_node_in_service.return_value = False
-    invoke_app("constraints", "--in-service", "test01", exit_code=69)
+    invoke_app_as_root("constraints", "--in-service", "test01", exit_code=69)
     assert log.info("constraints-failure")
 
 

--- a/pkgs/fc/agent/fc/maintenance/tests/test_reqmanager.py
+++ b/pkgs/fc/agent/fc/maintenance/tests/test_reqmanager.py
@@ -228,7 +228,7 @@ def test_enter_maintenance(log, reqmanager, monkeypatch):
     )
     monkeypatch.setattr("socket.gethostname", lambda: "host")
 
-    reqmanager.enter_maintenance()
+    reqmanager._enter_maintenance()
 
     assert log.has("enter-maintenance")
     connect_mock().mark_node_service_status.assert_called_with("host", False)
@@ -244,7 +244,7 @@ def test_enter_maintenance_postpone(log, reqmanager, monkeypatch):
     reqmanager.config["maintenance-enter"]["postpone"] = "exit 69"
 
     with pytest.raises(PostponeMaintenance):
-        reqmanager.enter_maintenance()
+        reqmanager._enter_maintenance()
 
     assert reqmanager.maintenance_marker_path.exists()
 
@@ -257,7 +257,7 @@ def test_enter_maintenance_tempfail(log, reqmanager, monkeypatch):
     reqmanager.config["maintenance-enter"]["tempfail"] = "exit 75"
 
     with pytest.raises(TempfailMaintenance):
-        reqmanager.enter_maintenance()
+        reqmanager._enter_maintenance()
 
     assert reqmanager.maintenance_marker_path.exists()
 
@@ -270,14 +270,14 @@ def test_execute_postpone(log, reqmanager, monkeypatch):
     def enter_maintenance_postpone():
         raise PostponeMaintenance()
 
-    reqmanager.runnable = lambda run_all_now, force_run: [req]
-    reqmanager.enter_maintenance = enter_maintenance_postpone
-    reqmanager.leave_maintenance = Mock()
+    reqmanager._runnable = lambda run_all_now, force_run: [req]
+    reqmanager._enter_maintenance = enter_maintenance_postpone
+    reqmanager._leave_maintenance = Mock()
     reqmanager.execute()
 
     assert req.state == State.postpone
     assert not req.execute.called
-    reqmanager.leave_maintenance.assert_called()
+    reqmanager._leave_maintenance.assert_called()
 
 
 def test_execute_tempfail(log, reqmanager, monkeypatch):
@@ -288,21 +288,21 @@ def test_execute_tempfail(log, reqmanager, monkeypatch):
     def enter_maintenance_tempfail():
         raise TempfailMaintenance()
 
-    reqmanager.runnable = lambda run_all_now, force_run: [req]
-    reqmanager.enter_maintenance = enter_maintenance_tempfail
-    reqmanager.leave_maintenance = MagicMock()
+    reqmanager._runnable = lambda run_all_now, force_run: [req]
+    reqmanager._enter_maintenance = enter_maintenance_tempfail
+    reqmanager._leave_maintenance = MagicMock()
     reqmanager.execute()
 
     assert req.state == State.due
     assert not req.execute.called
-    reqmanager.leave_maintenance.assert_not_called()
+    reqmanager._leave_maintenance.assert_not_called()
 
 
 @unittest.mock.patch("subprocess.run")
 @unittest.mock.patch("fc.util.directory.connect")
 def test_execute_activity_no_reboot(connect, run, reqmanager, log):
     req = reqmanager.add(Request(Activity(), 1))
-    reqmanager.runnable = lambda run_all_now, force_run: [req]
+    reqmanager._runnable = lambda run_all_now, force_run: [req]
     reqmanager.execute()
     run.assert_has_calls(
         [
@@ -347,7 +347,7 @@ def test_execute_activity_with_reboot(
 @unittest.mock.patch("time.sleep")
 def test_reboot_cold_reboot_has_precedence(sleep, run, reqmanager, log):
     with pytest.raises(SystemExit):
-        reqmanager.reboot_and_exit({RebootType.COLD, RebootType.WARM})
+        reqmanager._reboot_and_exit({RebootType.COLD, RebootType.WARM})
 
     sleep.assert_called_once_with(5)
     assert log.has("maintenance-poweroff")
@@ -580,7 +580,7 @@ def test_delete(request_population):
 
 def test_list_empty(reqmanager):
     console = Console(file=StringIO())
-    console.print(reqmanager)
+    console.print(reqmanager.__rich__())
     str_output = console.file.getvalue()
     assert "No maintenance requests at the moment.\n" == str_output
 
@@ -602,7 +602,7 @@ def test_list(reqmanager):
     r3.attempts = [att]
     reqmanager.add(r3)
     console = Console(file=StringIO())
-    console.print(reqmanager)
+    console.print(reqmanager.__rich__())
     str_output = console.file.getvalue()
     id1 = r1.id[:7]
     id2 = r2.id[:7]
@@ -640,10 +640,12 @@ def test_check_scheduled_requests_should_show_count_and_time(
     with request_population(2) as (rm, reqs):
         reqs[0].next_due = datetime.datetime(2016, 4, 20, 11, tzinfo=pytz.UTC)
         reqs[0].state = State.due
+        reqs[0].save()
         reqs[1].next_due = datetime.datetime(
             2016, 4, 20, 11, 10, tzinfo=pytz.UTC
         )
         reqs[1].state = State.due
+        reqs[1].save()
     res = rm.check()
     assert "2 scheduled" in res.ok_info[1]
     assert "2016-04-20 11:00" in res.ok_info[1]
@@ -666,7 +668,9 @@ def test_check_waiting_and_scheduled_requests(
     with request_population(2) as (rm, reqs):
         reqs[0].state = State.pending
         reqs[0].next_due = datetime.datetime(2016, 4, 20, 11, tzinfo=pytz.UTC)
+        reqs[0].save()
         reqs[1].state = State.pending
+        reqs[1].save()
     res = rm.check()
     assert res.ok_info
     assert "A maintenance request is due at 2016-04-20 11:00" in res.ok_info[1]

--- a/pkgs/fc/agent/fc/maintenance/tests/test_reqmanager.py
+++ b/pkgs/fc/agent/fc/maintenance/tests/test_reqmanager.py
@@ -173,13 +173,17 @@ def test_list_other_requests(reqmanager):
 
 @unittest.mock.patch("fc.util.directory.connect")
 def test_schedule_requests(connect, reqmanager):
-    req = reqmanager.add(Request(Activity(), 320, "comment"))
+    req = reqmanager.add(Request(Activity(), 320, "schedule"))
+    req_success = reqmanager.add(
+        Request(Activity(), 320, "done, do not schedule this")
+    )
+    req_success.state = State.success
     rpccall = connect().schedule_maintenance
     rpccall.return_value = {req.id: {"time": "2016-04-20T15:12:40.9+00:00"}}
     reqmanager.schedule()
-    #
+    # The estimate is expected to be 900 (15 min) which is the minimum.
     rpccall.assert_called_once_with(
-        {req.id: {"estimate": 900, "comment": "comment"}}
+        {req.id: {"estimate": 900, "comment": "schedule"}}
     )
     assert req.next_due == datetime.datetime(
         2016, 4, 20, 15, 12, 40, 900000, tzinfo=pytz.UTC

--- a/pkgs/fc/agent/fc/maintenance/tests/test_reqmanager.py
+++ b/pkgs/fc/agent/fc/maintenance/tests/test_reqmanager.py
@@ -231,9 +231,19 @@ def test_enter_maintenance(log, reqmanager, monkeypatch):
     reqmanager._enter_maintenance()
 
     assert log.has("enter-maintenance")
+    assert log.has(
+        "enter-maintenance-cmd",
+        subsystem="demo",
+        command='echo "entering demo"',
+    )
+    assert log.has("enter-maintenance-cmd-success", subsystem="demo")
     connect_mock().mark_node_service_status.assert_called_with("host", False)
     maintenance_entered_at = reqmanager.maintenance_marker_path.read_text()
     assert maintenance_entered_at == "2016-04-20T11:00:00+00:00"
+
+    import rich
+
+    rich.print(log.events)
 
 
 def test_enter_maintenance_postpone(log, reqmanager, monkeypatch):
@@ -262,7 +272,7 @@ def test_enter_maintenance_tempfail(log, reqmanager, monkeypatch):
     assert reqmanager.maintenance_marker_path.exists()
 
 
-def test_execute_postpone(log, reqmanager, monkeypatch):
+def test_execute_postpone(log, reqmanager):
     req = reqmanager.add(Request(Activity(), 1))
     req.state = State.due
     req.execute = Mock()
@@ -278,9 +288,10 @@ def test_execute_postpone(log, reqmanager, monkeypatch):
     assert req.state == State.postpone
     assert not req.execute.called
     reqmanager._leave_maintenance.assert_called()
+    log.has("execute-requests-postpone")
 
 
-def test_execute_tempfail(log, reqmanager, monkeypatch):
+def test_execute_tempfail(log, reqmanager):
     req = reqmanager.add(Request(Activity(), 1))
     req.state = State.due
     req.execute = Mock()
@@ -296,51 +307,45 @@ def test_execute_tempfail(log, reqmanager, monkeypatch):
     assert req.state == State.due
     assert not req.execute.called
     reqmanager._leave_maintenance.assert_not_called()
+    log.has("execute-requests-tempfail")
 
 
-@unittest.mock.patch("subprocess.run")
-@unittest.mock.patch("fc.util.directory.connect")
-def test_execute_activity_no_reboot(connect, run, reqmanager, log):
+def test_execute_activity_no_reboot(reqmanager, log):
     req = reqmanager.add(Request(Activity(), 1))
     reqmanager._runnable = lambda run_all_now, force_run: [req]
+    reqmanager._enter_maintenance = Mock()
+    reqmanager._leave_maintenance = Mock()
+
     reqmanager.execute()
-    run.assert_has_calls(
-        [
-            call('echo "entering demo"', shell=True, check=True),
-            call('echo "leaving demo"', shell=True, check=True),
-        ]
-    )
-    assert log.has("enter-maintenance")
-    assert log.has("leave-maintenance")
+
+    reqmanager._enter_maintenance.assert_called_once()
+    reqmanager._leave_maintenance.assert_called_once()
+    assert log.has("no-reboot-requested")
 
 
-@unittest.mock.patch("subprocess.run")
-@unittest.mock.patch("fc.util.directory.connect")
-@unittest.mock.patch("time.sleep")
-def test_execute_activity_with_reboot(
-    sleep: Mock, connect, run: Mock, reqmanager, log
-):
+def test_execute_activity_with_reboot(reqmanager, log, monkeypatch):
+    monkeypatch.setattr("time.sleep", sleep := Mock())
+    monkeypatch.setattr("subprocess.run", run := Mock())
+    reqmanager._enter_maintenance = Mock()
+    reqmanager._leave_maintenance = Mock()
+
     activity = Activity()
     activity.reboot_needed = RebootType.WARM
     req = reqmanager.add(Request(activity, 1))
-    req.state = State.due
+    reqmanager._runnable = lambda run_all_now, force_run: [req]
+
     with pytest.raises(SystemExit) as e:
-        reqmanager.execute(run_all_now=True)
+        reqmanager.execute()
 
     assert e.value.code == 0
 
-    run.assert_has_calls(
-        [
-            call('echo "entering demo"', shell=True, check=True),
-            call("reboot", check=True, capture_output=True, text=True),
-        ]
-    )
+    reqmanager._enter_maintenance.assert_called_once()
 
     sleep.assert_called_once_with(5)
-
-    assert log.has("enter-maintenance")
+    run.assert_called_once()
+    # Should stay in maintenance mode during the reboot.
+    reqmanager._leave_maintenance.assert_not_called()
     assert log.has("maintenance-reboot")
-    assert not log.has("leave-maintenance")
 
 
 @unittest.mock.patch("subprocess.run")
@@ -514,8 +519,7 @@ def test_execute_not_performed_on_connection_error(
     connect().mark_node_service_status.side_effect = socket.error()
     req = reqmanager.add(Request(Activity(), 1))
     req.state = State.due
-    with pytest.raises(OSError):
-        reqmanager.execute()
+    reqmanager.execute()
     assert execute.mock_calls == []
 
 

--- a/pkgs/fc/agent/fc/maintenance/tests/test_request.py
+++ b/pkgs/fc/agent/fc/maintenance/tests/test_request.py
@@ -252,6 +252,15 @@ def test_merge(monkeypatch):
     assert r._estimate == Estimate("20m")
 
 
+def test_merge_should_not_repeat_comment(monkeypatch):
+    monkeypatch.setattr(Request, "save", MagicMock())
+    r = Request(MergeableActivity(), Estimate("20m"), "First\n\nSecond")
+    other = Request(MergeableActivity(), Estimate("10m"), "Second")
+
+    res = r.merge(other)
+    assert r._comment == "First\n\nSecond"
+
+
 def test_incompatible_activities_should_not_merge(monkeypatch):
     r = Request(MergeableActivity(), Estimate("20m"), "First request.")
     other = Request(Activity(), Estimate("10m"), "Other request")

--- a/pkgs/fc/agent/fc/manage/cli.py
+++ b/pkgs/fc/agent/fc/manage/cli.py
@@ -1,5 +1,4 @@
 import os
-import sys
 import traceback
 from pathlib import Path
 from typing import NamedTuple
@@ -8,10 +7,10 @@ import fc.manage.manage
 import fc.util.enc
 import fc.util.logging
 import structlog
-import typer
 from fc.util import nixos
 from fc.util.lock import locked
-from typer import Argument, Exit, Option, Typer
+from fc.util.typer_utils import FCTyperApp
+from typer import Argument, Exit, Option
 
 
 class Context(NamedTuple):
@@ -27,7 +26,7 @@ class Context(NamedTuple):
 context: Context
 
 
-app = Typer(pretty_exceptions_show_locals=False)
+app = FCTyperApp("fc-manage")
 
 
 @app.command()
@@ -302,11 +301,5 @@ def fc_manage(
     log.info("fc-manage-succeeded", legacy_call=True)
 
 
-def main():
-    command = typer.main.get_command(app)
-    result = command(standalone_mode=False)
-    sys.exit(result)
-
-
 if __name__ == "__main__":
-    main()
+    app()

--- a/pkgs/fc/agent/fc/util/directory.py
+++ b/pkgs/fc/agent/fc/util/directory.py
@@ -53,9 +53,7 @@ class DirectoryAPI(xmlrpc.client.ServerProxy):
         # recognizable value.
         wrapper.__qualname__ = "DirectoryAPI." + name
 
-        retry = stamina.retry(
-            on=RETRY_EXCEPTIONS, wait_exp_base=10, attempts=2
-        )
+        retry = stamina.retry(on=RETRY_EXCEPTIONS, wait_exp_base=10, attempts=2)
         return retry(wrapper)
 
     def __repr__(self):

--- a/pkgs/fc/agent/fc/util/logging.py
+++ b/pkgs/fc/agent/fc/util/logging.py
@@ -217,6 +217,10 @@ class ConsoleFileRenderer:
         )
 
     def __call__(self, logger, method_name, event_dict):
+        log_settings = event_dict.pop("_log_settings", {})
+        if log_settings.get("console_ignore", False):
+            return
+
         console_io = io.StringIO()
         log_io = io.StringIO()
 
@@ -416,6 +420,9 @@ class SystemdJournalRenderer:
     def __call__(self, logger, method_name, event_dict):
         if method_name == "trace":
             return {}
+
+        # Unused
+        event_dict.pop("_log_settings", None)
 
         kv_renderer = structlog.processors.KeyValueRenderer(sort_keys=True)
         event_dict["message"] = event_dict["event"]
@@ -665,3 +672,8 @@ def init_logging(
             raise ValueError("A logdir is required for command logging.")
 
         init_command_logging(log, logdir)
+
+
+def logging_initialized():
+    logger_factory = structlog.get_config()["logger_factory"]
+    return isinstance(logger_factory, MultiOptimisticLoggerFactory)

--- a/pkgs/fc/agent/fc/util/typer_utils.py
+++ b/pkgs/fc/agent/fc/util/typer_utils.py
@@ -1,0 +1,44 @@
+import os
+
+import fc.util.logging
+import structlog
+import typer
+
+
+class FCTyperApp(typer.Typer):
+    def __init__(self, command_name):
+        # Showing local variables may leak secrets, don't do it in production!
+        super().__init__(pretty_exceptions_show_locals=False)
+        self.command_name = command_name
+
+    def __call__(self):
+        try:
+            super().__call__()
+        except Exception as e:
+            if fc.util.logging.logging_initialized():
+                try:
+                    log = structlog.get_logger()
+                    log.error(
+                        "unhandled-exception",
+                        exc_info=True,
+                        command=self.command_name,
+                        _log_settings=dict(console_ignore=True),
+                    )
+                except:
+                    # Raise the original exception when logging fails.
+                    print("WARNING: logging an unhandled exception failed.")
+                    raise e
+            else:
+                # Raise the original exception when our logging is not
+                # initialized.
+                print(
+                    "WARNING: could not log an unhandled exception because "
+                    "structured logging has not been initialized."
+                )
+                raise e
+
+            # Always raise the original exception if we are not running in a
+            # systemd unit. The exception hook installed by typer will take
+            # care of it and pretty-print the exception for interactive use.
+            if not os.environ.get("INVOCATION_ID"):
+                raise e

--- a/pkgs/fc/agent/setup.py
+++ b/pkgs/fc/agent/setup.py
@@ -66,7 +66,7 @@ setup(
             "fc-directory=fc.util.directory:directory_cli",
             "fc-graylog=fc.manage.graylog:main",
             "fc-maintenance=fc.maintenance.cli:app",
-            "fc-manage=fc.manage.cli:main",
+            "fc-manage=fc.manage.cli:app",
             "fc-qemu-scrub=fc.manage.qemu:main",
             "fc-monitor=fc.manage.monitor:main",
             "fc-resize-disk=fc.manage.resize_disk:app",

--- a/pkgs/fc/agent/setup.py
+++ b/pkgs/fc/agent/setup.py
@@ -52,6 +52,7 @@ setup(
         "requests",
         "rich",
         "shortuuid",
+        "stamina",
         "structlog",
         "typer",
     ],


### PR DESCRIPTION
Backport of #818 to NixOS 21.05, with a small, additional fix for a request comment merging bug and a sudo rule to allow admins to request a scheduled reboot. In combination with `fc-maintenance run --run-all-now` it's possible to reboot a system immediately in a safe way.

PL-131813

@flyingcircusio/release-managers

## Release process

Impact:

Changelog: (internal)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - see #818 
  - action potentially affecting availability like reboots must be limited to root and users in the admins group
- [x] Security requirements tested? (EVIDENCE)
  - checked sudo rules on a test VM, only reboots can be requested without password by admins users
  - tried out non-root fc-maintenance commands on a test VM
  - checked automated maintenance with a script activity on a dev KVM host 
