### PR TITLE
[PL-132197] nixos/dev-vm: run varnish as dualstack to be consistent with production VMs

### DIFF
--- a/nixos/infrastructure/dev-vm.nix
+++ b/nixos/infrastructure/dev-vm.nix
@@ -98,7 +98,7 @@ in
 
       flyingcircus.roles.mysql.listenAddresses = [ "::" ];
 
-      flyingcircus.roles.webproxy.listenAddresses = [ "[::]" ];
+      flyingcircus.roles.webproxy.listenAddresses = [ "[::]" "0.0.0.0" ];
 
       flyingcircus.services.nginx.defaultListenAddresses = [ "0.0.0.0" "[::]" ];
       flyingcircus.services.redis.listenAddresses = [ "[::]" ];


### PR DESCRIPTION
PL-132197

In some deployments we use IPv4 addresses for the
nginx->varnish->haproxy chain. This breaks when talking to varnish in a dev-host setup however as it listens to IPv6 only in a dev-host environment which is inconsistent with the production VMs.

`::` isn't enough for that, Varnish forces `::` to be IPv6-only[1].

[1] https://github.com/varnishcache/varnish-cache/blob/223847ea09a0a5440510fe8c383bdac56890dff5/lib/libvarnish/vtcp.c#L448-L460

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:
* Varnish listens on both IPv4 & IPv6 in a dev-host environment (PL-132197)

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Varnish should not be reachable from outside.
- [x] Security requirements tested? (EVIDENCE)
  - Confirmed via `nmap -Pn <host> -p 8008 -6` & `nmap -Pn <host> -p 8008` that the port is closed. The firewall only exposes the TCP ports `80`/`443`/`22`.
