### PR TITLE
Update mail server docs and tools to use yescrypt

### DIFF
--- a/doc/src/mailserver.md
+++ b/doc/src/mailserver.md
@@ -108,7 +108,7 @@ Edit {file}`/etc/local/mail/users.json` to add user accounts. Example:
 {
   "user1@test.fcio.net": {
     "aliases": ["first.last@test.fcio.net"],
-    "hashedPassword": "$5$NTTg86onSoM1MK$Xir/pTc9G/TLM1LResKlyAip1oO9XcsmUKXaf7ALIS2",
+    "hashedPassword": "$y$j9T$whHoksmVCZ1rjW2htMznw/$4WzPhNQAe8VcVllG7jC7kFGZMIy/TiIGSULMp3vzAL7",
     "quota": "4G",
     "sieveScript": null
   }
@@ -120,7 +120,7 @@ and the value is a attribute set of configuration options. Domain
 parts of all e-mail addresses must be listed in the `domains` option in
 {file}`/etc/local/mail/config.json`.
 
-The password must be hashed with {command}`mkpasswd -m sha-256 {PASSWORD}`.
+The password must be hashed with {command}`mkpasswd -m yescrypt {PASSWORD}`.
 
 ## How do mail users log into the mail server?
 
@@ -148,10 +148,10 @@ the initial password in {file}`/var/lib/dovecot/passwd` instead. This file
 consists of a e-mail address/password pair per user. Example:
 
 ```
-user1@test.fcio.net:$5$NwBmrzj2vPlIdoa0$Go0zrVY5ZQncFXlCAxA.Gqj.e4Ym6Ic242O6Mj3BK1
+user1@test.fcio.net:$y$j9T$whHoksmVCZ1rjW2htMznw/$4WzPhNQAe8VcVllG7jC7kFGZMIy/TiIGSULMp3vzAL7
 ```
 
-The initial password hash can be created with {command}`mkpasswd -m sha-256
+The initial password hash can be created with {command}`mkpasswd -m yescrypt
 {PASSWORD}` as shown above. Afterwards, user can log into the Roundcube web mail
 frontend and change their password in the settings menu.
 

--- a/nixos/services/mail/README
+++ b/nixos/services/mail/README
@@ -47,9 +47,9 @@ initial password in `/var/lib/dovecot/passwd` instead.
 
 Entries in the passwd file look like this:
 
-user1@test.fcio.net:$5$NwBmrzj2vPlIdoa0$Go0zrVY5ZQncFXlCAxA.Gqj.e4Ym6Ic242O6Mj3BK1
+user1@test.fcio.net:$y$j9T$whHoksmVCZ1rjW2htMznw/$4WzPhNQAe8VcVllG7jC7kFGZMIy/TiIGSULMp3vzAL7
 
-The password string can be created with `mkpasswd -m SHA-256`.
+The password string can be created with `mkpasswd -m yescrypt`.
 
 
 Further Configuration Files

--- a/nixos/services/mail/default.nix
+++ b/nixos/services/mail/default.nix
@@ -94,11 +94,11 @@ in {
 
         # refer to the source for a comprehensive list of options:
         # https://gitlab.com/simple-nixos-mailserver/nixos-mailserver/-/blob/master/default.nix
-        # generate password with `mkpasswd -m sha-256 PASSWD` and put it either
+        # generate password with `mkpasswd -m yescrypt PASSWD` and put it either
         # here (read-only) or into passwdFile (user-changeable)
         "local/mail/users.json.example".text = (toJSON {
           "user@${primaryDomain}" = {
-            hashedPassword = "(use 'mkpasswd -m sha-256 PASSWORD')";
+            hashedPassword = "(use 'mkpasswd -m yescrypt PASSWORD')";
             aliases = [ "user1@${primaryDomain}" ];
             quota = "4G";
             sieveScript = null;

--- a/nixos/services/mail/roundcube.nix
+++ b/nixos/services/mail/roundcube.nix
@@ -2,7 +2,7 @@
 
 let
   role = config.flyingcircus.roles.mailserver;
-  chpasswd = "${pkgs.fc.roundcube-chpasswd}/bin/roundcube-chpasswd";
+  chpasswd = "${pkgs.fc.roundcube-chpasswd-py}/bin/roundcube-chpasswd";
   fclib = config.fclib;
 
 in lib.mkMerge [
@@ -45,7 +45,7 @@ in lib.mkMerge [
         $config['archive_type'] = 'year';
         $config['managesieve_vacation'] = 1;
         $config['mime_types'] = '${pkgs.mailcap}/etc/mime.types';
-        $config['password_chpasswd_cmd'] = '/run/wrappers/bin/sudo -u vmail ${chpasswd} ${role.passwdFile}';
+        $config['password_chpasswd_cmd'] = '/run/wrappers/bin/sudo -u vmail ${chpasswd} --passwd-file ${role.passwdFile}';
         $config['password_confirm_current'] = true;
         $config['password_driver'] = 'chpasswd';
         $config['password_minimum_length'] = 10;

--- a/pkgs/fc/default.nix
+++ b/pkgs/fc/default.nix
@@ -18,6 +18,7 @@ rec {
   check-xfs-broken = callPackage ./check-xfs-broken {};
   blockdev = callPackage ./blockdev {};
   roundcube-chpasswd = callPackage ./roundcube-chpasswd {};
+  roundcube-chpasswd-py = callPackage ./roundcube-chpasswd-py {};
   fix-so-rpath = callPackage ./fix-so-rpath {};
   logcheckhelper = callPackage ./logcheckhelper { };
   # XXX: needs Python 2.7, untested on newer platform versions.

--- a/pkgs/fc/roundcube-chpasswd-py/default.nix
+++ b/pkgs/fc/roundcube-chpasswd-py/default.nix
@@ -1,0 +1,11 @@
+{ pkgs, python3Packages }:
+
+python3Packages.buildPythonApplication rec {
+  name = "fc-roundcube-chpasswd-${version}";
+  version = "1.0";
+  src = ./.;
+  propagatedBuildInputs = [
+    pkgs.mkpasswd
+    pkgs.apacheHttpd # for htpasswd
+  ];
+}

--- a/pkgs/fc/roundcube-chpasswd-py/fc/roundcube_chpasswd/chpasswd.py
+++ b/pkgs/fc/roundcube-chpasswd-py/fc/roundcube_chpasswd/chpasswd.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+
+import argparse
+import subprocess
+import sys
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-f",
+        "--passwd-file",
+        metavar="PATH",
+        help="Path to password file to be updated",
+        required=True,
+    )
+
+    args = parser.parse_args()
+    line = sys.stdin.readline()
+    data = line.strip().split(":")
+
+    if len(data) != 2:
+        raise RuntimeError("Input line must contain exactly one colon")
+
+    user, passwd = data
+
+    hashed = subprocess.check_output(
+        ["mkpasswd", "-s", "-m", "yescrypt"],
+        input=passwd.encode(),
+    ).decode()
+
+    # htpasswd will not create the file if it does not exist, so open
+    # for creation beforehand.
+    file = open(args.passwd_file, "a")
+
+    subprocess.run(
+        ["htpasswd", "-p", "-i", args.passwd_file, user],
+        input=hashed.encode(),
+        stderr=subprocess.DEVNULL,
+        check=True,
+    )
+
+    file.close()

--- a/pkgs/fc/roundcube-chpasswd-py/setup.py
+++ b/pkgs/fc/roundcube-chpasswd-py/setup.py
@@ -1,0 +1,10 @@
+from setuptools import setup
+
+setup(
+    packages=["fc.roundcube_chpasswd"],
+    entry_points={
+        "console_scripts": [
+            "roundcube-chpasswd=fc.roundcube_chpasswd.chpasswd:main",
+        ],
+    },
+)

--- a/tests/mail/default.nix
+++ b/tests/mail/default.nix
@@ -183,7 +183,7 @@ in
   };
   testScript = let
     passwdFile = "/var/lib/dovecot/passwd";
-    chpasswd = "${pkgs.fc.roundcube-chpasswd}/bin/roundcube-chpasswd";
+    chpasswd = "${pkgs.fc.roundcube-chpasswd-py}/bin/roundcube-chpasswd";
   in ''
     with subtest("postsuper sudo rule should be present for service group"):
       mail.succeed('grep %service /etc/sudoers | grep -q postsuper')
@@ -205,7 +205,7 @@ in
       mail.succeed(
         "sudo -u roundcube "
         "sudo -u vmail ${chpasswd} "
-        "${passwdFile} "
+        "--passwd-file ${passwdFile} "
         "<<< 'user1@example.local:pass'"
       )
       mail.succeed("grep user1@example.local: ${passwdFile}")


### PR DESCRIPTION
This change updates the mail server role documentation to use yescrypt for password hashes, as sha256 is considered deprecated for this use case.

Additionally a partial Python reimplementation of `roundcube-chpasswd` is introduced (which wraps `mkpasswd` and `htpasswd`) as the existing Rust version only supports sha256 and cannot be easily converted to use yescrypt. Without this, changing passwords through Roundcube could result in manually generated yescrypt hashes being downgraded to sha256 hashes.

PL-131839

@flyingcircusio/release-managers

## Release process

Impact:

Changelog: yescrypt is now documented as the recommended hashing algorithm to use for passwords in the mail server role. Passwords changed via the Roundcube web UI will now also be hashed using yescrypt. (PL-131839)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Documentation should recommend the use of strong password hashes by default, and internal tools should also use strong hashes by default.
- [x] Security requirements tested? (EVIDENCE)
  - Manual execution of Hydra tests on this branch passes cleanly.
  - Manually verified in a test environment that changing passwords through Roundcube with the replacement Python script results in a yescrypt hash being correctly generated in the Dovecot password file.