### PR TITLE
Revert Nginx rate limiting #897

### DIFF
--- a/nixos/services/nginx/base-module.nix
+++ b/nixos/services/nginx/base-module.nix
@@ -211,17 +211,6 @@ let
 
       server_tokens ${if cfg.serverTokens then "on" else "off"};
 
-      # CVE-2023-44487 handling with relatively high limits to
-      # not impact customer applications too much. Can be limited further
-      # if necessary.
-      limit_conn_zone $binary_remote_addr zone=addr:10m;
-      limit_conn addr 100;
-      limit_conn_status 429;
-
-      limit_req_zone $binary_remote_addr zone=perclient:10m rate=10r/s;
-      limit_req zone=perclient burst=50;
-      limit_req_status 429;
-
       ${cfg.commonHttpConfig}
 
       ${vhosts}

--- a/tests/nginx.nix
+++ b/tests/nginx.nix
@@ -348,21 +348,5 @@ in {
       assert_reachable(server4, "fe.local -6")
       assert_unreachable(server4, "fe.local -4")
       assert_unreachable(server4, "srv.local")
-
-    with subtest("[5] rate limiting connections"):
-      import re
-      # Running this against the other virtual hosts fails. I *think* this is
-      # because we have a "return 200" statement on the root location there
-      # which seems to short-circuit the rate limiting ... o_O
-      out = server4.execute("${pkgs.apacheHttpd}/bin/ab -n 1000 -c 75 http://localhost:81/")[1]
-      print(out)
-      assert re.search("Complete requests: +1000", out), "incomplete test"
-      error_match = re.search("Connect: ([0-9]+), Receive: ([0-9]+), Length: ([0-9]+), Exceptions: ([0-9]+)", out)
-      assert error_match, "Missing connection errors"
-      errors = error_match.groups()  # type: ignore
-      assert int(errors[0]) == 0
-      assert int(errors[1]) == 0
-      assert int(errors[2]) > 900
-      assert int(errors[3]) == 0
   '';
 })


### PR DESCRIPTION
This reverts commit 61ee83153719795586ffac73d47aa9dbd3519823 // PR #897.

We experienced some applications hitting the limits regularly with legitimate traffic. We'll come back with a configurable and better monitored solution later.

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

### PR release workflow (internal)

- [ ] PR has internal ticket
- [ ] internal issue ID (PL-…) part of branch name
- [ ] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - same as before the original change was done. We lose some DOS protection for the moment but we haven't experienced this problem, yet.
- [x] Security requirements tested? (EVIDENCE)
  - nothing to test, restores old state  
