### PR TITLE
agent: increase limit of file descriptors for system builds

### DIFF
--- a/pkgs/fc/agent/fc/util/tests/test_nixos.py
+++ b/pkgs/fc/agent/fc/util/tests/test_nixos.py
@@ -1,5 +1,6 @@
 import shlex
 import textwrap
+import unittest.mock
 from unittest import mock
 
 import pytest
@@ -56,7 +57,13 @@ def test_build_system_with_changes(log, monkeypatch):
         channel, build_options=["-v"], out_link="/run/fc-agent-test"
     )
 
-    popen_mock.assert_called_once_with(cmd, stdout=-1, stderr=-1, text=True)
+    popen_mock.assert_called_once_with(
+        cmd,
+        stdout=-1,
+        stderr=-1,
+        preexec_fn=nixos._increase_soft_fd_limit,
+        text=True,
+    )
     assert built_system_path == system_path
     assert log.has(
         "system-build-succeeded",
@@ -86,7 +93,13 @@ def test_build_system_unchanged(log, monkeypatch):
     built_system_path = nixos.build_system(channel)
 
     assert built_system_path == system_path
-    popen_mock.assert_called_once_with(cmd, stdout=-1, stderr=-1, text=True)
+    popen_mock.assert_called_once_with(
+        cmd,
+        stdout=-1,
+        stderr=-1,
+        preexec_fn=nixos._increase_soft_fd_limit,
+        text=True,
+    )
     assert log.has("system-build-succeeded", changed=False)
 
 

--- a/pkgs/fc/agent/shell.nix
+++ b/pkgs/fc/agent/shell.nix
@@ -2,6 +2,6 @@ let
   pkgs = import <fc> {};
   fcagent = pkgs.python310Packages.callPackage ./. {};
 in
-(fcagent.override { enableSlurm = true; }).overridePythonAttrs(_: {
+(fcagent.override { enableSlurm = false; }).overridePythonAttrs(_: {
   doCheck = true;
 })


### PR DESCRIPTION
We experienced fc-update-channel crashing while trying to run nix-build for the system, probably caused by a high number of Letsencrypt certs. Increase the soft limit to 2000 if it's still at the default value of
1024. It can be still set to a different value from the environment, the system unit, for example.

PL-131964

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

- agent: increase file descriptor limit for system builds. We have seen crashes of the `fc-update-channel` service on a single customer VM with a high number of Letsencrypt certificates (PL-131964).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - have resource limits at sensible values, only increase them where needed
- [x] Security requirements tested? (EVIDENCE)
  - checked on a test VM that the fd limit is at 2000 by default for the nix-build process and the main process is not affected by the change. Also checked that setting a limit from the environment (system unit LimitNOFile) still works. 
  - temporary fix of increasing the soft fd limit fixed the problem on the affected production machine 
