### PR TITLE
Various 23.11 fixes for the first prod release

### DIFF
--- a/nixos/platform/filebeat.nix
+++ b/nixos/platform/filebeat.nix
@@ -42,6 +42,13 @@ in
         mkdir -p $data_dir
       '';
       serviceConfig = {
+        # Workaround to stop beats from spamming the log with errors about not
+        # being able to open a directory at a path which makes no sense.
+        # Looks like the metrics code in beats is confused by the file permissions
+        # of /sys/fs/cgroup/system.slice/filebeat-journal-*.service/memory.pressure
+        # set by system 254 when MemoryPressureWatch is enabled. "skip" restores the
+        # old behaviour.
+        MemoryPressureWatch = "skip";
         StateDirectory = stateDir;
         # DynamicUser = true;
         ExecStart = ''

--- a/nixos/platform/journalbeat.nix
+++ b/nixos/platform/journalbeat.nix
@@ -62,6 +62,14 @@ in
               -c ${config} \
               -path.data ${statePath}/data
           '';
+
+          # Workaround to stop beats from spamming the log with errors about not
+          # being able to open a directory at a path which makes no sense.
+          # Looks like the metrics code in beats is confused by the file permissions
+          # of /sys/fs/cgroup/system.slice/filebeat-journal-*.service/memory.pressure
+          # set by system 254 when MemoryPressureWatch is enabled. "skip" restores the
+          # old behaviour.
+          MemoryPressureWatch = "skip";
           Restart = "always";
 
           # Security hardening

--- a/package-versions.json
+++ b/package-versions.json
@@ -15,9 +15,9 @@
     "version": "20.2.1"
   },
   "auditbeat7-oss": {
-    "name": "auditbeat-oss-7.17.4",
+    "name": "auditbeat-oss-7.17.16",
     "pname": "filebeat",
-    "version": "7.17.4"
+    "version": "7.17.16"
   },
   "automake": {
     "name": "automake-1.16.5",
@@ -180,9 +180,9 @@
     "version": "5.45"
   },
   "filebeat7-oss": {
-    "name": "filebeat-oss-7.17.4",
+    "name": "filebeat-oss-7.17.16",
     "pname": "filebeat",
-    "version": "7.17.4"
+    "version": "7.17.16"
   },
   "firefox": {
     "name": "firefox-120.0.1",

--- a/pkgs/beats.nix
+++ b/pkgs/beats.nix
@@ -2,16 +2,16 @@
 
 let beat = package: extraArgs: buildGoModule (rec {
   pname = package;
-  version = "7.17.4";
+  version = "7.17.16";
 
   src = fetchFromGitHub {
     owner = "elastic";
     repo = "beats";
     rev = "v${version}";
-    sha256 = "sha256-DE7XpzVBu9qL7fMXXYRYLdVXrr0WB0IL0KAG0Zc3TVo=";
+    hash = "sha256-0qwWHRIDLlnaPOCRmiiFGg+/jdanWuQtggM2QSaMR1o=";
   };
 
-  vendorSha256 = "sha256-TQrXUcLv7rFo3PP3bVx0wEC1WbtkJDsCm+/izHAxqBc=";
+  vendorHash = "sha256-rwCCpptppkpvwQWUtqTjBUumP8GSpPHBTCaj0nYVQv8=";
 
   subPackages = [ package ];
 

--- a/pkgs/fc/agent/fc/maintenance/tests/test_request.py
+++ b/pkgs/fc/agent/fc/maintenance/tests/test_request.py
@@ -251,6 +251,15 @@ def test_merge(monkeypatch):
     assert r._estimate == Estimate("20m")
 
 
+def test_merge_should_not_repeat_comment(monkeypatch):
+    monkeypatch.setattr(Request, "save", MagicMock())
+    r = Request(MergeableActivity(), Estimate("20m"), "First\n\nSecond")
+    other = Request(MergeableActivity(), Estimate("10m"), "Second")
+
+    res = r.merge(other)
+    assert r._comment == "First\n\nSecond"
+
+
 def test_incompatible_activities_should_not_merge(monkeypatch):
     r = Request(MergeableActivity(), Estimate("20m"), "First request.")
     other = Request(Activity(), Estimate("10m"), "Other request")

--- a/pkgs/fc/agent/fc/util/tests/test_nixos.py
+++ b/pkgs/fc/agent/fc/util/tests/test_nixos.py
@@ -194,14 +194,35 @@ def test_find_nix_build_error_missing_option():
     stderr = textwrap.dedent(
         """
         trace: [ "environment" ]
-        error: The option `flyingcircus.services.nginx.virtualHosts."test66.fe.rzob.fcio.net".forcSSL' does not exist. Definition values:
+        trace: Obsolete option `flyingcircus.roles.statshost.enable' is used. It was renamed to `flyingcircus.roles.statshost-global.enable'.
+        error:
+               … while calling the 'head' builtin
+
+                 at /nix/store/1hfsxsfgx9pzxx5mijz3n5rmvpfq7adj-source/nixpkgs/lib/attrsets.nix:850:11:
+
+                  849|         || pred here (elemAt values 1) (head values) then
+                  850|           head values
+                     |           ^
+                  851|         else
+
+               … while evaluating the attribute 'value'
+
+                 at /nix/store/1hfsxsfgx9pzxx5mijz3n5rmvpfq7adj-source/nixpkgs/lib/modules.nix:807:9:
+
+                  806|     in warnDeprecation opt //
+                  807|       { value = builtins.addErrorContext "while evaluating the option `${showOption loc}':" value;
+                     |         ^
+                  808|         inherit (res.defsFinal') highestPrio;
+
+               (stack trace truncated; use '--show-trace' to show the full trace)
+
+               error: The option `services.nginx.virtualHosts."test66.fe.rzob.fcio.net".forcSSL' does not exist. Definition values:
                - In `/etc/local/nixos/dev_vm.nix': true
-        (use '--show-trace' to show detailed location information)
         """
     )
     expected = textwrap.dedent(
         """
-        The option `flyingcircus.services.nginx.virtualHosts."test66.fe.rzob.fcio.net".forcSSL' does not exist. Definition values:
+        The option `services.nginx.virtualHosts."test66.fe.rzob.fcio.net".forcSSL' does not exist. Definition values:
         - In `/etc/local/nixos/dev_vm.nix': true
         """
     ).strip()
@@ -216,13 +237,35 @@ def test_find_nix_build_error_default_when_no_error_message():
 def test_find_nix_build_error_syntax():
     stderr = textwrap.dedent(
         """
-        error: syntax error, unexpected ';'
+        error:
+               … while evaluating the attribute 'config.system.build.toplevel'
+
+                 at /nix/store/1hfsxsfgx9pzxx5mijz3n5rmvpfq7adj-source/nixpkgs/lib/modules.nix:320:9:
+
+                  319|         options = checked options;
+                  320|         config = checked (removeAttrs config [ "_module" ]);
+                     |         ^
+                  321|         _module = checked (config._module);
+
+               … while calling the 'seq' builtin
+
+                 at /nix/store/1hfsxsfgx9pzxx5mijz3n5rmvpfq7adj-source/nixpkgs/lib/modules.nix:320:18:
+
+                  319|         options = checked options;
+                  320|         config = checked (removeAttrs config [ "_module" ]);
+                     |                  ^
+                  321|         _module = checked (config._module);
+
+               (stack trace truncated; use '--show-trace' to show the full trace)
+
+               error: syntax error, unexpected ';'
+
                at /etc/local/nixos/dev_vm.nix:190:1:
+
                   189| #flyingcircus.roles.k3s-server.enable = lib.mkForce true
                   190| ;
                      | ^
                   191|
-        (use '--show-trace' to show detailed location information)
         """
     )
     expected = textwrap.dedent(
@@ -254,19 +297,35 @@ def test_find_nix_build_error_builder_failed():
 def test_find_nix_build_error_type_error():
     stderr = textwrap.dedent(
         """
-        error: value is a string while a set was expected
-            at /nix/store/3fjl7jm2f0i2y3q0869svy801wpcracv-nixpkgs-09ba0ca4298/pkgs/build-support/trivial-builders.nix:89:8:
-                88|        })
-                89|     // builtins.removeAttrs derivationArgs [ "passAsFile" ]);
-                  |        ^
-                90|
+        building '/nix/store/my39ycs0z8xcx3ih78xb3j39r2mz5x88-firewall-local-rules.drv'...
+        error:
+               … while calling the 'head' builtin
+
+                 at /nix/store/1hfsxsfgx9pzxx5mijz3n5rmvpfq7adj-source/nixpkgs/lib/attrsets.nix:850:11:
+
+                  849|         || pred here (elemAt values 1) (head values) then
+                  850|           head values
+                     |           ^
+                  851|         else
+
+               … while evaluating the attribute 'value'
+
+                 at /nix/store/1hfsxsfgx9pzxx5mijz3n5rmvpfq7adj-source/nixpkgs/lib/modules.nix:807:9:
+
+                  806|     in warnDeprecation opt //
+                  807|       { value = builtins.addErrorContext "while evaluating the option `${showOption loc}':" value;
+                     |         ^
+                  808|         inherit (res.defsFinal') highestPrio;
+
+               (stack trace truncated; use '--show-trace' to show the full trace)
+
+               error: value is a string while a set was expected
         """
     )
 
     expected = textwrap.dedent(
         """
         value is a string while a set was expected
-        at /nix/store/3fjl7jm2f0i2y3q0869svy801wpcracv-nixpkgs-09ba0ca4298/pkgs/build-support/trivial-builders.nix:89:8:
         """
     ).strip()
     assert nixos.find_nix_build_error(stderr) == expected
@@ -276,17 +335,40 @@ def test_find_nix_build_error_conflicting_values():
     stderr = textwrap.dedent(
         """
         trace: [ "environment" ]
-        error: The option `security.dhparams.enable' has conflicting definition values:
+        trace: Obsolete option `flyingcircus.roles.statshost.enable' is used. It was renamed to `flyingcircus.roles.statshost-global.enable'.
+        trace: warning: The type `types.string` is deprecated. See https://github.com/NixOS/nixpkgs/pull/66346 for better alternative types.
+        error:
+               … while calling the 'head' builtin
+
+                 at /nix/store/1hfsxsfgx9pzxx5mijz3n5rmvpfq7adj-source/nixpkgs/lib/attrsets.nix:850:11:
+
+                  849|         || pred here (elemAt values 1) (head values) then
+                  850|           head values
+                     |           ^
+                  851|         else
+
+               … while evaluating the attribute 'value'
+
+                 at /nix/store/1hfsxsfgx9pzxx5mijz3n5rmvpfq7adj-source/nixpkgs/lib/modules.nix:807:9:
+
+                  806|     in warnDeprecation opt //
+                  807|       { value = builtins.addErrorContext "while evaluating the option `${showOption loc}':" value;
+                     |         ^
+                  808|         inherit (res.defsFinal') highestPrio;
+
+               (stack trace truncated; use '--show-trace' to show the full trace)
+
+               error: The option `security.dhparams.enable' has conflicting definition values:
                - In `/etc/local/nixos/dev_vm.nix': false
-               - In `/nix/store/csn87ili28ks7yjimihw3n4q9rqrk0cb-source/fc/nixos/platform': true
-        (use '--show-trace' to show detailed location information)
+               - In `/nix/store/1hfsxsfgx9pzxx5mijz3n5rmvpfq7adj-source/fc/nixos/platform': true
+               Use `lib.mkForce value` or `lib.mkDefault value` to change the priority on any of these definitions.
         """
     )
     expected = textwrap.dedent(
         """
         The option `security.dhparams.enable' has conflicting definition values:
         - In `/etc/local/nixos/dev_vm.nix': false
-        - In `/nix/store/csn87ili28ks7yjimihw3n4q9rqrk0cb-source/fc/nixos/platform': true
+        - In `/nix/store/1hfsxsfgx9pzxx5mijz3n5rmvpfq7adj-source/fc/nixos/platform': true
         """
     ).strip()
 
@@ -296,11 +378,34 @@ def test_find_nix_build_error_conflicting_values():
 def test_find_nix_build_error_failed_assertion():
     stderr = textwrap.dedent(
         """
+        trace: [ "environment" ]
+        trace: Obsolete option `flyingcircus.roles.statshost.enable' is used. It was renamed to `flyingcircus.roles.statshost-global.enable'.
+        trace: warning: The type `types.string` is deprecated. See https://github.com/NixOS/nixpkgs/pull/66346 for better alternative types.
         error:
+               … while calling the 'head' builtin
+
+                 at /nix/store/1hfsxsfgx9pzxx5mijz3n5rmvpfq7adj-source/nixpkgs/lib/attrsets.nix:850:11:
+
+                  849|         || pred here (elemAt values 1) (head values) then
+                  850|           head values
+                     |           ^
+                  851|         else
+
+               … while evaluating the attribute 'value'
+
+                 at /nix/store/1hfsxsfgx9pzxx5mijz3n5rmvpfq7adj-source/nixpkgs/lib/modules.nix:807:9:
+
+                  806|     in warnDeprecation opt //
+                  807|       { value = builtins.addErrorContext "while evaluating the option `${showOption loc}':" value;
+                     |         ^
+                  808|         inherit (res.defsFinal') highestPrio;
+
+               (stack trace truncated; use '--show-trace' to show the full trace)
+
+               error:
                Failed assertions:
                - The option definition `flyingcircus.roles.loghost.enable' in `/etc/local/nixos/dev_vm.nix' no longer has any effect; please remove it.
                Last platform version that supported graylog/loghost was 22.05.
-        (use '--show-trace' to show detailed location information)
         """
     )
     expected = textwrap.dedent(


### PR DESCRIPTION
- Set hostname after bootstrap. The upstream hostname activation script has been removed and host names are handled by systemd-hostnamed now. New VMs have a hostname of `default` which only changes after reboot. Set a transient host name during agent init to get the proper hostname earlier.
- Nix 2.18 changed the output format of error messages, update our parser which tries to extract the most significant lines from the error
- fix annoying filebeat metrics error messages about not being able to open a directory related to memory pressure monitoring
- add missing test for request merging with repeating comments from 21.05. The implementation for this has been commited accidentally before.

@flyingcircusio/release-managers

## Release process

Impact:

Changelog: (nothing interesting for customers)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - keep logs and error output from commands clean and readable
  - keep packages up-to-date
- [x] Security requirements tested? (EVIDENCE)
  - checked on a test VM that the metrics error messages from filebeat are gone and it still works
  - checked  on a freshly created VMs that the new code properly sets the hostname early in the agent init process.
  - error parser is covered by Python tests, also verified on a test VM that the parser works for real messages.