### PR TITLE
[PL-132155] roles/mailserver: require an actual url as imprintUrl

### DIFF
--- a/doc/src/mailserver.md
+++ b/doc/src/mailserver.md
@@ -50,7 +50,12 @@ Additionally, some mail providers (namely \[Telekom/T-Online\]
 has an imprint served at its hostname.
 
 For this you can either set `imprintUrl` to the location of your existing
-imprint, or use `imprintText` to specify an imprint in HTML format
+imprint, or use `imprintText` to specify an imprint in HTML format.
+
+:::{warning}
+Specifying `imprintUrl` without a protocol scheme is still supported, but
+deprecated and will give a warning on evaluation.
+:::
 
 Note that it is not possible to set both `imprintUrl` and `imprintText` at the
 same time and imprint cannot be used if you serve webmail under the
@@ -83,7 +88,7 @@ and *test2.fcio.net*:
       "autoconfig": false
     }
   },
-  "imprintUrl": "your-company.tld/imprint"
+  "imprintUrl": "https://your-company.tld/imprint"
 }
 ```
 

--- a/nixos/roles/mailserver.nix
+++ b/nixos/roles/mailserver.nix
@@ -170,6 +170,15 @@ in
           You can instead provide your imprint in text form using the imprintText option
         '';
         default = null;
+        apply = url:
+          if url == null || null != builtins.match "^https?://.+" url then
+            url
+          else
+            # FIXME get rid of this after a few releases as grace period.
+            # Use `types.nullOr (types.strMatching "^https?://.+")` then to make sure a protocol is specified.
+            warn
+              ''Specifying flyingcircus.roles.mailserver.imprintUrl without a protocol scheme is deprecated. Add https:// to the declaration (i.e. "${url}" -> "https://${url}") to get rid of this warning.''
+              "https://${url}";
       };
 
       imprintText = mkOption {

--- a/nixos/services/mail/default.nix
+++ b/nixos/services/mail/default.nix
@@ -261,7 +261,7 @@ in {
                 enableACME = true;
               }
               (lib.mkIf (role.imprintUrl != null) {
-                locations."/".return = "302 https://${role.imprintUrl}";
+                locations."/".return = "302 ${role.imprintUrl}";
               })
               (lib.mkIf (role.imprintText != null) {
                 root = with pkgs; writeTextDir "index.html" role.imprintText;


### PR DESCRIPTION

Even though the option was called `imprintUrl` the protocol scheme was prepended unconditionally. This means when defining an `imprintUrl` like

    https://example.org/impressum

a redirect to `https://https//example.org/impressum` will be issued which is pretty unintuitive.

Since the option claims to accept a URL I decided to change its semantics like this:

* A URL is expected now (as long as it's accepted by the `return` clause of nginx).

* For backwards-compatibility, a "URL" w/o a scheme (i.e. `example.com`) is also accepted. This behavior is deprecated however and gives the following warning at evaluation time:

      trace: warning: Specifying flyingcircus.roles.mailserver.imprintUrl without a protocol scheme is deprecated. Add https:// to the declaration (i.e. "example.com" -> "https://example.com") to get rid of this warning.

  We could drop the old behavior after e.g. the first platform release with NixOS 24.11. When doing that, the `apply` expression should be dropped and the validation should be done by using `nullOr (strMatching "")` instead.

A test-case to the integration test of the mailserver role was added which ensures that the redirect declared by `imprintUrl` works fine.

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:
* mailserver: `imprintUrl` now accepts a protocol scheme. Specifying this option without a protocol scheme still works as before, but is deprecated and will raise a warning (PL-132155)

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
    - Reduce the chance of human error: a misconfigured redirect to the imprint is accepted by the module and may be unnoticed. However, the lack of an imprint may violate the ToS of other mail providers which potentially causes the mailserver to be banned by other providers.
- [x] Security requirements tested? (EVIDENCE)
    - Additional testcase in the integration test ensures that an imprintUrl with a protocol scheme gets properly redirected.
    - Manually verified that an imprintUrl without a protocol scheme gets properly redirected and gives a deprecation warning.