### PR TITLE
[21.05] ceph: drop increased warning limit for max object skew

### DIFF
--- a/nixos/services/ceph/client.nix
+++ b/nixos/services/ceph/client.nix
@@ -49,7 +49,6 @@ let
 
     monData = "/srv/ceph/mon/$cluster-$id";
     monOsdAllowPrimaryAffinity = true;
-    monPgWarnMaxObjectSkew = 30;
 
     mgrData = "/srv/ceph/mgr/$cluster-$id";
   } // lib.optionalAttrs (cfg.cluster_network != null) { clusterNetwork = cfg.cluster_network;}


### PR DESCRIPTION
Our current actual max skew seems to be 0,02 -> 0,18 which is within the default range of 10x.

The associated OSDs are currently running with 70 pgs per OSD (1024 on the pool) and we could easily increase this to 2048 resulting in 150 PGs per OSD which is well within the OSD sizings if this becomes too big.

Re PL-131066

@flyingcircusio/release-managers

## Release process

Impact:

n/a

Changelog:

no changelog, internal only

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

no specific requirement, keep status infos clean

- [x] Security requirements tested? (EVIDENCE)

manually evaluated the new settings on the affected cluster, persisting them with this change.