### PR TITLE
openssh server: modify available DH key exchange algorithms

### DIFF
--- a/nixos/platform/default.nix
+++ b/nixos/platform/default.nix
@@ -404,8 +404,7 @@ in {
           "sntrup761x25519-sha512@openssh.com"
           "curve25519-sha256"
           "curve25519-sha256@libssh.org"
-          "diffie-hellman-group16-sha512"
-          "diffie-hellman-group18-sha512"
+          "diffie-hellman-group-exchange-sha256"
         ];
       };
 


### PR DESCRIPTION
Replace the two fixed-group diffie-hellmann-group key exchange algorithms with a dynamic-group one. Overall, DH key exchange needs to be kept for wider client compatibility as long as we do not want to enable nistp ECDHE curves instead.

**Still needs some internal discussion before filling out the security considerations!**

PL-131909

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Security implications

- [ ] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [ ] Security requirements tested? (EVIDENCE)
