### PR TITLE
Allow varnish command line to be overridden

### DIFF
--- a/nixos/roles/webproxy.nix
+++ b/nixos/roles/webproxy.nix
@@ -86,7 +86,7 @@ in
 
       flyingcircus.services.varnish = {
         enable = true;
-        extraCommandLine = "-s malloc,${toString cacheMemory}M";
+        extraCommandLine = fclib.mkPlatform "-s malloc,${toString cacheMemory}M";
         http_address = lib.concatMapStringsSep " -a "
           (addr: "${addr}:8008") fccfg.listenAddresses;
         virtualHosts = lib.optionalAttrs (varnishCfg != null) {


### PR DESCRIPTION
The varnish service provided by the platform (which itself is a wrapper around the upstream NixOS module) exposes an option to allow passing additional command line arguments to varnish. This is used by the webproxy role in order to configure memory limits in varnish, however the configuration is written such that it's not possible to override the command line further in other user-specified configuration.

This change adjusts the configuration in the webproxy role with `fclib.mkPlatform` to allow the varnish command line to be properly overridden elsewhere.

PL-132106

@flyingcircusio/release-managers

## Release process

Impact:

Changelog: The Varnish command line can now be overridden when the webproxy role is enabled by setting the `flyingcircus.services.varnish.extraCommandLine` option (PL-132106).

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Service configuration should be appropriately flexible to accommodate the requirements of customer applications while still providing sensible defaults.
- [x] Security requirements tested? (EVIDENCE)
  - Manually tested in a dev VM. Verified that the configuration example provided in the original ticket now builds correctly.