### PR TITLE
Fixup for old mongodb roles PR

### DIFF
--- a/nixos/roles/mongodb.nix
+++ b/nixos/roles/mongodb.nix
@@ -125,6 +125,12 @@ in {
       services.mongodb.pidFile = "/run/mongodb.pid";
       services.mongodb.package = mongodbPkgs."mongodb-${lib.replaceStrings ["."] ["_"] majorVersion}";
 
+      # Current telegraf only supports MongoDB 3.6+ so we need to use the package from
+      # 22.11 which still supports 3.4 and 3.2.
+      services.telegraf = lib.optionalAttrs (lib.versionOlder majorVersion "3.6") {
+        package = getPkg /nix/store/bxbhjphivdyp1fdqcz9d3jvnnsrjz8yr-telegraf-1.24.2;
+      };
+
       systemd.services.mongodb = {
         preStart = "echo never > /sys/kernel/mm/transparent_hugepage/defrag";
         postStop = "echo always > /sys/kernel/mm/transparent_hugepage/defrag";


### PR DESCRIPTION
- Fix telegraf for 3.2 and 3.4
- allow upgrades without switching off the role
   builtins.fetchClosure may not be available when building the system
   which is fixed by falling back to storePath in this case.

PL-131229

@flyingcircusio/release-managers

## Release process

Impact: 

Changelog: 

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - nothing new
- [x] Security requirements tested? (EVIDENCE)
  - checked on a test VM that telegraf works and getting the mongodb package works
