### PR TITLE
[21.05] BGP: Relax AS-path constraints for multipath routes

### DIFF
--- a/nixos/platform/network.nix
+++ b/nixos/platform/network.nix
@@ -234,6 +234,7 @@ in
           !
           router bgp ${toString fclib.underlay.asNumber}
            bgp router-id ${fclib.underlay.loopback}
+           bgp bestpath as-path multipath-relax
            no bgp ebgp-requires-policy
            neighbor switches peer-group
            neighbor switches remote-as external


### PR DESCRIPTION
From the commit message:

> The default behaviour of EBGP is such that two routes with different AS-paths are not considered equal, as on the public internet routes with different AS-paths will traverse a different set of networks (i.e. administrative domains), even if they're the same length. Only routes which have the same AS-path are considered eligible for merging into a single multipath route.
> 
> In the datacentre these conditions do not apply: in spite of using EBGP for exchanging routing information, all nodes are part of the same adminstrative domain. Hence only the lengths of the paths are relevant for calculating multi-path routes, and not the AS's within that path.

@flyingcircusio/release-managers

## Release process

Impact: internal

Changelog:

### PR release workflow (internal)

- [ ] PR has internal ticket
- [ ] internal issue ID (PL-…) part of branch name
- [ ] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Dynamic routing in the datacentre should use multipath routing where possible so the network continues to function in the case of equipment maintenance or failure.
- [x] Security requirements tested? (EVIDENCE)
  - Manually verified correct functioning with test hosts in dev.