### PR TITLE
[PL-132241] roles/gitlab: enable CSP by default

### DIFF
--- a/nixos/roles/gitlab.nix
+++ b/nixos/roles/gitlab.nix
@@ -53,6 +53,16 @@ in
         '';
       };
 
+      csp.enable = lib.mkOption {
+        default = true;
+        type = types.bool;
+        description = ''
+          Enable sending Content Security Policy headers.
+          See the [Mozilla documentation about CSP](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP)
+          for details.
+        '';
+      };
+
       hsts = {
         enable = lib.mkOption {
           # GitLab not being the default vhost is a heuristic for uncommon setups
@@ -138,6 +148,10 @@ in
       https = true;
       port = 443;
       host = cfg.hostName;
+
+      extraConfig.gitlab = lib.mkIf cfg.csp.enable {
+        content_security_policy = { enabled = true; report_only = fclib.mkPlatform false; };
+      };
 
       secrets = fclib.mkPlatform {
         dbFile = "${cfg.secretsDir}/db";

--- a/tests/gitlab.nix
+++ b/tests/gitlab.nix
@@ -97,12 +97,13 @@ import ./make-test-python.nix ({ pkgs, lib, testlib, ...} : with lib; {
 
     gitlab.wait_until_succeeds("curl -sSf http://gitlab/users/sign_in")
 
-    with subtest("Gitlab has HSTS headers"):
+    with subtest("Gitlab has HSTS/CSP headers"):
       # curl supports parsing HSTS headers, but only when connecting via HTTPS.
       # So just check for the header.
       request_headers = gitlab.succeed("curl http://gitlab/users/sign_in -I | cat").split('\n')
       print(request_headers)
       assert 'Strict-Transport-Security: max-age=3600; includeSubDomains' in map(lambda s: s.strip(), request_headers)
+      assert any(header.startswith("Content-Security-Policy: base-uri 'self';") for header in request_headers)
 
     with subtest("test basic Gitlab REST API actions"):
       gitlab.succeed(


### PR DESCRIPTION
PL-132241

See https://docs.gitlab.com/omnibus/settings/configuration.html#set-a-content-security-policy

By enabling this, the Rails application will generate a proper CSP header in accordance to what assets are delivered. From now on, this is the default for each GitLab.

Confirmed that this behaves properly by testing it on our test instance on fcstag60. Also wrote a small integration test to make sure that such a header is always delivered with a non-empty value (currently, the header already exists according to curl, but is empty).

@flyingcircusio/release-managers

## Release process

Impact:

Changelog: GitLab now sends the `Content-Security-Header` by default (PL-132241)

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - GitLab sends a correctly generated CSP header by default.
- [x] Security requirements tested? (EVIDENCE)
  - Added an assertion to the integration test to make sure this is the case
  - Confirmed manually that the header is sent and the page still works correctly on fcstag60.
