### PR TITLE
webgateway: add nginx mitigations against HTTP2 rapid reset attacks

### DIFF
--- a/nixos/services/nginx/base-module.nix
+++ b/nixos/services/nginx/base-module.nix
@@ -211,6 +211,17 @@ let
 
       server_tokens ${if cfg.serverTokens then "on" else "off"};
 
+      # CVE-2023-44487 handling with relatively high limits to
+      # not impact customer applications too much. Can be limited further
+      # if necessary.
+      limit_conn_zone $binary_remote_addr zone=addr:10m;
+      limit_conn addr 100;
+      limit_conn_status 429;
+
+      limit_req_zone $binary_remote_addr zone=perclient:10m rate=10r/s;
+      limit_req zone=perclient burst=50;
+      limit_req_status 429;
+
       ${cfg.commonHttpConfig}
 
       ${vhosts}

--- a/tests/nginx.nix
+++ b/tests/nginx.nix
@@ -348,5 +348,21 @@ in {
       assert_reachable(server4, "fe.local -6")
       assert_unreachable(server4, "fe.local -4")
       assert_unreachable(server4, "srv.local")
+
+    with subtest("[5] rate limiting connections"):
+      import re
+      # Running this against the other virtual hosts fails. I *think* this is
+      # because we have a "return 200" statement on the root location there
+      # which seems to short-circuit the rate limiting ... o_O
+      out = server4.execute("${pkgs.apacheHttpd}/bin/ab -n 1000 -c 75 http://localhost:81/")[1]
+      print(out)
+      assert re.search("Complete requests: +1000", out), "incomplete test"
+      error_match = re.search("Connect: ([0-9]+), Receive: ([0-9]+), Length: ([0-9]+), Exceptions: ([0-9]+)", out)
+      assert error_match, "Missing connection errors"
+      errors = error_match.groups()  # type: ignore
+      assert int(errors[0]) == 0
+      assert int(errors[1]) == 0
+      assert int(errors[2]) > 900
+      assert int(errors[3]) == 0
   '';
 })


### PR DESCRIPTION
Re PL-131836

@flyingcircusio/release-managers

## Release process

Impact:

none

Changelog:

* nginx servers (webgateway role) now have a default rate and connection limiting to further improve protections against the rapid reset HTTP/2 vulnerability (https://www.cisa.gov/news-events/alerts/2023/10/10/http2-rapid-reset-vulnerability-cve-2023-44487). (PL-131836)

  By default we limit per-client IP connections to 100 at a time and rate limit at 50 requests per client IP per second. This should leave ample room for all existing customer applications while still providing protection against aggressive DOS attempts.

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

Avoid DOS attacks. Reduce attack surface where possible.

- [x] Security requirements tested? (EVIDENCE)

Manually tested and covered with new NixOS test.