### PR TITLE
Update nixpkgs for gitlab and mastodon (2024-02-21)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -26,11 +26,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1707817777,
-        "narHash": "sha256-vHyIs1OULQ3/91wD6xOiuayfI71JXALGA5KLnDKAcy0=",
+        "lastModified": 1708538593,
+        "narHash": "sha256-2q3tdg3TirbrTEPaVFTfxMG0TJdE77GsC6s5aHJhWkQ=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "5a30b9e5ac7c6167e61b1f4193d5130bb9f8defa",
+        "rev": "f5d594f79022f4468fae9d04418cb607890a9347",
         "type": "github"
       },
       "original": {
@@ -202,11 +202,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1707995553,
-        "narHash": "sha256-/GTFOYJ628DM4AbK9bBHEINnrtY1NOOM0n5yjME8g1k=",
+        "lastModified": 1708542281,
+        "narHash": "sha256-qqVh1V539s7SyzQm1xDibQAgpUqZf1VxH6zFjuSZ+t0=",
         "owner": "flyingcircusio",
         "repo": "nixpkgs",
-        "rev": "6b5bfd4e08375ccb7aadb9e64b9391a89bb856e6",
+        "rev": "1500c3e4108bffa770168871073aa30132bef303",
         "type": "github"
       },
       "original": {

--- a/release/package-versions.json
+++ b/release/package-versions.json
@@ -215,9 +215,9 @@
     "version": "2.42.0"
   },
   "gitaly": {
-    "name": "gitaly-16.7.5",
+    "name": "gitaly-16.7.6",
     "pname": "gitaly",
-    "version": "16.7.5"
+    "version": "16.7.6"
   },
   "github-runner": {
     "name": "github-runner-2.313.0",
@@ -225,9 +225,9 @@
     "version": "2.313.0"
   },
   "gitlab": {
-    "name": "gitlab-16.7.5",
+    "name": "gitlab-16.7.6",
     "pname": "gitlab",
-    "version": "16.7.5"
+    "version": "16.7.6"
   },
   "gitlab-container-registry": {
     "name": "gitlab-container-registry-3.88.1",
@@ -235,14 +235,14 @@
     "version": "3.88.1"
   },
   "gitlab-ee": {
-    "name": "gitlab-ee-16.7.5",
+    "name": "gitlab-ee-16.7.6",
     "pname": "gitlab-ee",
-    "version": "16.7.5"
+    "version": "16.7.6"
   },
   "gitlab-pages": {
-    "name": "gitlab-pages-16.7.5",
+    "name": "gitlab-pages-16.7.6",
     "pname": "gitlab-pages",
-    "version": "16.7.5"
+    "version": "16.7.6"
   },
   "gitlab-runner": {
     "name": "gitlab-runner-16.7.0",
@@ -250,9 +250,9 @@
     "version": "16.7.0"
   },
   "gitlab-workhorse": {
-    "name": "gitlab-workhorse-16.7.5",
+    "name": "gitlab-workhorse-16.7.6",
     "pname": "gitlab-workhorse",
-    "version": "16.7.5"
+    "version": "16.7.6"
   },
   "glibc": {
     "name": "glibc-2.38-27",
@@ -460,9 +460,9 @@
     "version": "3.3.5"
   },
   "mastodon": {
-    "name": "mastodon-4.2.6",
+    "name": "mastodon-4.2.7",
     "pname": "mastodon",
-    "version": "4.2.6"
+    "version": "4.2.7"
   },
   "matomo": {
     "name": "matomo-4.15.1",

--- a/release/versions.json
+++ b/release/versions.json
@@ -8,9 +8,9 @@
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/"
   },
   "nixpkgs": {
-    "hash": "sha256-/GTFOYJ628DM4AbK9bBHEINnrtY1NOOM0n5yjME8g1k=",
+    "hash": "sha256-qqVh1V539s7SyzQm1xDibQAgpUqZf1VxH6zFjuSZ+t0=",
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "6b5bfd4e08375ccb7aadb9e64b9391a89bb856e6"
+    "rev": "1500c3e4108bffa770168871073aa30132bef303"
   }
 }


### PR DESCRIPTION
- gitlab: 16.7.5 -> 16.7.6 (CVE-2023-4895, CVE-2024-0861, CVE-2023-3509, CVE-2024-0410)
- mastodon: 4.2.6 -> 4.2.7 (CVE-2024-25623)

PL-132233

@flyingcircusio/release-managers

## Release process

Impact:

- \[NixOS 23.11] Gitlab will be restarted.

Changelog:

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - apply security updates asap 
- [x] Security requirements tested? (EVIDENCE)
  - checked on our Gitlab staging system that Gitlab works according to our checklist
  - mastodon 4.2.7 already in use on two VMs
