### PR TITLE
agent: fix handling of acceptable status codes

### DIFF
--- a/pkgs/fc/agent/fc/manage/monitor.py
+++ b/pkgs/fc/agent/fc/manage/monitor.py
@@ -48,8 +48,11 @@ def get_sensucheck_configuration(servicechecks):
             command.extend(["-a", auth_pair])
         if servicecheck["redirect"]:
             command.extend(["-f", "follow"])
-        if len(servicecheck["acceptable"]) > 0:
-            command.extend(["-e", ",".join(servicecheck["acceptable"])])
+        if servicecheck["acceptable"]:
+            command.append("-e")
+            command.append(
+                ",".join(str(status) for status in servicecheck["acceptable"]),
+            )
         checks[name] = dict(
             command=" ".join(command),
             interval=120,


### PR DESCRIPTION
`acceptable` is a list of ints, not str as previously expected.

PL-132208

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Security implications

- [ ] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [ ] Security requirements tested? (EVIDENCE)
