### PR TITLE
Change defaults for the phpfpm slowlog

### DIFF
--- a/nixos/roles/lamp.nix
+++ b/nixos/roles/lamp.nix
@@ -239,6 +239,10 @@ in {
                   "pm.start_servers" = "5";
                   "pm.min_spare_servers" = "5";
                   "pm.max_spare_servers" = "10";
+                  "slowlog" = "/var/log/httpd/${vhost.name}-slow.log";
+                  "request_slowlog_timeout" = "6s";
+                  "request_slowlog_trace_depth" = "100";
+                  "catch_workers_output" = "true";
                 };
               } vhost.pool; # only contains override values
           }) role.vhosts);


### PR DESCRIPTION
especially for debugging purposes, a phpfpm slowlog is very useful

@flyingcircusio/release-managers

## Release process

Impact:

Enable the phpfpm slow log by default.

Changelog:

- Enable the PHP-FPM slowlog by default.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - [x] all nixos tests still pass
- [x] Security requirements tested? (EVIDENCE) 
  - [x] tested on hydra01 
