### PR TITLE
lamp phpfpm-pools: relax provided phpfpm setting defaults to platform  defaults

### DIFF
--- a/nixos/roles/lamp.nix
+++ b/nixos/roles/lamp.nix
@@ -231,7 +231,7 @@ in {
                 user = config.services.httpd.user;
                 group = config.services.httpd.group;
                 phpOptions = phpOptions;
-                settings = {
+                settings = (builtins.mapAttrs (_: fclib.mkPlatform) {
                   "listen.owner" = config.services.httpd.user;
                   "listen.group" = config.services.httpd.group;
                   "pm" = "dynamic";
@@ -243,7 +243,7 @@ in {
                   "request_slowlog_timeout" = "6s";
                   "request_slowlog_trace_depth" = "100";
                   "catch_workers_output" = "true";
-                };
+                });
               } vhost.pool; # only contains override values
           }) role.vhosts);
 


### PR DESCRIPTION
Semantically, we provide default values that can optionally be overridden in a fine-grained way. So mark them as platfotm default priority, to enable separately overriding the phpfpm pool settings as long as defaults are used.

@flyingcircusio/release-managers

PL-132068

## Release process

Impact: none

Changelog:
- allow directly overriding the default `services.phpfpm.pools.<name>.settings` set by our lamp role

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - must not introduce any known regressions
  - for better agility and easier upgrade paths, default values shall be overridable unless there is a good reason against it
- [x] Security requirements tested? (EVIDENCE)
  - [x] manually tested overriding of values on a dev vm with the following config:
      ```
      { lib, ...}:{
     flyingcircus.roles.lamp = {
       enable = true;
       vhosts = [ { port = 8000; docroot = "/mnt/foo/website"; } ];
    };
     services.phpfpm.pools."lamp-8000".settings = {
        "pm" = lib.mkForce "static";
        "pm.max_children" = lib.mkForce "60";
        "catch_workers_output" = "true";
        "request_slowlog_trace_depth" = "100";
        "slowlog" = "/var/log/httpd/fpm-8000-slow.log";
        "request_slowlog_timeout" = "10";
      };
    }
    ```
  - decided against an automated regression suite test as catching broken evaluations is a bit complicated right now
  - [x] automated tests still pass