### PR TITLE
[23.05] webgateway: add future-compat option for smooth updates

### DIFF
--- a/nixos/roles/webgateway.nix
+++ b/nixos/roles/webgateway.nix
@@ -14,6 +14,12 @@ in
       enable = mkEnableOption "FC web gateway role (nginx/haproxy)";
       supportsContainers = fclib.mkEnableContainerSupport;
     };
+
+    # This is a no-op to allow upgrading to 23.11 smoothly.
+    flyingcircus.services.nginx.logPerVirtualHost = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+    };
   };
 
   config = lib.mkIf cfg.enable {


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Add (no-op) option `flyingcircus.services.nginx.logPerVirtualHost` to allow smooth updates between 23.05 and 23.11.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

n/a

- [x] Security requirements tested? (EVIDENCE)

n/a
