### PR TITLE
Use configuration recommended by Postfix upstream to prevent SMTP smuggling attacks

### DIFF
--- a/nixos/services/mail/default.nix
+++ b/nixos/services/mail/default.nix
@@ -306,6 +306,7 @@ in {
             "reject_rbl_client ix.dnsbl.manitu.net"
             "reject_unknown_client_hostname"
           ];
+          smtpd_forbid_bare_newline = "yes";
           smtpd_data_restrictions = "reject_unauth_pipelining";
           smtpd_helo_restrictions = [
             "permit_sasl_authenticated"

--- a/nixos/services/mail/default.nix
+++ b/nixos/services/mail/default.nix
@@ -306,7 +306,7 @@ in {
             "reject_rbl_client ix.dnsbl.manitu.net"
             "reject_unknown_client_hostname"
           ];
-          smtpd_forbid_bare_newline = "yes";
+          smtpd_forbid_bare_newline = "normalize";
           smtpd_data_restrictions = "reject_unauth_pipelining";
           smtpd_helo_restrictions = [
             "permit_sasl_authenticated"


### PR DESCRIPTION
Since the disclosure of the SMTP smuggling vulnerability against Postfix, new minor update versions (including 3.8.4 available in Nixpkgs) support an additional `smtpd_forbid_bare_newline` configuration option. This is intended to better protect against request smuggling, as documented here: https://www.postfix.org/smtp-smuggling.html.

This change enables the `smtpd_forbid_bare_newline` option in the default Postfix configuration in the mailserver role.

PL-132051

@flyingcircusio/release-managers

## Release process

Impact: internal.

Changelog:

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Application configuration should follow the security recommendations of the upstream software vendor.
- [x] Security requirements tested? (EVIDENCE)
  - Change deployed on a test system. Verified that sending and receiving mail from Roundcube functions as expected with this change applied.