### PR TITLE
Enforce slurm memory limits

### DIFF
--- a/nixos/roles/slurm/default.nix
+++ b/nixos/roles/slurm/default.nix
@@ -350,7 +350,7 @@ in
 
           # Enables resource containment using sched_setaffinity(). This
           # enables the --cpu-bind and/or --mem-bind srun options.
-          TaskPlugin = task/affinity
+          TaskPlugin = task/cgroup,task/affinity
 
         '' + (lib.optionalString (dbdserverService != null) ''
           AccountingStorageType = accounting_storage/slurmdbd


### PR DESCRIPTION
(maybe this should be configurable …)

FC-35724
PL-132161

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

- slurm: use task/cgroup to enforce memory limits on jobs (PL-132161, FC-35724).

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - enforce memory limits for user-run slurm job to avoid nodes being unresponsive due to memory pressure/swapping 
- [x] Security requirements tested? (EVIDENCE)
  - checked on slurm test cluster that jobs can be run with the new setting