### PR TITLE
Follow redirects in customer-defined HTTP service checks when configured

### DIFF
--- a/pkgs/fc/agent/fc/manage/monitor.py
+++ b/pkgs/fc/agent/fc/manage/monitor.py
@@ -46,6 +46,10 @@ def get_sensucheck_configuration(servicechecks):
         if url.username:
             auth_pair = ":".join([url.username, url.password or ""])
             command.extend(["-a", auth_pair])
+        if servicecheck["redirect"]:
+            command.extend(["-f", "follow"])
+        if len(servicecheck["acceptable"]) > 0:
+            command.extend(["-e", ",".join(servicecheck["acceptable"])])
         checks[name] = dict(
             command=" ".join(command),
             interval=120,


### PR DESCRIPTION
The directory API for retrieving customer-defined HTTP service checks has been extended with extra response fields to indicate whether the check for a given URL should follow HTTP redirects, and which HTTP status codes should be expected when retrieving the URL.

Hitherto the script which generates the check definitions for Sensu did not make use of these fields, effectively ignoring the settings in the directory. With this change, `fc-monitor configure-checks` now generates check definitions with the appropriate flags to follow redirects and check the return status code when a given check has these extra fields configured.

PL-131749

@flyingcircusio/release-managers

~~Please backport to 21.11 as well, as the machine which executes the generated service checks is currently running fc-21.11-production.~~ The service checks machine has been upgraded to 23.05, no backport needed.

## Release process

Impact: internal.

Changelog:

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Checks should be configured corresponding to the data retrieved from the directory, so that checks are executed in accordance with operator intention and expectations.
- [x] Security requirements tested? (EVIDENCE)
  - The added flags to the check program have been manually verified to function as desired.