### PR TITLE
[21.05] Update openssh to counter terrapin attack

### DIFF
--- a/nixos/platform/default.nix
+++ b/nixos/platform/default.nix
@@ -262,7 +262,7 @@ in {
       agent.collect-garbage = true;
     };
 
-    programs.ssh.package = pkgs.openssh_8_7;
+    programs.ssh.package = pkgs.openssh_9_6;
 
     # implementation for flyingcircus.passwordlessSudoRules
     security.sudo.extraRules = let

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -392,14 +392,19 @@ in {
     ];
   });
 
-  openssh_8_7 = super.openssh.overrideAttrs(_: rec {
-    version = "8.7p1";
+  openssh_9_6 = super.openssh.overrideAttrs(old_ssh: rec {
+    version = "9.6p1";
     name = "openssh-${version}";
 
     src = super.fetchurl {
       url = "mirror://openbsd/OpenSSH/portable/openssh-${version}.tar.gz";
-      sha256 = "090yxpi03pxxzb4ppx8g8hdpw7c4nf8p0avr6c7ybsaana5lp8vw";
+      hash = "sha256-kQIRwHJVqMWtZUORtA7lmABxDdgRndU2LeCThap6d3w=";
     };
+
+    patches = with builtins;
+      filter (p: ! (elem (builtins.baseNameOf p)
+                 ["CVE-2021-41617-1.patch" "CVE-2021-41617-2.patch"]))
+      old_ssh.patches;
 
   });
 


### PR DESCRIPTION
Re PL-132033

@flyingcircusio/release-managers

## Release process

Impact:

None

Changelog:

* Update OpenSSH to counter Terrapin attacks (CVE-2023-48795)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

quickly patch known issues

- [x] Security requirements tested? (EVIDENCE)

updated version is installed, relying on existing hydra integration tests