### PR TITLE
[21.05] fc.qemu: 1.4.2 -> 1.4.3

### DIFF
--- a/pkgs/fc/default.nix
+++ b/pkgs/fc/default.nix
@@ -30,12 +30,12 @@ rec {
   multiping = callPackage ./multiping.nix {};
 
   qemu-nautilus = callPackage ./qemu rec {
-    version = "1.4.2";
+    version = "1.4.3";
     src = pkgs.fetchFromGitHub {
       owner = "flyingcircusio";
       repo = "fc.qemu";
       rev = version;
-      hash = "sha256-5ZDF/sLmlhtltJW4d6vkio27O8ZvkjLAOYohEB08/os=";
+      hash = "sha256-1kMdHXjsxxIW0bEV6PfDeagdLVxZP87kPKm0Z4ZtXJA=";
     };
     qemu_ceph = pkgs.qemu-ceph-nautilus;
     ceph_client = pkgs.ceph-nautilus.ceph-client;


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact: internal  only

Changelog:
- fc.qemu: 1.4.2 -> 1.4.3, disables writeback cache

### PR release workflow (internal)

Deliberately sidestepping this, but it's a precondition to DIR-919

- [ ] PR has internal ticket
- [ ] internal issue ID (PL-…) part of branch name
- [ ] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - no known regressions
- [x] Security requirements tested? (EVIDENCE)
  - [x]  automated tests still pass