### PR TITLE
varnish: fix the varnish config value when rebuilding with a local varnish config

### DIFF
--- a/nixos/roles/webproxy.nix
+++ b/nixos/roles/webproxy.nix
@@ -12,7 +12,7 @@ let
   # if there is a default.vcl file, use that instead of the NixOS Varnish configuration
   rawVarnishCfg = fclib.configFromFile /etc/local/varnish/default.vcl null;
   # this is required for testing since the default.vcl file does not exist at build time
-  varnishCfg = if rawVarnishCfg == null && config.environment.etc ? "local/varnish/default.vcl" then config.environment.etc."local/varnish/default.vcl".text else null;
+  varnishCfg = if rawVarnishCfg == null && config.environment.etc ? "local/varnish/default.vcl" then config.environment.etc."local/varnish/default.vcl".text else rawVarnishCfg;
 in
 {
   options = with lib; {


### PR DESCRIPTION
fix the varnish config value when rebuilding with a local varnish config

@flyingcircusio/release-managers

## Release process

Impact:

- fixes the currently very broken varnish config from #857 

Changelog:

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - [x] fixes the varnish config 
- [x] Security requirements tested? (EVIDENCE)
  - [x] can not be tested in vm test currently (fc-manage switch does not work without an internet connection)  
