### PR TITLE
Allow and merge multiple definitions of extra command line arguments for Varnish.

### DIFF
--- a/doc/src/webproxy.md
+++ b/doc/src/webproxy.md
@@ -38,6 +38,14 @@ You can also put your verbatim Varnish configuration into {file}`/etc/local/varn
 Please note that this way of configuring Varnish is deprecated and will likely
 be removed in the future.
 
+The role passes a handful of command line arguments to Varnish to
+ensure reasonable default behaviour. If you wish to pass extra command
+line arguments to Varnish, then you should use the provided
+`flyingcircus.services.varnish.extraCommandLine` NixOS
+option. Arguments specified using this option (which may be defined
+multiple times) will be merged into the list of arguments passed to
+Varnish along with the role defaults.
+
 ### Monitoring
 
 - We monitor that the varnishd process is running.

--- a/nixos/roles/webproxy.nix
+++ b/nixos/roles/webproxy.nix
@@ -86,7 +86,7 @@ in
 
       flyingcircus.services.varnish = {
         enable = true;
-        extraCommandLine = fclib.mkPlatform "-s malloc,${toString cacheMemory}M";
+        extraCommandLine = "-s malloc,${toString cacheMemory}M";
         http_address = lib.concatMapStringsSep " -a "
           (addr: "${addr}:8008") fccfg.listenAddresses;
         virtualHosts = lib.optionalAttrs (varnishCfg != null) {

--- a/nixos/services/varnish/default.nix
+++ b/nixos/services/varnish/default.nix
@@ -70,7 +70,7 @@ in {
   options.flyingcircus.services.varnish = {
     enable = mkEnableOption "varnish";
     extraCommandLine = mkOption {
-      type = types.str;
+      type = types.separatedString " ";
       default = "";
     };
     http_address = mkOption {


### PR DESCRIPTION
By default the webproxy role provides command line arguments to the Varnish service to add limits for the memory-based cache backend. The role is implemented using the platform Varnish service, and the platform Varnish service is a wrapper around the upstream NixOS service which injects configuration into the latter. The role sets the platform service option `flyingcircus.services.varnish.extraCommandLine`, and the platform service uses this value to set the upstream service option `services.varnish.extraCommandLine`.

However, the two service options only allow a single definition, so passing additional command line arguments to Varnish beyond the defaults requires overriding either the platform or the upstream option and then including the default arguments in the overridden command line specified by the operator.

This change changes the type of `flyingcircus.services.varnish.extraCommandLine` to allow multiple definitions, which are then merged as a space-separated string. This allows the operator to specify additional options (e.g. timeout configuration) which are then merged with the default configuration supplied by the platform role. Additionally, this behaviour has been added to the role documentation to ensure that this is discoverable by Appops and customers.

PL-132136

@flyingcircusio/release-managers

## Release process

Impact:

Changelog: The webproxy role now supports multiple definitions of extra command line arguments to Varnish in the `flyingcircus.services.varnish.extraCommandLine` option. Multiple definitions will be merged as a space-separated string into the command line passed to the varnishd process. (PL-132136)

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - The configuration interface supplied by the platform should be sufficiently flexible to suit the needs of customer applications alongside the provided default values.
- [x] Security requirements tested? (EVIDENCE)
  - Manually verified in a development VM. Setting an extra command line argument in the host configuration is merged alongside the platform default arguments passed to the running Varnish process.