### PR TITLE
[21.05] Host configuration for EVPN-VXLAN

### DIFF
--- a/nixos/lib/network.nix
+++ b/nixos/lib/network.nix
@@ -215,7 +215,7 @@ rec {
       lib.nameValuePair vlan (
       let
         priority = routingPriority vlan;
-        bridged = interface.bridged;
+        bridged = interface.bridged || interface.policy == "vxlan";
 
         mtu = if hasAttr vlan config.flyingcircus.static.mtus
               then config.flyingcircus.static.mtus.${vlan}

--- a/nixos/lib/network.nix
+++ b/nixos/lib/network.nix
@@ -46,6 +46,10 @@ let
             cond = hasAttr "ul" encInterfaces && encInterfaces.ul.policy == "vxlan";
             fail = "The 'ul' network may not have policy 'vxlan'";
           }
+          {
+            cond = vxlanCount > 0 && (!hasAttr "ul" encInterfaces || encInterfaces.ul.policy != "underlay");
+            fail = "VXLAN devices cannot be configured without an underlay interface";
+          }
         ];
 in
 rec {

--- a/nixos/lib/network.nix
+++ b/nixos/lib/network.nix
@@ -307,4 +307,36 @@ rec {
         };
       }; });
 
+  underlay =
+    if !hasAttr "ul" interfaceData ||
+       (lib.attrByPath [ "ul" "policy" ] "puppet" interfaceData) != "underlay" ||
+       length (lib.attrByPath [ "ul" "nics" ] [] interfaceData) == 0
+    then null
+    else let
+      hostId = lib.attrByPath [ "parameters" "id" ] 0 config.flyingcircus.enc;
+      nics = interfaceData.ul.nics;
+
+      abbrName = name:
+        lib.concatMapStrings (s: substring 0 2 s) (lib.splitString "/" name);
+      abbrMac = mac:
+        lib.concatStrings (lib.drop 3 (lib.splitString ":" mac));
+      emptyLabels = any (n: n.external_label == "") nics;
+      uniqueAbbrs =
+        length nics == length (lib.unique (map (n: abbrName n.external_label) nics));
+
+      makeName = if emptyLabels || !uniqueAbbrs
+                 then (n: "ethM${abbrMac n.mac}")
+                 else (n: "ethL${abbrName n.external_label}");
+    in {
+      asNumber = 4200000000 + hostId;
+      loopback =
+        let addrs = network.ul.v4.addresses;
+        in if length addrs == 0
+           then throw "Underlay network has no address assigned"
+           else head addrs;
+      subnets = network.ul.v4.networks;
+      interfaces = listToAttrs
+        (map (n: lib.nameValuePair (makeName n) n.mac) nics);
+      mtu = config.flyingcircus.static.mtus.ul or 1500;
+    };
 }

--- a/nixos/lib/network.nix
+++ b/nixos/lib/network.nix
@@ -180,10 +180,10 @@ rec {
 
         vlanId = config.flyingcircus.static.vlanIds.${vlan};
 
-        device = if bridged then bridgedDevice else physicalDevice;
-        attachedDevices = if bridged then [physicalDevice] else [];
+        device = if bridged then bridgedDevice else layer2device;
+        attachedDevices = if bridged then [layer2device] else [];
         bridgedDevice = "br${vlan}";
-        physicalDevice = "eth${vlan}";
+        layer2device = "eth${vlan}";
 
         macFallback = "02:00:00:${fclib.byteToHex vlanId}:??:??";
         mac = lib.toLower

--- a/nixos/lib/network.nix
+++ b/nixos/lib/network.nix
@@ -225,7 +225,10 @@ rec {
         device = if bridged then bridgedDevice else layer2device;
         attachedDevices = if bridged then [layer2device] else [];
         bridgedDevice = "br${vlan}";
-        layer2device = "eth${vlan}";
+        layer2device =
+          if policy == "underlay" then "underlay"
+          else if policy == "vxlan" then "vx${vlan}"
+          else "eth${vlan}";
 
         macFallback = "02:00:00:${fclib.byteToHex vlanId}:??:??";
         mac = lib.toLower

--- a/nixos/platform/network.nix
+++ b/nixos/platform/network.nix
@@ -188,6 +188,10 @@ in
 
       wireguard.enable = true;
 
+      firewall.trustedInterfaces =
+        if isNull fclib.underlay || config.flyingcircus.infrastructureModule != "flyingcircus-physical"
+        then []
+        else [ "brsto" "brstb" ] ++ (attrNames fclib.underlay.interfaces);
     };
 
     flyingcircus.activationScripts = {

--- a/nixos/platform/network.nix
+++ b/nixos/platform/network.nix
@@ -147,7 +147,13 @@ in
           tempAddress = "disabled";
           mtu = fclib.underlay.mtu;
         }
-      )]));
+      )]) ++
+      (if isNull fclib.underlay then [] else
+        (map (iface: lib.nameValuePair iface {
+          tempAddress = "disabled";
+          mtu = fclib.underlay.mtu;
+        })
+          (attrNames fclib.underlay.interfaces))));
 
       bridges = listToAttrs (map (interface:
         (lib.nameValuePair

--- a/nixos/platform/network.nix
+++ b/nixos/platform/network.nix
@@ -8,6 +8,7 @@ let
   fclib = config.fclib;
 
   interfaces = filter (i: i.vlan != "ipmi" && i.vlan != "lo") (lib.attrValues fclib.network);
+  managedInterfaces = filter (i: i.policy != "unmanaged") interfaces;
 
   location = lib.attrByPath [ "parameters" "location" ] "" cfg.enc;
 
@@ -114,7 +115,7 @@ in
               defaultRoutes ++ additionalRoutes;
 
           mtu = interface.mtu;
-        })) interfaces);
+        })) managedInterfaces);
 
       bridges = listToAttrs (map (interface:
         (lib.nameValuePair
@@ -233,7 +234,7 @@ in
                 RemainAfterExit = true;
               };
             }))
-          interfaces)) //
+          managedInterfaces)) //
       (listToAttrs
         (map (interface:
           (lib.nameValuePair
@@ -266,7 +267,7 @@ in
                 RemainAfterExit = true;
               };
             }))
-          interfaces));
+          managedInterfaces));
 
     boot.kernel.sysctl = {
       "net.ipv4.tcp_congestion_control" = "bbr";

--- a/nixos/platform/network.nix
+++ b/nixos/platform/network.nix
@@ -54,8 +54,8 @@ let
 
   interfaceRules = lib.concatMapStrings
     (interface: ''
-      SUBSYSTEM=="net" , ATTR{address}=="${interface.mac}", NAME="${interface.layer2device}"
-      '') interfaces;
+      SUBSYSTEM=="net" , ATTR{address}=="${interface.mac}", NAME="${interface.name}"
+      '') ethernetDevices;
 in
 {
 

--- a/nixos/platform/network.nix
+++ b/nixos/platform/network.nix
@@ -8,7 +8,7 @@ let
   fclib = config.fclib;
 
   interfaces = filter (i: i.vlan != "ipmi" && i.vlan != "lo") (lib.attrValues fclib.network);
-  managedInterfaces = filter (i: i.policy != "unmanaged") interfaces;
+  managedInterfaces = filter (i: i.policy != "unmanaged" && i.policy != "null") interfaces;
   physicalInterfaces = filter (i: i.policy != "vxlan" && i.policy != "underlay") managedInterfaces;
 
   nonUnderlayInterfaces = filter (i: i.policy != "underlay") managedInterfaces;

--- a/nixos/platform/network.nix
+++ b/nixos/platform/network.nix
@@ -404,6 +404,7 @@ in
               wantedBy = [ "network-addresses-${iface.layer2device}.service"
                            "multi-user.target" ];
               before = wantedBy;
+              partOf = [ "network-addresses-underlay.service" ];
               path = [ pkgs.nettools pkgs.procps fclib.relaxedIp ];
               script = ''
                 IFACE=${iface.layer2device}

--- a/nixos/platform/network.nix
+++ b/nixos/platform/network.nix
@@ -35,7 +35,7 @@ let
 
   interfaceRules = lib.concatMapStrings
     (interface: ''
-      SUBSYSTEM=="net" , ATTR{address}=="${interface.mac}", NAME="${interface.physicalDevice}"
+      SUBSYSTEM=="net" , ATTR{address}=="${interface.mac}", NAME="${interface.layer2device}"
       '') interfaces;
 in
 {
@@ -180,21 +180,21 @@ in
       (listToAttrs
         (map (interface:
           (lib.nameValuePair
-            "network-link-properties-${interface.physicalDevice}-phy"
+            "network-link-properties-${interface.layer2device}-phy"
             rec {
-              description = "Ensure link properties for ${interface.physicalDevice}";
+              description = "Ensure link properties for ${interface.layer2device}";
               # We need to explicitly be wanted by the multi-user target,
               # otherwise we will not get initially added as the individual
               # address units won't get restarted because triggering
               # the multi-user alone does not propagated to the network-target
               # etc. etc.
-              wantedBy = [ "network-addresses-${interface.physicalDevice}.service"
+              wantedBy = [ "network-addresses-${interface.layer2device}.service"
                            "multi-user.target" ];
 
               before = wantedBy;
               path = [ pkgs.nettools pkgs.ethtool pkgs.procps fclib.relaxedIp];
               script = ''
-                IFACE=${interface.physicalDevice}
+                IFACE=${interface.layer2device}
 
                 IFACE_DRIVER=$(ethtool -i $IFACE | grep "driver: " | cut -d ':' -f 2 | sed -e 's/ //')
                 case $IFACE_DRIVER in

--- a/nixos/platform/network.nix
+++ b/nixos/platform/network.nix
@@ -278,6 +278,10 @@ in
       };
     };
 
+    # Don't automatically create a dummy0 interface when the kernel
+    # module is loaded.
+    boot.extraModprobeConfig = "options dummy numdummies=0";
+
     systemd.services =
       let
         sysctlSnippet = ''

--- a/nixos/platform/static.nix
+++ b/nixos/platform/static.nix
@@ -65,6 +65,8 @@ with lib;
         "tr3" = 18;
         # dynamic hardware pool: local endpoints for Kamp DHP tunnels
         "dhp" = 19;
+        # underlay: EVPN-VXLAN network virtualisation underlay
+        "ul" = 20;
         # video surveillance
         "video" = 23;
       };
@@ -72,6 +74,7 @@ with lib;
       mtus = {
         "sto" = 9000;
         "stb" = 9000;
+        "ul" = 9216;
       };
 
       nameservers = {

--- a/nixos/roles/external_net/vxlan-client.nix
+++ b/nixos/roles/external_net/vxlan-client.nix
@@ -41,7 +41,7 @@ in
         after = [ "network-addresses-${netdev}.service" "firewall.service" ];
         requires = after;
         wantedBy = [ "network.target" ];
-        bindsTo = [ "sys-subsystem-net-devices-${fclib.network.srv.physicalDevice}.device" ];
+        bindsTo = [ "sys-subsystem-net-devices-${fclib.network.srv.layer2device}.device" ];
         path = [ pkgs.gawk pkgs.iproute pkgs.glibc pkgs.iptables ];
 
         serviceConfig = {

--- a/nixos/roles/webdata_blackbee.nix
+++ b/nixos/roles/webdata_blackbee.nix
@@ -64,7 +64,7 @@ in
       after = [ "network-addresses-${netdev}.service" "firewall.service" ];
       requires = after;
       wantedBy = [ "multi-user.target" ];
-      bindsTo = [ "sys-subsystem-net-devices-${fclib.network.srv.physicalDevice}.device" ];
+      bindsTo = [ "sys-subsystem-net-devices-${fclib.network.srv.layer2device}.device" ];
       path = with pkgs; [ gawk iproute glibc iptables ];
 
       serviceConfig =

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -117,6 +117,8 @@ in {
     };
   });
 
+  inherit (nixpkgs-23_05) frr;
+
   gitlab = super.callPackage ./gitlab { };
   gitlab-workhorse = super.callPackage ./gitlab/gitlab-workhorse { };
 


### PR DESCRIPTION
### Summary

This change refactors the platform network configuration code to support the use of EVPN-VXLAN. The VXLAN-based operating mode is enabled when a special underlay interface is found in the ENC interface configuration, which triggers the creation of special kernel devices (including the underlay loopback and the VTEP interfaces) and the configuration of FRR to advertise local VTEP endpoints and learn remote VTEP endpoints.

Note that as 21.05 does not contain an FRR package, the package (and NixOS module) from 23.05 is used instead.

### Commentary

- When the ENC data contains an interface on the new `ul` VLAN (the underlay segment over which the overlay is operated), a new `fclib.underlay` attribute is exposed, which contains underlay-related configuration parameters which don't fit cleanly into the existing network-related data structures -- in particular the AS number for BGP, the loopback VTEP address, and the (possibly multiple) ethernet interfaces connected to the underlay segment. VXLAN configuration is enabled when `fclib.underlay` is set to a non-`null` value.
- Unmanaged network interfaces (including the directory interface policies `unmanaged` and `null`) are now properly ignored by the platform code.
- Previously, the network configuration code only distinguished between "virtual" (bridge) and "physical" (ethernet) kernel network devices. This taxonomy has been extended, as there are now four types of kernel network device: ethernet interfaces, bridge interfaces, loopback interfaces (provided by the kernel "dummy" driver), and VXLAN interfaces. The systemd units which configure device link properties are now separated to reflect this distinction. Additionally, udev rules are only generated for ethernet kernel devices.
- Each VXLAN interface is unconditionally connected to a bridge interface, as this appears to be required by FRR to announce the associated VNI to other hosts, irrespective of whether one is actually otherwise necessary for the host configuration.

@flyingcircusio/release-managers

## Release process

Impact: internal.

Changelog:

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - The new underlay network is an internal and sensitive network segment, comparable with the storage or storage backend network, and should be treated and protected accordingly.
  - The BGP control plane is critical to the operation of hosts operating with VXLAN, and should be appropriately secured.
- [x] Security requirements tested? (EVIDENCE)
  - This PR has been manually tested and verified on a spare KVM host in DEV.
  - VM networking is achieved through the use of bridge interfaces, which connects them directly to layer 2 ethernet segments without traffic passing through the host's IP stack. The underlay network is never exposed directly to any VMs.
  - The BGP control plane operates exclusively over the underlay network. FRR is directly configured to only connect over the ethernet devices explicitly declared as underlay interfaces in the ENC data, and filtering is used to ensure that only routes for networks given in the ENC configuration are accepted.
  - Security considerations for storage and backup hosts are unchanged, as these do not directly run customer workloads.
