### PR TITLE
[21.05] watchdog: disable on KVM servers, extend to 300s on all others

### DIFF
--- a/nixos/infrastructure/flyingcircus-physical.nix
+++ b/nixos/infrastructure/flyingcircus-physical.nix
@@ -30,7 +30,6 @@ mkIf (cfg.infrastructureModule == "flyingcircus-physical") {
       kernelParams = [
         # Drivers
         "dolvm"
-        "ipmi_watchdog.timeout=60"
         "igb.InterruptThrottleRate=1"
         "ixgbe.InterruptThrottleRate=1"
       ];

--- a/nixos/infrastructure/flyingcircus-virtual.nix
+++ b/nixos/infrastructure/flyingcircus-virtual.nix
@@ -86,9 +86,6 @@ mkIf (cfg.infrastructureModule == "flyingcircus") {
 
   systemd = {
     ctrlAltDelUnit = "poweroff.target";
-    extraConfig = ''
-      RuntimeWatchdogSec=60
-    '';
 
     timers.serial-console-liveness = {
       description = "Timer for Serial console liveness marker";

--- a/nixos/platform/default.nix
+++ b/nixos/platform/default.nix
@@ -349,9 +349,6 @@ in {
       ];
 
       ctrlAltDelUnit = "poweroff.target";
-      extraConfig = ''
-        RuntimeWatchdogSec=60
-      '';
     };
 
 

--- a/nixos/platform/ipmi.nix
+++ b/nixos/platform/ipmi.nix
@@ -22,6 +22,11 @@ in {
         description = "Manage the IPMI controller.";
         type = types.bool;
       };
+      watchdogTimeout = mkOption {
+         default = 300;
+         description = "Watchdog timeout (0 = off)";
+         type = types.int;
+      };
       check_additional_options = mkOption {
         default = "";
         description = "Additional options to pass to `check_ipmi_sensor`.";
@@ -36,6 +41,10 @@ in {
 
     boot.blacklistedKernelModules = [ "wdat_wdt" ];
     boot.kernelModules = [ "ipmi_watchdog" ];
+
+    systemd.extraConfig = ''
+      RuntimeWatchdogSec=${toString cfg.ipmi.watchdogTimeout}
+    '';
 
     services.udev.extraRules = ''
       KERNEL=="ipmi[0-9]", GROUP="adm", MODE="0660"

--- a/nixos/roles/kvm.nix
+++ b/nixos/roles/kvm.nix
@@ -45,6 +45,10 @@ in
 
   config = lib.mkIf role.enable {
 
+    # Do not enable the watchdog for KVM hosts globally as we dealt with
+    # way too many times.
+    flyingcircus.ipmi.watchdogTimeout = fclib.mkPlatform 0;
+
     flyingcircus.services.ceph.client = {
       enable = true;
       cephRelease = role.cephRelease;


### PR DESCRIPTION
Re PL-131466

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

*  Disable watchdog on KVM hosts as they appear to trigger spuriously. Increase watchdog timeout on other servers to ensure the kernel has sufficient time to log diagnostic information. (PL-131466)
* 
## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

n/a

- [x] Security requirements tested? (EVIDENCE)

n/a
