### PR TITLE
doc/firewall: suggest prepending instead of appending when adding rules to nixos-fw

### DIFF
--- a/doc/src/firewall.md
+++ b/doc/src/firewall.md
@@ -75,19 +75,19 @@ nixos-drop
 Accept TCP traffic on ethfe to port 32542:
 
 ```bash
-ip46tables -A nixos-fw -p tcp -i ethfe --dport 32542 -j nixos-fw-accept
+ip46tables -I nixos-fw 1 -p tcp -i ethfe --dport 32542 -j nixos-fw-accept
 ```
 
 Refuse UDP traffic on ethsrv to port 2222:
 
 ```bash
-ip46tables -A nixos-fw -p udp -i ethsrv --dport 2222 -j nixos-fw-refuse
+ip46tables -I nixos-fw 1 -p udp -i ethsrv --dport 2222 -j nixos-fw-refuse
 ```
 
 Refuse traffic from specific subnet (with logging):
 
 ```bash
-ip6tables -A nixos-fw -s 2001:db8:33::/48 -j nixos-fw-log-refuse
+ip6tables -I nixos-fw 1 -s 2001:db8:33::/48 -j nixos-fw-log-refuse
 ```
 
 Masquerade outgoing traffic on ethsrv:


### PR DESCRIPTION
The final rule of `nixos-fw` is

    -A nixos-fw -j nixos-fw-log-refuse

which eventually drops (or rejects) packets. With such a firewall in place, appending another rule behind that means that the rule is never reached since every packet is dropped before.

This actually lead to confusion a few days ago.
See also FC-35143.

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:
* Improve documentation about adding rules to `nixos-fw` iptables chain (FC-35143)

## Security implications

- [ ] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [ ] Security requirements tested? (EVIDENCE)
