### PR TITLE
[21.05]: full-disk encryption continuation, encrypted backups

### DIFF
--- a/nixos/platform/full-disk-encryption.nix
+++ b/nixos/platform/full-disk-encryption.nix
@@ -1,6 +1,7 @@
 { lib, pkgs, config, options, ... }:
 
 let
+  fclib = config.fclib;
   keysMountDir = "/mnt/keys";
   check_key_file = pkgs.writeShellScript "check_key_file" ''
 
@@ -28,6 +29,8 @@ let
 
       exit 0
     '';
+
+  cephPkgs = fclib.ceph.mkPkgs "nautilus";  # FIXME: just a workaround
 in
 {
 
@@ -51,6 +54,8 @@ in
   {
       environment.systemPackages = with pkgs; [
         cryptsetup
+        # FIXME: isolate fc-luks tooling into separate package
+        cephPkgs.fc-ceph
       ];
 
       flyingcircus.services.sensu-client.checks.keystickMounted = {

--- a/nixos/roles/backyserver.nix
+++ b/nixos/roles/backyserver.nix
@@ -68,6 +68,18 @@ in
       cephRelease = fclib.ceph.releaseOption // {
         description = "Codename of the Ceph release series used as external backy tooling.";
       };
+
+      # this indirection is required by the tests as a config input
+      fsOptions = lib.mkOption {
+        type = lib.types.attrs;
+        readOnly = true;
+        internal = true;
+        default =  {
+          device = "/dev/disk/by-label/backy";
+          fsType = "xfs";
+          options = [ "nofail" "nodev" "nosuid" "noatime" "nodiratime"];
+        };
+      };
     };
 
   };
@@ -94,10 +106,7 @@ in
       backy	${role.blockDevice}	/mnt/keys/${config.networking.hostName}.key	discard,nofail,submit-from-crypt-cpus${lib.optionalString role.externalCryptHeader ",header=${external_header}"}
     '';
 
-    fileSystems.${backyMountDir} = {
-      device = "/dev/disk/by-label/backy";
-      fsType = "xfs";
-    };
+    fileSystems.${backyMountDir} = role.fsOptions;
 
     services.telegraf.extraConfig.inputs.disk = [
       { mount_points = [ "/srv/backy" ]; }

--- a/nixos/roles/backyserver.nix
+++ b/nixos/roles/backyserver.nix
@@ -47,7 +47,7 @@ in
       blockDevice = lib.mkOption {
         type = lib.types.str;
         description = ''
-          The *unencrypted* blockdevice to be used as a base for an encrypted Backy volume.
+          The underlying blockdevice to be used as a base for an encrypted Backy volume.
           Can be provided in fstab/ crypttab syntax as well, e.g. `LABEL=`.
           Examples are a partition, mdraid or logical volume.'';
         default = "/dev/vgbackup/backy-crypted";

--- a/pkgs/fc/ceph/default.nix
+++ b/pkgs/fc/ceph/default.nix
@@ -33,7 +33,7 @@ py.buildPythonApplication rec {
   };
 
   checkPhase = ''
-    pytest src/fc/ceph
+    pytest -vv src/fc/ceph
   '';
 
 }

--- a/pkgs/fc/ceph/src/fc/ceph/backup.py
+++ b/pkgs/fc/ceph/src/fc/ceph/backup.py
@@ -22,12 +22,14 @@ class BackyVolume:
     MKFS_OPTS = ["-K"]
     MOUNT_OPTS = "nodev,nosuid,noatime,nodiratime"
 
-    def __init__(self, name: str, mountpoint: str = "/srv/backy"):
-        self.name = f"backy-{name}"
+    def __init__(self, name: str, mountpoint: str):
+        self.name = name
         self.mountpoint = mountpoint
         self.lv = GenericLogicalVolume(self.name)
 
-    def create(self, blockdevices: list[str], encrypt: bool = True):
+    def create(
+        self, blockdevices: list[str], vgname: str, encrypt: bool = True
+    ):
         # underlay Mdraid hopefully always self-assembles, no need to keep an
         # instance-wide reference after successful creation
         raid = MdraidDevice.create(self.name, blockdevices)

--- a/pkgs/fc/ceph/src/fc/ceph/backup.py
+++ b/pkgs/fc/ceph/src/fc/ceph/backup.py
@@ -1,0 +1,61 @@
+from fc.ceph.lvm import (
+    AutomountActivationMixin,
+    GenericLogicalVolume,
+    MdraidDevice,
+)
+from fc.ceph.util import console, run
+
+
+class BackupManager:
+    @staticmethod
+    def create(
+        name: str, vgname: str, disks: list[str], encrypt: bool, mountpoint: str
+    ):
+        console.print(
+            f"Creating new backup volume {vgname}/{name} on disks {', '.join(disks)}…"
+        )
+        vol = BackyVolume(name, mountpoint)
+        vol.create(disks, vgname, encrypt)
+
+
+class BackyVolume:
+    MKFS_OPTS = ["-K"]
+    MOUNT_OPTS = "nodev,nosuid,noatime,nodiratime"
+
+    def __init__(self, name: str, mountpoint: str = "/srv/backy"):
+        self.name = f"backy-{name}"
+        self.mountpoint = mountpoint
+        self.lv = GenericLogicalVolume(self.name)
+
+    def create(self, blockdevices: list[str], encrypt: bool = True):
+        # underlay Mdraid hopefully always self-assembles, no need to keep an
+        # instance-wide reference after successful creation
+        raid = MdraidDevice.create(self.name, blockdevices)
+        self.lv = GenericLogicalVolume.create(
+            self.name, vgname, raid, encrypt, size="100%vg"
+        )
+        run.mkfs_xfs(
+            # fmt: off
+            "-f",
+            "-L", self.name,
+            *self.MKFS_OPTS,
+            self.device
+        )
+        run.sync()
+        self.activate()
+
+    def activate(self):
+        self.lv.activate()
+        # for the mdraid, we rely on the OS for automatically assembling it
+
+    @property
+    def encrypted(self) -> bool:
+        return self.lv.encrypted
+
+    @property
+    def exists(self) -> bool:
+        return self.lv.exists(self.name)
+
+    @property
+    def device(self):
+        return self.lv.device

--- a/pkgs/fc/ceph/src/fc/ceph/backup.py
+++ b/pkgs/fc/ceph/src/fc/ceph/backup.py
@@ -1,3 +1,5 @@
+import os
+
 from fc.ceph.lvm import (
     AutomountActivationMixin,
     GenericLogicalVolume,
@@ -44,6 +46,22 @@ class BackyVolume:
             self.device
         )
         run.sync()
+
+        if os.path.exists(ext_header := f"{self.mountpoint}.luks"):
+            console.print(
+                f"Found a stale external LUKS header from a previous volume in {ext_header}."
+            )
+            while True:
+                resp = input("Delete the file? y/[n]")
+                match resp:
+                    case "y":
+                        os.remove(ext_header)
+                        break
+                    case "n" | "":
+                        breakpoint
+                    case _:
+                        console.print("invalid choice, retry.")
+
         self.activate()
 
     def activate(self):

--- a/pkgs/fc/ceph/src/fc/ceph/luks.py
+++ b/pkgs/fc/ceph/src/fc/ceph/luks.py
@@ -4,6 +4,7 @@ import secrets
 import shutil
 from pathlib import Path
 from socket import gethostname
+from typing import Optional
 
 from fc.ceph.lvm import XFSCephVolume
 from fc.ceph.util import console, mlockall, run
@@ -74,7 +75,13 @@ class LUKSKeyStoreManager(object):
                 "Keystore destroyed, but not overwritten.", style="bold yellow"
             )
 
-    def rekey(self, lvs="*", slot="local"):
+    def rekey(
+        self,
+        lvs: Optional[str],
+        device: Optional[str],
+        header: Optional[str],
+        slot="local",
+    ):
         """Update keyslots, using the opposite key for assurance."""
 
         if slot == "local":
@@ -84,70 +91,103 @@ class LUKSKeyStoreManager(object):
         else:
             raise ValueError(f"slot={slot}")
 
+        if not (lvs or device):
+            raise ValueError("Need to provide --lvs or --device.")
+        if not bool(lvs) ^ bool(device):
+            raise ValueError(
+                "--device and --lvs are mutually exclusive arguments, choose one."
+            )
+
         # Ensure to request the admin key early on.
         KEYSTORE.admin_key_for_input()
 
-        candidates = run.json.lvs("-S", "lv_name=~\\-crypted$")
-        for candidate in candidates:
-            name = candidate["lv_name"].removesuffix("-crypted")
-            if not fnmatch.fnmatch(name, lvs):
-                continue
-            console.print(f"Replacing key for {name}")
-
-            vg_name = candidate["vg_name"].replace("-", "--")
-            lv_name_mapper = candidate["lv_name"].replace("-", "--")
-
-            device = f"/dev/mapper/{vg_name}-{lv_name_mapper}"
-
-            if slot == "local":
-                # Rekey a new local key. Use the admin key for verifying.
-                key_file_verification = "-"
-                new_key_file = KEYSTORE.local_key_path()
-                kill_input = add_input = KEYSTORE.admin_key_for_input()
-            elif slot == "admin":
-                key_file_verification = KEYSTORE.local_key_path()
-                new_key_file = "-"
-                kill_input = None
-                add_input = KEYSTORE.admin_key_for_input()
-            slot_id = KEYSTORE.slots[slot]
-
-            dump = run.cryptsetup("luksDump", device, encoding="ascii")
-            if f"  {slot_id}: luks2" in dump:
-                run.cryptsetup(
-                    "luksKillSlot",
-                    f"--key-file={key_file_verification}",
-                    device,
-                    slot_id,
-                    input=kill_input,
-                )
-            run.cryptsetup(
-                "luksAddKey",
-                f"--key-file={key_file_verification}",
-                f"--key-slot={slot_id}",
-                device,
-                new_key_file,
-                input=add_input,
+        if device:
+            self._do_rekey(
+                device=device,
+                header=header,
+                slot=slot,
             )
+        else:
+            candidates = run.json.lvs("-S", "lv_name=~\\-crypted$")
+            for candidate in candidates:
+                name = candidate["lv_name"].removesuffix("-crypted")
+                if not fnmatch.fnmatch(name, lvs):
+                    continue
+                console.print(f"Replacing key for {name}")
+
+                vg_name = candidate["vg_name"].replace("-", "--")
+                lv_name_mapper = candidate["lv_name"].replace("-", "--")
+
+                f"/dev/mapper/{vg_name}-{lv_name_mapper}"
+
+                self._do_rekey(
+                    slot=slot,
+                    device=f"/dev/mapper/{vg_name}-{lv_name_mapper}",
+                    header=header,
+                )
 
         console.print("Key updated.", style="bold green")
+
+    def _do_rekey(self, slot: str, device: str, header: Optional[str]):
+        if slot == "local":
+            # Rekey a new local key. Use the admin key for verifying.
+            key_file_verification = "-"
+            new_key_file = KEYSTORE.local_key_path()
+            kill_input = add_input = KEYSTORE.admin_key_for_input()
+        elif slot == "admin":
+            key_file_verification = KEYSTORE.local_key_path()
+            new_key_file = "-"
+            kill_input = None
+            add_input = KEYSTORE.admin_key_for_input()
+        slot_id = KEYSTORE.slots[slot]
+
+        header_arg = [f"--header={header}"] if header else []
+
+        dump = run.cryptsetup("luksDump", *header_arg, device, encoding="ascii")
+        if f"  {slot_id}: luks2" in dump:
+            run.cryptsetup(
+                "luksKillSlot",
+                f"--key-file={key_file_verification}",
+                *header_arg,
+                device,
+                slot_id,
+                input=kill_input,
+            )
+        run.cryptsetup(
+            "luksAddKey",
+            f"--key-file={key_file_verification}",
+            f"--key-slot={slot_id}",
+            *header_arg,
+            device,
+            new_key_file,
+            input=add_input,
+        )
+
+        if header:
+            KEYSTORE.backup_external_header(Path(header))
 
 
 class LUKSKeyStore(object):
     __admin_key = None
 
     slots = {"admin": "1", "local": "0"}
+    local_key_dir: Path = Path("/mnt/keys/")
 
     def __init__(self):
         # Ensure we're locking memory early to reduce risk
         mlockall()
 
-    def local_key_path(self):
-        return f"/mnt/keys/{gethostname()}.key"
+    def local_key_path(self) -> str:
+        return str(self.local_key_dir / f"{gethostname()}.key")
 
-    def admin_key_for_input(self):
+    def admin_key_for_input(self) -> str:
         if not self.__admin_key:
             self.__admin_key = get_password("LUKS admin key for this location")
         return self.__admin_key.encode("ascii")
+
+    def backup_external_header(self, headerfile: Path):
+        # assumption: all external volume headers of a mchine have distinct names
+        shutil.copy(headerfile, self.local_key_dir)
 
 
 KEYSTORE = LUKSKeyStore()

--- a/pkgs/fc/ceph/src/fc/ceph/luks/__init__.py
+++ b/pkgs/fc/ceph/src/fc/ceph/luks/__init__.py
@@ -3,7 +3,7 @@ import shutil
 from pathlib import Path
 from socket import gethostname
 
-from fc.ceph.util import console, mlockall
+from fc.ceph.util import console, mlockall, run
 
 
 def get_password(prompt):
@@ -38,6 +38,70 @@ class LUKSKeyStore(object):
     def backup_external_header(self, headerfile: Path):
         # assumption: all external volume headers of a mchine have distinct names
         shutil.copy(headerfile, self.local_key_dir)
+
+
+class Cryptsetup:
+    """
+    Opinionated method wrapper around cryptsetup in general and some of its
+    methods in particular.
+    Useful to ensure that certain default tunable parameters are applied.
+    """
+
+    cryptsetup_tunables = [
+        # fmt: off
+        # inspired by the measurements done in https://ceph.io/en/news/blog/2023/ceph-encryption-performance/:
+        "--perf-submit_from_crypt_cpus",
+        # for larger writes throughput
+        # might be useful as well and is discussed to be enabled in Ceph,
+        # but requires kernel >=5.9: https://github.com/ceph/ceph/pull/49554
+        # especially relevant for SSDs, see https://blog.cloudflare.com/speeding-up-linux-disk-encryption/
+        # "--perf-no_read_workqueue", "--perf-no_write_workqueue"
+        # fmt: on
+    ]
+    # reduce CPU load for larger writes, can be removed after cryptsetup >=2.40
+    _tunables_sectorsize = ("--sector-size", "4096")
+
+    # tunables that apply when (re)creating a LUKS volume and its data or reencrypting it
+    _tunables_cipher = (
+        # fmt: off
+        "--cipher", "aes-xts-plain64",
+        "--key-size", "512",
+        # fmt: on
+    )
+    # tunables that apply when (re)creating a LUKS volume header
+    _tunables_luks_header = (
+        # fmt: off
+        "--pbkdf", "argon2id",
+        "--type", "luks2",
+        # fmt: on
+    )
+
+    @classmethod
+    def cryptsetup(cls, *args: str, **kwargs):
+        """cryptsetup wrapper that adds default tunable options to the calls"""
+        return run.cryptsetup("-q", *cls.cryptsetup_tunables, *args, **kwargs)
+
+    @classmethod
+    def luksFormat(cls, *args: str, **kwargs):
+        return cls.cryptsetup(
+            # fmt: off
+            *cls._tunables_sectorsize,
+            *cls._tunables_luks_header,
+            *cls._tunables_cipher,
+            "luksFormat",
+            *args, **kwargs,
+            # fmt: on
+        )
+
+    @classmethod
+    def luksAddKey(cls, *args: str, **kwargs):
+        return cls.cryptsetup(
+            # fmt: off
+            *cls._tunables_luks_header,
+            "luksAddKey",
+            *args, **kwargs,
+            # fmt: on
+        )
 
 
 KEYSTORE = LUKSKeyStore()

--- a/pkgs/fc/ceph/src/fc/ceph/luks/__init__.py
+++ b/pkgs/fc/ceph/src/fc/ceph/luks/__init__.py
@@ -1,0 +1,43 @@
+import getpass
+import shutil
+from pathlib import Path
+from socket import gethostname
+
+from fc.ceph.util import console, mlockall
+
+
+def get_password(prompt):
+    pw1 = pw2 = None
+    while not pw1:
+        pw1 = getpass.getpass(f"{prompt}: ")
+        pw2 = getpass.getpass(f"{prompt}, repeated: ")
+        if pw1 != pw2:
+            console.print("Keys do not match. Try again.", style="red")
+            pw1 = pw2 = None
+    return pw1
+
+
+class LUKSKeyStore(object):
+    __admin_key = None
+
+    slots = {"admin": "1", "local": "0"}
+    local_key_dir: Path = Path("/mnt/keys/")
+
+    def __init__(self):
+        # Ensure we're locking memory early to reduce risk
+        mlockall()
+
+    def local_key_path(self) -> str:
+        return str(self.local_key_dir / f"{gethostname()}.key")
+
+    def admin_key_for_input(self) -> str:
+        if not self.__admin_key:
+            self.__admin_key = get_password("LUKS admin key for this location")
+        return self.__admin_key.encode("ascii")
+
+    def backup_external_header(self, headerfile: Path):
+        # assumption: all external volume headers of a mchine have distinct names
+        shutil.copy(headerfile, self.local_key_dir)
+
+
+KEYSTORE = LUKSKeyStore()

--- a/pkgs/fc/ceph/src/fc/ceph/luks/manage.py
+++ b/pkgs/fc/ceph/src/fc/ceph/luks/manage.py
@@ -5,13 +5,13 @@ from pathlib import Path
 from typing import Optional
 
 from fc.ceph.luks import KEYSTORE  # singleton
-from fc.ceph.lvm import XFSCephVolume
+from fc.ceph.lvm import XFSVolume
 from fc.ceph.util import console, run
 
 
 class LUKSKeyStoreManager(object):
     def __init__(self):
-        self.volume = XFSCephVolume("keys", "/mnt/keys", automount=True)
+        self.volume = XFSVolume("keys", "/mnt/keys", automount=True)
         self._KEYSTORE = KEYSTORE  # don't use directly, overridable in test
 
     def create(self, device):

--- a/pkgs/fc/ceph/src/fc/ceph/lvm.py
+++ b/pkgs/fc/ceph/src/fc/ceph/lvm.py
@@ -541,8 +541,7 @@ class GenericCephVolume:
         return [int(vg["vg_name"].replace("vgosd-", "", 1)) for vg in vgs]
 
 
-# TODO: name can be a bit misleading, as we also utilise this for the XFS key volume
-class XFSCephVolume(AutomountActivationMixin, GenericCephVolume):
+class XFSVolume(AutomountActivationMixin, GenericCephVolume):
     MKFS_OPTS = ["-m", "crc=1,finobt=1", "-i", "size=2048", "-K"]
     MOUNT_OPTS = "nodev,nosuid,noatime,nodiratime,logbsize=256k"
     FSTYPE = "xfs"

--- a/pkgs/fc/ceph/src/fc/ceph/lvm.py
+++ b/pkgs/fc/ceph/src/fc/ceph/lvm.py
@@ -92,8 +92,6 @@ class MdraidDevice(GenericBlockDevice):
             and str(os.readlink(potential_name)).startswith("/dev/md")
         )
 
-    # TODO do we need activating?
-
 
 class PartitionedDisk(GenericBlockDevice):
     """name denotes the path to the whole unpartitioned disk"""

--- a/pkgs/fc/ceph/src/fc/ceph/lvm.py
+++ b/pkgs/fc/ceph/src/fc/ceph/lvm.py
@@ -124,9 +124,16 @@ class PartitionedDisk(GenericBlockDevice):
         return obj
 
     @classmethod
-    def exists(cls, name) -> bool:
+    def ensure(cls, disk: str):
+        if cls.exists(disk):
+            return cls(disk)
+        else:
+            return cls.create(disk)
+
+    @classmethod
+    def exists(cls, disk) -> bool:
         return any(
-            [os.path.exists(part) for part in cls._partition_candidates(name)]
+            [os.path.exists(part) for part in cls._partition_candidates(disk)]
         )
 
 
@@ -142,6 +149,7 @@ class AutomountActivationMixin:
             os.makedirs(self.mountpoint)
 
         if self.automount:
+            console.print("Waiting for automount…", style="grey50")
             time.sleep(1)
             try:
                 run.mount(

--- a/pkgs/fc/ceph/src/fc/ceph/main.py
+++ b/pkgs/fc/ceph/src/fc/ceph/main.py
@@ -82,7 +82,7 @@ def ceph(args=sys.argv[1:]):
     parser_create_bs.add_argument(
         "--encrypt",
         action=argparse.BooleanOptionalAction,
-        default=False,  # FIXME: at some point, decide to switch defaults
+        default=True,
         help="(Experimental) Set up OSD disk volumes with encryption",
     )
     parser_create_bs.set_defaults(action="create_bluestore")
@@ -202,7 +202,7 @@ def ceph(args=sys.argv[1:]):
     parser_create.add_argument(
         "--encrypt",
         action=argparse.BooleanOptionalAction,
-        default=False,  # FIXME: at some point, decide to switch defaults
+        default=True,
         help="(Experimental) Set up manager volumes with encryption",
     )
     parser_create.set_defaults(action="create")
@@ -247,7 +247,7 @@ def ceph(args=sys.argv[1:]):
     parser_create.add_argument(
         "--encrypt",
         action=argparse.BooleanOptionalAction,
-        default=False,  # FIXME: at some point, decide to switch defaults
+        default=True,
         help="(Experimental) Set up manager volumes with encryption",
     )
     parser_create.set_defaults(action="create")

--- a/pkgs/fc/ceph/src/fc/ceph/main.py
+++ b/pkgs/fc/ceph/src/fc/ceph/main.py
@@ -441,16 +441,13 @@ def luks(args=sys.argv[1:]):
 
     parser_rekey = keystore_sub.add_parser("rekey", help="Rekey volumes.")
     parser_rekey.add_argument(
-        "--lvs",
-        help="Names of encrypted LVs to update (globbing allowed), e.g. 'osd-1*'. Mutually exclusive with `--device`.",
-    )
-    parser_rekey.add_argument(
-        "--device",
-        help="Path to the underlying blockdevice of the encrypted volume to update, e.g. /dev/md/backup. Mutually exclusive with `--lvs`.",
+        "name_glob",
+        help="Names of LUKS volumes to update (globbing allowed), e.g. '*osd-*', 'backy'. Mutually exclusive with `--device`.",
     )
     parser_rekey.add_argument(
         "--header",
-        help="When using an external LUKS header file, provide a path to it here.",
+        help="When using an external LUKS header file, provide a path to it here."
+        "\nDefaults to autodetecting and using a file called ${mountpoint}.luks",
     )
     parser_rekey.add_argument(
         "--slot",

--- a/pkgs/fc/ceph/src/fc/ceph/main.py
+++ b/pkgs/fc/ceph/src/fc/ceph/main.py
@@ -440,8 +440,15 @@ def luks(args=sys.argv[1:]):
     parser_rekey = keystore_sub.add_parser("rekey", help="Rekey volumes.")
     parser_rekey.add_argument(
         "--lvs",
-        help="Names of encrypted LVs to update (globbing allowed), e.g. 'osd-1*'.",
-        default="*",
+        help="Names of encrypted LVs to update (globbing allowed), e.g. 'osd-1*'. Mutually exclusive with `--device`.",
+    )
+    parser_rekey.add_argument(
+        "--device",
+        help="Path to the underlying blockdevice of the encrypted volume to update, e.g. /dev/md/backup. Mutually exclusive with `--lvs`.",
+    )
+    parser_rekey.add_argument(
+        "--header",
+        help="When using an external LUKS header file, provide a path to it here.",
     )
     parser_rekey.add_argument(
         "--slot",

--- a/pkgs/fc/ceph/src/fc/ceph/mgr/nautilus.py
+++ b/pkgs/fc/ceph/src/fc/ceph/mgr/nautilus.py
@@ -3,7 +3,7 @@ import resource
 import shutil
 import socket
 
-from fc.ceph.lvm import XFSCephVolume
+from fc.ceph.lvm import XFSVolume
 from fc.ceph.mon.nautilus import find_vg_for_mon
 from fc.ceph.util import console, kill, run
 
@@ -11,7 +11,7 @@ from fc.ceph.util import console, kill, run
 class Manager(object):
     def __init__(self):
         self.id = socket.gethostname()
-        self.volume = XFSCephVolume("ceph-mgr", f"/srv/ceph/mgr/ceph-{self.id}")
+        self.volume = XFSVolume("ceph-mgr", f"/srv/ceph/mgr/ceph-{self.id}")
 
         self.pid_file = f"/run/ceph/mgr.{self.id}.pid"
         self.mgr_key_template = f"/etc/ceph/ceph.mgr.{self.id}.keyring"

--- a/pkgs/fc/ceph/src/fc/ceph/mon/nautilus.py
+++ b/pkgs/fc/ceph/src/fc/ceph/mon/nautilus.py
@@ -4,7 +4,7 @@ import shutil
 import socket
 import tempfile
 
-from fc.ceph.lvm import XFSCephVolume
+from fc.ceph.lvm import XFSVolume
 from fc.ceph.util import kill, run
 
 
@@ -28,7 +28,7 @@ def find_vg_for_mon():
 class Monitor(object):
     def __init__(self):
         self.id = socket.gethostname()
-        self.volume = XFSCephVolume("ceph-mon", f"/srv/ceph/mon/ceph-{self.id}")
+        self.volume = XFSVolume("ceph-mon", f"/srv/ceph/mon/ceph-{self.id}")
         self.pid_file = f"/run/ceph/mon.{self.id}.pid"
 
     def activate(self):

--- a/pkgs/fc/ceph/src/fc/ceph/osd/nautilus.py
+++ b/pkgs/fc/ceph/src/fc/ceph/osd/nautilus.py
@@ -350,7 +350,7 @@ class WALVolume:
         )
 
     def create(self, disk: str, encrypt: bool, location: str):
-        disk_block = PartitionedDisk.create(disk)
+        disk_block = PartitionedDisk.ensure(disk)
         # External WAL
         if location == "external":
             lvm_wal_vg = JournalVG.get_largest_free()
@@ -453,7 +453,7 @@ class BlockVolume(GenericCephVolume):
 
     def create(self, disk: str, encrypt: bool, size: str = "100%vg"):
         print(f"Creating block volume on {disk}...")
-        disk_block = PartitionedDisk.create(disk)
+        disk_block = PartitionedDisk.ensure(disk)
         self.lv = GenericLogicalVolume.create(
             name=self.name,
             vg_name=self.vg_name,

--- a/pkgs/fc/ceph/src/fc/ceph/osd/nautilus.py
+++ b/pkgs/fc/ceph/src/fc/ceph/osd/nautilus.py
@@ -13,7 +13,7 @@ from fc.ceph.lvm import (
     GenericCephVolume,
     GenericLogicalVolume,
     PartitionedDisk,
-    XFSCephVolume,
+    XFSVolume,
 )
 from fc.ceph.util import kill, run
 
@@ -485,7 +485,7 @@ class GenericOSD(object):
         self.name = f"osd.{id}"
         self.pid_file = f"/run/ceph/osd.{self.id}.pid"
 
-        self.data_volume = XFSCephVolume(
+        self.data_volume = XFSVolume(
             f"ceph-osd-{self.id}", f"/srv/ceph/osd/ceph-{self.id}"
         )
 

--- a/pkgs/fc/ceph/src/fc/ceph/osd/nautilus.py
+++ b/pkgs/fc/ceph/src/fc/ceph/osd/nautilus.py
@@ -9,10 +9,10 @@ from subprocess import CalledProcessError
 from typing import List, Optional
 
 from fc.ceph.lvm import (
+    DiskWithSinglePartition,
     GenericBlockDevice,
     GenericCephVolume,
     GenericLogicalVolume,
-    PartitionedDisk,
     XFSVolume,
 )
 from fc.ceph.util import kill, run
@@ -313,7 +313,7 @@ class JournalVG:
 
         jnl_vg = "vgjnl{:02d}".format(id_)
 
-        # TODO: could be switched to PartitionedDisk as well
+        # TODO: could be switched to DiskWithSinglePartition as well
         run.sgdisk("-Z", device)
         run.sgdisk("-a", "8192", "-n", "1:0:0", "-t", "1:8e00", device)
 
@@ -350,7 +350,7 @@ class WALVolume:
         )
 
     def create(self, disk: str, encrypt: bool, location: str):
-        disk_block = PartitionedDisk.ensure(disk)
+        disk_block = DiskWithSinglePartition.ensure(disk)
         # External WAL
         if location == "external":
             lvm_wal_vg = JournalVG.get_largest_free()
@@ -453,7 +453,7 @@ class BlockVolume(GenericCephVolume):
 
     def create(self, disk: str, encrypt: bool, size: str = "100%vg"):
         print(f"Creating block volume on {disk}...")
-        disk_block = PartitionedDisk.ensure(disk)
+        disk_block = DiskWithSinglePartition.ensure(disk)
         self.lv = GenericLogicalVolume.create(
             name=self.name,
             vg_name=self.vg_name,

--- a/pkgs/fc/ceph/src/fc/ceph/osd/nautilus.py
+++ b/pkgs/fc/ceph/src/fc/ceph/osd/nautilus.py
@@ -531,15 +531,15 @@ class GenericOSD(object):
 
         By default, the `ceph osd ok-to-stop` is run and checks for remaining
         data availability.
-        With `stric_safety_check`, the more strict `ceph osd safe-to-destroy`
+        With `strict_safety_check`, the more strict `ceph osd safe-to-destroy`
         checks whether edundancy is affected in any ways.
 
         Raises a SystemExit if the check fails.
         """
-        ids = map(str, ids)
+        idstr = map(str, ids)
         if strict_safety_check:
             try:
-                run.ceph("osd", "safe-to-destroy", *ids)
+                run.ceph("osd", "safe-to-destroy", *idstr)
             except CalledProcessError as e:
                 print(
                     # fmt: off
@@ -552,7 +552,7 @@ class GenericOSD(object):
                 sys.exit(e.returncode)
         else:
             try:
-                run.ceph("osd", "ok-to-stop", *ids)
+                run.ceph("osd", "ok-to-stop", *idstr)
             except CalledProcessError as e:
                 print(
                     # fmt: off

--- a/pkgs/fc/ceph/src/fc/ceph/tests/test_luks.py
+++ b/pkgs/fc/ceph/src/fc/ceph/tests/test_luks.py
@@ -102,9 +102,9 @@ def mock_LUKSKeyStoreManager(monkeypatch):
     monkeypatch.setattr(
         "fc.ceph.util.run.json.lvs", (lambda *args, **kwargs: LV_DUMMY_DATA)
     )
-    monkeypatch.setattr(fc.ceph.luks, "KEYSTORE", LUKSKeyStoreMock())
-    keyman = fc.ceph.luks.LUKSKeyStoreManager()
+    keyman = fc.ceph.luks.manage.LUKSKeyStoreManager()
 
+    keyman._KEYSTORE = LUKSKeyStoreMock()
     keyman._do_rekey = do_nothing
     return keyman
 

--- a/pkgs/fc/ceph/src/fc/ceph/tests/test_luks.py
+++ b/pkgs/fc/ceph/src/fc/ceph/tests/test_luks.py
@@ -1,0 +1,129 @@
+import fc.ceph.luks
+import pytest
+
+# extracted from cartman06
+LV_DUMMY_DATA = [
+    {
+        "lv_name": "ceph-mgr-crypted",
+        "vg_name": "vgjnl00",
+        "lv_attr": "-wi-ao----",
+        "lv_size": "8.00g",
+        "pool_lv": "",
+        "origin": "",
+        "data_percent": "",
+        "metadata_percent": "",
+        "move_pv": "",
+        "mirror_log": "",
+        "copy_percent": "",
+        "convert_lv": "",
+    },
+    {
+        "lv_name": "ceph-mon-crypted",
+        "vg_name": "vgjnl00",
+        "lv_attr": "-wi-ao----",
+        "lv_size": "8.00g",
+        "pool_lv": "",
+        "origin": "",
+        "data_percent": "",
+        "metadata_percent": "",
+        "move_pv": "",
+        "mirror_log": "",
+        "copy_percent": "",
+        "convert_lv": "",
+    },
+    {
+        "lv_name": "ceph-osd-0-wal-crypted",
+        "vg_name": "vgjnl00",
+        "lv_attr": "-wi-ao----",
+        "lv_size": "1.00g",
+        "pool_lv": "",
+        "origin": "",
+        "data_percent": "",
+        "metadata_percent": "",
+        "move_pv": "",
+        "mirror_log": "",
+        "copy_percent": "",
+        "convert_lv": "",
+    },
+    {
+        "lv_name": "ceph-osd-0-block-crypted",
+        "vg_name": "vgosd-0",
+        "lv_attr": "-wi-ao----",
+        "lv_size": "<556.91g",
+        "pool_lv": "",
+        "origin": "",
+        "data_percent": "",
+        "metadata_percent": "",
+        "move_pv": "",
+        "mirror_log": "",
+        "copy_percent": "",
+        "convert_lv": "",
+    },
+    {
+        "lv_name": "ceph-osd-0-crypted",
+        "vg_name": "vgosd-0",
+        "lv_attr": "-wi-ao----",
+        "lv_size": "1.00g",
+        "pool_lv": "",
+        "origin": "",
+        "data_percent": "",
+        "metadata_percent": "",
+        "move_pv": "",
+        "mirror_log": "",
+        "copy_percent": "",
+        "convert_lv": "",
+    },
+    {
+        "lv_name": "ceph-osd-0-wal-backup-crypted",
+        "vg_name": "vgosd-0",
+        "lv_attr": "-wi-a-----",
+        "lv_size": "1.00g",
+        "pool_lv": "",
+        "origin": "",
+        "data_percent": "",
+        "metadata_percent": "",
+        "move_pv": "",
+        "mirror_log": "",
+        "copy_percent": "",
+        "convert_lv": "",
+    },
+]
+
+
+@pytest.fixture
+def mock_LUKSKeyStoreManager(monkeypatch):
+    class LUKSKeyStoreMock(fc.ceph.luks.LUKSKeyStore):
+        def admin_key_for_input(*args, **kwargs):
+            return "foo"
+
+    def do_nothing(*args, **kwargs):
+        pass
+
+    monkeypatch.setattr(
+        "fc.ceph.util.run.json.lvs", (lambda *args, **kwargs: LV_DUMMY_DATA)
+    )
+    monkeypatch.setattr(fc.ceph.luks, "KEYSTORE", LUKSKeyStoreMock())
+    keyman = fc.ceph.luks.LUKSKeyStoreManager()
+
+    keyman._do_rekey = do_nothing
+    return keyman
+
+
+def test_keystore_rekey_argument_errors(mock_LUKSKeyStoreManager):
+    keyman = mock_LUKSKeyStoreManager
+    with pytest.raises(ValueError):
+        keyman.rekey(lvs=None, device=None, header=None)
+    with pytest.raises(ValueError):
+        keyman.rekey(lvs="*", device="/dev/foo", header="/srv/foo.luks")
+    with pytest.raises(ValueError):
+        keyman.rekey(
+            lvs="*", device=None, slot="whatever", header="/srv/foo.luks"
+        )
+
+
+def test_keystore_rekey_argument_calls(mock_LUKSKeyStoreManager):
+    keyman = mock_LUKSKeyStoreManager
+    keyman.rekey(lvs="*", device=None, header=None)
+    keyman.rekey(lvs="*", slot="local", header="/srv/foo.luks", device=None)
+    keyman.rekey(lvs="*", slot="admin", header="/srv/foo.luks", device=None)
+    keyman.rekey(device="/dev/foo", header="/srv/foo.luks", lvs=None)

--- a/tests/backy_volumes.nix
+++ b/tests/backy_volumes.nix
@@ -1,0 +1,114 @@
+import ./make-test-python.nix ({ pkgs, lib, testlib, ... }:
+let
+  migrationScript = pkgs.writeShellScript "backy-reencrypter" ''
+    PLAIN_DEVICE="/dev/disk/by-id/md-name-legacyBacky:md0"
+    systemctl stop backy.service
+    umount /srv/backy
+    systemd-run --property=Type=oneshot -r -u backy-reencrypt cryptsetup -q reencrypt --encrypt  --header /srv/backy.luks --pbkdf=argon2id -d /mnt/keys/$(hostname).key --resilience=journal $PLAIN_DEVICE backy
+    sleep 30
+    mount /dev/mapper/backy /srv/backy
+    systemctl start backy.service
+    # create an early header backup
+    cp /srv/backy.luks /mnt/keys/
+  '';
+  mkMachine = backyserverRoleConfig: {config, lib, ...}:{
+    imports = [
+      ../nixos
+      ../nixos/roles
+      (testlib.fcConfig { net.fe = false; })
+    ];
+
+    flyingcircus.roles.backyserver = {
+      enable = true;
+    } // backyserverRoleConfig;
+    flyingcircus.services.ceph.client.enable = lib.mkForce false;
+    flyingcircus.services.consul.enable = lib.mkForce false;
+    flyingcircus.enc.name = "machine";
+
+    virtualisation.emptyDiskImages = [1000 1000 1000 1000 1000 1100];
+    # :( Work-around the split between qemu-built systems and regular systems.
+    virtualisation.fileSystems."/mnt/keys" = config.flyingcircus.infrastructure.fullDiskEncryption.fsOptions;
+    virtualisation.fileSystems."/srv/backy" = config.flyingcircus.roles.backyserver.fsOptions;
+    # Cotherwise fc-luks OOMs
+    virtualisation.memorySize = 1000;
+  };
+
+in
+{
+  name = "backy-volumes";
+
+  nodes = {
+    # as specialisations do not persist reboots, just sequentially use 2 different machines with slightly adjusted config
+    legacyBacky = mkMachine {
+      blockDevice = "/dev/disk/by-id/md-name-legacyBacky:md0";
+      externalCryptHeader = true;
+    };
+    newBacky = mkMachine {};
+  };
+  testScript = {nodes, ...}:''
+    from time import sleep
+
+
+    def setupKeystore(machine):
+        with subtest("Initialise keystore"):
+          machine.succeed("fc-luks keystore create /dev/vdg > /dev/kmsg 2>&1")
+          print(machine.succeed("lsblk"))
+          machine.succeed("${pkgs.util-linux}/bin/findmnt /mnt/keys > /dev/kmsg 2>&1")
+
+    def test_reboot_automount(machine):
+      with subtest("automount of volume works at boot"):
+        machine.execute("systemctl poweroff --force")
+        machine.wait_for_shutdown()
+        machine.start()
+        machine.wait_for_unit("local-fs.target")
+
+        # The target only pulls the mount unit in for activation, but does not imply a chronological ordering.
+        # We still need to wait for the mount to happen.
+        machine.wait_until_succeeds("${pkgs.util-linux}/bin/findmnt /srv/backy > /dev/kmsg 2>&1")
+        print(machine.succeed("lsblk"))
+        print(machine.succeed('cat /etc/crypttab'))
+        print(machine.succeed('cat /etc/fstab'))
+        print(machine.succeed('ls -l /dev/disk/by-id/'))
+        print(machine.execute('systemctl status srv-backy.mount')[1])
+
+        machine.succeed('lsblk | egrep "crypt[[:space:]]+/srv/backy"')
+
+    print(legacyBacky.succeed("lsblk"))
+    # preparing an unencrypted legacy RAID setup
+    legacyBacky.succeed(f"mdadm --create /dev/md/md0 --level=6 --raid-devices=4 /dev/vdb /dev/vdc /dev/vdd /dev/vde > /dev/kmsg 2>&1")
+    legacyBacky.succeed(f"mdadm --add /dev/md/md0 /dev/vdf > /dev/kmsg 2>&1")
+
+    print(legacyBacky.succeed("ls -l /dev/disk/by-id/"))
+
+    legacyBacky.succeed(f"mkfs.xfs -L backy /dev/md/md0 > /dev/kmsg 2>&1")
+    legacyBacky.execute("systemctl daemon-reload")
+    legacyBacky.succeed("systemctl start srv-backy.mount > /dev/kmsg 2>&1")
+    print(legacyBacky.succeed("lsblk"))
+
+    setupKeystore(legacyBacky)
+
+    with subtest("manual reencryptioon of a legacy device:"):
+      legacyBacky.succeed("${pkgs.util-linux}/bin/findmnt /srv/backy > /dev/kmsg 2>&1")
+      legacyBacky.execute("echo FOOTEST > /srv/backy/testfile")
+      legacyBacky.succeed("${migrationScript}")
+      legacyBacky.wait_for_unit("backy-reencrypt.service")
+      print(legacyBacky.execute('systemctl status backy-reencrypt.service')[1])
+      legacyBacky.succeed('echo -e "newphrase\nnewphrase" | setsid -w fc-luks keystore rekey --slot=admin --header /srv/backy.luks --device=${nodes.legacyBacky.config.flyingcircus.roles.backyserver.blockDevice} > /dev/kmsg 2>&1')
+      legacyBacky.succeed("${pkgs.util-linux}/bin/findmnt /srv/backy > /dev/kmsg 2>&1")
+      legacyBacky.succeed("grep FOOTEST /srv/backy/testfile")
+
+    test_reboot_automount(legacyBacky)
+
+    legacyBacky.execute("systemctl poweroff --force")
+    legacyBacky.wait_for_shutdown()
+
+    # test fc-luks backup create
+    setupKeystore(newBacky)
+
+    with subtest("Creating new backy volume from scratch"):
+      newBacky.succeed('echo -e "adminphrase\nadminphrase" | setsid -w fc-luks backup create /dev/vdb /dev/vdc /dev/vdd /dev/vde /dev/vdf > /dev/kmsg 2>&1')
+      newBacky.succeed("${pkgs.util-linux}/bin/findmnt /srv/backy > /dev/kmsg 2>&1")
+
+    test_reboot_automount(newBacky)
+  '';
+})

--- a/tests/backy_volumes.nix
+++ b/tests/backy_volumes.nix
@@ -93,7 +93,7 @@ in
       legacyBacky.succeed("${migrationScript}")
       legacyBacky.wait_for_unit("backy-reencrypt.service")
       print(legacyBacky.execute('systemctl status backy-reencrypt.service')[1])
-      legacyBacky.succeed('echo -e "newphrase\nnewphrase" | setsid -w fc-luks keystore rekey --slot=admin --header /srv/backy.luks --device=${nodes.legacyBacky.config.flyingcircus.roles.backyserver.blockDevice} > /dev/kmsg 2>&1')
+      legacyBacky.succeed('echo -e "newphrase\nnewphrase" | setsid -w fc-luks keystore rekey --slot=admin backy > /dev/kmsg 2>&1')
       legacyBacky.succeed("${pkgs.util-linux}/bin/findmnt /srv/backy > /dev/kmsg 2>&1")
       legacyBacky.succeed("grep FOOTEST /srv/backy/testfile")
 

--- a/tests/ceph-nautilus.nix
+++ b/tests/ceph-nautilus.nix
@@ -341,8 +341,8 @@ in
 
       assert_clean_cluster(host2, 2, 3, 2, 320)
 
-      host1.succeed('fc-ceph mon create --size 500m > /dev/kmsg 2>&1')
-      host1.succeed('fc-ceph mgr create --size 500m > /dev/kmsg 2>&1')
+      host1.succeed('echo -e "adminphrase\nadminphrase" | setsid -w fc-ceph mon create --size 500m > /dev/kmsg 2>&1')
+      host1.execute('echo -e "adminphrase\nadminphrase" | setsid -w fc-ceph mgr create --size 500m > /dev/kmsg 2>&1')
       host1.sleep(5)
       show(host1, 'tail -n 500 /var/log/ceph/*mon*')
       show(host1, 'tail -n 500 /var/log/ceph/*mgr*')
@@ -358,7 +358,7 @@ in
       host1.fail('fc-ceph osd rebuild --strict-safety-check all> /dev/kmsg 2>&1')
 
     with subtest("Initialize extra OSD to enable safe rebuilding (bluestore)"):
-      host1.execute('fc-ceph osd create-bluestore /dev/vdd > /dev/kmsg 2>&1')
+      host1.execute('fc-ceph osd create-bluestore --no-encrypt /dev/vdd > /dev/kmsg 2>&1')
       assert_clean_cluster(host2, 3, 4, 3, 320)
 
     with subtest("Rebuild the 2nd OSD on host 1 from bluestore to bluestore and disable encryption without redundancy loss"):

--- a/tests/ceph-nautilus.nix
+++ b/tests/ceph-nautilus.nix
@@ -289,17 +289,17 @@ in
 
     with subtest("Initialize second MON and OSD (bluestore, internal WAL)"):
       host2.succeed('fc-ceph osd prepare-journal /dev/vdb')
-      host2.succeed('fc-ceph mon create --size 500m > /dev/kmsg 2>&1')
-      host2.execute('fc-ceph mgr create --size 500m > /dev/kmsg 2>&1')
+      host2.succeed('fc-ceph mon create --no-encrypt --size 500m > /dev/kmsg 2>&1')
+      host2.execute('fc-ceph mgr create --no-encrypt --size 500m > /dev/kmsg 2>&1')
       # cover explicit specification of internal and external journals
-      host2.succeed('fc-ceph osd create-bluestore --wal=internal /dev/vdc > /dev/kmsg 2>&1')
+      host2.succeed('fc-ceph osd create-bluestore --no-encrypt --wal=internal /dev/vdc > /dev/kmsg 2>&1')
 
     with subtest("Initialize third MON and OSD (bluestore, external WAL)"):
       host3.succeed('fc-ceph osd prepare-journal /dev/vdb')
-      host3.succeed('fc-ceph mon create --size 500m')
-      host3.execute('fc-ceph mgr create --size 500m > /dev/kmsg 2>&1')
+      host3.succeed('fc-ceph mon create --no-encrypt --size 500m')
+      host3.execute('fc-ceph mgr create --no-encrypt --size 500m > /dev/kmsg 2>&1')
       # cover explicit specification of internal and external journals
-      host3.succeed('fc-ceph osd create-bluestore --wal=external /dev/vdc > /dev/kmsg 2>&1')
+      host3.succeed('fc-ceph osd create-bluestore --no-encrypt --wal=external /dev/vdc > /dev/kmsg 2>&1')
 
     with subtest("Move OSDs to correct crush location"):
       host1.succeed('ceph osd crush move host1 root=default')
@@ -361,13 +361,13 @@ in
       host1.execute('fc-ceph osd create-bluestore /dev/vdd > /dev/kmsg 2>&1')
       assert_clean_cluster(host2, 3, 4, 3, 320)
 
-    with subtest("Rebuild the 2nd OSD on host 1 from bluestore to bluestore and enable encryption without redundancy loss"):
+    with subtest("Rebuild the 2nd OSD on host 1 from bluestore to bluestore and disable encryption without redundancy loss"):
       # set OSDs out and wait for cluster to rebalance
       host1.execute('ceph osd out 3')
       host1.sleep(5)
       assert_clean_cluster(host2, 3, (4, 3), 3, 320)
       # then rebuild
-      host1.succeed('echo -e "adminphrase\nadminphrase" | setsid -w fc-ceph osd rebuild --encrypt --strict-safety-check 3 > /dev/kmsg 2>&1')
+      host1.succeed('echo -e "adminphrase\nadminphrase" | setsid -w fc-ceph osd rebuild --no-encrypt --strict-safety-check 3 > /dev/kmsg 2>&1')
       # and set the osds in again
       host1.execute('ceph osd in $(ceph osd ls-tree host1)')
       show(host1, "lsblk")
@@ -423,8 +423,8 @@ in
       wait_for_cluster_status(host3, "PG_AVAILABILITY")
       host3.succeed('ceph health | grep "Reduced data availability" > /dev/kmsg 2>&1')
       # re-provision the 2 OSDs and allow the cluster to recover
-      host2.succeed('fc-ceph osd create-bluestore --wal=internal /dev/vdc > /dev/kmsg 2>&1')
-      host3.succeed('fc-ceph osd create-bluestore --wal=external /dev/vdc > /dev/kmsg 2>&1')
+      host2.succeed('fc-ceph osd create-bluestore --no-encrypt --wal=internal /dev/vdc > /dev/kmsg 2>&1')
+      host3.succeed('fc-ceph osd create-bluestore --no-encrypt --wal=external /dev/vdc > /dev/kmsg 2>&1')
       assert_clean_cluster(host2, 3, 3, 3, 320)
 
     with subtest("The check discovers non-conforming host key conditions"):

--- a/tests/ceph-nautilus.nix
+++ b/tests/ceph-nautilus.nix
@@ -393,8 +393,9 @@ in
     with subtest("Destroy and re-create the keystore, rekey the OSD"):
       host1.succeed("fc-luks keystore destroy --no-overwrite > /dev/kmsg 2>&1")
       host1.succeed("fc-luks keystore create /dev/vde > /dev/kmsg 2>&1")
-      host1.succeed('echo -e "adminphrase\nadminphrase" | setsid -w fc-luks keystore rekey > /dev/kmsg 2>&1')
-      host1.succeed('echo -e "newphrase\nnewphrase" | setsid -w fc-luks keystore rekey --slot=admin > /dev/kmsg 2>&1')
+      host1.succeed('echo -e "adminphrase\nadminphrase" | setsid -w fc-luks keystore rekey --lvs "*" > /dev/kmsg 2>&1')
+      host1.succeed('echo -e "newphrase\nnewphrase" | setsid -w fc-luks keystore rekey --slot=admin --lvs "*" > /dev/kmsg 2>&1')
+      host1.succeed('echo -e "newphrase\nnewphrase" | setsid -w fc-luks keystore rekey --device /dev/vgosd-0/ceph-osd-0-crypted > /dev/kmsg 2>&1')
       host1.succeed("fc-ceph osd reactivate all")
       assert_clean_cluster(host2, 3, 3, 3, 320)
 

--- a/tests/ceph-nautilus.nix
+++ b/tests/ceph-nautilus.nix
@@ -393,9 +393,9 @@ in
     with subtest("Destroy and re-create the keystore, rekey the OSD"):
       host1.succeed("fc-luks keystore destroy --no-overwrite > /dev/kmsg 2>&1")
       host1.succeed("fc-luks keystore create /dev/vde > /dev/kmsg 2>&1")
-      host1.succeed('echo -e "adminphrase\nadminphrase" | setsid -w fc-luks keystore rekey --lvs "*" > /dev/kmsg 2>&1')
-      host1.succeed('echo -e "newphrase\nnewphrase" | setsid -w fc-luks keystore rekey --slot=admin --lvs "*" > /dev/kmsg 2>&1')
-      host1.succeed('echo -e "newphrase\nnewphrase" | setsid -w fc-luks keystore rekey --device /dev/vgosd-0/ceph-osd-0-crypted > /dev/kmsg 2>&1')
+      host1.succeed('echo -e "adminphrase\nadminphrase" | setsid -w fc-luks keystore rekey "*" > /dev/kmsg 2>&1')
+      host1.succeed('echo -e "newphrase\nnewphrase" | setsid -w fc-luks keystore rekey --slot=admin "*" > /dev/kmsg 2>&1')
+      host1.succeed('echo -e "newphrase\nnewphrase" | setsid -w fc-luks keystore rekey "ceph-osd-0" > /dev/kmsg 2>&1')
       host1.succeed("fc-ceph osd reactivate all")
       assert_clean_cluster(host2, 3, 3, 3, 320)
 

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -33,6 +33,7 @@ in {
   antivirus = callTest ./antivirus.nix {};
   audit = callTest ./audit.nix {};
   backyserver_ceph-nautilus = callTest ./backyserver.nix { clientCephRelease = "nautilus"; };
+  backyserver_volumes = callTest ./backy_volumes.nix {};
   channel = callTest ./channel.nix {};
   ceph-nautilus = callTest ./ceph-nautilus.nix {};
   coturn = callTest ./coturn.nix {};

--- a/tests/kvm_host_ceph-nautilus.nix
+++ b/tests/kvm_host_ceph-nautilus.nix
@@ -424,17 +424,17 @@ in
 
     with subtest("Initialize first mon"):
       host1.succeed('fc-ceph osd prepare-journal /dev/vdb')
-      host1.execute('fc-ceph mon create --size 500m --bootstrap-cluster > /dev/kmsg 2>&1')
+      host1.execute('fc-ceph mon create --no-encrypt --size 500m --bootstrap-cluster > /dev/kmsg 2>&1')
       host1.sleep(5)
       host1.succeed('ceph -s > /dev/kmsg 2>&1')
       host1.succeed('fc-ceph keys mon-update-single-client host1 ceph_osd,ceph_mon,kvm_host salt-for-host-1-dhkasjy9')
       host1.succeed('fc-ceph keys mon-update-single-client host2 kvm_host salt-for-host-2-dhkasjy9')
 
       # mgr keys rely on 'fc-ceph keys' to be executes first
-      host1.execute('fc-ceph mgr create --size 500m > /dev/kmsg 2>&1')
+      host1.execute('fc-ceph mgr create --no-encrypt --size 500m > /dev/kmsg 2>&1')
 
     with subtest("Initialize OSD"):
-      host1.execute('fc-ceph osd create-bluestore /dev/vdc')
+      host1.execute('fc-ceph osd create-bluestore --no-encrypt /dev/vdc')
       host1.succeed('ceph osd crush move host1 root=default')
 
     with subtest("Create pools and images"):


### PR DESCRIPTION
@flyingcircusio/release-managers
PL-131325

Continuation of the full-disk encryption platform integration work.

- main feature: encrypted backup volumes
  - NixOS integration of automated unlocking of encrypted and unencrypted (legacy) backup volumes
  - `fc-luks` tooling adapted to new requirements: Refactoring, MDRaid volumes, external headers
  - new LVM-based encrypted backup volume layout + tooling for its creation
  - NixOS test coverage
- pins certain encryption parameters in our tooling
- initial unit tests for `fc-luks`
- `fc-ceph` defaults to creating encrypted volumes

## Release process

Impact: internal

Changelog:

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
  - instead- `nofail` mount options have been adopted to support both unencrypted and encrypted systems 
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - improve data at rest security of backups by encrypting them
  - no new known regressions must be introduced
  - integration test of common lifecycle actions
  - ensure that desired encryption parameters are actually used
  - use safe defaults
- [x] Security requirements tested? (EVIDENCE)
  - [x] tested new configuration on development backup server
  - [x] manually re-encrypted that backup server
  - [x] for external headers, ensure they are stored redundantly as well to avoid a single point of failure
  - [x] basic unit test coverage of `fc-luks` CLI
  - [x] NixOS tests for migrating existing and setting up new backup volumes
  - [x] pin certain desired encryption parameters
  - [ ] automated tests still pass
  - [x] default to encrypted volumes, now that they have been rolled out to production and are proven to be reliable