### PR TITLE
[23.05] Update nixpkgs for glibc security fix (2024-02-01)

### DIFF
--- a/package-versions.json
+++ b/package-versions.json
@@ -250,7 +250,7 @@
     "version": "16.6.0"
   },
   "glibc": {
-    "name": "glibc-2.37-45",
+    "name": "glibc-2.37-64",
     "pname": "glibc",
     "version": "2.37"
   },

--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "026fa132b1ec8f0def774c933d2869fff5fb983d",
-    "hash": "sha256-5jeCWva/ByH4VvmL8QN8x3y/xEOUkW1kFUTz+vxygQo="
+    "rev": "5a7db58a8a8528e558b5d4bf10433b43766249bf",
+    "hash": "sha256-0FjW2Ry6sZHq6lroqn7uyqPS+VrGKPONOPDveX4LRck="
   },
   "nixos-mailserver": {
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/",


### PR DESCRIPTION
- glibc: 2.37-45 -> 2.37-64, add patch for qsort mem corruption (CVE-2023-6246, CVE-2023-6779, CVE-2023-6780)

PL-132173

See https://github.com/flyingcircusio/nixpkgs/commit/2c68378cc9f5e6973925e3a8edeb606385cb24cd for the actual change to glibc. Updates to the latest patch level of glibc 2.37.

@flyingcircusio/release-managers

## Release process

Impact:

* \[NixOS 23.05] Most services will restart due to a core dependency change.

Changelog:

- glibc: 2.37-45 -> 2.37-64, add patch for qsort mem corruption (CVE-2023-6246, CVE-2023-6779, CVE-2023-6780)

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - patch important security vulnerabilities on platform versions which are EOL upstream
- [x] Security requirements tested? (EVIDENCE)
  - checked on a test VM with many roles that nothing is obviously broken