### PR TITLE
Add flyingcircus.passwordlessSudoPackages and use it

### DIFF
--- a/nixos/infrastructure/flyingcircus-physical.nix
+++ b/nixos/infrastructure/flyingcircus-physical.nix
@@ -111,12 +111,13 @@ mkIf (cfg.infrastructureModule == "flyingcircus-physical") {
 
     flyingcircus.ipmi.enable = true;
 
-    flyingcircus.passwordlessSudoRules = [
+    flyingcircus.passwordlessSudoPackages = [
       {
-        commands = with pkgs; [
-          "${fc.sensuplugins}/bin/check_interfaces"
-          "${fc.sensuplugins}/bin/check_lvm_integrity"
+        commands = [
+          "bin/check_interfaces"
+          "bin/check_lvm_integrity"
         ];
+        package = pkgs.fc.sensuplugins;
         groups = [ "sensuclient" ];
       }
     ];

--- a/nixos/platform/agent.nix
+++ b/nixos/platform/agent.nix
@@ -204,34 +204,38 @@ in
               + (lib.concatMapStrings (u: " --in-service ${u}") machines);
         };
 
-      flyingcircus.passwordlessSudoRules = [
+      flyingcircus.passwordlessSudoPackages = [
         {
           commands = [
-            "/run/current-system/sw/bin/fc-collect-garbage"
-            "/run/current-system/sw/bin/fc-manage"
-            "/run/current-system/sw/bin/fc-maintenance delete"
-            "/run/current-system/sw/bin/fc-maintenance -v delete"
+            "bin/fc-collect-garbage"
+            "bin/fc-manage"
+            "bin/fc-maintenance delete"
+            "bin/fc-maintenance -v delete"
           ];
+          package = cfg.agent.package;
           groups = [ "admins" "sudo-srv" "service" ];
         }
         {
-          commands = [ "${cfg.agent.package}/bin/fc-manage check" ];
+          commands = [ "bin/fc-manage check" ];
+          package = cfg.agent.package;
           users = [ "sensuclient" ];
         }
         {
-          commands = [ "${cfg.agent.package}/bin/fc-postgresql check-autoupgrade-unexpected-dbs" ];
+          commands = [ "bin/fc-postgresql check-autoupgrade-unexpected-dbs" ];
+          package = cfg.agent.package;
           users = [ "sensuclient" ];
           runAs = "postgres";
         }
         {
           commands = [
-            "/run/current-system/sw/bin/fc-maintenance run"
-            "/run/current-system/sw/bin/fc-maintenance run --run-all-now"
-            "/run/current-system/sw/bin/fc-maintenance schedule"
-            "/run/current-system/sw/bin/fc-maintenance -v run"
-            "/run/current-system/sw/bin/fc-maintenance -v run --run-all-now"
-            "/run/current-system/sw/bin/fc-maintenance -v schedule"
+            "bin/fc-maintenance run"
+            "bin/fc-maintenance run --run-all-now"
+            "bin/fc-maintenance schedule"
+            "bin/fc-maintenance -v run"
+            "bin/fc-maintenance -v run --run-all-now"
+            "bin/fc-maintenance -v schedule"
           ];
+          package = cfg.agent.package;
           groups = [ "admins" ];
         }
       ];

--- a/nixos/platform/default.nix
+++ b/nixos/platform/default.nix
@@ -188,10 +188,50 @@ in {
       };
     };
 
+    flyingcircus.passwordlessSudoPackages = mkOption {
+      description = ''
+        Works similar to security.sudo.extraRules, but `commands` are
+        interpreted as paths relative to a given `package` so binary can be
+        run from the full Nix store path with `sudo`.
+
+        This option also creates a corresponding rule for
+        `/run/current-system/sw/` to be able to run the globally installed
+        binary from $PATH with `sudo`.
+
+        You still need to add the package to `environment.systemPackages`
+        yourself to make it globally available.
+
+        Like `flyingcircus.passwordlessSudoRules`, this automatically sets
+        passwordless mode and places rules after rules with default order
+        number(uses `mkOrder 1100`)
+      '';
+
+      example = literalExpression ''
+        [
+          {
+            commands = [ "bin/a" "bin/b --option" ];
+            package = pkgs.example;
+            groups = [ "admins" ];
+          }
+        ]
+      '';
+
+      default = [];
+    };
+
     flyingcircus.passwordlessSudoRules = mkOption {
       description = ''
         Works like security.sudo.extraRules, but sets passwordless mode and
         places rules after rules with default order number (uses mkOrder 1100).
+      '';
+
+      example = literalExpression ''
+        [
+          {
+            commands = [ "''${exampleStorePath}" ];
+            groups = [ "admins" ];
+          }
+        ];
       '';
 
       default = [];
@@ -319,6 +359,17 @@ in {
         (map
           (rule: rule // { commands = (map addPasswordOption rule.commands); })
           config.flyingcircus.passwordlessSudoRules);
+
+    # implementation for flyingcircus.passwordlessSudoPackages
+    flyingcircus.passwordlessSudoRules =
+      map
+        (e: {
+          commands = lib.flatten (map (path: [
+            "/run/current-system/sw/${path}"
+            "${e.package}/${path}"
+          ]) e.commands);
+        } // (filterAttrs (n: v: n != "commands" && n != "package") e))
+        cfg.passwordlessSudoPackages;
 
     security.dhparams.enable = true;
 

--- a/nixos/platform/default.nix
+++ b/nixos/platform/default.nix
@@ -191,7 +191,7 @@ in {
     flyingcircus.passwordlessSudoPackages = mkOption {
       description = ''
         Works similar to security.sudo.extraRules, but `commands` are
-        interpreted as paths relative to a given `package` so binary can be
+        interpreted as paths relative to a given `package` so the binary can be
         run from the full Nix store path with `sudo`.
 
         This option also creates a corresponding rule for

--- a/nixos/platform/firewall.nix
+++ b/nixos/platform/firewall.nix
@@ -135,19 +135,23 @@ in
 
       };
 
-    flyingcircus.passwordlessSudoRules =
-      let ipt = x: "/run/current-system/sw/bin/ip${x}tables";
+    flyingcircus.passwordlessSudoPackages =
+      let ipt = x: "bin/ip${x}tables";
       in [
         {
           commands = [ "${ipt ""} -L*"
                        "${ipt "6"} -L*" ];
+          package = pkgs.iptables;
           groups = [ "users" "service" ];
         }
-        {
-          commands = [ "${checkIPTables}" ];
-          groups = [ "sensuclient" ];
-        }
       ];
+
+    flyingcircus.passwordlessSudoRules = [
+      {
+        commands = [ "${checkIPTables}" ];
+        groups = [ "sensuclient" ];
+      }
+    ];
 
     flyingcircus.localConfigDirs.firewall = {
       dir = toString localCfgDir;

--- a/nixos/platform/ipmi.nix
+++ b/nixos/platform/ipmi.nix
@@ -78,11 +78,10 @@ in {
       '';
     };
 
-    flyingcircus.passwordlessSudoRules = [
+    flyingcircus.passwordlessSudoPackages = [
       {
-        commands = with pkgs; [
-          "${pkgs.check_ipmi_sensor}/bin/check_ipmi_sensor"
-        ];
+        commands = [ "bin/check_ipmi_sensor" ];
+        package = pkgs.check_ipmi_sensor;
         groups = [ "sensuclient" ];
       }
     ];

--- a/nixos/platform/packages.nix
+++ b/nixos/platform/packages.nix
@@ -71,9 +71,10 @@
 
     programs.mtr.enable = config.fclib.mkPlatform true;
 
-    flyingcircus.passwordlessSudoRules = [
+    flyingcircus.passwordlessSudoPackages = [
       {
-        commands = [ "/run/current-system/sw/bin/iotop" ];
+        commands = [ "bin/iotop" ];
+        package = pkgs.iotop;
         groups = [ "admins" "sudo-srv" "service" ];
       }
     ];

--- a/nixos/platform/users.nix
+++ b/nixos/platform/users.nix
@@ -228,9 +228,13 @@ in
         groups = [ "sudo-srv" ];
         runAs = "%service";
       }
+    ];
+
+    flyingcircus.passwordlessSudoPackages = [
       # Allow applying config and restarting services to service users
       {
-        commands = [ "/run/current-system/sw/bin/systemctl" ];
+        commands = [ "bin/systemctl" ];
+        package = pkgs.systemd;
         groups = [ "admins" "sudo-srv" "service" ];
       }
     ];

--- a/nixos/roles/backyserver.nix
+++ b/nixos/roles/backyserver.nix
@@ -131,8 +131,9 @@ in
 
     };
 
-    flyingcircus.passwordlessSudoRules = [
-      { commands = [ "${backy}/bin/backy check" ];
+    flyingcircus.passwordlessSudoPackages = [
+      { commands = [ "bin/backy check" ];
+        package = backy;
         groups = [ "sensuclient" ];
       }
     ];

--- a/nixos/roles/ceph/mon.nix
+++ b/nixos/roles/ceph/mon.nix
@@ -81,11 +81,10 @@ in
         };
       };
 
-      flyingcircus.passwordlessSudoRules = [
+      flyingcircus.passwordlessSudoPackages = [
         {
-          commands = with pkgs; [
-            "${pkgs.fc.check-ceph}/bin/check_ceph"
-          ];
+          commands = [ "bin/check_ceph" ];
+          package = pkgs.fc.check-ceph;
           groups = [ "sensuclient" ];
         }
       ];

--- a/nixos/roles/k3s/default.nix
+++ b/nixos/roles/k3s/default.nix
@@ -66,12 +66,10 @@
     }
 
     (lib.mkIf (server || agent) {
-      flyingcircus.passwordlessSudoRules = [
+      flyingcircus.passwordlessSudoPackages = [
         {
-          commands = [
-            "${config.flyingcircus.agent.package}/bin/fc-kubernetes"
-            "/run/current-system/sw/bin/fc-kubernetes"
-          ];
+          commands = [ "bin/fc-kubernetes" ];
+          package = config.flyingcircus.agent.package;
           groups = [ "admins" "sudo-srv" ];
         }
       ];

--- a/nixos/roles/mailserver.nix
+++ b/nixos/roles/mailserver.nix
@@ -221,12 +221,10 @@ in
       flyingcircus.services.nginx.enable = true;
       flyingcircus.services.redis.enable = true;
 
-      flyingcircus.passwordlessSudoRules = [
+      flyingcircus.passwordlessSudoPackages = [
         {
-          commands = [
-            "${pkgs.postfix}/bin/postsuper"
-            "/run/current-system/sw/bin/postsuper"
-          ];
+          commands = [ "bin/postsuper" ];
+          package = pkgs.postfix;
           groups = [ "sudo-srv" "service" ];
         }
       ];

--- a/nixos/roles/matomo.nix
+++ b/nixos/roles/matomo.nix
@@ -36,23 +36,25 @@ in
 
     flyingcircus.services.nginx.enable = true;
 
-    flyingcircus.passwordlessSudoRules = [
+    flyingcircus.passwordlessSudoPackages = [
       {
-        commands = [
-          "${serviceCfg.tools.matomoConsole}/bin/matomo-console"
-          "/run/current-system/sw/bin/matomo-console"
-        ];
+        commands = [ "bin/matomo-console" ];
+        package = serviceCfg.tools.matomoConsole;
         users = [ "sensuclient" ];
         groups = [ "service" "sudo-srv" ];
         runAs = "matomo";
       }
       {
+        commands = [ "bin/matomo-check-permissions" ];
+        package = serviceCfg.tools.matomoCheckPermissions;
+        users = [ "sensuclient" ];
+        groups = ["service" ];
+      }
+      {
         commands = [
-          "/run/current-system/sw/bin/matomo-check-permissions"
-          "/run/current-system/sw/bin/stat /var/lib/matomo/share/config/config.ini.php"
-          "${serviceCfg.tools.matomoCheckPermissions}/bin/matomo-check-permissions"
-          "${pkgs.coreutils}/bin/stat /var/lib/matomo/share/config/config.ini.php"
+          "bin/stat /var/lib/matomo/share/config/config.ini.php"
         ];
+        package = pkgs.coreutils;
         users = [ "sensuclient" ];
         groups = ["service" ];
       }

--- a/nixos/roles/mysql.nix
+++ b/nixos/roles/mysql.nix
@@ -133,12 +133,13 @@ in
         groups = [ "sudo-srv" "service" ];
         runAs = "mysql";
       }
+    ];
+
+    flyingcircus.passwordlessSudoPackages = [
       {
-        commands = [
-          "${xtraPackage}/bin/xtrabackup"
-          "/run/current-system/sw/bin/xtrabackup"
-        ];
-        groups = ["service"];
+        commands = [ "bin/xtrabackup" ];
+        package = xtraPackage;
+        groups = [ "service" ];
       }
     ];
 

--- a/nixos/roles/slurm/default.nix
+++ b/nixos/roles/slurm/default.nix
@@ -312,11 +312,12 @@ in
           groups = [ "sudo-srv" ];
           runAs = "slurm";
         }
+      ];
+
+      flyingcircus.passwordlessSudoPackages = [
         {
-          commands = [
-            "${config.flyingcircus.agent.package}/bin/fc-slurm"
-            "/run/current-system/sw/bin/fc-slurm"
-          ];
+          commands = [ "bin/fc-slurm" ];
+          package = config.flyingcircus.agent.package;
           groups = [ "sudo-srv" ];
         }
       ];

--- a/nixos/services/ceph/server.nix
+++ b/nixos/services/ceph/server.nix
@@ -77,9 +77,10 @@ in
       { ceph_binary =  "${ceph_sudo}/bin/ceph-sudo"; }
     ];
 
-    flyingcircus.passwordlessSudoRules = [
+    flyingcircus.passwordlessSudoPackages = [
       {
-        commands = [ "${pkgs.ceph}/bin/ceph" ];
+        commands = [ "bin/ceph" ];
+        package = pkgs.ceph;
         users = [ "telegraf" ];
       }
     ];

--- a/nixos/services/mail/default.nix
+++ b/nixos/services/mail/default.nix
@@ -31,7 +31,6 @@ let
     concatMapStringsSep "\n"
       (e: "${e.uid}: ${concatStringsSep ", " e.email_addresses}")
       config.flyingcircus.users.userData;
-  checkMailq = "${pkgs.fc.check-postfix}/bin/check_mailq";
 
 in {
   imports = [
@@ -150,6 +149,7 @@ in {
       let
         plug = "${pkgs.monitoring-plugins}/bin";
         mailq = "${pkgs.postfix}/bin/mailq";
+        checkMailq = "${pkgs.fc.check-postfix}/bin/check_mailq";
       in {
         postfix_mailq = {
           command = "sudo ${checkMailq} -w 200 -c 2000 --mailq ${mailq}";
@@ -175,11 +175,15 @@ in {
         };
       };
 
-      flyingcircus.passwordlessSudoRules = [
+      flyingcircus.passwordlessSudoPackages = [
         {
-          commands = [ checkMailq ];
+          commands = [ "bin/check_mailq" ];
+          package = pkgs.fc.check-postfix;
           groups = [ "sensuclient" ];
         }
+      ];
+
+      flyingcircus.passwordlessSudoRules = [
         {
           commands = [ "ALL" ];
           groups = [ "sudo-srv" ];

--- a/nixos/services/mail/roundcube.nix
+++ b/nixos/services/mail/roundcube.nix
@@ -2,7 +2,7 @@
 
 let
   role = config.flyingcircus.roles.mailserver;
-  chpasswd = "${pkgs.fc.roundcube-chpasswd-py}/bin/roundcube-chpasswd";
+  chpasswdPkg = pkgs.fc.roundcube-chpasswd-py;
   fclib = config.fclib;
 
 in lib.mkMerge [
@@ -27,8 +27,9 @@ in lib.mkMerge [
       };
     };
 
-    flyingcircus.passwordlessSudoRules = [{
-      commands = [ chpasswd ];
+    flyingcircus.passwordlessSudoPackages = [{
+      commands = [ "bin/roundcube-chpasswd" ];
+      package = chpasswdPkg;
       users = [ "roundcube" ];
       runAs = "vmail";
     }];
@@ -45,7 +46,7 @@ in lib.mkMerge [
         $config['archive_type'] = 'year';
         $config['managesieve_vacation'] = 1;
         $config['mime_types'] = '${pkgs.mailcap}/etc/mime.types';
-        $config['password_chpasswd_cmd'] = '/run/wrappers/bin/sudo -u vmail ${chpasswd} --passwd-file ${role.passwdFile}';
+        $config['password_chpasswd_cmd'] = '/run/wrappers/bin/sudo -u vmail ${chpasswdPkg}/bin/roundcube-chpasswd --passwd-file ${role.passwdFile}';
         $config['password_confirm_current'] = true;
         $config['password_driver'] = 'chpasswd';
         $config['password_minimum_length'] = 10;

--- a/nixos/services/mail/stub.nix
+++ b/nixos/services/mail/stub.nix
@@ -80,6 +80,7 @@ in {
       postfix_mailq =
         let
           mailq = "${pkgs.postfix}/bin/mailq";
+          checkMailq = "${pkgs.fc.check-postfix}/bin/check_mailq";
         in {
           command = "sudo ${checkMailq} -w 50 -c 500 --mailq ${mailq}";
           notification = "Too many undelivered mails in Postfix mail queue";
@@ -97,9 +98,10 @@ in {
       };
     };
 
-    flyingcircus.passwordlessSudoRules = [
+    flyingcircus.passwordlessSudoPackages = [
       {
-        commands = [ checkMailq ];
+        commands = [ "bin/check_mailq" ];
+        package = pkgs.fc.check-postfix;
         groups = [ "sensuclient" ];
       }
     ];

--- a/nixos/services/postgresql/default.nix
+++ b/nixos/services/postgresql/default.nix
@@ -232,13 +232,15 @@ in {
           groups = [ "sudo-srv" "service" ];
           runAs = "postgres";
         }
+      ];
+
+      flyingcircus.passwordlessSudoPackages = [
         {
           commands = [
-            "/run/current-system/sw/bin/systemctl start postgresql"
-            "/run/current-system/sw/bin/systemctl stop postgresql"
-            "${pkgs.systemd}/bin/systemctl start postgresql"
-            "${pkgs.systemd}/bin/systemctl stop postgresql"
+            "bin/systemctl start postgresql"
+            "bin/systemctl stop postgresql"
           ];
+          package = pkgs.systemd;
           users = [ "postgres" ];
         }
       ];

--- a/nixos/services/sensu/client.nix
+++ b/nixos/services/sensu/client.nix
@@ -326,14 +326,20 @@ in {
           "${pkgs.perl}/bin/json_pp < ${sensuClientConfigFile}")
       ];
 
-      flyingcircus.passwordlessSudoRules = [
+      flyingcircus.passwordlessSudoPackages = [
         {
-          commands = with pkgs; [
-            "${fc.multiping}/bin/multiping"
-            "${fc.sensuplugins}/bin/check_disk"
-          ];
+          commands = [ "bin/multiping" ];
+          package = pkgs.fc.multiping;
           groups = [ "sensuclient" ];
         }
+        {
+          commands = [ "bin/check_disk" ];
+          package = pkgs.fc.sensuplugins;
+          groups = [ "sensuclient" ];
+        }
+      ];
+
+      flyingcircus.passwordlessSudoRules = [
         # Allow sensuclient group to become service user for running custom checks
         {
           commands = [ "ALL" ];


### PR DESCRIPTION
Add flyingcircus.passwordlessSudoPackages and use it

The new option built on top of `passwordlessSudoRules` is more
convenient, especially with recent sudo versions as it requires a rule
for the Nix store path and /run/current-system for typical use cases.

PL-132015

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

- (internal)

## Security implications

Older sudo versions resolved symlinks from /run/current-system to `/nix/store` so having rules for Nix store paths was enough.
This change is mostly a refactoring to reduce rule duplication. Using the new option in cases where the rule for the other path  didn't exist (either an oversight or the rule wasn't needed) adds some new generated rules but without giving additional sudo permissions. 

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - [x] this change should not introduce new possibilities to use sudo without password
- [x] Security requirements tested? (EVIDENCE)
  - looked at sudoers file generated on a test VM with many roles: no unexpected rules found
  - some NixOS tests check sudo rules