### PR TITLE
[22.11] mongodb: remove from allowed unfree packages

### DIFF
--- a/nixpkgs-config.nix
+++ b/nixpkgs-config.nix
@@ -6,10 +6,6 @@
     # fc-sensuplugins and thus needed on all machines. Should be moved to
     # the raid service after decoupling fc-sensuplugins.
     "megacli"
-    # MongoDB starting with 4.0 uses the SSPL license, which is declared
-    # as unfree. We don't have alternatives to mongodb right now so we have
-    # to enable it.
-    "mongodb"
   ];
 
   permittedInsecurePackages = [

--- a/tests/mongodb.nix
+++ b/tests/mongodb.nix
@@ -24,6 +24,7 @@ in {
           gateways = {};
         };
       };
+      flyingcircus.allowedUnfreePackageNames = ["mongodb"];
     };
 
 


### PR DESCRIPTION
We cannot and do not want to allow installing unfree mongodb versions anymore by default (SSPL).

Machines requiring unfree mongodb versions need to set the following local config, of course after checking for licence compliance: flyingcircus.allowedUnfreePackageNames = ["mongodb"];

PL-132080

Backport of #912

@flyingcircusio/release-managers

## Release process

Impact:
- already running mongodb40 and mongodb42 deployments might need to explicitly allow mongodb as an unfree package

Changelog:
- `mongodb` is not allowed as an unfree package anymore by default.
  - affected roles: mongodb40, mongodb42
  - after checking for SSPL compliance, add `flyingcircus.allowedUnfreePackageNames = ["mongodb"];` to local VM config to allow installation

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - must not introduce any known regressions
  - test override instructions
- [x] Security requirements tested? (EVIDENCE)
  - [x] NixOS tests still pass
  - [x] manually checked override config on a 22.05 test VM
