### PR TITLE
Update nixpkgs for gitlab 16.5.6

### DIFF
--- a/package-versions.json
+++ b/package-versions.json
@@ -220,9 +220,9 @@
     "version": "2.311.0"
   },
   "gitlab": {
-    "name": "gitlab-16.5.4",
+    "name": "gitlab-16.5.6",
     "pname": "gitlab",
-    "version": "16.5.4"
+    "version": "16.5.6"
   },
   "gitlab-container-registry": {
     "name": "gitlab-container-registry-3.88.0",
@@ -230,9 +230,9 @@
     "version": "3.88.0"
   },
   "gitlab-ee": {
-    "name": "gitlab-ee-16.5.4",
+    "name": "gitlab-ee-16.5.6",
     "pname": "gitlab-ee",
-    "version": "16.5.4"
+    "version": "16.5.6"
   },
   "gitlab-runner": {
     "name": "gitlab-runner-16.6.0",

--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "5e75070eaa501746b12067f4c7d50598550e5482",
-    "hash": "sha256-Gnw9JWf187DMC+9q/rMJ3QWkG14g2kECYMUPrEPrXbI="
+    "rev": "6efc5e37f636417b01a68a96c7590acd7929a046",
+    "hash": "sha256-JNSSmF+TMU4mvtl4gMOBumelR/hrx2cSJwa+DIHXAr4="
   },
   "nixos-mailserver": {
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/",


### PR DESCRIPTION
PL-132090

@flyingcircusio/release-managers

## Release process

Impact:

* [NixOS 23.11] Gitlab will be restarted

Changelog:

- gitlab: 16.5.4 -> 16.5.6. This change will be released as a hotfix for Gitlab systems.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - apply security updates asap 
- [x] Security requirements tested? (EVIDENCE)
  - checked on our Gitlab staging system that Gitlab works