### PR TITLE
Ensure docker firewall rules are deleted when role is removed.

### DIFF
--- a/nixos/roles/docker.nix
+++ b/nixos/roles/docker.nix
@@ -2,6 +2,7 @@
 
 let
   fclib = config.fclib;
+  cfg = config.flyingcircus.roles.docker;
 in
 {
   options = {
@@ -11,40 +12,51 @@ in
     };
   };
 
-  config = lib.mkIf config.flyingcircus.roles.docker.enable {
-    environment.systemPackages = [ pkgs.docker-compose ];
-    flyingcircus.users.serviceUsers.extraGroups = [ "docker" ];
-    virtualisation.docker.enable = true;
+  config = lib.mkMerge [
+    (lib.mkIf (cfg.enable) {
+      environment.systemPackages = [ pkgs.docker-compose ];
+      flyingcircus.users.serviceUsers.extraGroups = [ "docker" ];
+      virtualisation.docker.enable = true;
 
-    networking.firewall.extraCommands = lib.mkOrder 1200 ''
-      # FC docker rules (1200)
-      # allow access to host from docker networks, we consider this identical
-      # to access from locally running processes.
-      # We grant the full RFC1918 172.16.0.0/12 range.
-      iptables -w -A nixos-fw -i br-+ -s 172.16.0.0/12 -j nixos-fw-accept
-      iptables -w -A nixos-fw -i docker+ -s 172.16.0.0/12 -j nixos-fw-accept
+      networking.firewall.extraCommands = lib.mkOrder 1200 ''
+        # FC docker rules (1200)
+        # allow access to host from docker networks, we consider this identical
+        # to access from locally running processes.
+        # We grant the full RFC1918 172.16.0.0/12 range.
+        iptables -w -A nixos-fw -i br-+ -s 172.16.0.0/12 -j nixos-fw-accept
+        iptables -w -A nixos-fw -i docker+ -s 172.16.0.0/12 -j nixos-fw-accept
 
-      ip46tables -N fc-docker 2>/dev/null || true
-      ip46tables -A fc-docker -m conntrack --ctstate RELATED,ESTABLISHED -j nixos-fw-accept
-      ip46tables -A fc-docker -i ethsrv -j fc-resource-group
-      ip46tables -A fc-docker -i ethsrv -j nixos-fw-refuse
-      ip46tables -A fc-docker -i ethfe -j nixos-fw-refuse
+        ip46tables -N fc-docker 2>/dev/null || true
+        ip46tables -A fc-docker -m conntrack --ctstate RELATED,ESTABLISHED -j nixos-fw-accept
+        ip46tables -A fc-docker -i ethsrv -j fc-resource-group
+        ip46tables -A fc-docker -i ethsrv -j nixos-fw-refuse
+        ip46tables -A fc-docker -i ethfe -j nixos-fw-refuse
 
-      ip46tables -N DOCKER-USER 2>/dev/null || true
-      ip46tables -I DOCKER-USER 1 ! -i docker+ -o docker+ -j fc-docker
-      # End FC docker rules (1200)
-    '';
+        ip46tables -N DOCKER-USER 2>/dev/null || true
+        ip46tables -I DOCKER-USER 1 ! -i docker+ -o docker+ -j fc-docker
+        # End FC docker rules (1200)
+      '';
 
-    networking.firewall.extraStopCommands = lib.mkOrder 1100 ''
-      # FC docker rules (1100)
-      iptables -w -D nixos-fw -i br-+ -s 172.16.0.0/12 -j nixos-fw-accept 2>/dev/null || true
-      iptables -w -D nixos-fw -i docker+ -s 172.16.0.0/12 -j nixos-fw-accept 2>/dev/null || true
-      ip46tables -D DOCKER-USER ! -i docker+ -o docker+ -j fc-docker 2>/dev/null || true
-      ip46tables -F fc-docker 2>/dev/null || true
-      ip46tables -X fc-docker 2>/dev/null || true
-      # End FC docker rules (1100)
-    '';
+      networking.firewall.extraStopCommands = lib.mkOrder 1100 ''
+        # FC docker rules (1100)
+        iptables -w -D nixos-fw -i br-+ -s 172.16.0.0/12 -j nixos-fw-accept 2>/dev/null || true
+        iptables -w -D nixos-fw -i docker+ -s 172.16.0.0/12 -j nixos-fw-accept 2>/dev/null || true
+        ip46tables -D DOCKER-USER ! -i docker+ -o docker+ -j fc-docker 2>/dev/null || true
+        ip46tables -F fc-docker 2>/dev/null || true
+        ip46tables -X fc-docker 2>/dev/null || true
+        # End FC docker rules (1100)
+      '';
+    })
 
-  };
+    (lib.mkIf (!cfg.enable) {
+      networking.firewall.extraStopCommands = lib.mkOrder 1100 ''
+        # FC docker rules (1100) -- ensure absence of docker firewall configuration
+        ip46tables -D DOCKER-USER ! -i docker+ -o docker+ -j fc-docker 2>/dev/null || true
+        ip46tables -F fc-docker 2>/dev/null || true
+        ip46tables -X fc-docker 2>/dev/null || true
+        # End FC docker rules (1100)
+      '';
+    })
 
+  ];
 }


### PR DESCRIPTION
The docker roles adds a number of iptables chains in order to link the platform-provided firewall with the rules managed by the docker daemon. However, when the docker role is removed, these extra chains are not properly removed, as the commands for removing them are also removed from the firewall management scripts. As the additional docker-related chains contain references to other NixOS-managed chains, reloading the firewall after removing the docker role will fail, as the references from the docker chains will prevent the NixOS chains from being deleted and re-created properly.

This change introduces extra commands to the firewall management script when the docker role is *not* enabled, in order to ensure that the docker-related firewall chains are not present which might interfere with the rest of the firewall scripts.

PL-131699

@flyingcircusio/release-managers

## Release process

Impact:

Changelog: The firewall should now continue to function properly after the Docker role is removed (PL-131699).

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - The platform-provided firewall should continue to function correctly when host configuration and the set of enabled roles is changed.
- [x] Security requirements tested? (EVIDENCE)
  - Manually verified on a test VM. When disabling the Docker role with this change applied, the firewall is reloaded and the system rebuild process exit without errors.