### PR TITLE
[23.11] Update nixpkgs (2023-11-28)

### DIFF
--- a/package-versions.json
+++ b/package-versions.json
@@ -60,9 +60,9 @@
     "version": "3.92"
   },
   "calibre": {
-    "name": "calibre-6.29.0",
+    "name": "calibre-7.0.0",
     "pname": "calibre",
-    "version": "6.29.0"
+    "version": "7.0.0"
   },
   "ceph": {
     "name": "ceph-18.2.0",
@@ -185,9 +185,9 @@
     "version": "7.17.4"
   },
   "firefox": {
-    "name": "firefox-119.0.1",
+    "name": "firefox-120.0",
     "pname": "firefox",
-    "version": "119.0.1"
+    "version": "120.0"
   },
   "gcc": {
     "name": "gcc-wrapper-12.3.0",
@@ -411,9 +411,9 @@
     "version": "0.2.5"
   },
   "linux": {
-    "name": "linux-6.1.62",
+    "name": "linux-6.1.63",
     "pname": "linux",
-    "version": "6.1.62"
+    "version": "6.1.63"
   },
   "logrotate": {
     "name": "logrotate-3.21.0",
@@ -431,9 +431,9 @@
     "version": "3.16"
   },
   "mariadb": {
-    "name": "mariadb-server-10.11.5",
+    "name": "mariadb-server-10.11.6",
     "pname": "mariadb-server",
-    "version": "10.11.5"
+    "version": "10.11.6"
   },
   "mariadb-connector-c": {
     "name": "mariadb-connector-c-3.3.5",
@@ -466,9 +466,9 @@
     "version": "1.6.22"
   },
   "mysql": {
-    "name": "mariadb-server-10.11.5",
+    "name": "mariadb-server-10.11.6",
     "pname": "mariadb-server",
-    "version": "10.11.5"
+    "version": "10.11.6"
   },
   "mysql80": {
     "name": "mysql-8.0.35",
@@ -636,14 +636,14 @@
     "version": "8.0.30"
   },
   "php81": {
-    "name": "php-with-extensions-8.1.25",
+    "name": "php-with-extensions-8.1.26",
     "pname": "php-with-extensions",
-    "version": "8.1.25"
+    "version": "8.1.26"
   },
   "php82": {
-    "name": "php-with-extensions-8.2.12",
+    "name": "php-with-extensions-8.2.13",
     "pname": "php-with-extensions",
-    "version": "8.2.12"
+    "version": "8.2.13"
   },
   "phpPackages.composer": {
     "name": "composer-2.6.5",
@@ -661,9 +661,9 @@
     "version": "4.7.2"
   },
   "poetry": {
-    "name": "poetry-1.6.1",
+    "name": "poetry-1.7.0",
     "pname": "poetry",
-    "version": "1.6.1"
+    "version": "1.7.0"
   },
   "polkit": {
     "name": "polkit-123",
@@ -837,9 +837,9 @@
     "version": "7.2.3"
   },
   "roundcube": {
-    "name": "roundcube-1.6.4",
+    "name": "roundcube-1.6.5",
     "pname": "roundcube",
-    "version": "1.6.4"
+    "version": "1.6.5"
   },
   "rsync": {
     "name": "rsync-3.2.7",
@@ -927,14 +927,14 @@
     "version": "3.3a"
   },
   "tomcat10": {
-    "name": "apache-tomcat-10.0.27",
+    "name": "apache-tomcat-10.1.15",
     "pname": "apache-tomcat",
-    "version": "10.0.27"
+    "version": "10.1.15"
   },
   "tomcat9": {
-    "name": "apache-tomcat-9.0.75",
+    "name": "apache-tomcat-9.0.82",
     "pname": "apache-tomcat",
-    "version": "9.0.75"
+    "version": "9.0.82"
   },
   "unzip": {
     "name": "unzip-6.0",

--- a/update-nixpkgs.py
+++ b/update-nixpkgs.py
@@ -25,14 +25,15 @@ app = Typer()
 class NixOSVersion(str, Enum):
     NIXOS_2211 = "nixos-22.11"
     NIXOS_2305 = "nixos-23.05"
-    NIXOS_UNSTABLE = "nixos-23.11"
+    NIXOS_2311 = "nixos-23.11"
+    NIXOS_UNSTABLE = "nixos-24.05"
 
     @property
-    def upstream_branch(self):
+    def upstream_branch(self) -> str:
         if self == NixOSVersion.NIXOS_UNSTABLE:
             return "nixos-unstable"
 
-        return str(self)
+        return self.value
 
 
 def run_on_hydra(*args):
@@ -326,7 +327,7 @@ context: Context
 
 @app.callback(no_args_is_help=True)
 def update_nixpkgs(
-    nixos_version: NixOSVersion = Option(default=None),
+    nixos_version: NixOSVersion = Option(default="nixos-23.11"),
     fc_nixos_path: Path = Option(
         ".", dir_okay=True, file_okay=False, writable=True
     ),

--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "e9275f5e73ae09655da72fb53292499ee4918305",
-    "sha256": "kokxr1Yu7JpgG9jUGYEz2VUr3xNdCvg4uI+FCMGWQnM="
+    "rev": "6adef034dacc21bab456e99734f436dae4de158d",
+    "sha256": "GgEjvBFadYr+HYLX1saOlh8V+XyPjwOx9HDfmz41BII="
   },
   "nixos-mailserver": {
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/",


### PR DESCRIPTION
@flyingcircusio/release-managers

Pull upstream NixOS changes, security fixes and package updates:

- calibre: 6.29.0 -> 7.0.0
- chromium: Fix build with at-spi2-core 2.49
- chromium: add libglvnd to rpath
- chromium: add rpath to libGLESv2.so from libANGLE (#269414)
- firefox: 119.0.1 -> 120.0
- gitlab: downgrade Ruby from 3.2 to 3.1 (#269204)
- jitsi-videobridge: 2.3-44-g8983b11f -> 2.3-59-g5c48e421
- libtiff: introduce libtiff_4_5
- mastodon: easier build patching
- nginx: fix build on darwin
- php81: 8.1.25 -> 8.1.26
- php82: 8.2.12 -> 8.2.13
- poetry: 1.6.1 -> 1.7.0
- pystemd: fix runtime deps
- roundcube: 1.6.4 -> 1.6.5
- tomcat10: 10.0.27 -> 10.1.15
- tomcat9: 9.0.75 -> 9.0.82
- linux: 5.15.138 -> 5.15.139

Also adapts the update-nixpkgs.py script to work against the branched off NixOS 23.11 release.

Additionally I was able to drop our own urllib-build tool fix on top of nixpkgs.

#PL-131955

## Release process

Impact:
- Due to updated dependencies, services including or relying in the following components might be restarted:
  - php81/2
  - roundcube webmail
  - tomcat 9/10
  - mastodon
  - jitsi
  - gitlab
- machines will schedule a maintenance reboot to activate the changed linux kernel

Changelog: see commit message

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - [x] regularly pull in upstream security package updates
- [x] Security requirements tested? (EVIDENCE)
  - [x] checked for latest gitlab patch release
  - [x] automated NixOS tests still pass
