### PR TITLE
Update nixpkgs 2024-01-15

### DIFF
--- a/package-versions.json
+++ b/package-versions.json
@@ -10,9 +10,9 @@
     "version": "2.4.58"
   },
   "asterisk": {
-    "name": "asterisk-20.5.1",
+    "name": "asterisk-20.5.2",
     "pname": "asterisk",
-    "version": "20.5.1"
+    "version": "20.5.2"
   },
   "auditbeat7-oss": {
     "name": "auditbeat-oss-7.17.16",
@@ -75,9 +75,9 @@
     "version": "120.0.6099.109"
   },
   "chromium": {
-    "name": "chromium-120.0.6099.129",
+    "name": "chromium-120.0.6099.216",
     "pname": "chromium",
-    "version": "120.0.6099.129"
+    "version": "120.0.6099.216"
   },
   "cifs-utils": {
     "name": "cifs-utils-7.0",
@@ -150,9 +150,9 @@
     "version": "2.3.21"
   },
   "element-web": {
-    "name": "element-web-1.11.52",
+    "name": "element-web-1.11.53",
     "pname": "element-web",
-    "version": "1.11.52"
+    "version": "1.11.53"
   },
   "erlang": {
     "name": "erlang-25.3.2.7",
@@ -185,9 +185,9 @@
     "version": "7.17.16"
   },
   "firefox": {
-    "name": "firefox-121.0",
+    "name": "firefox-121.0.1",
     "pname": "firefox",
-    "version": "121.0"
+    "version": "121.0.1"
   },
   "gcc": {
     "name": "gcc-wrapper-12.3.0",
@@ -215,9 +215,9 @@
     "version": "2.42.0"
   },
   "gitaly": {
-    "name": "gitaly-16.5.6",
+    "name": "gitaly-16.7.2",
     "pname": "gitaly",
-    "version": "16.5.6"
+    "version": "16.7.2"
   },
   "github-runner": {
     "name": "github-runner-2.311.0",
@@ -225,9 +225,9 @@
     "version": "2.311.0"
   },
   "gitlab": {
-    "name": "gitlab-16.5.6",
+    "name": "gitlab-16.7.2",
     "pname": "gitlab",
-    "version": "16.5.6"
+    "version": "16.7.2"
   },
   "gitlab-container-registry": {
     "name": "gitlab-container-registry-3.88.0",
@@ -235,14 +235,14 @@
     "version": "3.88.0"
   },
   "gitlab-ee": {
-    "name": "gitlab-ee-16.5.6",
+    "name": "gitlab-ee-16.7.2",
     "pname": "gitlab-ee",
-    "version": "16.5.6"
+    "version": "16.7.2"
   },
   "gitlab-pages": {
-    "name": "gitlab-pages-16.5.6",
+    "name": "gitlab-pages-16.7.2",
     "pname": "gitlab-pages",
-    "version": "16.5.6"
+    "version": "16.7.2"
   },
   "gitlab-runner": {
     "name": "gitlab-runner-16.6.0",
@@ -250,9 +250,9 @@
     "version": "16.6.0"
   },
   "gitlab-workhorse": {
-    "name": "gitlab-workhorse-16.5.6",
+    "name": "gitlab-workhorse-16.7.2",
     "pname": "gitlab-workhorse",
-    "version": "16.5.6"
+    "version": "16.7.2"
   },
   "glibc": {
     "name": "glibc-2.38-27",
@@ -300,9 +300,9 @@
     "version": "2.8.4"
   },
   "imagemagick": {
-    "name": "imagemagick-7.1.1-21",
+    "name": "imagemagick-7.1.1-25",
     "pname": "imagemagick",
-    "version": "7.1.1-21"
+    "version": "7.1.1-25"
   },
   "imagemagick6": {
     "name": "imagemagick-6.9.12-68",
@@ -310,9 +310,9 @@
     "version": "6.9.12-68"
   },
   "imagemagick7": {
-    "name": "imagemagick-7.1.1-21",
+    "name": "imagemagick-7.1.1-25",
     "pname": "imagemagick",
-    "version": "7.1.1-21"
+    "version": "7.1.1-25"
   },
   "inetutils": {
     "name": "inetutils-2.4",
@@ -335,19 +335,19 @@
     "version": "12.0.3"
   },
   "jicofo": {
-    "name": "jicofo-1.0-1057",
+    "name": "jicofo-1.0-1059",
     "pname": "jicofo",
-    "version": "1.0-1057"
+    "version": "1.0-1059"
   },
   "jitsi-meet": {
-    "name": "jitsi-meet-1.0.7629",
+    "name": "jitsi-meet-1.0.7712",
     "pname": "jitsi-meet",
-    "version": "1.0.7629"
+    "version": "1.0.7712"
   },
   "jitsi-videobridge": {
-    "name": "jitsi-videobridge2-2.3-61-g814bffd6",
+    "name": "jitsi-videobridge2-2.3-64-g719465d1",
     "pname": "jitsi-videobridge2",
-    "version": "2.3-61-g814bffd6"
+    "version": "2.3-64-g719465d1"
   },
   "jq": {
     "name": "jq-1.7",
@@ -365,9 +365,9 @@
     "version": "1.27.6+k3s1"
   },
   "keycloak": {
-    "name": "keycloak-23.0.3",
+    "name": "keycloak-23.0.4",
     "pname": "keycloak",
-    "version": "23.0.3"
+    "version": "23.0.4"
   },
   "kubernetes-helm": {
     "name": "kubernetes-helm-3.13.2",
@@ -430,9 +430,9 @@
     "version": "0.2.5"
   },
   "linux_5_15": {
-    "name": "linux-5.15.145",
+    "name": "linux-5.15.146",
     "pname": "linux",
-    "version": "5.15.145"
+    "version": "5.15.146"
   },
   "logrotate": {
     "name": "logrotate-3.21.0",
@@ -950,14 +950,14 @@
     "version": "3.3a"
   },
   "tomcat10": {
-    "name": "apache-tomcat-10.1.16",
+    "name": "apache-tomcat-10.1.18",
     "pname": "apache-tomcat",
-    "version": "10.1.16"
+    "version": "10.1.18"
   },
   "tomcat9": {
-    "name": "apache-tomcat-9.0.83",
+    "name": "apache-tomcat-9.0.85",
     "pname": "apache-tomcat",
-    "version": "9.0.83"
+    "version": "9.0.85"
   },
   "unzip": {
     "name": "unzip-6.0",

--- a/package-versions.json
+++ b/package-versions.json
@@ -215,9 +215,9 @@
     "version": "2.42.0"
   },
   "gitaly": {
-    "name": "gitaly-16.7.2",
+    "name": "gitaly-16.7.3",
     "pname": "gitaly",
-    "version": "16.7.2"
+    "version": "16.7.3"
   },
   "github-runner": {
     "name": "github-runner-2.311.0",
@@ -225,9 +225,9 @@
     "version": "2.311.0"
   },
   "gitlab": {
-    "name": "gitlab-16.7.2",
+    "name": "gitlab-16.7.3",
     "pname": "gitlab",
-    "version": "16.7.2"
+    "version": "16.7.3"
   },
   "gitlab-container-registry": {
     "name": "gitlab-container-registry-3.88.0",
@@ -235,14 +235,14 @@
     "version": "3.88.0"
   },
   "gitlab-ee": {
-    "name": "gitlab-ee-16.7.2",
+    "name": "gitlab-ee-16.7.3",
     "pname": "gitlab-ee",
-    "version": "16.7.2"
+    "version": "16.7.3"
   },
   "gitlab-pages": {
-    "name": "gitlab-pages-16.7.2",
+    "name": "gitlab-pages-16.7.3",
     "pname": "gitlab-pages",
-    "version": "16.7.2"
+    "version": "16.7.3"
   },
   "gitlab-runner": {
     "name": "gitlab-runner-16.6.0",
@@ -250,9 +250,9 @@
     "version": "16.6.0"
   },
   "gitlab-workhorse": {
-    "name": "gitlab-workhorse-16.7.2",
+    "name": "gitlab-workhorse-16.7.3",
     "pname": "gitlab-workhorse",
-    "version": "16.7.2"
+    "version": "16.7.3"
   },
   "glibc": {
     "name": "glibc-2.38-27",

--- a/versions.json
+++ b/versions.json
@@ -1,16 +1,16 @@
 {
+  "nixos-mailserver": {
+    "deepClone": false,
+    "fetchSubmodules": false,
+    "hash": "sha256-2ai0rYD6o8fQgweO3zKqPbbQBy/SQC8Hs+ZTf+GeXuU=",
+    "leaveDotGit": false,
+    "rev": "b3d6e950b71f7f9a29268beb9de03003705765e8",
+    "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/"
+  },
   "nixpkgs": {
+    "hash": "sha256-17xewyD3pJ+yyPfjkuDkAdeO9pWehss+fabuSh/Axck=",
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "6efc5e37f636417b01a68a96c7590acd7929a046",
-    "hash": "sha256-JNSSmF+TMU4mvtl4gMOBumelR/hrx2cSJwa+DIHXAr4="
-  },
-  "nixos-mailserver": {
-    "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/",
-    "rev": "b3d6e950b71f7f9a29268beb9de03003705765e8",
-    "hash": "sha256-2ai0rYD6o8fQgweO3zKqPbbQBy/SQC8Hs+ZTf+GeXuU=",
-    "fetchSubmodules": false,
-    "deepClone": false,
-    "leaveDotGit": false
+    "rev": "fa1270addb5483cfbab53db6fcc5df084f7b6373"
   }
 }

--- a/versions.json
+++ b/versions.json
@@ -8,9 +8,9 @@
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/"
   },
   "nixpkgs": {
-    "hash": "sha256-17xewyD3pJ+yyPfjkuDkAdeO9pWehss+fabuSh/Axck=",
+    "hash": "sha256-/dWZO7D8M6leuIe7ny0p3T8oMB7i9W92U6sIAcglCgU=",
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "fa1270addb5483cfbab53db6fcc5df084f7b6373"
+    "rev": "59068595c8a4f66d4ec007b15e8dc331d4682f3f"
   }
 }


### PR DESCRIPTION
Pull upstream NixOS changes, security fixes and package updates:

- asterisk: 20.5.1 -> 20.5.2
- chromium: 120.0.6099.129 -> 120.0.6099.216
- element-web: 1.11.52 -> 1.11.53
- firefox: 121.0 -> 121.0.1
- gitlab: 16.5.6 -> 16.7.3
- imagemagick: 7.1.1-21 -> 7.1.1-25
- jicofo: 1.0-1057 -> 1.0-1059
- jitsi-meet: 1.0.7629 -> 1.0.7712
- jitsi-videobridge: 2.3-61-g814bffd6 -> 2.3-64-g719465d1
- keycloak: 23.0.3 -> 23.0.4
- linux_5_15: 5.15.145 -> 5.15.146
- tomcat10: 10.1.16 -> 10.1.18
- tomcat9: 9.0.83 -> 9.0.85

PL-132102

@flyingcircusio/release-managers

## Release process

Impact:

- \[NixOS 23.11\] Machines will reboot after the update to activate the changed kernel.

Changelog:

(include changed packages from commit msg)

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - pull in upstream security fixes regularly
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still run, works on various test VMs including Jitsi; validated update checklist for staging Gitlab
  - checked commit log for fixed CVEs and possible problems with updates, looked at [GitLab 16 changes](https://docs.gitlab.com/ee/update/versions/gitlab_16_changes.html)
