### PR TITLE
nginx: deprecation warnings, add defaultListenAddresses option

### DIFF
--- a/nixos/services/nginx/base-module.nix
+++ b/nixos/services/nginx/base-module.nix
@@ -271,9 +271,7 @@ let
             # [::0] being ipv6only=on.
             # We decided for this combination based on the recommendations
             # in https://serverfault.com/questions/638367/do-you-need-separate-ipv4-and-ipv6-listen-directives-in-nginx
-            let addrs = if vhost.listenAddresses != [] then vhost.listenAddresses else (
-              [ "0.0.0.0" ] ++ optional enableIPv6 "[::0]"
-            );
+            let addrs = if vhost.listenAddresses != [] then vhost.listenAddresses else cfg.defaultListenAddresses;
             in
           optionals (hasSSL || vhost.rejectSSL) (map (addr: { inherit addr; port = 443; ssl = true; }) addrs)
           ++ optionals (!onlySSL) (map (addr: { inherit addr; port = 80; ssl = false; }) addrs);
@@ -557,6 +555,16 @@ in
         description = "
           Change the proxy related timeouts in recommendedProxySettings.
         ";
+      };
+
+      defaultListenAddresses = mkOption {
+        type = types.listOf types.str;
+        default = [ "0.0.0.0" ] ++ optional enableIPv6 "[::0]";
+        defaultText = literalExpression ''[ "0.0.0.0" ] ++ lib.optional config.networking.enableIPv6 "[::0]"'';
+        example = literalExpression ''[ "10.0.0.12" "[2002:a00:1::]" ]'';
+        description = lib.mdDoc ''
+          If vhosts do not specify listenAddresses, use these addresses by default.
+        '';
       };
 
       package = mkOption {


### PR DESCRIPTION
- deprecations, will be removed in 24.05 
  - root as masterUser => nginx user
  - JSON config => upstream NixOS config 
  - listenAddress(6) => listenAddresses
- add defaultListenAddresses option from upstream to be able to replicate the behaviour of JSON config which binds to FE addresses by default.

PL-131984

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

 - nginx: warn when deprecated features which are planned for removal with the 24.05 platform version are used: `masterUser = "root"`, JSON config in `/etc/local/nginx` and the `listenAddress(6)` options.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - reduce diff to upstream NixOS
  - warn users early about features that won't work with the next platform upgrade
- [x] Security requirements tested? (EVIDENCE)
  - checked on a test VM that warnings are issued as expected and that the dynamically generated hints for fixing problems are correct