### PR TITLE
Update nixpkgs (2023-12-12)

### DIFF
--- a/important_packages.json
+++ b/important_packages.json
@@ -149,6 +149,7 @@
   "python3",
   "python310",
   "python311",
+  "python312",
   "python38",
   "python39",
   "python3Packages.boto3",

--- a/package-versions.json
+++ b/package-versions.json
@@ -731,6 +731,11 @@
     "pname": "python3",
     "version": "3.11.6"
   },
+  "python312": {
+    "name": "python3-3.12.0",
+    "pname": "python3",
+    "version": "3.12.0"
+  },
   "python38": {
     "name": "python3-3.8.18",
     "pname": "python3",

--- a/package-versions.json
+++ b/package-versions.json
@@ -70,14 +70,14 @@
     "version": "18.2.0"
   },
   "chromedriver": {
-    "name": "chromedriver-119.0.6045.105",
+    "name": "chromedriver-120.0.6099.71",
     "pname": "chromedriver",
-    "version": "119.0.6045.105"
+    "version": "120.0.6099.71"
   },
   "chromium": {
-    "name": "chromium-119.0.6045.199",
+    "name": "chromium-120.0.6099.71",
     "pname": "chromium",
-    "version": "119.0.6045.199"
+    "version": "120.0.6099.71"
   },
   "cifs-utils": {
     "name": "cifs-utils-7.0",
@@ -150,9 +150,9 @@
     "version": "2.3.21"
   },
   "element-web": {
-    "name": "element-web-1.11.50",
+    "name": "element-web-1.11.51",
     "pname": "element-web",
-    "version": "1.11.50"
+    "version": "1.11.51"
   },
   "erlang": {
     "name": "erlang-25.3.2.7",
@@ -220,19 +220,19 @@
     "version": "2.311.0"
   },
   "gitlab": {
-    "name": "gitlab-16.5.1",
+    "name": "gitlab-16.5.3",
     "pname": "gitlab",
-    "version": "16.5.1"
+    "version": "16.5.3"
   },
   "gitlab-container-registry": {
-    "name": "gitlab-container-registry-3.85.0",
+    "name": "gitlab-container-registry-3.86.2",
     "pname": "gitlab-container-registry",
-    "version": "3.85.0"
+    "version": "3.86.2"
   },
   "gitlab-ee": {
-    "name": "gitlab-ee-16.5.1",
+    "name": "gitlab-ee-16.5.3",
     "pname": "gitlab-ee",
-    "version": "16.5.1"
+    "version": "16.5.3"
   },
   "gitlab-runner": {
     "name": "gitlab-runner-16.6.0",
@@ -346,9 +346,9 @@
     "version": "1.27.6+k3s1"
   },
   "keycloak": {
-    "name": "keycloak-22.0.5",
+    "name": "keycloak-23.0.0",
     "pname": "keycloak",
-    "version": "22.0.5"
+    "version": "23.0.0"
   },
   "kubernetes-helm": {
     "name": "kubernetes-helm-3.13.2",
@@ -411,9 +411,9 @@
     "version": "0.2.5"
   },
   "linux_5_15": {
-    "name": "linux-5.15.140",
+    "name": "linux-5.15.142",
     "pname": "linux",
-    "version": "5.15.140"
+    "version": "5.15.142"
   },
   "logrotate": {
     "name": "logrotate-3.21.0",
@@ -441,9 +441,9 @@
     "version": "3.3.5"
   },
   "mastodon": {
-    "name": "mastodon-4.2.1",
+    "name": "mastodon-4.2.3",
     "pname": "mastodon",
-    "version": "4.2.1"
+    "version": "4.2.3"
   },
   "matomo": {
     "name": "matomo-4.15.1",
@@ -551,9 +551,9 @@
     "version": "2.4.58"
   },
   "opensearch": {
-    "name": "opensearch-2.11.0",
+    "name": "opensearch-2.11.1",
     "pname": "opensearch",
-    "version": "2.11.0"
+    "version": "2.11.1"
   },
   "opensearch-dashboards": {
     "name": "opensearch-dashboards-2.11.0",
@@ -732,9 +732,9 @@
     "version": "3.11.6"
   },
   "python312": {
-    "name": "python3-3.12.0",
+    "name": "python3-3.12.1",
     "pname": "python3",
-    "version": "3.12.0"
+    "version": "3.12.1"
   },
   "python38": {
     "name": "python3-3.8.18",
@@ -817,9 +817,9 @@
     "version": "2.0.7"
   },
   "qemu": {
-    "name": "qemu-8.1.2",
+    "name": "qemu-8.1.3",
     "pname": "qemu",
-    "version": "8.1.2"
+    "version": "8.1.3"
   },
   "rabbitmq-server": {
     "name": "rabbitmq-server-3.12.7",
@@ -932,14 +932,14 @@
     "version": "3.3a"
   },
   "tomcat10": {
-    "name": "apache-tomcat-10.1.15",
+    "name": "apache-tomcat-10.1.16",
     "pname": "apache-tomcat",
-    "version": "10.1.15"
+    "version": "10.1.16"
   },
   "tomcat9": {
-    "name": "apache-tomcat-9.0.82",
+    "name": "apache-tomcat-9.0.83",
     "pname": "apache-tomcat",
-    "version": "9.0.82"
+    "version": "9.0.83"
   },
   "unzip": {
     "name": "unzip-6.0",
@@ -962,9 +962,9 @@
     "version": "9.0.2048"
   },
   "webkitgtk": {
-    "name": "webkitgtk-2.42.2+abi=4.0",
+    "name": "webkitgtk-2.42.3+abi=4.0",
     "pname": "webkitgtk",
-    "version": "2.42.2"
+    "version": "2.42.3"
   },
   "wget": {
     "name": "wget-1.21.4",

--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "ba252eff709a140e5acc6665da79c6cb6291a0a2",
-    "sha256": "7nKpJxcuSMeMCgVLxB139VthF7/a5Dr8loQUfOzrNyg="
+    "rev": "4498ffb2f5aa90bb2527d4e57cbafb67d24ce0a6",
+    "sha256": "IreOpI9fC3iBJn8wq00t7W6oBelVHT7rMhFZvo4JQAU="
   },
   "nixos-mailserver": {
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/",


### PR DESCRIPTION
Update nixpkgs

Pull upstream NixOS changes, security fixes and package updates:

- chromedriver: 119.0.6045.105 -> 120.0.6099.71
- chromium: 119.0.6045.199 -> 120.0.6099.71
- element-web: 1.11.50 -> 1.11.51
- gitlab-container-registry: 3.85.0 -> 3.86.2
- gitlab: 16.5.1 -> 16.5.3
- keycloak: 22.0.5 -> 23.0.0
- linux_5_15: 5.15.140 -> 5.15.142
- mastodon: 4.2.1 -> 4.2.3
- opensearch: 2.11.0 -> 2.11.1
- qemu: 8.1.2 -> 8.1.3
- python312: 3.12.0 -> 3.12.1 (CVE-2023-6507)
- tomcat10: 10.1.15 -> 10.1.16
- tomcat9: 9.0.82 -> 9.0.83
- webkitgtk: 2.42.2 → 2.42.3 (CVE-2023-42916, CVE-2023-42917)

PL-131990


@flyingcircusio/release-managers

## Release process

Impact

- (doesn't matter, first prod release of 23.11)

Changelog:

(include changed packages from commit msg)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - pull in upstream security fixes regularly
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still run, works on test VMs and staging Gitlab
  - checked commit log for fixed CVEs