### PR TITLE
doc/rabbitmq: fix markdown typo

### DIFF
--- a/doc/src/rabbitmq.md
+++ b/doc/src/rabbitmq.md
@@ -42,7 +42,7 @@ upgrade. This conserves the specific rabbitmq config for the machine and
 cannot be used on new 23.11 machines.
 
 The upgrade process starts with generating Nix config on the running machine.
-Put the generated config in :file:`/etc/local/nixos/rabbitmq365-frozen.nix`.
+Put the generated config in {file}`/etc/local/nixos/rabbitmq365-frozen.nix`.
 
 ```shell
 #!/usr/bin/env sh


### PR DESCRIPTION
fix typo in docs of PL-131333

@dpausp If you'd like to add some further changes to the docs, feel free to use this PR and add them here.

@flyingcircusio/release-managers

## Release process

Impact: none

Changelog: -

### PR release workflow (internal)

just a small fixup, no ticket needed

- [ ] PR has internal ticket
- [ ] internal issue ID (PL-…) part of branch name
- [ ] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - none, typo fix
- [x] Security requirements tested? (EVIDENCE)
