### PR TITLE
Make connection options in MongoDB check script configurable

### DIFF
--- a/pkgs/fc/check-mongodb/fc/check_mongodb/mongodb.py
+++ b/pkgs/fc/check-mongodb/fc/check_mongodb/mongodb.py
@@ -109,13 +109,73 @@ def _main():
         default="admin",
         help="Specify the database to check",
     )
+    p.add_option(
+        "-h",
+        "--hostname",
+        action="store",
+        dest="hostname",
+        default="localhost",
+        help="Hostname to connect to",
+    )
+    p.add_option(
+        "-p",
+        "--port",
+        action="store",
+        type=int,
+        dest="port",
+        default=27017,
+        help="Port to connect to",
+    )
+    p.add_option(
+        "-t",
+        "--tls",
+        action="store_true",
+        dest="tls",
+        help="Use TLS when connecting to database",
+    )
+    p.add_option(
+        "-V",
+        "--tls-insecure",
+        action="store_true",
+        dest="tls_insecure",
+        help="Disable TLS certificate validation when connection to database",
+    )
+    p.add_option(
+        "-U",
+        "--username",
+        action="store",
+        dest="username",
+        help="Username to use when connecting",
+    )
+    p.add_option(
+        "-P",
+        "--password-file",
+        action="store",
+        dest="password_file",
+        help="Path to file containing password to use when connecting",
+    )
 
     options, _ = p.parse_args()
     action = options.action
 
     start = time.time()
 
-    con = pymongo.MongoClient()
+    params = {}
+
+    if options.tls:
+        params["tls"] = True
+        if options.tls_insecure:
+            params["tlsInsecure"] = True
+
+    if options.username is not None:
+        params["username"] = options.username
+
+        if options.password_file is not None:
+            with open(options.password_file, "r") as pf:
+                password = pf.read().strip()
+                params["password"] = password
+
+    con = pymongo.MongoClient(options.hostname, options.port, **params)
 
     try:
         # Ping to check that the server is responding.


### PR DESCRIPTION
The Python script used by the Sensu check for MongoDB is hardcoded to assume that the database server is listening on localhost without authentication. This PR introduces additional options to the `check_mongodb` script to allow the endpoint address, authentication, and TLS to be configured, in order to support a wider variety of deployment scenarios. Additionally, this PR introduces a new `flyingcircus.roles.mongodb<version>.extraCheckArgs` NixOS option to allow the script arguments in the Sensu configuration to be customised by the operator. 

PL-131766

@flyingcircusio/release-managers

## Release process

Impact:

Changelog: A new `flyingcircus.roles.mongodb<version>.extraCheckArgs` NixOS option has been added to allow the operator to customise the arguments passed to the MongoDB monitoring script (PL-131766).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Service monitoring should be sufficiently configurable to support customer deployments.
- [x] Security requirements tested? (EVIDENCE)
  - Manually verified on a test machine that the monitoring configuration continues to function as expected with this change applied.
