### PR TITLE
[21.05] util-physical: fix fs-check and migrate-vm dependency to rbd-locktool

### DIFF
--- a/pkgs/fc/util-physical/default.nix
+++ b/pkgs/fc/util-physical/default.nix
@@ -1,6 +1,6 @@
 {
   lib, stdenv, makeWrapper
-, bash, ceph, utillinux, systemd, coreutils, gnugrep, xfsprogs
+, bash, ceph-client, utillinux, systemd, coreutils, gnugrep, xfsprogs
 , fc
 }:
 
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   dontConfigure = true;
 
   nativeBuildInputs = [ makeWrapper ];
-  propagatedBuildInputs = [ bash ceph systemd fc.agent gnugrep utillinux coreutils xfsprogs ];
+  propagatedBuildInputs = [ bash ceph-client systemd fc.agent gnugrep utillinux coreutils xfsprogs ];
 
   installPhase = ''
     mkdir $out


### PR DESCRIPTION
@flyingcircusio/release-managers
PL-132137

## Release process

Impact: internal bugfix only

Changelog:
- fix missing dependencies of `fs-check` and `migrate-vm`

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - keep operator tooling working
  - do not introduce any known regressions, fix existing ones
  - test successful execution
  - a wider ticket for potentially similar cases of missing dependencies has been created as a separate follow-up 
- [ ] Security requirements tested? (EVIDENCE)
  - [ ] NixOS tests still pass
  - [x] `fs-check` has been manualls tested in dev; `migrate-vm` was *not* tested but profits from the same fix