### PR TITLE
mailserver: fix dynamicMap reloading.

### DIFF
--- a/nixos/services/mail/default.nix
+++ b/nixos/services/mail/default.nix
@@ -13,6 +13,9 @@ with lib;
 let
   inherit (import ../../../versions.nix { }) nixos-mailserver;
 
+  copyToStore = pathString:
+    let p = builtins.path { path = pathString; }; in "${p}";
+
   role = config.flyingcircus.roles.mailserver;
   svc = config.flyingcircus.services.mail;
   fclib = config.fclib;
@@ -49,6 +52,10 @@ in {
   config =
   let
     dynamicMapFiles = lib.flatten (lib.attrValues role.dynamicMaps);
+    # The way we use the mapFiles attribute has a collision potential on files
+    # with the same name in different paths. To avoid this, we hash the
+    # path and suffix the basename with the hash. This will not cause reloads
+    # if the content changes! (PL-132088)
     dynamicMapHash = p: "${baseNameOf p}-${substring 0 8 (hashString "sha1" p)}";
   in lib.mkMerge [
     (lib.mkIf (domains != []) {
@@ -327,7 +334,9 @@ in {
 
         mapFiles = listToAttrs (map (path: {
           name = dynamicMapHash path;
-          value = path;
+          # The map files need to be in the store to ensure that they
+          # properly trigger reloads when their content changes.
+          value = copyToStore path;
         }) dynamicMapFiles);
 
         extraConfig = ''


### PR DESCRIPTION
To trigger the postfix-setup unit properly the maps need to be copied to the store, thus we need to reference them as paths.

Fixes PL-132085

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* mailserver: fix reload of postfix maps declared using the `dynamicMaps` attribute. This was stuck until a reboot happened when the `postfix-setup` unit was triggered explicitly. (PL-132085)

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

changes must be applied properly/reliably

- [x] Security requirements tested? (EVIDENCE)

manually tested and inspected the relevant output files on test38 as our automated tests do not properly cover this.
