### PR TITLE
Update nixpkgs (mitigation for glibc vuln, runc security fixes) (2024-02-06)

### DIFF
--- a/important_packages.json
+++ b/important_packages.json
@@ -97,6 +97,7 @@
   "matrix-synapse",
   "mcpp",
   "memcached",
+  "monitoring-plugins",
   "mysql",
   "mysql80",
   "nfs-utils",

--- a/package-versions.json
+++ b/package-versions.json
@@ -75,9 +75,9 @@
     "version": "121.0.6167.85"
   },
   "chromium": {
-    "name": "chromium-121.0.6167.85",
+    "name": "chromium-121.0.6167.139",
     "pname": "chromium",
-    "version": "121.0.6167.85"
+    "version": "121.0.6167.139"
   },
   "cifs-utils": {
     "name": "cifs-utils-7.0",
@@ -100,9 +100,9 @@
     "version": "1.16.4"
   },
   "containerd": {
-    "name": "containerd-1.7.11",
+    "name": "containerd-1.7.13",
     "pname": "containerd",
-    "version": "1.7.11"
+    "version": "1.7.13"
   },
   "coturn": {
     "name": "coturn-4.6.2",
@@ -150,9 +150,9 @@
     "version": "2.3.21"
   },
   "element-web": {
-    "name": "element-web-1.11.55",
+    "name": "element-web-1.11.57",
     "pname": "element-web",
-    "version": "1.11.55"
+    "version": "1.11.57"
   },
   "erlang": {
     "name": "erlang-25.3.2.7",
@@ -300,9 +300,9 @@
     "version": "2.8.4"
   },
   "imagemagick": {
-    "name": "imagemagick-7.1.1-25",
+    "name": "imagemagick-7.1.1-26",
     "pname": "imagemagick",
-    "version": "7.1.1-25"
+    "version": "7.1.1-26"
   },
   "imagemagick6": {
     "name": "imagemagick-6.9.12-68",
@@ -310,9 +310,9 @@
     "version": "6.9.12-68"
   },
   "imagemagick7": {
-    "name": "imagemagick-7.1.1-25",
+    "name": "imagemagick-7.1.1-26",
     "pname": "imagemagick",
-    "version": "7.1.1-25"
+    "version": "7.1.1-26"
   },
   "inetutils": {
     "name": "inetutils-2.5",
@@ -365,9 +365,9 @@
     "version": "1.27.6+k3s1"
   },
   "keycloak": {
-    "name": "keycloak-23.0.4",
+    "name": "keycloak-23.0.6",
     "pname": "keycloak",
-    "version": "23.0.4"
+    "version": "23.0.6"
   },
   "kubernetes-helm": {
     "name": "kubernetes-helm-3.13.2",
@@ -460,9 +460,9 @@
     "version": "3.3.5"
   },
   "mastodon": {
-    "name": "mastodon-4.2.4",
+    "name": "mastodon-4.2.5",
     "pname": "mastodon",
-    "version": "4.2.4"
+    "version": "4.2.5"
   },
   "matomo": {
     "name": "matomo-4.15.1",
@@ -470,9 +470,9 @@
     "version": "4.15.1"
   },
   "matrix-synapse": {
-    "name": "matrix-synapse-wrapped-1.99.0",
+    "name": "matrix-synapse-wrapped-1.100.0",
     "pname": "matrix-synapse-wrapped",
-    "version": "1.99.0"
+    "version": "1.100.0"
   },
   "mcpp": {
     "name": "mcpp-2.7.2.1",
@@ -485,9 +485,9 @@
     "version": "1.6.22"
   },
   "monitoring-plugins": {
-    "name": "monitoring-plugins-2.3.0",
+    "name": "monitoring-plugins-2.3.5",
     "pname": "monitoring-plugins",
-    "version": "2.3.0"
+    "version": "2.3.5"
   },
   "mysql": {
     "name": "mariadb-server-10.11.6",
@@ -495,9 +495,9 @@
     "version": "10.11.6"
   },
   "mysql80": {
-    "name": "mysql-8.0.35",
+    "name": "mysql-8.0.36",
     "pname": "mysql",
-    "version": "8.0.35"
+    "version": "8.0.36"
   },
   "nfs-utils": {
     "name": "nfs-utils-2.6.2",
@@ -840,9 +840,9 @@
     "version": "2.0.7"
   },
   "qemu": {
-    "name": "qemu-8.1.4",
+    "name": "qemu-8.1.5",
     "pname": "qemu",
-    "version": "8.1.4"
+    "version": "8.1.5"
   },
   "rabbitmq-server": {
     "name": "rabbitmq-server-3.12.7",
@@ -860,9 +860,9 @@
     "version": "3.1"
   },
   "redis": {
-    "name": "redis-7.2.3",
+    "name": "redis-7.2.4",
     "pname": "redis",
-    "version": "7.2.3"
+    "version": "7.2.4"
   },
   "roundcube": {
     "name": "roundcube-1.6.6",
@@ -885,14 +885,14 @@
     "version": "2.7.8"
   },
   "ruby_3_2": {
-    "name": "ruby-3.2.2",
+    "name": "ruby-3.2.3",
     "pname": "ruby",
-    "version": "3.2.2"
+    "version": "3.2.3"
   },
   "runc": {
-    "name": "runc-1.1.10",
+    "name": "runc-1.1.12",
     "pname": "runc",
-    "version": "1.1.10"
+    "version": "1.1.12"
   },
   "screen": {
     "name": "screen-4.9.1",
@@ -910,9 +910,9 @@
     "version": "8.11.2"
   },
   "strace": {
-    "name": "strace-6.6",
+    "name": "strace-6.7",
     "pname": "strace",
-    "version": "6.6"
+    "version": "6.7"
   },
   "strongswan": {
     "name": "strongswan-5.9.11",
@@ -975,9 +975,9 @@
     "version": "2.39.2"
   },
   "varnish": {
-    "name": "varnish-7.4.1",
+    "name": "varnish-7.4.2",
     "pname": "varnish",
-    "version": "7.4.1"
+    "version": "7.4.2"
   },
   "vim": {
     "name": "vim-9.0.2116",

--- a/package-versions.json
+++ b/package-versions.json
@@ -484,6 +484,11 @@
     "pname": "memcached",
     "version": "1.6.22"
   },
+  "monitoring-plugins": {
+    "name": "monitoring-plugins-2.3.0",
+    "pname": "monitoring-plugins",
+    "version": "2.3.0"
+  },
   "mysql": {
     "name": "mariadb-server-10.11.6",
     "pname": "mariadb-server",

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -204,23 +204,11 @@ in {
   mysql = super.mariadb;
 
   monitoring-plugins = super.monitoring-plugins.overrideAttrs(_: rec {
-    name = "monitoring-plugins-2.3.0";
-
-      src = super.fetchFromGitHub {
-        owner  = "monitoring-plugins";
-        repo   = "monitoring-plugins";
-        rev    = "v2.3";
-        sha256 = "125w3rnslk9wfpzafbviwag0xvix1fzkhnjdxzb1h5fg58wlgf68";
-      };
-
-      patches = [];
-
-      postInstall = super.monitoring-plugins.postInstall + ''
-        cp plugins-root/check_dhcp $out/bin
-        cp plugins-root/check_icmp $out/bin
-      '';
-
-    });
+    postInstall = ''
+    cp plugins-root/check_dhcp $out/bin
+    cp plugins-root/check_icmp $out/bin
+    '';
+  });
 
   # This is our default version.
   nginxStable = (super.nginxStable.override {

--- a/versions.json
+++ b/versions.json
@@ -8,9 +8,9 @@
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/"
   },
   "nixpkgs": {
-    "hash": "sha256-Y84SHnPDzqHKngShgt0Omm/bWc941+t0pnsSVuyQkUg=",
+    "hash": "sha256-ij9KXfU+kBRzd65RKhkGQAXSoLUon7ThBNQobj9af9s=",
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "159aa075fe1fe7ccaf1027345b9f28a342c50dae"
+    "rev": "2c79fa4b41fd977305d366cc1bb1e805f85b4b3b"
   }
 }


### PR DESCRIPTION
Update nixpkgs

Pull upstream NixOS changes, security fixes and package updates:

- chromium: 121.0.6167.85 -> 121.0.6167.139
- containerd: 1.7.11 -> 1.7.13 (CVE-2024-21626)
- imagemagick: 7.1.1-25 -> 7.1.1-26
- keycloak: 23.0.4 -> 23.0.6
- mastodon: 4.2.4 -> 4.2.5 (CVE-2024-23832)
- monitoring-plugins: 2.3.0 -> 2.3.5
- mysql80: 8.0.35 -> 8.0.36
- qemu: 8.1.4 -> 8.1.5
- qemu: add patch for CVE-2023-6693
- redis: 7.2.3 -> 7.2.4 (7.2.3 -> 7.2.4)
- ruby_3_2: 3.2.2 -> 3.2.3
- runc: 1.1.10 -> 1.1.12 (CVE-2024-21626)
- security wrappers (setuid binaries): limit argv0 length as mitigation
   for a glibc vulnerability (CVE-2023-6246).
- strace: 6.6 -> 6.7
- varnish: 7.4.1 -> 7.4.2 (CVE-2023-44487)


Cleaned up our override for monitoring-plugins, we are using the newer upstream version now.

PL-132173


@flyingcircusio/release-managers

## Release process

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

Impact:


Changelog:

(include changed packages from commit msg)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - pull in important upstream security fixes (here: glibc, runc)
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still run, works on a test VM with many roles
  - checked commit log for fixed CVEs and possible problems with updates