### PR TITLE
Only allow TLS 1.2 and later in Postfix

### DIFF
--- a/nixos/services/mail/default.nix
+++ b/nixos/services/mail/default.nix
@@ -307,6 +307,10 @@ in {
             "permit_sasl_authenticated"
             "reject_unknown_helo_hostname"
           ];
+          smtpd_tls_mandatory_protocols = lib.mkForce ">=TLSv1.2";
+          smtpd_tls_protocols = lib.mkForce ">=TLSv1.2";
+          smtp_tls_mandatory_protocols = lib.mkForce ">=TLSv1.2";
+          smtp_tls_protocols = lib.mkForce ">=TLSv1.2";
         } //
         (lib.optionalAttrs role.explicitSmtpBind {
           smtp_bind_address = role.smtpBind4;


### PR DESCRIPTION
In the default nixos-mailserver configuration, Postfix supports all TLS versions greater than or equal to 1.0. This change overrides this default to set the supported TLS versions to 1.2 and later only.

PL-131937

@flyingcircusio/release-managers

## Release process

Impact:

Changelog: 

* The mailserver role now requires TLS versions 1.2 and later both when acting as an SMTP server and SMTP client. Encryption is still optional by default. (PL-131937).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Older security protocols considered less secure should be phased out in favour of newer protocols.
- [x] Security requirements tested? (EVIDENCE)
  - Manually verified in a test environment that applying this change causes TLS handshakes to fail when using TLS version 1.1 or earlier. TLS connections using 1.2 or later continue to function as expected.