### PR TITLE
Gitlab 16.7.5

### DIFF
--- a/package-versions.json
+++ b/package-versions.json
@@ -215,9 +215,9 @@
     "version": "2.42.0"
   },
   "gitaly": {
-    "name": "gitaly-16.7.4",
+    "name": "gitaly-16.7.5",
     "pname": "gitaly",
-    "version": "16.7.4"
+    "version": "16.7.5"
   },
   "github-runner": {
     "name": "github-runner-2.312.0",
@@ -225,24 +225,24 @@
     "version": "2.312.0"
   },
   "gitlab": {
-    "name": "gitlab-16.7.4",
+    "name": "gitlab-16.7.5",
     "pname": "gitlab",
-    "version": "16.7.4"
+    "version": "16.7.5"
   },
   "gitlab-container-registry": {
-    "name": "gitlab-container-registry-3.88.0",
+    "name": "gitlab-container-registry-3.88.1",
     "pname": "gitlab-container-registry",
-    "version": "3.88.0"
+    "version": "3.88.1"
   },
   "gitlab-ee": {
-    "name": "gitlab-ee-16.7.4",
+    "name": "gitlab-ee-16.7.5",
     "pname": "gitlab-ee",
-    "version": "16.7.4"
+    "version": "16.7.5"
   },
   "gitlab-pages": {
-    "name": "gitlab-pages-16.7.4",
+    "name": "gitlab-pages-16.7.5",
     "pname": "gitlab-pages",
-    "version": "16.7.4"
+    "version": "16.7.5"
   },
   "gitlab-runner": {
     "name": "gitlab-runner-16.7.0",
@@ -250,9 +250,9 @@
     "version": "16.7.0"
   },
   "gitlab-workhorse": {
-    "name": "gitlab-workhorse-16.7.4",
+    "name": "gitlab-workhorse-16.7.5",
     "pname": "gitlab-workhorse",
-    "version": "16.7.4"
+    "version": "16.7.5"
   },
   "glibc": {
     "name": "glibc-2.38-27",

--- a/versions.json
+++ b/versions.json
@@ -8,9 +8,9 @@
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/"
   },
   "nixpkgs": {
-    "hash": "sha256-ij9KXfU+kBRzd65RKhkGQAXSoLUon7ThBNQobj9af9s=",
+    "hash": "sha256-1hxtQlAMcdqM+HgNih3y41P4hYw8VJjCMIK5Y+Y+KHw=",
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "2c79fa4b41fd977305d366cc1bb1e805f85b4b3b"
+    "rev": "ba2e1304f4d32379d4d884abe679df5ad06fbfa0"
   }
 }


### PR DESCRIPTION
- gitlab: 16.7.4 -> 16.7.5 (CVE-2023-6840, CVE-2023-6386, CVE-2024-1066)
- gitlab-container-registry: 3.88.0 -> 3.88.1

PL-132184

@flyingcircusio/release-managers

## Release process

Impact:

- \[NixOS 23.11] Gitlab will be restarted.

Changelog:

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - apply security updates asap 
- [x] Security requirements tested? (EVIDENCE)
  - checked on our Gitlab staging system that Gitlab works
