### PR TITLE
rabbitmq 3.6.5 role for upgrades from NixOS 20.09

### DIFF
--- a/doc/src/rabbitmq.md
+++ b/doc/src/rabbitmq.md
@@ -34,4 +34,41 @@ After upgrading a cluster, enable all feature flags:
 sudo -u rabbitmq rabbitmqctl enable_feature_flag all
 ```
 
+## Upgrading from NixOS 20.09 while keeping RabbitMQ 3.6.5
+
+To be able to upgrade NixOS 20.09 machines using the `rabbitmq36_5` role,
+we provide a way to keep the unchanged rabbitmq service running after the system
+upgrade. This conserves the specific rabbitmq config for the machine and
+cannot be used on new 23.11 machines.
+
+The upgrade process starts with generating Nix config on the running machine.
+Put the generated config in :file:`/etc/local/nixos/rabbitmq365-frozen.nix`.
+
+```shell
+#!/usr/bin/env sh
+service=$(realpath /etc/systemd/system/rabbitmq.service)
+storePath=${service%%/rabbitmq.service}
+cat <<EOF
+# Generated config to freeze the existing rabbitmq unit file and all dependencies
+# to keep it running after an upgrade to 23.11.
+{ lib, ... }:
+{
+  # This no-op option declaration is needed for building the 20.09 system.
+  options.flyingcircus.services.rabbitmq365Frozen.service = lib.mkOption {};
+
+  # On 20.09, this setting changes nothing. It's only effective on 23.11.
+  config.flyingcircus.services.rabbitmq365Frozen.service =
+    builtins.storePath $storePath;
+}
+EOF
+```
+
+After that, change the VM environment to a 23.11 edition, keep the
+`rabbitmq36_5` role enabled and rebuild. The `rabbitmq.service` will stay
+active during the upgrade.
+
+Changes to RabbitMQ's configuration via NixOS options or
+`/etc/local/rabbitmq`. are not possible after the upgrade.
+
+
 % vim: set spell spelllang=en:

--- a/nixos/services/default.nix
+++ b/nixos/services/default.nix
@@ -36,7 +36,8 @@ in {
     ./percona.nix
     ./postgresql
     ./prometheus.nix
-    ./rabbitmq.nix
+    ./rabbitmq
+    ./rabbitmq/365frozen.nix
     ./raid
     ./redis.nix
     ./sensu/client.nix

--- a/nixos/services/rabbitmq/365frozen.nix
+++ b/nixos/services/rabbitmq/365frozen.nix
@@ -1,0 +1,158 @@
+{ config, lib, pkgs, ... }:
+
+with builtins;
+
+let
+  cfg = config.flyingcircus.services.rabbitmq365Frozen;
+  inherit (config) fclib;
+  listenAddress = head (fclib.network.srv.v4.addresses);
+  telegrafPassword = fclib.derivePasswordForHost "telegraf";
+  sensuPassword = fclib.derivePasswordForHost "sensu";
+in
+{
+  options = with lib; {
+    flyingcircus.services.rabbitmq365Frozen = {
+      enable = mkEnableOption "RabbitMQ server, an Advanced Message Queuing Protocol (AMQP) broker (3.6.x series)";
+
+      package = mkOption {
+        type = types.package;
+        default = storePath /nix/store/sqap94f4a0z8pxdal5wfgsm83ncwwbbd-rabbitmq-server-3.6.5;
+        description = ''
+          Which rabbitmq package to use. Should be the same as used in `service`.
+        '';
+      };
+
+      service = mkOption {
+        type = types.package;
+        example =
+          literalExpression
+            "builtins.storePath /nix/store/4vn6482k7vhafyqdq1lvw9yyb37agv8z-unit-rabbitmq.service;";
+        description = ''
+          Which rabbitmq service package to use. The package is expected to
+          contain a `rabbitmq.service` unit file. This is usually generated
+          from running config on NixOS 20.09 using the "freeze" script from
+          the role documentation.
+        '';
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+
+    environment.systemPackages = [ cfg.package ];
+
+    flyingcircus.localConfigDirs.rabbitmq = {
+      dir = "/etc/local/rabbitmq";
+      user = "rabbitmq";
+    };
+
+    environment.etc."local/rabbitmq/README.txt".text = ''
+      This machine runs RabbitMQ 3.6.5 with "frozen" config.
+      The configuration of RabbitMQ cannot be changed via this directory or NixOS options anymore.
+    '';
+
+    flyingcircus.services = {
+
+      sensu-client.checks.rabbitmq-alive = {
+        notification = "rabbitmq amqp alive";
+        command = ''
+          ${pkgs.sensu-plugins-rabbitmq}/bin/check-rabbitmq-amqp-alive.rb \
+            -u fc-sensu -w ${listenAddress} -p ${sensuPassword}
+        '';
+      };
+
+      sensu-client.checks.rabbitmq-node-health = {
+        notification = "rabbitmq node healthy";
+        command = ''
+          ${pkgs.sensu-plugins-rabbitmq}/bin/check-rabbitmq-node-health.rb \
+            -u fc-sensu -w ${listenAddress} -p ${sensuPassword}
+        '';
+      };
+
+      telegraf.inputs.rabbitmq = [
+        {
+          client_timeout = "10s";
+          header_timeout = "10s";
+          url = "http://${config.networking.hostName}:15672";
+          username = "fc-telegraf";
+          password = telegrafPassword;
+          nodes = [ "rabbit@${config.networking.hostName}" ];
+          # Drop string fields. They are converted to labels in Prometheus
+          # which blows up the number of metrics.
+          fielddrop = [ "idle_since" ];
+        }
+      ];
+    };
+
+    systemd.packages = [
+      (pkgs.runCommand "rabbitmq-3.6.5-service" {} ''
+        service_dir=$out/lib/systemd/system
+        mkdir -p $service_dir
+        cp ${cfg.service}/rabbitmq.service $service_dir
+      '')
+      ];
+
+    systemd.services.fc-rabbitmq-settings = {
+      description = "Check/update FCIO rabbitmq settings (for monitoring)";
+      requires = [ "rabbitmq.service" ];
+      after = [ "rabbitmq.service" ];
+      wantedBy = [ "multi-user.target" ];
+      path = [ cfg.package ];
+      serviceConfig = {
+        Type = "oneshot";
+        User = "rabbitmq";
+        Group = "rabbitmq";
+      };
+
+      script = ''
+        # Delete user guest, if it's there with default password, and
+        # administrator privileges.
+        rabbitmqctl list_users | grep guest && \
+          rabbitmqctl delete_user guest
+
+        # Create user for telegraf, if it does not exist and make sure that the password is set
+        rabbitmqctl list_users | grep fc-telegraf || \
+          rabbitmqctl add_user fc-telegraf ${telegrafPassword}
+
+        rabbitmqctl change_password fc-telegraf ${telegrafPassword}
+
+        # Create user for sensu, if it does not exist and make sure that the password is set
+        rabbitmqctl list_users | grep fc-sensu || \
+          rabbitmqctl add_user fc-sensu ${sensuPassword}
+
+        rabbitmqctl change_password fc-sensu ${sensuPassword}
+
+        rabbitmqctl set_user_tags fc-telegraf monitoring || true
+        rabbitmqctl set_user_tags fc-sensu monitoring || true
+
+        for vhost in $(rabbitmqctl list_vhosts -q); do
+          rabbitmqctl set_permissions fc-telegraf -p "$vhost" "" "" ".*"
+        done
+
+        rabbitmqctl set_permissions fc-sensu "^aliveness-test$" "^amq\.default$" "^(amq\.default|aliveness-test)$"
+      '';
+    };
+
+    systemd.timers.fc-rabbitmq-settings = {
+      description = "Runs the FC RabbitMQ preparation script regularly.";
+      wantedBy = [ "timers.target" ];
+      timerConfig = {
+        OnUnitActiveSec = "1h";
+        AccuracySec = "10m";
+      };
+    };
+
+    users.users.rabbitmq = {
+      description = "RabbitMQ server user";
+      home = "/var/lib/rabbitmq";
+      shell = "/run/current-system/sw/bin/bash";
+      createHome = true;
+      group = "rabbitmq";
+      uid = config.ids.uids.rabbitmq;
+    };
+
+    users.groups.rabbitmq.gid = config.ids.gids.rabbitmq;
+
+  };
+
+}

--- a/tests/sensuclient.nix
+++ b/tests/sensuclient.nix
@@ -31,7 +31,7 @@ in
       flyingcircus.encServices = encServices;
       networking.domain = "gocept.net";
       flyingcircus.services.sensu-client.enable = true;
-      flyingcircus.roles.rabbitmq.enable = true;
+      flyingcircus.services.rabbitmq.enable = true;
       flyingcircus.services.rabbitmq.listenAddress = lib.mkOverride 90 "::";
       systemd.services.prepare-rabbitmq-for-sensu = {
         description = "Prepare rabbitmq for sensu-server.";


### PR DESCRIPTION
This is a new type of role: it only exists for upgrading existing VMs directly from NixOS 20.09. The rabbitmq service from the old version is "frozen" by generating local config that just takes the existing unit file and its dependencies and adds it as a systemd package. This way, the service doesn't even restart when the system is upgraded to 23.11 as nothing changed for the service.

The added platform code is mostly just lifted from the 20.09 rabbitmq36_5 role and the corresponding service.

PL-131333

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

- (no need to announce)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - For rabbitmq itself, nothing should change. We replicate the behaviour of the role on NixOS 20.09. This change is about being able to upgrade VMs that still run legacy RabbitMQ versions. This is obviously a compromise regarding security but it's better than keeping old platform versions running. 
- [x] Security requirements tested? (EVIDENCE)
  - checked on a test VM that upgrading from 20.09 to 23.11 works without changing the rabbitmq service, rabbitmq itself listens on SRV 5672, management on 15672 and 25672, all interfaces (but protected by firewall and management requires login), basic functionality test of sending and receiving a message via Python `pika`.
  -  checked on another test VM that current rabbitmq role still runs as expected
  - automatic test covers current rabbitmq