### PR TITLE
doc: Add label to index page for intersphinx

### DIFF
--- a/doc/src/index.md
+++ b/doc/src/index.md
@@ -1,3 +1,4 @@
+(nixos-platform-index)=
 # NixOS {{ release }} edition
 
 Platform & roles documentation for Flying Circus [NixOS] edition


### PR DESCRIPTION
This allows referencing the full page itself via intersphinx with {external+platform-current:ref}`nixos-platform-index`

For generating a proper intersphinx reference pelacing the broken `[](/roles/current/)`, a top-level label is required as a target.
PL-132142

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - none
- [x] Security requirements tested? (EVIDENCE)
  - [x] checked that docs still build and references are linked
