### PR TITLE
[23.05] Update nixpkgs for openssh "Terrapin" fix

### DIFF
--- a/package-versions.json
+++ b/package-versions.json
@@ -590,9 +590,9 @@
     "version": "2.6.0"
   },
   "openssh": {
-    "name": "openssh-9.3p2",
+    "name": "openssh-9.6p1",
     "pname": "openssh",
-    "version": "9.3p2"
+    "version": "9.6p1"
   },
   "openssl": {
     "name": "openssl-3.0.12",

--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "01bf6f9ff739fce5f01dd247a4c27d21f0702e90",
-    "sha256": "/OGdoaTfLDR3foFqFfXFGMjXaX24KZPfHNDbXsMDWyI="
+    "rev": "e8b676d267c5024421cf177527f271da5a0c6344",
+    "sha256": "J2n8ge6q6W2nGaXqqQg/t+aZzaG86ERv6SApvwLVd4w="
   },
   "nixos-mailserver": {
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/",


### PR DESCRIPTION
- openssh: 9.3p2 -> 9.6p1 (CVE-2023-48795, CVE-2023-46445, CVE-2023-46446)

PL-132033

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

- openssh: fix critical vulnerabilities known as "Terrapin". We expect no immediate danger from these vulnerabilities but we will release this as a hotfix.
  - update 9.3p2 -> 9.6p1 (CVE-2023-48795, CVE-2023-46445, CVE-2023-46446).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - patch critical security issues with openssh ASAP. 
- [x] Security requirements tested? (EVIDENCE)
  - checked on a test VM that SSH still works