### PR TITLE
k3s agent: fix missing k3s executable for agent enter/leave commands

### DIFF
--- a/nixos/roles/k3s/agent.nix
+++ b/nixos/roles/k3s/agent.nix
@@ -128,6 +128,9 @@ in
         };
       };
 
+      # The agent needs k3s to run `fc-kubernetes` in enter and exit commands.
+      systemd.services.fc-agent.path = [ config.services.k3s.package ];
+
       ### Fixes for upstream issues
 
       # https://github.com/NixOS/nixpkgs/issues/103158


### PR DESCRIPTION
k3s is already globally installed on agents and we also need it in the PATH of the agent service to run fc-kubernetes.

PL-131945

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

(none)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - automated maintenance of k3s agents should work (bug fix for #813)
- [x] Security requirements tested? (EVIDENCE)
  - checked on the test k3s cluster that agent maintenance runs now work properly when executed by the fc-agent service