### PR TITLE
[21.05] backup: fix race condition in restore-single-files.

### DIFF
--- a/pkgs/restore-single-files/restore-single-files.sh
+++ b/pkgs/restore-single-files/restore-single-files.sh
@@ -51,9 +51,13 @@ echo $LOOPDEV
 
 TERMINATE="umount $LOOPMNT; losetup -d $LOOPDEV; sleep 1; fusermount -u $FUSEMNT"
 trap "$TERMINATE" ERR 1 2 3 5 15
+LOOPPART="${LOOPDEV}p1"
+while [ ! -e $LOOPPART ]; do
+	sleep 0.2
+done
 
 info "Mounting image"
-mount -oloop ${LOOPDEV}p1 $LOOPMNT
+mount -oloop ${LOOPPART} $LOOPMNT
 
 info "Image data ready in ${HILITE}$LOOPMNT${NORMAL}"
 while true; do


### PR DESCRIPTION
losetup does trigger a partscan but returns before the udev rules have been processed. Add a polling loop to wait for the device to appear.

Fixes PL-132027

@flyingcircusio/release-managers

## Release process

Impact:

none

Changelog:

internal only

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

no specific requirements

- [x] Security requirements tested? (EVIDENCE)

functionally tested manually on backup server
