### PR TITLE
Update nixpkgs (2024-01-30)

### DIFF
--- a/package-versions.json
+++ b/package-versions.json
@@ -70,14 +70,14 @@
     "version": "18.2.0"
   },
   "chromedriver": {
-    "name": "chromedriver-120.0.6099.109",
+    "name": "chromedriver-121.0.6167.85",
     "pname": "chromedriver",
-    "version": "120.0.6099.109"
+    "version": "121.0.6167.85"
   },
   "chromium": {
-    "name": "chromium-120.0.6099.216",
+    "name": "chromium-121.0.6167.85",
     "pname": "chromium",
-    "version": "120.0.6099.216"
+    "version": "121.0.6167.85"
   },
   "cifs-utils": {
     "name": "cifs-utils-7.0",
@@ -150,9 +150,9 @@
     "version": "2.3.21"
   },
   "element-web": {
-    "name": "element-web-1.11.53",
+    "name": "element-web-1.11.55",
     "pname": "element-web",
-    "version": "1.11.53"
+    "version": "1.11.55"
   },
   "erlang": {
     "name": "erlang-25.3.2.7",
@@ -185,9 +185,9 @@
     "version": "7.17.16"
   },
   "firefox": {
-    "name": "firefox-121.0.1",
+    "name": "firefox-122.0",
     "pname": "firefox",
-    "version": "121.0.1"
+    "version": "122.0"
   },
   "gcc": {
     "name": "gcc-wrapper-12.3.0",
@@ -215,19 +215,19 @@
     "version": "2.42.0"
   },
   "gitaly": {
-    "name": "gitaly-16.7.3",
+    "name": "gitaly-16.7.4",
     "pname": "gitaly",
-    "version": "16.7.3"
+    "version": "16.7.4"
   },
   "github-runner": {
-    "name": "github-runner-2.311.0",
+    "name": "github-runner-2.312.0",
     "pname": "github-runner",
-    "version": "2.311.0"
+    "version": "2.312.0"
   },
   "gitlab": {
-    "name": "gitlab-16.7.3",
+    "name": "gitlab-16.7.4",
     "pname": "gitlab",
-    "version": "16.7.3"
+    "version": "16.7.4"
   },
   "gitlab-container-registry": {
     "name": "gitlab-container-registry-3.88.0",
@@ -235,24 +235,24 @@
     "version": "3.88.0"
   },
   "gitlab-ee": {
-    "name": "gitlab-ee-16.7.3",
+    "name": "gitlab-ee-16.7.4",
     "pname": "gitlab-ee",
-    "version": "16.7.3"
+    "version": "16.7.4"
   },
   "gitlab-pages": {
-    "name": "gitlab-pages-16.7.3",
+    "name": "gitlab-pages-16.7.4",
     "pname": "gitlab-pages",
-    "version": "16.7.3"
+    "version": "16.7.4"
   },
   "gitlab-runner": {
-    "name": "gitlab-runner-16.6.0",
+    "name": "gitlab-runner-16.7.0",
     "pname": "gitlab-runner",
-    "version": "16.6.0"
+    "version": "16.7.0"
   },
   "gitlab-workhorse": {
-    "name": "gitlab-workhorse-16.7.3",
+    "name": "gitlab-workhorse-16.7.4",
     "pname": "gitlab-workhorse",
-    "version": "16.7.3"
+    "version": "16.7.4"
   },
   "glibc": {
     "name": "glibc-2.38-27",
@@ -270,9 +270,9 @@
     "version": "2.4.1"
   },
   "go": {
-    "name": "go-1.21.4",
+    "name": "go-1.21.5",
     "pname": "go",
-    "version": "1.21.4"
+    "version": "1.21.5"
   },
   "go_1_19": {
     "name": "go-1.19.13",
@@ -280,9 +280,9 @@
     "version": "1.19.13"
   },
   "go_1_20": {
-    "name": "go-1.20.11",
+    "name": "go-1.20.12",
     "pname": "go",
-    "version": "1.20.11"
+    "version": "1.20.12"
   },
   "grafana": {
     "name": "grafana-10.2.2",
@@ -315,9 +315,9 @@
     "version": "7.1.1-25"
   },
   "inetutils": {
-    "name": "inetutils-2.4",
+    "name": "inetutils-2.5",
     "pname": "inetutils",
-    "version": "2.4"
+    "version": "2.5"
   },
   "jdk": {
     "name": "openjdk-19.0.2+7",
@@ -330,9 +330,9 @@
     "version": "17.0.7-b829.16"
   },
   "jetty": {
-    "name": "jetty-12.0.3",
+    "name": "jetty-12.0.5",
     "pname": "jetty",
-    "version": "12.0.3"
+    "version": "12.0.5"
   },
   "jicofo": {
     "name": "jicofo-1.0-1059",
@@ -350,9 +350,9 @@
     "version": "2.3-64-g719465d1"
   },
   "jq": {
-    "name": "jq-1.7",
+    "name": "jq-1.7.1",
     "pname": "jq",
-    "version": "1.7"
+    "version": "1.7.1"
   },
   "jre": {
     "name": "openjdk-19.0.2+7",
@@ -430,9 +430,9 @@
     "version": "0.2.5"
   },
   "linux_5_15": {
-    "name": "linux-5.15.146",
+    "name": "linux-5.15.148",
     "pname": "linux",
-    "version": "5.15.146"
+    "version": "5.15.148"
   },
   "logrotate": {
     "name": "logrotate-3.21.0",
@@ -460,9 +460,9 @@
     "version": "3.3.5"
   },
   "mastodon": {
-    "name": "mastodon-4.2.3",
+    "name": "mastodon-4.2.4",
     "pname": "mastodon",
-    "version": "4.2.3"
+    "version": "4.2.4"
   },
   "matomo": {
     "name": "matomo-4.15.1",
@@ -470,9 +470,9 @@
     "version": "4.15.1"
   },
   "matrix-synapse": {
-    "name": "matrix-synapse-wrapped-1.98.0",
+    "name": "matrix-synapse-wrapped-1.99.0",
     "pname": "matrix-synapse-wrapped",
-    "version": "1.98.0"
+    "version": "1.99.0"
   },
   "mcpp": {
     "name": "mcpp-2.7.2.1",
@@ -545,9 +545,9 @@
     "version": "4.35"
   },
   "nss_latest": {
-    "name": "nss-3.96.1",
+    "name": "nss-3.97",
     "pname": "nss",
-    "version": "3.96.1"
+    "version": "3.97"
   },
   "openjdk": {
     "name": "openjdk-19.0.2+7",
@@ -660,9 +660,9 @@
     "version": "8.1.27"
   },
   "php82": {
-    "name": "php-with-extensions-8.2.14",
+    "name": "php-with-extensions-8.2.15",
     "pname": "php-with-extensions",
-    "version": "8.2.14"
+    "version": "8.2.15"
   },
   "phpPackages.composer": {
     "name": "composer-2.6.5",
@@ -690,9 +690,9 @@
     "version": "123"
   },
   "postfix": {
-    "name": "postfix-3.8.4",
+    "name": "postfix-3.8.5",
     "pname": "postfix",
-    "version": "3.8.4"
+    "version": "3.8.5"
   },
   "postgresql": {
     "name": "postgresql-15.5",
@@ -725,9 +725,9 @@
     "version": "4.8.4"
   },
   "prometheus": {
-    "name": "prometheus-2.48.0",
+    "name": "prometheus-2.49.0",
     "pname": "prometheus",
-    "version": "2.48.0"
+    "version": "2.49.0"
   },
   "prosody": {
     "name": "prosody-0.12.4",
@@ -835,9 +835,9 @@
     "version": "2.0.7"
   },
   "qemu": {
-    "name": "qemu-8.1.3",
+    "name": "qemu-8.1.4",
     "pname": "qemu",
-    "version": "8.1.3"
+    "version": "8.1.4"
   },
   "rabbitmq-server": {
     "name": "rabbitmq-server-3.12.7",
@@ -860,9 +860,9 @@
     "version": "7.2.3"
   },
   "roundcube": {
-    "name": "roundcube-1.6.5",
+    "name": "roundcube-1.6.6",
     "pname": "roundcube",
-    "version": "1.6.5"
+    "version": "1.6.6"
   },
   "rsync": {
     "name": "rsync-3.2.7",
@@ -975,9 +975,9 @@
     "version": "7.4.1"
   },
   "vim": {
-    "name": "vim-9.0.2048",
+    "name": "vim-9.0.2116",
     "pname": "vim",
-    "version": "9.0.2048"
+    "version": "9.0.2116"
   },
   "webkitgtk": {
     "name": "webkitgtk-2.42.4+abi=4.0",

--- a/versions.json
+++ b/versions.json
@@ -8,9 +8,9 @@
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/"
   },
   "nixpkgs": {
-    "hash": "sha256-/dWZO7D8M6leuIe7ny0p3T8oMB7i9W92U6sIAcglCgU=",
+    "hash": "sha256-Y84SHnPDzqHKngShgt0Omm/bWc941+t0pnsSVuyQkUg=",
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "59068595c8a4f66d4ec007b15e8dc331d4682f3f"
+    "rev": "159aa075fe1fe7ccaf1027345b9f28a342c50dae"
   }
 }


### PR DESCRIPTION
Pull upstream NixOS changes, security fixes and package updates:

- chromium: 120.0.6099.216 -> 121.0.6167.85
- curl: apply 8.5.0 security fixes (CVE-2023-46218, CVE-2023-46219)
- github-runner: 2.311.0 -> 2.312.0
- gitlab-runner: 16.6.0 -> 16.7.0
- gitlab: 16.7.3 -> 16.7.4 (CVE-2024-0402, CVE-2023-6159, CVE-2023-5933, CVE-2023-5612)
- go: 1.21.4 -> 1.21.5
- go_1_20: 1.20.11 -> 1.20.12
- inetutils: 2.4 -> 2.5 (CVE-2022-39028, CVE-2019-0053)
- jq: 1.7 -> 1.7.1
- linux_5_15: 5.15.146 -> 5.15.148
- mastodon: 4.2.3 -> 4.2.4
- nss_latest: 3.96.1 -> 3.97
- postfix: 3.8.4 -> 3.8.5
- prometheus: 2.48.0 -> 2.49.0
- python3Packages.pip: add patches for CVE-2023-5752
- qemu: 8.1.3 -> 8.1.4
- roundcube: 1.6.5 -> 1.6.6
- vim: 9.0.2048 -> 9.0.2116

PL-131814

@flyingcircusio/release-managers

## Release process

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team


Impact:

- \[NixOS 23.11\] Machines will reboot after the update to activate the
   changed kernel.

Changelog:

(include changed packages from commit msg)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - pull in upstream security fixes regularly
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still run, works on various test VM, including a mailserver and Gitlab
  - checked commit log for fixed CVEs and possible problems with updates, looked at [Postfix stable release 3.8.5, 3.7.10, 3.6.14, 3.5.24](http://www.postfix.org/announcements/postfix-3.8.5.html), [prometheus/CHANGELOG.md at main · prometheus/prometheus](https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md), [GitLab Critical Security Release: 16.8.1, 16.7.4, 16.6.6, 16.5.8 | GitLab](https://about.gitlab.com/releases/2024/01/25/critical-security-release-gitlab-16-8-1-released/)