### PR TITLE
[21.05] RadosGW usage accounting integration

### DIFF
--- a/nixos/roles/ceph/rgw.nix
+++ b/nixos/roles/ceph/rgw.nix
@@ -159,6 +159,13 @@ in
         '';
       };
 
+      systemd.services.fc-ceph-rgw-accounting = {
+        description = "Upload S3 usage data to the Directory";
+        path = [ cephPkgs.ceph ];
+        serviceConfig.Type = "oneshot";
+        script = "${pkgs.fc.agent}/bin/fc-s3accounting --enc ${config.flyingcircus.encPath}";
+      };
+
       services.logrotate.extraConfig = ''
         /var/log/ceph/client.radosgw.log {
             create 0644 root adm
@@ -187,6 +194,15 @@ in
         timerConfig = {
           OnBootSec = "10m";
           OnUnitActiveSec = "10m";
+        };
+      };
+
+      systemd.timers.fc-ceph-rgw-accounting = {
+        description = "Timer for uploading S3 usage data to the Directory";
+        wantedBy = [ "timers.target" ];
+        timerConfig = {
+          Persistent = true;
+          OnCalendar = "*:2/10";
         };
       };
 

--- a/pkgs/fc/agent/fc/manage/s3accounting.py
+++ b/pkgs/fc/agent/fc/manage/s3accounting.py
@@ -1,0 +1,47 @@
+"""Uploads usage data from Ceph/RadosGW into the Directory"""
+
+import argparse
+import json
+import subprocess
+
+from fc.util.directory import connect
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Flying Circus S3 usage accounting"
+    )
+    parser.add_argument(
+        "-E",
+        "--enc",
+        default="/etc/nixos/enc.json",
+        help="Path to enc.json (default: %(default)s)",
+    )
+
+    args = parser.parse_args()
+    with open(args.enc) as f:
+        enc = json.load(f)
+
+    result = subprocess.run(
+        ["radosgw-admin", "user", "list"], check=True, capture_output=True
+    )
+    users = json.loads(result.stdout)
+
+    usage = dict()
+    for user in users:
+        result = subprocess.run(
+            ["radosgw-admin", "user", "stats", "--uid", user],
+            check=True,
+            capture_output=True,
+        )
+        stats = json.loads(result.stdout)
+        usage[user] = str(stats["stats"]["total_bytes"])
+
+    location = enc["parameters"]["location"]
+
+    directory = connect(enc, ring=0)
+    directory.store_s3(location, usage)
+
+
+if __name__ == "__main__":
+    main()

--- a/pkgs/fc/agent/setup.py
+++ b/pkgs/fc/agent/setup.py
@@ -72,6 +72,7 @@ setup(
             "fc-qemu-scrub=fc.manage.qemu:main",
             "fc-monitor=fc.manage.monitor:main",
             "fc-resize-disk=fc.manage.resize_disk:app",
+            "fc-s3accounting=fc.manage.s3accounting:main",
             "fctl=fc.util.fctl:app",
         ],
     },


### PR DESCRIPTION
This change integrates the script which uploads S3 usage metrics from RadosGW to the directory into the agent as `fc-s3accounting`. This script is then run from a systemd timer on machines with the ceph-rgw role which are designated as the primary machine with this role.

PL-131757

@flyingcircusio/release-managers

## Release process

Impact: internal.
- Operator notes: this change supersedes manual configuration already deployed on one Ceph host in each location. When this change is deployed, the corresponding manually configured timer must be removed.

Changelog:

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Collection of accounting information should be automated by the platform to ensure that service usage is recorded properly.
- [x] Security requirements tested? (EVIDENCE)
  - Manually verified that `fc-s3accounting` exits without errors when run on a development host.
  - Manually verified that the systemd timer runs correctly when deployed in the development Ceph cluster.