### PR TITLE
Update nixpkgs for openssh "Terrapin" fix

### DIFF
--- a/package-versions.json
+++ b/package-versions.json
@@ -561,9 +561,9 @@
     "version": "2.11.0"
   },
   "openssh": {
-    "name": "openssh-9.5p1",
+    "name": "openssh-9.6p1",
     "pname": "openssh",
-    "version": "9.5p1"
+    "version": "9.6p1"
   },
   "openssl": {
     "name": "openssl-3.0.12",

--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "4498ffb2f5aa90bb2527d4e57cbafb67d24ce0a6",
-    "sha256": "IreOpI9fC3iBJn8wq00t7W6oBelVHT7rMhFZvo4JQAU="
+    "rev": "2370ae203043de61d67ddeee10753d3a557cf68c",
+    "sha256": "xIkRdxCGSBTXllV/spzGEwySj/GFS/2IHdnH7Srdnnk="
   },
   "nixos-mailserver": {
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/",


### PR DESCRIPTION
- openssh: 9.5p1 -> 9.6p1 (CVE-2023-48795, CVE-2023-46445, CVE-2023-46446)

PL-132033

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

- openssh: fix critical vulnerabilities known as "Terrapin". We expect no immediate danger from these vulnerabilities but we will release this as a hotfix.
  - update 9.5p1 -> 9.6p1 (CVE-2023-48795, CVE-2023-46445, CVE-2023-46446).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - patch criitcal security issues with openssh ASAP. 
- [x] Security requirements tested? (EVIDENCE)
  - checked on a test VM that SSH still works