### PR TITLE
[21.05] fc.qemu: fix dependency for rbd-locktool (via ceph-client)

### DIFF
--- a/pkgs/fc/default.nix
+++ b/pkgs/fc/default.nix
@@ -38,6 +38,7 @@ rec {
       hash = "sha256-Lf4i2pwZMpVGuWVohTzM5/x9X6GmFy2kLmgz25uSgFM=";
     };
     qemu_ceph = pkgs.qemu-ceph-nautilus;
+    ceph_client = pkgs.ceph-nautilus.ceph-client;
   };
 
   # Enable this temporarily during development, but DO NOT commit this as

--- a/pkgs/fc/qemu/default.nix
+++ b/pkgs/fc/qemu/default.nix
@@ -5,16 +5,15 @@
   python3Packages,
   lib,
   libceph,
-  # as long as `qemu_ceph` pulls in the full `ceph` due to requiring ceph.dev, use that
-  # package here as well instead of ceph-client
-  ceph,
+  ceph_client,
   fetchFromGitHub,
   qemu_ceph,
   stdenv,
   gptfdisk,
   parted,
   xfsprogs,
-  procps
+  procps,
+  systemd
 }:
 
 let
@@ -85,14 +84,14 @@ in
       py.psutil
       py.pyyaml
       py.setuptools
-      qemu_ceph
       (py.toPythonModule libceph)
-      procps
-      gptfdisk
-      parted
-      xfsprogs
-      # XXX is in PATH anyways due to services.ceph.client, but specified here for
-      # completeness sake. If necessary, fc.qemu needs to be parameterised via /etc/ceph/fc-ceph.conf
-      ceph
     ];
+
+    # These are runtime dependencies on the binaries but not intended to become
+    # part of the Python package dependencies and thus must not be placed
+    # in the propagatedBuildInputs.
+    makeWrapperArgs = [
+      "--prefix PATH : ${lib.makeBinPath [procps systemd gptfdisk parted xfsprogs ceph_client qemu_ceph]}"
+    ];
+
   }

--- a/tests/kvm_host_ceph-nautilus.nix
+++ b/tests/kvm_host_ceph-nautilus.nix
@@ -475,7 +475,10 @@ in
     show(host1, "rbd ls rbd.ssd")
 
     with subtest("Check maintenance enter/exit works"):
-      result = show(host1, "fc-qemu --verbose maintenance enter")
+      # The dance with unsetting the path here is to ensure
+      # that we do not rely on global PATH settings. This bit us once
+      # when fc-qemu was called from the agent in a "clean" systemd unit.
+      result = show(host1, "PATH= /run/current-system/sw/bin/fc-qemu --verbose maintenance enter")
       assert "D enter-maintenance" in result
       assert "D ensure-maintenance-volume" in result
       assert "D creating maintenance volume" in result
@@ -485,9 +488,9 @@ in
       assert "I evacuation-running" in result
       assert "I evacuation-success" in result
 
-      result = show(host1, "fc-qemu --verbose maintenance leave")
+      result = show(host1, "PATH= /run/current-system/sw/bin/fc-qemu --verbose maintenance leave")
 
-      result = show(host1, "fc-qemu --verbose maintenance enter")
+      result = show(host1, "PATH= /run/current-system/sw/bin/fc-qemu --verbose maintenance enter")
       assert "D enter-maintenance" in result
       assert "D ensure-maintenance-volume" in result
       assert "D creating maintenance volume" not in result


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

none

Changelog:

* Fix bug that stopped the agent from being able to call the `maintenance leave/enter` commands.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
n/a
- [x] Security requirements tested? (EVIDENCE)
n/a