### PR TITLE
[21.05] More VXLAN configuration changes

### DIFF
--- a/nixos/infrastructure/flyingcircus-physical.nix
+++ b/nixos/infrastructure/flyingcircus-physical.nix
@@ -63,7 +63,6 @@ mkIf (cfg.infrastructureModule == "flyingcircus-physical") {
       nvme-cli
       pciutils
       smartmontools
-      tcpdump-vxlan
     ];
 
     fileSystems = {

--- a/nixos/platform/network.nix
+++ b/nixos/platform/network.nix
@@ -138,7 +138,7 @@ in
           mtu = interface.mtu;
         })) nonUnderlayInterfaces) ++
       (if isNull fclib.underlay then [] else [(
-        lib.nameValuePair "underlay" {
+        lib.nameValuePair "ul-loopback" {
           ipv4.addresses = [{
             address = fclib.underlay.loopback;
             prefixLength = 32;
@@ -377,15 +377,15 @@ in
           )) bridgedInterfaces) ++
         (if isNull fclib.underlay then [] else
           [(lib.nameValuePair
-            "network-link-properties-underlay-virt"
+            "network-link-properties-ul-loopback-virt"
             rec {
-              description = "Ensure network link properties for virtual interface underlay";
-              wantedBy = [ "network-addresses-underlay.service"
+              description = "Ensure network link properties for virtual interface ul-loopback";
+              wantedBy = [ "network-addresses-ul-loopback.service"
                            "multi-user.target" ];
               before = wantedBy;
               path = [ pkgs.nettools pkgs.procps fclib.relaxedIp ];
               script = ''
-                IFACE=underlay
+                IFACE=ul-loopback
 
                 # Create virtual interface underlay
                 ip link add $IFACE type dummy
@@ -395,7 +395,7 @@ in
                 ${sysctlSnippet}
               '';
               preStop = ''
-                IFACE=underlay
+                IFACE=ul-loopback
                 ip link delete $IFACE
               '';
               serviceConfig = {
@@ -407,10 +407,10 @@ in
             "network-underlay-routing-fallback"
             rec {
               description = "Ensure fallback unreachable route for underlay prefixes";
-              wantedBy = [ "network-addresses-underlay.service"
+              wantedBy = [ "network-addresses-ul-loopback.service"
                            "multi-user.target" ];
               before = wantedBy;
-              after = [ "network-link-properties-underlay-virt.service" ];
+              after = [ "network-link-properties-ul-loopback-virt.service" ];
               path = [ fclib.relaxedIp ];
               script = ''
                 ${lib.concatMapStringsSep "\n"
@@ -454,7 +454,7 @@ in
               wantedBy = [ "network-addresses-${iface.layer2device}.service"
                            "multi-user.target" ];
               before = wantedBy;
-              partOf = [ "network-addresses-underlay.service" ];
+              partOf = [ "network-addresses-ul-loopback.service" ];
               path = [ pkgs.nettools pkgs.procps fclib.relaxedIp ];
               script = ''
                 IFACE=${iface.layer2device}

--- a/nixos/platform/network.nix
+++ b/nixos/platform/network.nix
@@ -436,7 +436,7 @@ in
               description = "Ensure link properties for physical underlay interface ${iface}";
               wantedBy = [ "network-addresses-${iface}.service"
                            "multi-user.target" ];
-              after = [ "network-link-proprties-${iface}-phy.service" ];
+              after = [ "network-link-properties-${iface}-phy.service" ];
               path = [ pkgs.procps ];
               script = ''
                 sysctl net.ipv4.conf.${iface}.rp_filter=0
@@ -459,7 +459,7 @@ in
               script = ''
                 IFACE=${iface.layer2device}
 
-                # Create virtual inteface ${iface.layer2device}
+                # Create virtual interface ${iface.layer2device}
                 ip link add $IFACE type vxlan \
                   id ${toString iface.vlanId} \
                   local ${fclib.underlay.loopback} \

--- a/nixos/platform/network.nix
+++ b/nixos/platform/network.nix
@@ -258,16 +258,6 @@ in
             neighbor switches activate
             advertise-all-vni
             advertise-svi-ip
-            ${ # Workaround for FRR not advertising SVI IP when
-               # globally configured
-              lib.concatMapStringsSep "\n  "
-                (iface: concatStringsSep "\n  " [
-                  ("vni " + (toString iface.vlanId))
-                  " advertise-svi-ip"
-                  "exit-vni"
-                ])
-                vxlanInterfaces
-            }
            exit-address-family
           !
           exit

--- a/nixos/services/consul/default.nix
+++ b/nixos/services/consul/default.nix
@@ -38,7 +38,7 @@ in
       acl.default_policy = "deny";
       acl.down_policy = "extend-cache";
 
-      client_addr = "{{ GetInterfaceIPs \"lo\" }}";
+      client_addr = "{{ GetInterfaceIPs \"^lo$\" }}";
       datacenter = dc;
       dns_config = { node_ttl = "3s"; service_ttl = {"*" = "3s";};};
       enable_script_checks = true;

--- a/nixos/services/frr.nix
+++ b/nixos/services/frr.nix
@@ -187,7 +187,7 @@ in
               wantedBy = [ "multi-user.target" ];
               after = [ "network-pre.target" "systemd-sysctl.service" ] ++ lib.optionals (service != "zebra") [ "zebra.service" ];
               bindsTo = lib.optionals (service != "zebra") [ "zebra.service" ];
-              wants = [ "network.target" ];
+              wants = [ "network.target" ] ++ lib.optionals (service == "zebra") (map (svc: "${daemonName svc}.service") (filter isEnabled services));
 
               description = if service == "zebra" then "FRR Zebra routing manager"
                 else "FRR ${toUpper service} routing daemon";

--- a/nixos/services/frr.nix
+++ b/nixos/services/frr.nix
@@ -207,7 +207,7 @@ in
                   + optionalString (scfg.vtyListenPort != null) " -P ${toString scfg.vtyListenPort}"
                   + " " + (concatStringsSep " " scfg.extraOptions);
                 ExecReload = "${pkgs.python3.interpreter} ${pkgs.frr}/libexec/frr/frr-reload.py --reload --daemon ${daemonName service} --bindir ${pkgs.frr}/bin --rundir /run/frr /etc/frr/${service}.conf";
-                Restart = "on-abnormal";
+                Restart = "always";
               };
             });
        in

--- a/pkgs/dstat-interface-altnames.patch
+++ b/pkgs/dstat-interface-altnames.patch
@@ -1,0 +1,46 @@
+From 1eaf72a37ac9d4d960c0872c3992be725a7d222e Mon Sep 17 00:00:00 2001
+From: Molly Miller <mm@flyingcircus.io>
+Date: Wed, 7 Feb 2024 09:30:54 +0100
+Subject: [PATCH] Use canonical network interface names from the kernel.
+
+Under Linux it's possible for network interfaces to have alias
+names (or "altnames"), added by "ip link property add
+altname". However, /proc/net/dev only lists interfaces with their
+canonical names, which means that dstat will reject alias names as
+unknown. Instead, use if_nametoindex(3) and if_indextoname(3) to
+discover the canonical names of the user-specified interfaces.
+---
+ dstat | 10 +++++++++-
+ 1 file changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/dstat b/dstat
+index 9359965..799d523 100755
+--- a/dstat
++++ b/dstat
+@@ -30,6 +30,7 @@ import re
+ import resource
+ import sched
+ import six
++import socket
+ import sys
+ import time
+ 
+@@ -1343,7 +1344,14 @@ class dstat_net(dstat):
+     def vars(self):
+         ret = []
+         if op.netlist:
+-            varlist = op.netlist
++            varlist = []
++            for iface in op.netlist:
++                try:
++                    idx = socket.if_nametoindex(iface)
++                    name = socket.if_indextoname(idx)
++                    varlist.append(name)
++                except OSError:
++                    pass
+         elif not op.full:
+             varlist = ('total',)
+         else:
+-- 
+2.39.3 (Apple Git-145)
+

--- a/pkgs/fc/default.nix
+++ b/pkgs/fc/default.nix
@@ -25,6 +25,7 @@ rec {
   fix-so-rpath = callPackage ./fix-so-rpath {};
   ledtool = pkgs.writers.writePython3Bin "fc-ledtool"
     {} (builtins.readFile ./ledtool/led.py);
+  lldp-to-altname = callPackage ./lldp-to-altname {};
   logcheckhelper = callPackage ./logcheckhelper { };
   megacli = callPackage ./megacli { };
   multiping = callPackage ./multiping.nix {};

--- a/pkgs/fc/lldp-to-altname/default.nix
+++ b/pkgs/fc/lldp-to-altname/default.nix
@@ -1,0 +1,26 @@
+{ lib, stdenv, makeWrapper, python3, lldpd, iproute2 }:
+
+stdenv.mkDerivation rec {
+  version = "1";
+  pname = "fc-lldp-to-altname";
+
+  src = ./.;
+  unpackPhase = ":";
+  dontBuild = true;
+  dontConfigure = true;
+  nativeBuildInputs = [ makeWrapper ];
+  propagatedBuildInputs = [ python3 lldpd iproute2 ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cd $src
+    install fc-lldp-to-altname.py $out/bin/fc-lldp-to-altname
+    wrapProgram $out/bin/fc-lldp-to-altname --prefix PATH : \
+      ${lib.makeBinPath propagatedBuildInputs}
+  '';
+
+  meta = with lib; {
+    description = "Script to assign interface altnames based on LLDP information";
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/fc/lldp-to-altname/fc-lldp-to-altname.py
+++ b/pkgs/fc/lldp-to-altname/fc-lldp-to-altname.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import socket
+import subprocess
+import sys
+
+
+class Runner(object):
+    ALTNAME_PREFIX = "ul-port-"
+
+    def __init__(self, args):
+        self.quiet = args.quiet
+        self.dry_run = args.dry_run
+
+        # canonicalise interface names
+        indices = set()
+        for iface in args.interfaces:
+            try:
+                index = socket.if_nametoindex(iface)
+            except OSError as ex:
+                print(
+                    "Could not find interface by name: {}: {}".format(
+                        iface, ex
+                    ),
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+            indices.add(index)
+
+        interfaces = set()
+        for index in indices:
+            try:
+                iface = socket.if_indextoname(index)
+            except OSError as ex:
+                print(
+                    "Could not find interface by index: {}: {}".format(
+                        index, ex
+                    ),
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+            interfaces.add(iface)
+
+        # sort to ensure stable renames in case of altname collisions
+        self.interfaces = sorted(list(interfaces))
+
+    def check_json_output(self, *args):
+        if not self.quiet:
+            print("$ {}".format(" ".join(args)))
+        data = subprocess.check_output(args)
+        return json.loads(data.decode("utf-8"))
+
+    def cmd(self, *args):
+        if not self.quiet:
+            print("$ {}".format(" ".join(args)))
+        if not self.dry_run:
+            subprocess.run(args, check=True)
+
+    def run(self):
+        oldnames = dict()
+        lldpnames = dict()
+        for iface in self.interfaces:
+            oldnames[iface] = set()
+            data = self.check_json_output("ip", "-j", "link", "show", iface)
+
+            for datum in data:
+                if "altnames" in datum:
+                    names = [
+                        name
+                        for name in datum["altnames"]
+                        if name.startswith(self.ALTNAME_PREFIX)
+                    ]
+                    oldnames[iface].update(names)
+
+            lldpnames[iface] = set()
+            data = self.check_json_output("lldpctl", "-f", "json", iface)
+            data = data["lldp"]
+            if (
+                "interface" in data
+                and iface in data["interface"]
+                and "chassis" in data["interface"][iface]
+            ):
+                data = data["interface"][iface]["chassis"]
+                lldpnames[iface].update(data.keys())
+
+        # ensure that peer names learned from lldp are globally unique
+        # across all interfaces.
+        for this_index, this_iface in enumerate(self.interfaces):
+            for this_name in lldpnames[this_iface]:
+                this_count = 0
+                for next_iface in self.interfaces[this_index + 1 :]:
+                    next_names = lldpnames[next_iface]
+                    if this_name in next_names:
+                        next_name = f"{this_name}-{this_count}"
+                        next_names.remove(this_name)
+                        next_names.add(next_name)
+                        this_count += 1
+
+        newnames = dict()
+        for iface in self.interfaces:
+            newnames[iface] = set(
+                map(lambda n: self.ALTNAME_PREFIX + n, lldpnames[iface])
+            )
+            newnames[iface].discard(iface)
+
+        for iface in self.interfaces:
+            addnames = newnames[iface] - oldnames[iface]
+            delnames = oldnames[iface] - newnames[iface]
+            for name in addnames:
+                self.cmd(
+                    "ip",
+                    "link",
+                    "property",
+                    "add",
+                    "altname",
+                    name,
+                    "dev",
+                    iface,
+                )
+            for name in delnames:
+                self.cmd(
+                    "ip",
+                    "link",
+                    "property",
+                    "del",
+                    "altname",
+                    name,
+                    "dev",
+                    iface,
+                )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(prog="fc-lldp-to-altname")
+    parser.add_argument(
+        "--quiet",
+        "-q",
+        action="store_true",
+        help="Do not print commands when executed",
+    )
+    parser.add_argument(
+        "--dry-run",
+        "-n",
+        action="store_true",
+        help="Do not change interface configuration, only print calculated commands",
+    )
+    parser.add_argument(
+        "interfaces", metavar="IFACES", nargs="+", help="Interfaces to process"
+    )
+
+    args = parser.parse_args()
+    runner = Runner(args)
+    runner.run()

--- a/pkgs/frr/0001-zebra-re-install-nhg-on-interface-up.patch
+++ b/pkgs/frr/0001-zebra-re-install-nhg-on-interface-up.patch
@@ -1,0 +1,153 @@
+From 2af4eb5a55225975d721dafdd1015dd50d2b820b Mon Sep 17 00:00:00 2001
+From: Ashwini Reddy <ashred@nvidia.com>
+Date: Wed, 19 Apr 2023 11:35:25 -0700
+Subject: [PATCH 1/3] zebra: re-install nhg on interface up
+
+Intermittently zebra and kernel are out of sync
+when interface flaps and the add's/dels are in
+same processing queue and zebra assumes no change in nexthop.
+Hence we need to bring in a reinstall to kernel
+of the nexthops and routes to sync their states.
+
+Upon interface flap kernel would have deleted NHGs
+associated to a interface (the one flapped),
+zebra retains NHGs for 3 mins even though upper
+layer protocol removes the nexthops (associated NHG).
+As part of interface address add ,
+re-add singleton NHGs associated to interface.
+
+Ticket: #3173663
+Issue: 3173663
+
+Signed-off-by: Ashwini Reddy <ashred@nvidia.com>
+Signed-off-by: Chirag Shah <chirag@nvidia.com>
+---
+ lib/nexthop.c        |  9 +++++++++
+ lib/nexthop.h        |  3 +++
+ zebra/redistribute.c |  4 ++++
+ zebra/zebra_nhg.c    | 46 ++++++++++++++++++++++++++++++++++++++++++++
+ zebra/zebra_nhg.h    |  1 +
+ 5 files changed, 63 insertions(+)
+
+diff --git a/lib/nexthop.c b/lib/nexthop.c
+index 1eeed4adf..b888b9a0a 100644
+--- a/lib/nexthop.c
++++ b/lib/nexthop.c
+@@ -1092,3 +1092,12 @@ static ssize_t printfrr_nh(struct fbuf *buf, struct printfrr_eargs *ea,
+ 	}
+ 	return -1;
+ }
++
++bool nexthop_is_ifindex_type(const struct nexthop *nh)
++{
++	if (nh->type == NEXTHOP_TYPE_IFINDEX ||
++	    nh->type == NEXTHOP_TYPE_IPV4_IFINDEX ||
++	    nh->type == NEXTHOP_TYPE_IPV6_IFINDEX)
++		return true;
++	return false;
++}
+diff --git a/lib/nexthop.h b/lib/nexthop.h
+index f35cc5e4e..8eb4d210c 100644
+--- a/lib/nexthop.h
++++ b/lib/nexthop.h
+@@ -255,6 +255,9 @@ extern struct nexthop *nexthop_dup(const struct nexthop *nexthop,
+ extern struct nexthop *nexthop_dup_no_recurse(const struct nexthop *nexthop,
+ 					      struct nexthop *rparent);
+ 
++/* Check nexthop of IFINDEX type */
++extern bool nexthop_is_ifindex_type(const struct nexthop *nh);
++
+ /*
+  * Parse one or more backup index values, as comma-separated numbers,
+  * into caller's array of uint8_ts. The array must be NEXTHOP_MAX_BACKUPS
+diff --git a/zebra/redistribute.c b/zebra/redistribute.c
+index 4a8fe938e..fccbee7d8 100644
+--- a/zebra/redistribute.c
++++ b/zebra/redistribute.c
+@@ -561,6 +561,10 @@ void zebra_interface_address_add_update(struct interface *ifp,
+ 						client, ifp, ifc);
+ 		}
+ 	}
++	/* interface associated NHGs may have been deleted,
++	 * re-sync zebra -> dplane NHGs
++	 */
++	zebra_interface_nhg_reinstall(ifp);
+ }
+ 
+ /* Interface address deletion. */
+diff --git a/zebra/zebra_nhg.c b/zebra/zebra_nhg.c
+index b3336abc3..78fa22de7 100644
+--- a/zebra/zebra_nhg.c
++++ b/zebra/zebra_nhg.c
+@@ -3003,6 +3003,12 @@ void zebra_nhg_install_kernel(struct nhg_hash_entry *nhe)
+ 	/* Resolve it first */
+ 	nhe = zebra_nhg_resolve(nhe);
+ 
++	if (zebra_nhg_set_valid_if_active(nhe)) {
++		if (IS_ZEBRA_DEBUG_NHG_DETAIL)
++			zlog_debug("%s: valid flag set for nh %pNG", __func__,
++				   nhe);
++	}
++
+ 	/* Make sure all depends are installed/queued */
+ 	frr_each(nhg_connected_tree, &nhe->nhg_depends, rb_node_dep) {
+ 		zebra_nhg_install_kernel(rb_node_dep->nhe);
+@@ -3585,3 +3591,43 @@ static ssize_t printfrr_nhghe(struct fbuf *buf, struct printfrr_eargs *ea,
+ 	ret += bputs(buf, "]");
+ 	return ret;
+ }
++
++/*
++ * On interface add the nexthop that resolves to this intf needs
++ * a re-install. There are following scenarios when the nexthop group update
++ * gets skipped:
++ * 1. When upper level protocol sends removal of NHG, there is
++ * timer running to keep NHG for 180 seconds, during this interval, same route
++ * with same set of nexthops installation is given , the same NHG is used
++ * but since NHG is not reinstalled on interface address add, it is not aware
++ * in Dplan/Kernel.
++ * 2. Due to a quick port flap due to interface add and delete
++ * to be processed in same queue one after another. Zebra believes that
++ * there is no change in nhg in this case. Hence this re-install will
++ * make sure the nexthop group gets updated to Dplan/Kernel.
++ */
++void zebra_interface_nhg_reinstall(struct interface *ifp)
++{
++	struct nhg_connected *rb_node_dep = NULL;
++	struct zebra_if *zif = ifp->info;
++	struct nexthop *nh;
++
++	if (IS_ZEBRA_DEBUG_NHG_DETAIL)
++		zlog_debug(
++			"%s: Installing interface %s associated NHGs into kernel",
++			__func__, ifp->name);
++
++	frr_each (nhg_connected_tree, &zif->nhg_dependents, rb_node_dep) {
++		nh = rb_node_dep->nhe->nhg.nexthop;
++		if (zebra_nhg_set_valid_if_active(rb_node_dep->nhe)) {
++			if (IS_ZEBRA_DEBUG_NHG_DETAIL)
++				zlog_debug(
++					"%s: Setting the valid flag for nhe %pNG, interface: %s",
++					__func__, rb_node_dep->nhe, ifp->name);
++		}
++		/* Check for singleton NHG associated to interface */
++		if (nexthop_is_ifindex_type(nh) &&
++		    zebra_nhg_depends_is_empty(rb_node_dep->nhe))
++			zebra_nhg_install_kernel(rb_node_dep->nhe);
++	}
++}
+diff --git a/zebra/zebra_nhg.h b/zebra/zebra_nhg.h
+index 9b925bf10..18914b785 100644
+--- a/zebra/zebra_nhg.h
++++ b/zebra/zebra_nhg.h
+@@ -374,6 +374,7 @@ extern uint8_t zebra_nhg_nhe2grp(struct nh_grp *grp, struct nhg_hash_entry *nhe,
+ /* Dataplane install/uninstall */
+ extern void zebra_nhg_install_kernel(struct nhg_hash_entry *nhe);
+ extern void zebra_nhg_uninstall_kernel(struct nhg_hash_entry *nhe);
++extern void zebra_interface_nhg_reinstall(struct interface *ifp);
+ 
+ /* Forward ref of dplane update context type */
+ struct zebra_dplane_ctx;
+-- 
+2.39.3 (Apple Git-145)
+

--- a/pkgs/frr/0002-zebra-re-install-dependent-nhgs-on-interface-up.patch
+++ b/pkgs/frr/0002-zebra-re-install-dependent-nhgs-on-interface-up.patch
@@ -1,0 +1,105 @@
+From f6feefc2d6829ab81c3e81ab913a3c39ececba2c Mon Sep 17 00:00:00 2001
+From: Chirag Shah <chirag@nvidia.com>
+Date: Fri, 28 Apr 2023 19:09:55 -0700
+Subject: [PATCH 2/3] zebra:re-install dependent nhgs on interface up
+
+Upon interface up associated singleton NHG's
+dependent NHGs needs to be reinstalled as
+kernel would have deleted if there is no route
+referencing it.
+
+Ticket:#3416477
+Issue:3416477
+Testing Done:
+flap interfaces which are part of route NHG,
+upon interfaces up event, NHGs are resynced
+into dplane.
+
+Signed-off-by: Chirag Shah <chirag@nvidia.com>
+---
+ zebra/zebra_nhg.c | 43 ++++++++++++++++++++++++++++++++++++++-----
+ 1 file changed, 38 insertions(+), 5 deletions(-)
+
+diff --git a/zebra/zebra_nhg.c b/zebra/zebra_nhg.c
+index 78fa22de7..b17167540 100644
+--- a/zebra/zebra_nhg.c
++++ b/zebra/zebra_nhg.c
+@@ -1140,13 +1140,23 @@ static void zebra_nhg_handle_uninstall(struct nhg_hash_entry *nhe)
+ 	zebra_nhg_free(nhe);
+ }
+ 
+-static void zebra_nhg_handle_install(struct nhg_hash_entry *nhe)
++static void zebra_nhg_handle_install(struct nhg_hash_entry *nhe, bool install)
+ {
+ 	/* Update validity of groups depending on it */
+ 	struct nhg_connected *rb_node_dep;
+ 
+-	frr_each_safe(nhg_connected_tree, &nhe->nhg_dependents, rb_node_dep)
++	frr_each_safe (nhg_connected_tree, &nhe->nhg_dependents, rb_node_dep) {
+ 		zebra_nhg_set_valid(rb_node_dep->nhe);
++		/* install dependent NHG into kernel */
++		if (install) {
++			if (IS_ZEBRA_DEBUG_NHG_DETAIL)
++				zlog_debug(
++					"%s nh id %u (flags 0x%x) associated dependent NHG %pNG install",
++					__func__, nhe->id, nhe->flags,
++					rb_node_dep->nhe);
++			zebra_nhg_install_kernel(rb_node_dep->nhe);
++		}
++	}
+ }
+ 
+ /*
+@@ -3035,7 +3045,7 @@ void zebra_nhg_install_kernel(struct nhg_hash_entry *nhe)
+ 			break;
+ 		case ZEBRA_DPLANE_REQUEST_SUCCESS:
+ 			SET_FLAG(nhe->flags, NEXTHOP_GROUP_INSTALLED);
+-			zebra_nhg_handle_install(nhe);
++			zebra_nhg_handle_install(nhe, false);
+ 			break;
+ 		}
+ 	}
+@@ -3109,7 +3119,7 @@ void zebra_nhg_dplane_result(struct zebra_dplane_ctx *ctx)
+ 		if (status == ZEBRA_DPLANE_REQUEST_SUCCESS) {
+ 			SET_FLAG(nhe->flags, NEXTHOP_GROUP_VALID);
+ 			SET_FLAG(nhe->flags, NEXTHOP_GROUP_INSTALLED);
+-			zebra_nhg_handle_install(nhe);
++			zebra_nhg_handle_install(nhe, true);
+ 
+ 			/* If daemon nhg, send it an update */
+ 			if (PROTO_OWNED(nhe))
+@@ -3627,7 +3637,30 @@ void zebra_interface_nhg_reinstall(struct interface *ifp)
+ 		}
+ 		/* Check for singleton NHG associated to interface */
+ 		if (nexthop_is_ifindex_type(nh) &&
+-		    zebra_nhg_depends_is_empty(rb_node_dep->nhe))
++		    zebra_nhg_depends_is_empty(rb_node_dep->nhe)) {
++			struct nhg_connected *rb_node_dependent;
++
++			if (IS_ZEBRA_DEBUG_NHG)
++				zlog_debug(
++					"%s install nhe %pNG nh type %u flags 0x%x",
++					__func__, rb_node_dep->nhe, nh->type,
++					rb_node_dep->nhe->flags);
+ 			zebra_nhg_install_kernel(rb_node_dep->nhe);
++
++			/* mark depedent uninstall, when interface associated
++			 * singleton is installed, install depedent
++			 */
++			frr_each_safe (nhg_connected_tree,
++				       &rb_node_dep->nhe->nhg_dependents,
++				       rb_node_dependent) {
++				if (IS_ZEBRA_DEBUG_NHG)
++					zlog_debug(
++						"%s dependent nhe %pNG unset installed flag",
++						__func__,
++						rb_node_dependent->nhe);
++				UNSET_FLAG(rb_node_dependent->nhe->flags,
++					   NEXTHOP_GROUP_INSTALLED);
++			}
++		}
+ 	}
+ }
+-- 
+2.39.3 (Apple Git-145)
+

--- a/pkgs/frr/0003-zebra-fix-nhg-out-of-sync-between-zebra-and-kernel.patch
+++ b/pkgs/frr/0003-zebra-fix-nhg-out-of-sync-between-zebra-and-kernel.patch
@@ -1,0 +1,91 @@
+From 18042874ba5de1873e4dc312ef628c1f54255716 Mon Sep 17 00:00:00 2001
+From: anlan_cs <vic.lan@pica8.com>
+Date: Mon, 24 Jul 2023 14:40:22 +0800
+Subject: [PATCH 3/3] zebra: fix nhg out of sync between zebra and kernel
+
+PR#13413 introduces reinstall mechanism, but there is problem with the route
+leak scenario.
+
+With route leak configuration: ( `x1` and `x2` are binded to `vrf1` )
+```
+vrf vrf2
+ ip route 75.75.75.75/32 77.75.1.75 nexthop-vrf vrf1
+ ip route 75.75.75.75/32 77.75.2.75 nexthop-vrf vrf1
+exit-vrf
+```
+
+Firstly, all are ok.  But after `x1` is set down and up ( The interval
+between the down and up operations should be less than 180 seconds. ) ,
+`x1` is lost from the nexthop group:
+```
+anlan# ip nexthop
+id 121 group 122/123 proto zebra
+id 122 via 77.75.1.75 dev x1 scope link proto zebra
+id 123 via 77.75.2.75 dev x2 scope link proto zebra
+anlan# ip route show table 2
+75.75.75.75 nhid 121 proto 196 metric 20
+        nexthop via 77.75.1.75 dev x1 weight 1
+        nexthop via 77.75.2.75 dev x2 weight 1
+anlan# ip link set dev x1 down
+anlan# ip link set dev x1 up
+anlan# ip route show table 2 <- Wrong, one nexthop lost from group
+75.75.75.75 nhid 121 via 77.75.2.75 dev x2 proto 196 metric 20
+anlan# ip nexthop
+id 121 group 123 proto zebra
+id 122 via 77.75.1.75 dev x1 scope link proto zebra
+id 123 via 77.75.2.75 dev x2 scope link proto zebra
+anlan# show ip route vrf vrf2 <- Still ok
+VRF vrf2:
+S>* 75.75.75.75/32 [1/0] via 77.75.1.75, x1 (vrf vrf1), weight 1, 00:00:05
+  *                      via 77.75.2.75, x2 (vrf vrf1), weight 1, 00:00:05
+```
+
+From the impact on kernel:
+The `nh->type` of `id 122` is *always* `NEXTHOP_TYPE_IPV4` in the route leak
+case.  Then, `nexthop_is_ifindex_type()` introduced by commit `5bb877` always
+returns `false`, so its dependents can't be reinstalled.  After `x1` is down,
+there is only `id 123` in the group of `id 121`.  So, Finally `id 121` remains
+unchanged after `x1` is up, i.e., `id 122` is not added to the group even it is
+reinstalled itself.
+
+From the impact on zebra:
+The `show ip route vrf vrf2` is still ok because the `id`s are reused/reinstalled
+successfully within 180 seconds after `x1` is down and up.  The group of `id 121`
+is with old `NEXTHOP_GROUP_INSTALLED` flag, and it is still the group of `id 122`
+and `id 123` as before.
+
+In this way, kernel and zebra have become out of sync.
+
+The `nh->type` of `id 122` should be adjusted to `NEXTHOP_TYPE_IPV4_IFINDEX`
+after nexthop resolved.  This commit is for doing this to make that reinstall
+mechanism work.
+
+Signed-off-by: anlan_cs <anlan_cs@tom.com>
+---
+ zebra/zebra_nhg.c | 9 ++++++---
+ 1 file changed, 6 insertions(+), 3 deletions(-)
+
+diff --git a/zebra/zebra_nhg.c b/zebra/zebra_nhg.c
+index b17167540..5a5daecf5 100644
+--- a/zebra/zebra_nhg.c
++++ b/zebra/zebra_nhg.c
+@@ -2375,10 +2375,13 @@ static int nexthop_active(struct nexthop *nexthop, struct nhg_hash_entry *nhe,
+ 							    nexthop->ifindex);
+ 
+ 			newhop = match->nhe->nhg.nexthop;
+-			if (nexthop->type == NEXTHOP_TYPE_IPV4 ||
+-			    nexthop->type == NEXTHOP_TYPE_IPV6)
++			if (nexthop->type == NEXTHOP_TYPE_IPV4) {
+ 				nexthop->ifindex = newhop->ifindex;
+-			else if (nexthop->ifindex != newhop->ifindex) {
++				nexthop->type = NEXTHOP_TYPE_IPV4_IFINDEX;
++			} else if (nexthop->type == NEXTHOP_TYPE_IPV6) {
++				nexthop->ifindex = newhop->ifindex;
++				nexthop->type = NEXTHOP_TYPE_IPV6_IFINDEX;
++			} else if (nexthop->ifindex != newhop->ifindex) {
+ 				if (IS_ZEBRA_DEBUG_RIB_DETAILED)
+ 					zlog_debug(
+ 						"%s: %pNHv given ifindex does not match nexthops ifindex found: %pNHv",
+-- 
+2.39.3 (Apple Git-145)
+

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -546,14 +546,10 @@ in {
     })];
   });
 
-  tcpdump-vxlan = (super.tcpdump.override {
+  tcpdump = (super.tcpdump.override {
     libpcap = self.libpcap-vxlan;
   }).overrideAttrs(old: {
     pname = "tcpdump-vxlan";
-    fixupPhase = ''
-      mv $out/bin/tcpdump $out/bin/tcpdump-vxlan
-      rm $out/bin/tcpdump.${super.tcpdump.version}
-    '';
   });
 
   temporal_tables = super.callPackage ./postgresql/temporal_tables { };

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -114,7 +114,17 @@ in {
     };
   });
 
-  inherit (nixpkgs-23_05) frr;
+  frr = nixpkgs-23_05.frr.overrideAttrs (old: rec {
+    version = "8.5.4";
+    src = super.fetchFromGitHub {
+      owner = "FRRouting";
+      repo = old.pname;
+      rev = "${old.pname}-${version}";
+      sha256 = "1hyb5ji6fdzlhl28syvlqf1h4d6bv56rw5m547rbk3b1nknlmrbh";
+    };
+
+    patches = [];
+  });
 
   gitlab = super.callPackage ./gitlab { };
   gitlab-workhorse = super.callPackage ./gitlab/gitlab-workhorse { };

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -78,6 +78,10 @@ in {
 
   docsplit = super.callPackage ./docsplit { };
 
+  dstat = super.dstat.overrideAttrs(old: rec {
+    patches = old.patches ++ [ ./dstat-interface-altnames.patch ];
+  });
+
   elasticsearch7 = (super.elasticsearch7.override {
     jre_headless = self.jdk11_headless;
   }).overrideAttrs(_: rec {

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -127,7 +127,11 @@ in {
       sha256 = "1hyb5ji6fdzlhl28syvlqf1h4d6bv56rw5m547rbk3b1nknlmrbh";
     };
 
-    patches = [];
+    patches = [
+      ./frr/0001-zebra-re-install-nhg-on-interface-up.patch
+      ./frr/0002-zebra-re-install-dependent-nhgs-on-interface-up.patch
+      ./frr/0003-zebra-fix-nhg-out-of-sync-between-zebra-and-kernel.patch
+    ];
   });
 
   gitlab = super.callPackage ./gitlab { };

--- a/tests/frr.nix
+++ b/tests/frr.nix
@@ -1,0 +1,141 @@
+import ./make-test-python.nix ({ pkgs, ... }:
+let
+
+  makeAddress = idx: "192.168.42.${toString idx}";
+
+  makeHost = idx: isRouter: { lib, pkgs, ... }: let
+    vlans = [ idx (if idx == 4 then 1 else idx + 1)];
+  in {
+    imports = [ ../nixos ../nixos/roles ];
+    services.telegraf.enable = false;
+    virtualisation.vlans = vlans;
+    networking = lib.mkForce {
+      useDHCP = false;
+        firewall.allowPing = true;
+        firewall.checkReversePath = false;
+        interfaces.eth1 = {};
+        interfaces.eth2 = {};
+        interfaces.underlay.ipv4.addresses = [
+          { address = makeAddress idx; prefixLength = 32; }
+        ];
+        firewall.trustedInterfaces = [ "eth1" "eth2" ];
+    };
+
+    boot.kernel.sysctl."net.ipv4.conf.all.ip_forward" = 1;
+    boot.extraModprobeConfig = "options dummy numdummies=0";
+    boot.initrd.availableKernelModules = [ "dummy" ];
+
+    systemd.services."network-link-properties-underlay" = rec {
+      description = "Set up underlay loopback device";
+      wantedBy = [ "network-addresses-underlay.service" "multi-user.target" ];
+      before = wantedBy;
+      path = [ pkgs.iproute2 ];
+      script = "ip link add underlay type dummy";
+      preStop = "ip link delete underlay";
+      serviceConfig.Type = "oneshot";
+      serviceConfig.RemainAfterExit = true;
+    };
+
+    services.frr = {
+      zebra.enable = true;
+      zebra.config = ''
+          frr version 8.5.1
+          frr defaults datacentre
+          !
+          route-map set-source-address permit 1
+           set src ${makeAddress idx}
+          exit
+          !
+          ip protocol bgp route-map set-source-address
+      '';
+      bfd.enable = true;
+      bgp.enable = true;
+      bgp.config = ''
+          frr version 8.5.1
+          frr defaults datacenter
+          !
+          router bgp 6500${toString idx}
+           bgp router-id ${makeAddress idx}
+           bgp bestpath as-path multipath-relax
+           no bgp ebgp-requires-policy
+           neighbor remotes peer-group
+           neighbor remotes remote-as external
+           neighbor remotes capability extended-nexthop
+           neighbor remotes bfd
+           neighbor eth1 interface peer-group remotes
+           neighbor eth2 interface peer-group remotes
+           !
+           address-family ipv4 unicast
+            redistribute connected
+            neighbor remotes prefix-list accept-all in
+            neighbor remotes prefix-list ${if isRouter then "accept-all" else "accept-self"} out
+           exit-address-family
+          !
+          exit
+          !
+          ip prefix-list accept-self seq 1 permit ${makeAddress idx}/32
+          !
+          ip prefix-list accept-all seq 1 permit ${makeAddress 0}/24 le 32
+      '';
+    };
+  };
+
+in {
+  name = "frr";
+  nodes = {
+    host1 = makeHost 1 false;
+    switch1 = makeHost 2 true;
+    host2 = makeHost 3 false;
+    switch2 = makeHost 4 true;
+  };
+
+  testScript = ''
+    start_all()
+    all_vms = [host1, host2, switch1, switch2]
+    for vm in all_vms:
+        vm.wait_for_unit("network-online.target")
+
+    for vm in all_vms:
+        x = vm.succeed("vtysh -c 'show version'")
+        print(x)
+
+    with subtest("wait for multi-path BGP routes to appear"):
+        for host, remote, peer_addr in [
+            (host1, 3, ["203", "104"]),
+            (host2, 1, ["303", "404"]),
+        ]:
+            for addr in peer_addr:
+                host.wait_until_succeeds(
+                    f"ip route show 192.168.42.{remote} | grep -F fe80::5054:ff:fe12:{addr}"
+                )
+
+    with subtest("check basic network reachability"):
+        host1.succeed("ping -c1 192.168.42.3")
+        host2.succeed("ping -c1 192.168.42.1")
+
+    with subtest("check nexthop group sync for indirect routes after link loss"):
+        # bug in (at least) 8.5.4: when a link goes down, nexthops pointing
+        # to the faulty link are deleted and removed from nexthop groups
+        # (for ecmp routes) by the kernel. when the link comes back up, frr
+        # recreates the nexthops pointing to the link, but does not
+        # correctly reinstall them into nexthop groups for indirect ecmp routes.
+
+        # simulate link loss (e.g. hardware fluke) by simply setting the
+        # link down.
+        host1.succeed("ip link set eth1 down")
+        host1.wait_until_succeeds("journalctl -u bgpd | grep -E 'eth1.*in vrf default Down'")
+        host1.sleep(2)
+
+        # recover from link loss event
+        host1.succeed("ip link set eth1 up")
+        host1.wait_until_succeeds("journalctl -u bgpd -n1 | grep -F 'End-of-RIB for IPv4 Unicast from eth1'")
+        host1.sleep(5)
+
+        out = host1.succeed("ip route show 192.168.42.3")
+        print(out)
+
+        host1.succeed("ip route show 192.168.42.3 | grep -F fe80::5054:ff:fe12:203")
+        host1.succeed("ip route show 192.168.42.3 | grep -F fe80::5054:ff:fe12:104")
+
+  '';
+})


### PR DESCRIPTION
This change includes further configuration changes and adjustments to improve usability and stability of VXLAN in the platform.

- The naming scheme of underlay interfaces has changed. The virtual loopback device is now called `ul-loopback`, and the underlay ethernet interfaces are now more clearly named based on dash-separated components of the interface label -- e.g. an interface with the label "external/upper" now becomes `ul-extern-upper`.
- Underlay interfaces now have regularly updated alias names ("altnames" in iproute2) based on the hostname of the switch device learned via LLDP -- e.g. the interface attached to the switch stan31 will be assigned an alias `ul-port-stan31`. dstat has been extended with support for using alias names as well as canonical interface names.
- FRR has been updated to the latest stable version on the 8.5 branch, with some additional patches backported to fix issues with synchronisation of nexthop groups with the kernel. FRR's routing daemons are also now consistently restarted after crashes.
- rp_filter sysctls are now set more reliably on the underlay network interfaces.
- There is a new regression test to attempt to detect problems with nexthop group synchronisation which we've run into previously.

PL-131630

@flyingcircusio/release-managers

## Release process

Impact: internal

Changelog:

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Platform network functionality should provide stable operations to avoid disruptions to customer service.
- [x] Security requirements tested? (EVIDENCE)
  - Manually tested on a development host, including verification of the fix for the nexthop group synchronisation issue in FRR.
  - The integration test correctly fails with FRR 8.5.1 from NixOS 23.05, and passes with FRR 8.5.4 with the backported patches.