### PR TITLE
Update nixpkgs (2024-02-14)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -26,11 +26,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1707004164,
-        "narHash": "sha256-9Hr8onWtvLk5A8vCEkaE9kxA0D7PR62povFokM1oL5Q=",
+        "lastModified": 1707817777,
+        "narHash": "sha256-vHyIs1OULQ3/91wD6xOiuayfI71JXALGA5KLnDKAcy0=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "0e68853bb27981a4ffd7a7225b59ed84f7180fc7",
+        "rev": "5a30b9e5ac7c6167e61b1f4193d5130bb9f8defa",
         "type": "github"
       },
       "original": {
@@ -202,11 +202,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1707338246,
-        "narHash": "sha256-1hxtQlAMcdqM+HgNih3y41P4hYw8VJjCMIK5Y+Y+KHw=",
+        "lastModified": 1707995553,
+        "narHash": "sha256-/GTFOYJ628DM4AbK9bBHEINnrtY1NOOM0n5yjME8g1k=",
         "owner": "flyingcircusio",
         "repo": "nixpkgs",
-        "rev": "ba2e1304f4d32379d4d884abe679df5ad06fbfa0",
+        "rev": "6b5bfd4e08375ccb7aadb9e64b9391a89bb856e6",
         "type": "github"
       },
       "original": {

--- a/release/package-versions.json
+++ b/release/package-versions.json
@@ -75,9 +75,9 @@
     "version": "121.0.6167.85"
   },
   "chromium": {
-    "name": "chromium-121.0.6167.139",
+    "name": "chromium-121.0.6167.160",
     "pname": "chromium",
-    "version": "121.0.6167.139"
+    "version": "121.0.6167.160"
   },
   "cifs-utils": {
     "name": "cifs-utils-7.0",
@@ -85,9 +85,9 @@
     "version": "7.0"
   },
   "clamav": {
-    "name": "clamav-1.2.1",
+    "name": "clamav-1.2.2",
     "pname": "clamav",
-    "version": "1.2.1"
+    "version": "1.2.2"
   },
   "cmake": {
     "name": "cmake-3.27.7",
@@ -185,9 +185,9 @@
     "version": "7.17.16"
   },
   "firefox": {
-    "name": "firefox-122.0",
+    "name": "firefox-122.0.1",
     "pname": "firefox",
-    "version": "122.0"
+    "version": "122.0.1"
   },
   "gcc": {
     "name": "gcc-wrapper-12.3.0",
@@ -220,9 +220,9 @@
     "version": "16.7.5"
   },
   "github-runner": {
-    "name": "github-runner-2.312.0",
+    "name": "github-runner-2.313.0",
     "pname": "github-runner",
-    "version": "2.312.0"
+    "version": "2.313.0"
   },
   "gitlab": {
     "name": "gitlab-16.7.5",
@@ -460,9 +460,9 @@
     "version": "3.3.5"
   },
   "mastodon": {
-    "name": "mastodon-4.2.5",
+    "name": "mastodon-4.2.6",
     "pname": "mastodon",
-    "version": "4.2.5"
+    "version": "4.2.6"
   },
   "matomo": {
     "name": "matomo-4.15.1",
@@ -700,29 +700,29 @@
     "version": "3.8.5"
   },
   "postgresql": {
-    "name": "postgresql-15.5",
+    "name": "postgresql-15.6",
     "pname": "postgresql",
-    "version": "15.5"
+    "version": "15.6"
   },
   "postgresql_12": {
-    "name": "postgresql-12.17",
+    "name": "postgresql-12.18",
     "pname": "postgresql",
-    "version": "12.17"
+    "version": "12.18"
   },
   "postgresql_13": {
-    "name": "postgresql-13.13",
+    "name": "postgresql-13.14",
     "pname": "postgresql",
-    "version": "13.13"
+    "version": "13.14"
   },
   "postgresql_14": {
-    "name": "postgresql-14.10",
+    "name": "postgresql-14.11",
     "pname": "postgresql",
-    "version": "14.10"
+    "version": "14.11"
   },
   "postgresql_15": {
-    "name": "postgresql-15.5",
+    "name": "postgresql-15.6",
     "pname": "postgresql",
-    "version": "15.5"
+    "version": "15.6"
   },
   "powerdns": {
     "name": "pdns-4.8.4",
@@ -985,9 +985,9 @@
     "version": "9.0.2116"
   },
   "webkitgtk": {
-    "name": "webkitgtk-2.42.4+abi=4.0",
+    "name": "webkitgtk-2.42.5+abi=4.0",
     "pname": "webkitgtk",
-    "version": "2.42.4"
+    "version": "2.42.5"
   },
   "wget": {
     "name": "wget-1.21.4",

--- a/release/versions.json
+++ b/release/versions.json
@@ -8,9 +8,9 @@
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/"
   },
   "nixpkgs": {
-    "hash": "sha256-1hxtQlAMcdqM+HgNih3y41P4hYw8VJjCMIK5Y+Y+KHw=",
+    "hash": "sha256-/GTFOYJ628DM4AbK9bBHEINnrtY1NOOM0n5yjME8g1k=",
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "ba2e1304f4d32379d4d884abe679df5ad06fbfa0"
+    "rev": "6b5bfd4e08375ccb7aadb9e64b9391a89bb856e6"
   }
 }


### PR DESCRIPTION
Pull upstream NixOS changes, security fixes and package updates:

- chromium: 121.0.6167.139 -> 121.0.6167.160
- github-runner: 2.312.0 -> 2.313.0
- mastodon: 4.2.5 -> 4.2.6 (CVE-2024-25122, CVE-2024-25062, CVE-2024-25618)
- postgresql_12: 12.17 -> 12.18 (CVE-2024-0985)
- postgresql_13: 13.13 -> 13.14 (CVE-2024-0985)
- postgresql_14: 14.10 -> 14.11 (CVE-2024-0985)
- postgresql_15: 15.5 -> 15.6 (CVE-2024-0985)
- webkitgtk: 2.42.4 → 2.42.5 (CVE-2024-23222, CVE-2024-23206, CVE-2024-23213)

PL-132189

@flyingcircusio/release-managers

## Release process


### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

Impact:

- \[NixOS 23.11\] Machines will reboot after the update to activate the
   changed kernel.

Changelog:

(include changed packages from commit msg)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - pull in upstream security fixes regularly
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still run, works on various test VM
  - checked commit log for fixed CVEs and possible problems with updates, looked at [PostgreSQL: Release Notes](https://www.postgresql.org/docs/release/16.2/)