### PR TITLE
MySQL: Decrease amount of logging caused by log_queries_not_using_indexes

### DIFF
--- a/nixos/roles/mysql.nix
+++ b/nixos/roles/mysql.nix
@@ -208,7 +208,7 @@ in
         slow_query_log_file = '/var/log/mysql/mysql.slow'
         log_slow_admin_statements = ON
         log_queries_not_using_indexes = ON
-        log_throttle_queries_not_using_indexes = 50
+        log_throttle_queries_not_using_indexes = 5
 
         init-connect               = 'SET NAMES ${charset} COLLATE ${collation}'
         character-set-server       = ${charset}


### PR DESCRIPTION
PL-131975

@flyingcircusio/release-managers

## Release process

Impact:
- Will restart MySQL 

Changelog:
- MySQL: Log fewer queries without index per minute to prevent too verbose slow log.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [x] Security requirements tested? (EVIDENCE)


```
mysql> show variables like 'log_queries_not_using_indexes';
+-------------------------------+-------+
| Variable_name                 | Value |
+-------------------------------+-------+
| log_queries_not_using_indexes | OFF   |
+-------------------------------+-------+
1 row in set (0.04 sec)
```

```
mysql> show variables like 'log_throttle_queries_not_using_indexes';
+----------------------------------------+-------+
| Variable_name                          | Value |
+----------------------------------------+-------+
| log_throttle_queries_not_using_indexes | 5     |
+----------------------------------------+-------+
1 row in set (0.01 sec)
```