### PR TITLE
Bring back old MongoDB roles 3.4-4.2 for upgrades

### DIFF
--- a/doc/src/mongodb.md
+++ b/doc/src/mongodb.md
@@ -3,8 +3,60 @@
 # MongoDB
 
 :::{warning}
-MongoDB is currently not supported on NixOS 23.11.
-We will bring back older MongoDB versions (up to and including 4.2) for upgrading purposes only.
-As a long-term solution we are evaluating [FerretDB](https://www.ferretdb.com/) which builds on PostgreSQL
-and is compatible to MongoDB for many use cases.
+Platform support for MongoDB will be discontinued. The supported MongoDB
+versions are outdated and are only provided for the purpose of upgrading
+older machines to 23.11.
+
+New projects should not use MongoDB. As a replacement, we offer a
+{ref}`FerretDB role <nixos-ferretdb>` which is currently in beta.
+[FerretDB](https://www.ferretdb.com) builds on PostgreSQL and is compatible
+to MongoDB for many use cases.
 :::
+
+Managed instance of [MongoDB](https://www.mongodb.com).
+There's a role for each supported major version:
+
+- mongodb32
+- mongodb34
+- mongodb36
+- mongodb40
+- mongodb42
+
+## Configuration
+
+MongoDB works out-of-the box without configuration.
+You can put additional configuration in {file}`/etc/local/mongodb/mongodb.yaml`.
+It will be joined with the basic config.
+
+## Command Line Interface
+
+You can use the {command}`mongo` Shell to query and update data as well
+as perform administrative operations.
+
+(nixos-mongodb-upgrade)=
+
+## Upgrade
+
+:::{warning}
+Upgrade paths must include all major versions: 3.2 -> 3.4 -> 3.6 -> 4.0 -> 4.2.
+Before each upgrade step, the feature compatibility version must be set to the
+current running mongodb version.
+:::
+
+Set the compatibility version in the {command}`mongo` Shell, for example:
+
+```
+db.adminCommand( { setFeatureCompatibilityVersion: "4.2" } )
+```
+
+To upgrade, disable the current role and enable the role for the next major version.
+MongoDB will be upgraded and restarted on the next management task run.
+This happens automatically after some time. You can trigger a rebuild with
+{code}`sudo fc-manage --build --directory` immediately.
+
+The restart will fail if the feature compatibility version is too old ("error 62").
+To fix this, go back to the last working role version, rebuild, and set the version.
+
+## Monitoring
+
+Our monitoring checks that the mongodb daemon is running and responds to requests.

--- a/nixos/platform/default.nix
+++ b/nixos/platform/default.nix
@@ -297,7 +297,7 @@ in {
         fallback = true
         http-connections = 2
         log-lines = 25
-        extra-experimental-features = nix-command flakes
+        experimental-features = nix-command flakes fetch-closure
       '';
 
       settings = {

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -75,8 +75,11 @@ in {
   mailstub = callTest ./mail/stub.nix {};
   matomo = callTest ./matomo.nix {};
   memcached = callTest ./memcached.nix {};
-  # XXX: Not available on 23.11, should we add newer mongodb versions?
-  #mongodb42 = callTest ./mongodb.nix { version = "4.2"; };
+  mongodb32 = callTest ./mongodb.nix { version = "3.2"; };
+  mongodb34 = callTest ./mongodb.nix { version = "3.4"; };
+  mongodb36 = callTest ./mongodb.nix { version = "3.6"; };
+  mongodb40 = callTest ./mongodb.nix { version = "4.0"; };
+  mongodb42 = callTest ./mongodb.nix { version = "4.2"; };
   mysql57 = callTest ./mysql.nix { rolename = "mysql57"; };
   network = callSubTests ./network {};
   nfs = callTest ./nfs.nix {};


### PR DESCRIPTION
Bring back old MongoDB roles 3.4-4.2 for upgrades

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

- mongodb roles from version 3.2 to 4.2 are now available again to allow upgrades of older machines (PL-131229).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - nothing new, we bring back legacy MongoDB versions to be able to upgrade outdated VMs. Packages are taken from older platform versions and the role/service is the same as on 23.05 with added compatibility code from older platform versions.
- [x] Security requirements tested? (EVIDENCE)
   - checked on a test VM that upgrades with mongodb32 from 15.09 up to 23.11 work as expected (with 19.03 and 20.09 as intermediary steps, role has to be deactivated on 20.09)