### PR TITLE
Make Maximilian Bosch admin

### DIFF
--- a/nixos/platform/static.nix
+++ b/nixos/platform/static.nix
@@ -129,6 +129,7 @@ with lib;
         os = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJemLKFmr09o6zBscLJSD3KcAs/dnIYBjgxYzJ59VvHx os@Olivers-MBP-3";
         molly = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAmJVyCt6/vSslsEp3dATDD/kk56kaxLggm+3ppwZWbj molly@aqueduct.local";
         phil = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILRVZrVfZrUggrw4wNNcX7r9o7NQ0VjLHTkovVnZBmYH phil";
+        ma27 = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICHlbPnJm1jkJ9wmEXpzO+WFInQkNyc2TzpBR0jXGlzV ma27@frickellinux.local";
       };
 
     };


### PR DESCRIPTION
Re FC-34774
Please backport as far as reasonable

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Introduce Maximilian Bosch as new global admin (FC-34774)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
    - [x] strong protections for the private key implemented (Strong passphrase, separate from all other keys, not automatically activated on session logins)
- [ ] Security requirements tested? (EVIDENCE)
    - [ ] reviewed setup
