### PR TITLE
gitlab: pull in update 16.7.3->16.7.4 as security hotfix

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -8,9 +8,9 @@
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/"
   },
   "nixpkgs": {
-    "hash": "sha256-/dWZO7D8M6leuIe7ny0p3T8oMB7i9W92U6sIAcglCgU=",
+    "hash": "sha256-kjYIOqmBnUhXQXxI9Gh2O15w4XRm+MFEXqQZEF4FikI=",
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "59068595c8a4f66d4ec007b15e8dc331d4682f3f"
+    "rev": "bcd39d8604ee3ab7cba5dcd63cd25c8bc559bcb4"
   }
 }


### PR DESCRIPTION
Not supposed to land in the regular fc-… workflow branches, as hopefully this upgrade will land in -dev anyways via the next nixpkgs update next week.

@flyingcircusio/release-managers

 PL-132145

## Release process

Impact: restarts gitlab on the individual machines where this hotfix is rolled out

Changelog:
- gitlab: 16.7.3->16.7.4
  - fixes several CVEs, most importantly CVE-2024-0402.

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - [x] roll out security fixes of upstream projects
  - [x] for critical vulnerabilities that only affect a few machines, roll out the fixes as a separate hotfix for better agility
  - [x] must not introduce known regressions
- [x] Security requirements tested? (EVIDENCE)
  - [x] automated tests still pass
  - [x] manual tests on staging/ test VMs with a checklist