### PR TITLE
lamp: Ensure access to /var/log/httpd logfiles for sudo-srv and service groups

### DIFF
--- a/nixos/roles/lamp.nix
+++ b/nixos/roles/lamp.nix
@@ -262,8 +262,10 @@ in {
         };
 
         systemd.tmpfiles.rules = [
-          "d /var/log/httpd 0750 root service"
-          "a+ /var/log/httpd - - - - group:sudo-srv:r-x"
+          "D /var/log/httpd 2750 root service"
+          "a+ /var/log/httpd - - - - default:group::r-X,default:group:sudo-srv:r-X,default:group:service:r-X,default:mask::r-X"
+          # recursive is required as well to adjust permissions of existing files
+          "A+ /var/log/httpd - - - - group:sudo-srv:r-X,group:service:r-X,group::r-X,mask::r-X"
         ];
 
       })


### PR DESCRIPTION
Enabling our customers to investigate and debug their deployments requires access to logfiles. This concerns the `service` groups (deployment users) and `sudo-srv` (customer admin users) specifically. This PR sets the permissions on `/var/log/httpd` accordingly to give them access:
- ACLs to enable specific permissions for different named groups
- recursive systemd-tmpfiles rule to adjust permissions of existing files
- default ACLs and setgid bit on the directory itself to influence default permissions of newly created files

Special concerns had to be made for php-fpm log files like the slow log. As upstream php-fpm unfortunately explicitly sets the file permissions to 0600, we now need to patch php to more permissive defaults.

@flyingcircusio/release-managers

PL-131938

## Release process

Impact:
- phpfpm services will restart

Changelog:
- ensure read access to `/var/log/httpd/*` files for users from sudo-srv and services groups 

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - provide fine-grainde access control to log files that is as permissive as needed, but still restricts undesired access
- [x] Security requirements tested? (EVIDENCE)
  - [x] explicitly setting ACLs for named permitted groups allows specific grants of access
  - [x] manually tested permissions on a test vm, including logrotate invocations
  - [x] new automated test case
  - [x] automated tests still pass, no known regressions
