### PR TITLE
[23.05] Update nixpkgs for gitlab 16.5.6

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "0337338999a6aa4d294b9b5f71294787de04e673",
-    "hash": "sha256-hafWUznQLdFdYLGoed5YQNCZgpaNT1+tNqIQdi3i27g="
+    "rev": "026fa132b1ec8f0def774c933d2869fff5fb983d",
+    "hash": "sha256-5jeCWva/ByH4VvmL8QN8x3y/xEOUkW1kFUTz+vxygQo="
   },
   "nixos-mailserver": {
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/",


### PR DESCRIPTION
PL-132090

@flyingcircusio/release-managers

## Release process

Impact:

* [NixOS 23.11] Gitlab will be restarted

Changelog:

- gitlab: 16.5.3 -> 16.5.6. This change will be released as a hotfix for Gitlab systems.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - apply security updates asap 
- [x] Security requirements tested? (EVIDENCE)
  - checked on our Gitlab staging system that Gitlab works
