### PR TITLE
[23.05] Update nixpkgs 2024-01-02

### DIFF
--- a/package-versions.json
+++ b/package-versions.json
@@ -10,9 +10,9 @@
     "version": "2.4.58"
   },
   "asterisk": {
-    "name": "asterisk-20.2.1",
+    "name": "asterisk-20.5.1",
     "pname": "asterisk",
-    "version": "20.2.1"
+    "version": "20.5.1"
   },
   "auditbeat7-oss": {
     "name": "auditbeat-oss-7.17.4",
@@ -55,9 +55,9 @@
     "version": "2.4.13"
   },
   "cacert": {
-    "name": "nss-cacert-3.92",
+    "name": "nss-cacert-3.95",
     "pname": "nss-cacert",
-    "version": "3.92"
+    "version": "3.95"
   },
   "calibre": {
     "name": "calibre-6.17.0",
@@ -70,14 +70,14 @@
     "version": "17.2.5"
   },
   "chromedriver": {
-    "name": "chromedriver-120.0.6099.71",
+    "name": "chromedriver-120.0.6099.109",
     "pname": "chromedriver",
-    "version": "120.0.6099.71"
+    "version": "120.0.6099.109"
   },
   "chromium": {
-    "name": "chromium-120.0.6099.71",
+    "name": "chromium-120.0.6099.129",
     "pname": "chromium",
-    "version": "120.0.6099.71"
+    "version": "120.0.6099.129"
   },
   "cifs-utils": {
     "name": "cifs-utils-7.0",
@@ -150,9 +150,9 @@
     "version": "2.3.21"
   },
   "element-web": {
-    "name": "element-web-1.11.51",
+    "name": "element-web-1.11.52",
     "pname": "element-web",
-    "version": "1.11.51"
+    "version": "1.11.52"
   },
   "erlang": {
     "name": "erlang-25.3.2",
@@ -195,9 +195,9 @@
     "version": "7.17.4"
   },
   "firefox": {
-    "name": "firefox-120.0.1",
+    "name": "firefox-121.0",
     "pname": "firefox",
-    "version": "120.0.1"
+    "version": "121.0"
   },
   "gcc": {
     "name": "gcc-wrapper-12.2.0",
@@ -215,9 +215,9 @@
     "version": "2.3.3"
   },
   "ghostscript": {
-    "name": "ghostscript-with-X-10.02.0",
+    "name": "ghostscript-with-X-10.02.1",
     "pname": "ghostscript-with-X",
-    "version": "10.02.0"
+    "version": "10.02.1"
   },
   "git": {
     "name": "git-2.40.1",
@@ -285,9 +285,9 @@
     "version": "1.20.8"
   },
   "grafana": {
-    "name": "grafana-9.5.13",
+    "name": "grafana-9.5.15",
     "pname": "grafana",
-    "version": "9.5.13"
+    "version": "9.5.15"
   },
   "haproxy": {
     "name": "haproxy-2.7.10",
@@ -430,9 +430,9 @@
     "version": "0.2.5"
   },
   "linux_5_15": {
-    "name": "linux-5.15.142",
+    "name": "linux-5.15.145",
     "pname": "linux",
-    "version": "5.15.142"
+    "version": "5.15.145"
   },
   "logrotate": {
     "name": "logrotate-3.21.0",
@@ -555,9 +555,9 @@
     "version": "4.35"
   },
   "nss_latest": {
-    "name": "nss-3.95",
+    "name": "nss-3.96",
     "pname": "nss",
-    "version": "3.95"
+    "version": "3.96"
   },
   "openjdk": {
     "name": "openjdk-19.0.2+7",
@@ -700,9 +700,9 @@
     "version": "122"
   },
   "postfix": {
-    "name": "postfix-3.8.2",
+    "name": "postfix-3.8.4",
     "pname": "postfix",
-    "version": "3.8.2"
+    "version": "3.8.4"
   },
   "postgresql": {
     "name": "postgresql-14.9",
@@ -905,9 +905,9 @@
     "version": "4.9.0"
   },
   "slurm": {
-    "name": "slurm-23.02.6.1",
+    "name": "slurm-23.02.7.1",
     "pname": "slurm",
-    "version": "23.02.6.1"
+    "version": "23.02.7.1"
   },
   "solr": {
     "name": "solr-8.11.2",
@@ -990,9 +990,9 @@
     "version": "9.0.1441"
   },
   "webkitgtk": {
-    "name": "webkitgtk-2.42.3+abi=4.0",
+    "name": "webkitgtk-2.42.4+abi=4.0",
     "pname": "webkitgtk",
-    "version": "2.42.3"
+    "version": "2.42.4"
   },
   "wget": {
     "name": "wget-1.21.4",

--- a/versions.json
+++ b/versions.json
@@ -3,12 +3,12 @@
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
     "rev": "e8b676d267c5024421cf177527f271da5a0c6344",
-    "sha256": "J2n8ge6q6W2nGaXqqQg/t+aZzaG86ERv6SApvwLVd4w="
+    "hash": "sha256-J2n8ge6q6W2nGaXqqQg/t+aZzaG86ERv6SApvwLVd4w="
   },
   "nixos-mailserver": {
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/",
     "rev": "524e141124e29e1292cd97329aa3b2885a58cef8",
-    "sha256": "b6e3154f6b9c9bbaceba9ada6cbb326c4692bff6db9c5b78097ebd66f0ed7eb2",
+    "hash": "sha256-tuMVT2ucm7rOuprabLsybEaSv/bbnFt4CX69ZvDtfrI=",
     "fetchSubmodules": false,
     "deepClone": false,
     "leaveDotGit": false

--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "e8b676d267c5024421cf177527f271da5a0c6344",
-    "hash": "sha256-J2n8ge6q6W2nGaXqqQg/t+aZzaG86ERv6SApvwLVd4w="
+    "rev": "0337338999a6aa4d294b9b5f71294787de04e673",
+    "hash": "sha256-hafWUznQLdFdYLGoed5YQNCZgpaNT1+tNqIQdi3i27g="
   },
   "nixos-mailserver": {
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/",

--- a/versions.nix
+++ b/versions.nix
@@ -17,7 +17,7 @@ let
         }
       else
       pkgs.fetchFromGitHub {
-        inherit (repoInfo) owner repo rev sha256;
+        inherit (repoInfo) owner repo rev hash;
         name = "${name}-${substring 0 11 repoInfo.rev}";
       })
       versions;


### PR DESCRIPTION
Update nixpkgs

Pull upstream NixOS changes, security fixes and package updates:

- asterisk: 20.2.1 -> 20.5.1 (CVE-2023-49294, CVE-2023-49786, CVE-2022-23537)
- cacert: 3.92 -> 3.95
- chromedriver: 120.0.6099.71 -> 120.0.6099.129
- chromium: 120.0.6099.71 -> 120.0.6099.129
- ghostscript: 10.02.0 -> 10.02.1
- grafana: 9.5.13 -> 9.5.15
- grub: apply fixes for CVE-2023-4692 and CVE-2023-4693
- linux_5_15: 5.15.142 -> 5.15.145
- nss_latest: 3.95 -> 3.96
- postfix: 3.8.2 -> 3.8.4 (CVE-2023-51764)
- python3Packages.urllib3: revert upstream commit to fix jupyter-server
- slurm: 23.02.6.1 -> 23.02.7.1 (CVE-2023-49935, CVE-2023-49936, CVE-2023-49937, CVE-2023-49938, CVE-2023-49933)
- webkitgtk: 2.42.3 → 2.42.4

@flyingcircusio/release-managers

## Release process

Impact:

- \[NixOS 23.05\] Machines will reboot after the update to activate the changed kernel.

Changelog:

(include changed packages from commit msg)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - pull in upstream security fixes regularly
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still run, works on a test VM, new postfix and slurm version tested on 23.11
  - checked commit log for fixed CVEs and possible problems with updates, looked at [slurm/NEWS at master · SchedMD/slurm](https://github.com/SchedMD/slurm/blob/master/NEWS) and  [Grafana changelog](https://github.com/grafana/grafana/blob/main/CHANGELOG.md)