### PR TITLE
[21.05] ceph-client: fix missing udev runtime dependency for rbd-mount

### DIFF
--- a/pkgs/ceph/nautilus/default.nix
+++ b/pkgs/ceph/nautilus/default.nix
@@ -222,7 +222,7 @@ in rec {
 
      outputs = [ "out" "man" ];
     } (
-    let scriptDependencies = [ bash utillinux coreutils xfsprogs python3Packages.python ];
+    let scriptDependencies = [ bash utillinux udev coreutils xfsprogs python3Packages.python ];
     in
       ''
       mkdir -p $out/{bin,etc,${sitePackages}}

--- a/pkgs/ceph/nautilus/rbd-mount.sh
+++ b/pkgs/ceph/nautilus/rbd-mount.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck shell=bash
 set -e
 
 usage() {
@@ -63,7 +64,7 @@ else
 fi
 
 if ! rbd info "$VOLUME" &>/dev/null; then
-    echo "$0: volume ${VOLUME} not found" &>2
+    echo "$0: volume ${VOLUME} not found" >&2
     exit 66
 fi
 


### PR DESCRIPTION
@flyingcircusio/release-managers

During refactoring of the `ceph-client` package, the runtime dependency of `udevadm` was lost.
During manual testing I also discovered and fixed an issue with error reporting.

## Release process

Impact: internal only

Changelog:
- fix `rbd-mount` by adding a missing runtime dependency

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  -  fix regression that made `rbd-mount` basically non-functional
  - no other known regressions msut be introduced
  - test the fix actually resolves this regression
  - consider extending automatic test coverage
- [x] Security requirements tested? (EVIDENCE)
  - [x] manually verified this fix on a dev host
  - [x] automated NixOS tests still pass
  - [x] decided __not__ to include `rbd-mount` tests in automated test coverage; reasons:
    - that test case would require a dummy rbd image with the correct partition layout
    - the ceph test is already very long
    - `rbd-mount` is just a convenience tool and can be replaced by manual invocations of `rbd lock`, `rbd map` and `mount` if broken
    - => not worth the additional effort for now 
