### PR TITLE
[21.05] This has bitten us just today causing OSDs to flap and never

### DIFF
--- a/nixos/roles/ceph/osd.nix
+++ b/nixos/roles/ceph/osd.nix
@@ -243,6 +243,10 @@ in
           ExecStop = ''
             ${cephPkgs.fc-ceph}/bin/fc-ceph osd deactivate --as-systemd-unit %i
           '';
+
+          # OSDs may sometimes take a bit longer and the default timeout can
+          # quickly produce a volatile state.
+          TimeoutSec = "15m";
         };
 
       };


### PR DESCRIPTION
properly start.

@flyingcircusio/release-managers

## Release process

Impact:

none

Changelog:

internal only

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

availability

- [x] Security requirements tested? (EVIDENCE)

manually tested
