### PR TITLE
[21.05] roles.backyserver: add missing autorestart directive to service

### DIFF
--- a/nixos/roles/backyserver.nix
+++ b/nixos/roles/backyserver.nix
@@ -128,6 +128,7 @@ in
 
         serviceConfig = {
           ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
+          Restart = "always";
         };
 
         script = ''


### PR DESCRIPTION
@flyingcircusio/release-managers

PL-132037

## Release process

Impact: internal only

Changelog: auto-restart backy.service after failure

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - availability: auto-restart backy.service after failure
  - no known regressions
- [x] Security requirements tested? (EVIDENCE)
  - [x] manually tested auto-restart on a host in dev
  - [x] automated tests still pass