### PR TITLE
mysql: use socket auth for sensu and telegraf

### DIFF
--- a/tests/mysql.nix
+++ b/tests/mysql.nix
@@ -33,7 +33,7 @@ in
   let
     config = nodes.master.config;
     sensuChecks = config.flyingcircus.services.sensu-client.checks;
-    mysqlCheck = sensuChecks.mysql.command;
+    mysqlCheck = "sudo -u sensuclient " + sensuChecks.mysql.command;
     version = config.services.percona.package.version;
     expectedAddresses = if lib.versionAtLeast version "8.0" then [
       # 8.0 binds to lo and srv with port 3306


### PR DESCRIPTION
We ran into problems with replicated monitoring passwords. After replication, monitoring couldn't log in anymore with the locally generated passwords on the secondary. Using socket auth solves the issue. I had to replace the Sensu monitoring plugin as it didn't support socket auth.  Sensu is using a simple mysql command which returns the version number as connection check now.

PL-132034

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

- mysql/percona: fix monitoring on secondary databases when using replication (PL-132034).

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - monitoring should also work reliably for secondaries in a replicated setup
  - don't increase the attack surface: the monitoring passwords were already in the Nix store in cleartext so they offer no real protection. Moreover, permissions for monitoring users are limited and log in is only possible locally 
- [x] Security requirements tested? (EVIDENCE)
  - checked on test VMs that monitoring works