### PR TITLE
FerretDB and postgresql16 roles

### DIFF
--- a/doc/src/ferretdb.md
+++ b/doc/src/ferretdb.md
@@ -1,0 +1,72 @@
+(nixos-ferretdb)=
+
+# FerretDB
+
+:::{note}
+FerretDB support is in beta. Feel free to use it but we suggest contacting
+our support before putting anything into production.
+:::
+
+Managed instance of [FerretDB](https://www.ferretdb.io), an Apache-licensed
+MongoDB alternative supporting multiple backend stores.
+
+## Configuration
+
+FerretDB works out-of-the box without configuration.
+PostgreSQL is used as default backend. We automatically enable PostgreSQL and
+create a database `ferretdb` owned by the `ferretdb` user.
+Updates to new PostgreSQL versions are done automatically as long as there's only
+the `ferretdb` database in it.
+
+FerretDB supports only one listen address. By default, it listens to the SRV
+interface, port 27017 like MongoDB, using IPv4.
+
+## Command Line Interface
+
+As FerretDB is mostly line protocol-compatible with MongoDB, you can use tools
+built for MongoDB. We install `mongodb-tools` and `mongosh` globally by default.
+
+Use {command}`mongosh` to query and update data as well as perform
+administrative operations:
+
+```shell
+mongosh $HOST
+```
+
+## Authentication
+
+Authenticating connections to FerretDB is not supported at the moment.
+(nixos-ferretdb-upgrade)=
+
+## Migrating from MongoDB
+
+:::{warning}
+Feature compatibility with MongoDB (namely version 6) is good and FerretDB is
+mostly a drop-in replacement. However, make sure to properly test your
+application with FerretDB in a staging environment before rolling it out to
+production.
+:::
+
+Data dumps from MongoDB can be imported into a FerretDB instance.
+
+On the FerretDB machine called `example01`, dump all collections from a
+MongoDB instance running on `example03`, assuming default configuration of
+the MongoDB role with no authentication needed.
+
+See http://docs.mongodb.com/database-tools/mongodump/ for more information.
+
+
+```shell
+mongodump mongodb://example03 -o mongodb_dump
+```
+
+Import dump to FerretDB:
+
+```shell
+mongorestore mongodb://example01 mongodb_dump
+```
+
+## Monitoring
+
+Our monitoring checks that the ferretdb daemon is running and responds to requests.
+We also monitor the underlying PostgreSQL instance.

--- a/doc/src/index.md
+++ b/doc/src/index.md
@@ -30,6 +30,7 @@ fc_collect_garbage_userscan
 devhost
 docker
 external_net
+ferretdb
 kubernetes
 lamp
 mailserver

--- a/doc/src/postgresql.md
+++ b/doc/src/postgresql.md
@@ -6,7 +6,7 @@ Managed instance of the [PostgreSQL](http://postgresql.org) database server.
 
 ## Components
 
-- PostgreSQL server (versions 12, 13, 14, 15)
+- PostgreSQL server (versions 12, 13, 14, 15, 16)
 
 :::{warning}
 
@@ -28,7 +28,7 @@ To grant `CREATE` privilege to user `test` using SQL, execute:
 GRANT CREATE ON SCHEMA public TO test;
 ~~~
 
-See [Schemas and Privileges](https://www.postgresql.org/docs/15/ddl-schemas.html#DDL-SCHEMAS-PRIV)
+See [Schemas and Privileges](https://www.postgresql.org/docs/16/ddl-schemas.html#DDL-SCHEMAS-PRIV)
 in the PostgreSQL documentation for more information.
 :::
 

--- a/nixos/platform/systemd.nix
+++ b/nixos/platform/systemd.nix
@@ -13,7 +13,7 @@ in
 
       journalReadGroups = mkOption {
         description = "Groups that are allowed to read the system journal.";
-        type = types.listOf types.string;
+        type = types.listOf types.str;
       };
 
     };

--- a/nixos/roles/default.nix
+++ b/nixos/roles/default.nix
@@ -15,6 +15,7 @@ in {
     ./ceph/rgw.nix
     ./devhost
     ./external_net
+    ./ferretdb.nix
     ./gitlab.nix
     ./jitsi
     ./k3s

--- a/nixos/roles/ferretdb.nix
+++ b/nixos/roles/ferretdb.nix
@@ -1,0 +1,20 @@
+{ config, lib, pkgs, ... }:
+
+with builtins;
+
+let
+  inherit (config) fclib;
+  cfg = config.flyingcircus.roles.ferretdb;
+in
+{
+  options = with lib; {
+    flyingcircus.roles.ferretdb = {
+      enable = mkEnableOption "Enable the ferretdb role, a (mostly) drop-in replacement for MongoDB";
+      supportsContainers = fclib.mkEnableContainerSupport;
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    flyingcircus.services.ferretdb.enable = true;
+  };
+}

--- a/nixos/roles/postgresql.nix
+++ b/nixos/roles/postgresql.nix
@@ -18,6 +18,7 @@ in
       postgresql13 = mkRole "13";
       postgresql14 = mkRole "14";
       postgresql15 = mkRole "15";
+      postgresql16 = mkRole "16";
     };
   };
 
@@ -28,6 +29,7 @@ in
       "13" = postgresql13.enable;
       "14" = postgresql14.enable;
       "15" = postgresql15.enable;
+      "16" = postgresql16.enable;
     };
     enabledRoles = lib.filterAttrs (n: v: v) pgroles;
     enabledRolesCount = length (lib.attrNames enabledRoles);

--- a/nixos/services/default.nix
+++ b/nixos/services/default.nix
@@ -19,6 +19,7 @@ in {
     ./ceph/client.nix
     ./ceph/server.nix
     ./consul.nix
+    ./ferretdb.nix
     ./haproxy
     ./jitsi/jibri.nix
     ./jitsi/jicofo.nix

--- a/nixos/services/ferretdb.nix
+++ b/nixos/services/ferretdb.nix
@@ -1,0 +1,94 @@
+{ config, lib, pkgs, ... }:
+
+with builtins;
+
+let
+  inherit (config) fclib;
+  cfg = config.flyingcircus.services.ferretdb;
+  checkMongoCmd = "${pkgs.fc.check-mongodb}/bin/check_mongodb";
+in
+{
+  options = with lib; {
+    flyingcircus.services.ferretdb = {
+      enable = mkEnableOption "Enable FerretDB, a (mostly) drop-in replacement for MongoDB";
+      supportsContainers = fclib.mkEnableContainerSupport;
+
+      address = mkOption {
+        type = types.str;
+        default = head fclib.network.srv.v4.addresses;
+        defaultText = "First SRV IPv4 address";
+        description = "Address to listen to. FerretDB only supports listen on a single address.";
+      };
+
+      extraCheckArgs = with lib; mkOption {
+        type = types.str;
+        default = "-h ${cfg.address} -p ${toString cfg.port}";
+        example = "-h example00.fe.rzob.fcio.net -p 27017 -t";
+        description = "Extra arguments to be passed to the check_mongodb script";
+      };
+
+      port = mkOption {
+        type = types.port;
+        default = 27017;
+      };
+    };
+  };
+
+  config = lib.mkMerge [
+    (lib.mkIf cfg.enable {
+
+      environment.systemPackages = with pkgs; [
+        mongodb-tools
+        fc.check-mongodb
+        mongosh
+        ferretdb
+      ];
+
+      flyingcircus.services.postgresql.enable = true;
+      flyingcircus.services.postgresql.majorVersion = "16";
+      flyingcircus.services.postgresql.autoUpgrade = {
+        enable = true;
+        expectedDatabases = [ "ferretdb" ];
+      };
+
+      flyingcircus.services.sensu-client = {
+        checks = {
+          ferretdb = {
+            notification = "FerretDB not functional";
+            command = ''
+              ${checkMongoCmd} -d ferretdb ${cfg.extraCheckArgs}
+            '';
+          };
+        };
+
+        expectedConnections = {
+          warning = 60000;
+          critical = 63000;
+        };
+      };
+
+      services.ferretdb = {
+        enable = true;
+        settings = {
+          FERRETDB_HANDLER = "pg";
+          FERRETDB_LISTEN_ADDR = fclib.mkPlatform "${cfg.address}:${toString cfg.port}";
+          FERRETDB_POSTGRESQL_URL = fclib.mkPlatform "postgres:///ferretdb?host=/run/postgresql&user=ferretdb";
+          FERRETDB_TELEMETRY = "disable";
+        };
+      };
+
+      services.postgresql.ensureDatabases = [ "ferretdb" ];
+      services.postgresql.ensureUsers = [{
+        name = "ferretdb";
+        ensureDBOwnership = true;
+      }];
+
+      systemd.services.ferretdb = {
+        serviceConfig = {
+          stopIfChanged = false;
+        };
+      };
+
+    })
+  ];
+}

--- a/nixos/services/opensearch.nix
+++ b/nixos/services/opensearch.nix
@@ -81,7 +81,7 @@ in
 
 
       nodeName = mkOption {
-        type = types.nullOr types.string;
+        type = types.nullOr types.str;
         default = config.networking.hostName;
         description = ''
           The name for this node. Defaults to the hostname.

--- a/nixos/services/postgresql/default.nix
+++ b/nixos/services/postgresql/default.nix
@@ -7,11 +7,11 @@ let
   upstreamCfg = config.services.postgresql;
   fclib = config.fclib;
   packages = {
-    "11" = pkgs.postgresql_11;
     "12" = pkgs.postgresql_12;
     "13" = pkgs.postgresql_13;
     "14" = pkgs.postgresql_14;
     "15" = pkgs.postgresql_15;
+    "16" = pkgs.postgresql_16;
   };
 
   oldestMajorVersion = head (lib.attrNames packages);
@@ -115,11 +115,7 @@ in {
     let
       postgresqlPkg = getAttr cfg.majorVersion packages;
 
-      extensions = lib.optionals (lib.versionOlder cfg.majorVersion "12") [
-        (pkgs.postgis_2_5.override { postgresql = postgresqlPkg; })
-        (pkgs.temporal_tables.override { postgresql = postgresqlPkg; })
-        postgresqlPkg.pkgs.rum
-      ] ++ lib.optionals (lib.versionAtLeast cfg.majorVersion "12") [
+      extensions = [
         postgresqlPkg.pkgs.periods
         postgresqlPkg.pkgs.postgis
         postgresqlPkg.pkgs.rum

--- a/nixos/services/redis.nix
+++ b/nixos/services/redis.nix
@@ -32,7 +32,7 @@ in {
       };
 
       password = mkOption {
-        type = types.nullOr types.string;
+        type = types.nullOr types.str;
         default = null;
         description = ''
           The password for redis. If null, a random password will be generated.

--- a/pkgs/fc/agent/fc/util/postgresql.py
+++ b/pkgs/fc/agent/fc/util/postgresql.py
@@ -37,6 +37,7 @@ class PGVersion(str, Enum):
     PG13 = "13"
     PG14 = "14"
     PG15 = "15"
+    PG16 = "16"
 
 
 def run_as_postgres(cmd, **kwargs):

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -90,6 +90,7 @@ in {
   postgresql13 = callTest ./postgresql { version = "13"; };
   postgresql14 = callTest ./postgresql { version = "14"; };
   postgresql15 = callTest ./postgresql { version = "15"; };
+  postgresql16 = callTest ./postgresql { version = "16"; };
   postgresql-autoupgrade = callSubTests ./postgresql/upgrade.nix {};
   prometheus = callTest ./prometheus.nix {};
   rabbitmq = callTest ./rabbitmq.nix {};

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -40,6 +40,7 @@ in {
   devhost = callTest ./devhost.nix {};
   docker = callTest ./docker.nix {};
   fcagent = callSubTests ./fcagent.nix {};
+  ferretdb = callTest ./ferretdb.nix {};
   ffmpeg = callTest ./ffmpeg.nix {};
   filebeat = callTest ./filebeat.nix {};
   collect-garbage = callTest ./collect-garbage.nix {};

--- a/tests/ferretdb.nix
+++ b/tests/ferretdb.nix
@@ -1,0 +1,57 @@
+import ./make-test-python.nix ({ lib, pkgs, testlib, ... }:
+let
+  ipv4 = testlib.fcIP.srv4 1;
+  ipv6 = testlib.fcIP.srv6 1;
+
+in {
+  name = "ferretdb";
+  nodes.machine =
+    { ... }:
+    {
+      imports = [
+        (testlib.fcConfig { net.fe = false; })
+      ];
+      flyingcircus.roles.ferretdb.enable = true;
+    };
+
+
+  testScript = { nodes, ... }:
+  let
+    testJs = pkgs.writeText "test-ferretdb.js" ''
+      coll = db.getCollection("test")
+      coll.insertOne({test: "helloferret"})
+      coll.find({test: "helloferret"}).forEach(printjson)
+    '';
+
+    check = ipaddr: ''
+    '';
+
+    sensuCheck = testlib.sensuCheckCmd nodes.machine;
+  in ''
+      machine.wait_for_unit("ferretdb.service")
+
+      with subtest("Ferretdb should respond"):
+        machine.wait_until_succeeds('mongosh ${ipv4} --eval db')
+
+      with subtest(f"Inserting and finding a document should work"):
+        machine.succeed('mongosh "mongodb://${ipv4}:27017/test" ${testJs} | grep helloferret');
+
+      with subtest("ferretdb sensu check should be green"):
+        machine.succeed("${sensuCheck "ferretdb"}")
+
+      with subtest("killing the ferretdb process should trigger an automatic restart"):
+        _, out = machine.systemctl("show ferretdb --property MainPID --value")
+        previous_pid = int(out.strip())
+        machine.succeed("systemctl kill -s KILL ferretdb")
+        machine.wait_until_succeeds('test $(systemctl show ferretdb --property NRestarts --value) -eq "1"')
+        machine.wait_until_succeeds("${sensuCheck "ferretdb"}")
+        _, out = machine.systemctl("show ferretdb --property MainPID --value")
+        new_pid = int(out.strip())
+        assert new_pid != previous_pid, f"Expected new PID but is still the same: {new_pid}"
+
+      with subtest("ferretdb sensu check should be red after shutting down ferretdb"):
+        machine.systemctl("stop ferretdb")
+        machine.fail("${sensuCheck "ferretdb"}")
+    '';
+
+})

--- a/tests/testlib.nix
+++ b/tests/testlib.nix
@@ -34,7 +34,7 @@ rec {
       lib.replaceStrings
         ["\\" "\n"]
         ["" " "]
-        machine.config.flyingcircus.services.sensu-client.checks.${checkName}.command;
+        machine.flyingcircus.services.sensu-client.checks.${checkName}.command;
 
   /*
     Get a basic configuration for a virtual machine


### PR DESCRIPTION
Add experimental support for FerretDB to test replacing MongoDB.

Also adds PostgreSQL 16 which is used as backend for FerretDB.


@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

- Add `postgresql16` role (PL-132063).
- Add experimental `ferretdb` role, an alternative to MongoDB (PL-132063).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - FerretDB doesn't properly support authentication. We at least have to make sure that is only reachable from the same RG, so it should only listen on SRV (like MongoDB).
  - diagnostics endpoint (8088) should be only reachable on localhost
- [x] Security requirements tested? (EVIDENCE)
  - checked on a test VM:
    -  that FerretDB is listening on SRV only and that the diagnostics endpoint is listening only on localhost
    - that PostgreSQL is listening on SRV and localhost, both IPv4 and IPv6
  - tested migration from MongoDB by dumping data, importing it into FerretDB, tried out basic MongoDB operations on a test VM using the new postgresql16 role
  - New NixOS test checks basic functionality like for MongoDB
  - new postgresql role is already covered by the existing test