### PR TITLE
[21.05] backy: fix restore-single-files to require a revision argument

### DIFF
--- a/pkgs/restore-single-files/restore-single-files.sh
+++ b/pkgs/restore-single-files/restore-single-files.sh
@@ -27,8 +27,8 @@ warn()
 	printf "${BAD}* $*${NORMAL}\n"
 }
 
-VM="$1"
-REV="${2:-last}"
+VM="${1?need VM name}"
+REV="${2?need revision identifier}"
 
 if [[ -z "$VM" ]]; then
 	warn "VM or revision not specified"


### PR DESCRIPTION
backy used to provide a symlink for 'last' revisions but that was unwieldy in some situations.

restore-single-files was using 'last' as the default revision and failed now.

Remove the 'last' as default and error with a proper message.

Fixes PL-131963

@flyingcircusio/release-managers

## Release process

Impact:

none

Changelog:

none

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

n/a

- [x] Security requirements tested? (EVIDENCE)

n/a, new behaviour tested manually