### PR TITLE
[21.05] devhost: don't save ssh host keys

### DIFF
--- a/nixos/roles/devhost/fc-devhost.py
+++ b/nixos/roles/devhost/fc-devhost.py
@@ -277,7 +277,7 @@ class Manager:
                     run(
                         "rsync",
                         "-e",
-                        "ssh -o StrictHostKeyChecking=no -i /var/lib/devhost/ssh_bootstrap_key",
+                        "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i /var/lib/devhost/ssh_bootstrap_key",
                         "--rsync-path=sudo rsync",
                         f.name,
                         f"developer@{self.name}:/etc/nixos/enc.json",
@@ -345,6 +345,8 @@ class Manager:
                 "/var/lib/devhost/ssh_bootstrap_key",
                 "-o",
                 "StrictHostKeyChecking=no",
+                "-o",
+                "UserKnownHostsFile=/dev/null",
                 "-l",
                 "developer",
                 self.name,


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - It's safe to not store the known hosts as we are already on the devhost host. As devhost VMs are meant to be often destroyed and rebuild, their known hosts change 
- [x] Security requirements tested? (EVIDENCE)
  - This PR is tested on largo01.
