### PR TITLE
agent check free disk before upgrading, sensu check

### DIFF
--- a/nixos/platform/agent.nix
+++ b/nixos/platform/agent.nix
@@ -147,6 +147,24 @@ in
         '';
       };
 
+      diskKeepFree = mkOption {
+        default = 5;
+        type = types.numbers.positive;
+        description = ''
+          Amount of disk space (GiB) to keep free when preparing system updates.
+
+          Updates are refused when less than this value plus the current system size
+          is available. The `fc-agent` Sensu check will also become critical.
+
+          The sensu check issues a warning when less than this value plus
+          double the current system size is available.
+
+          Example: current system closure size is 2.5 GiB, so at least 7.5 GiB
+          have to be available for the update preparation to start.
+          The Sensu check will warn if less than 10 GiB are available.
+        '';
+      };
+
       maintenancePreparationSeconds = mkOption {
         default = 300;
         description = ''
@@ -241,6 +259,9 @@ in
       ];
 
       environment.etc."fc-agent.conf".text = ''
+         [limits]
+         disk_keep_free = ${toString cfg.agent.diskKeepFree}
+
          [maintenance]
          preparation_seconds = ${toString cfg.agent.maintenancePreparationSeconds}
 

--- a/pkgs/fc/agent/fc/conftest.py
+++ b/pkgs/fc/agent/fc/conftest.py
@@ -1,3 +1,4 @@
+import configparser
 import contextlib
 import shutil
 import textwrap
@@ -21,6 +22,9 @@ def agent_maintenance_config(tmp_path):
         f.write(
             textwrap.dedent(
                 """\
+            [limits]
+            disk_keep_free = 4.9
+
             [maintenance-enter]
             demo = echo "entering demo"
 
@@ -31,6 +35,13 @@ def agent_maintenance_config(tmp_path):
             )
         )
     return config_file
+
+
+@fixture
+def agent_configparser(agent_maintenance_config):
+    config = configparser.ConfigParser()
+    config.read(agent_maintenance_config)
+    return config
 
 
 @fixture

--- a/pkgs/fc/agent/fc/maintenance/activity/__init__.py
+++ b/pkgs/fc/agent/fc/maintenance/activity/__init__.py
@@ -1,4 +1,5 @@
 """Base class for maintenance activities."""
+from configparser import ConfigParser
 from enum import Enum
 from typing import NamedTuple, Optional
 
@@ -44,6 +45,7 @@ class Activity:
     comment = ""
     estimate = Estimate("10m")
     log = None
+    config: None | ConfigParser
 
     def __init__(self):
         """Creates activity object (add args if you like).

--- a/pkgs/fc/agent/fc/maintenance/activity/tests/test_update.py
+++ b/pkgs/fc/agent/fc/maintenance/activity/tests/test_update.py
@@ -281,11 +281,11 @@ def test_update_activity_deserialize(activity, logger):
 
 
 def test_update_activity_loading_outdated_serialization_should_work(
-    logger, tmp_path
+    logger, tmp_path, agent_configparser
 ):
     request_path = tmp_path / "request.yaml"
     request_path.write_text(OUTDATED_SERIALIZED_REQUEST)
-    request = Request.load(tmp_path, logger)
+    request = Request.load(tmp_path, agent_configparser, logger)
     activity = request.activity
     assert activity.changelog_url is None
     assert activity.current_release is None

--- a/pkgs/fc/agent/fc/maintenance/cli.py
+++ b/pkgs/fc/agent/fc/maintenance/cli.py
@@ -15,14 +15,11 @@ from fc.maintenance.maintenance import (
     request_reboot_for_qemu,
     request_update,
 )
-from fc.maintenance.reqmanager import (
-    DEFAULT_CONFIG_FILE,
-    DEFAULT_SPOOLDIR,
-    ReqManager,
-)
+from fc.maintenance.reqmanager import DEFAULT_SPOOLDIR, ReqManager
 from fc.maintenance.request import Request
 from fc.maintenance.state import EXIT_POSTPONE, EXIT_TEMPFAIL
 from fc.util import nixos
+from fc.util.constants import DEFAULT_AGENT_CONFIG_FILE
 from fc.util.directory import directory_connection
 from fc.util.enc import load_enc
 from fc.util.lock import locked
@@ -86,7 +83,7 @@ def fc_maintenance(
     ),
     config_file: Path = Option(
         dir_okay=False,
-        default=DEFAULT_CONFIG_FILE,
+        default=DEFAULT_AGENT_CONFIG_FILE,
         help="Path to the agent config file.",
     ),
     # Normal users cannot read the default file but that's ok for many commands.
@@ -329,7 +326,7 @@ def update():
 
     with locked(log, context.lock_dir):
         try:
-            request = request_update(log, enc, current_requests)
+            request = request_update(log, enc, rm.config, current_requests)
         except nixos.ChannelException:
             raise Exit(2)
 

--- a/pkgs/fc/agent/fc/maintenance/lib/tests/test_legacy_reboot.py
+++ b/pkgs/fc/agent/fc/maintenance/lib/tests/test_legacy_reboot.py
@@ -27,11 +27,11 @@ updated_at: null
 
 
 def test_legacy_reboot_activity_loading_serialization_should_work(
-    logger, tmp_path
+    logger, tmp_path, agent_configparser
 ):
     request_path = tmp_path / "request.yaml"
     request_path.write_text(SERIALIZED_REQUEST)
-    request = Request.load(tmp_path, logger)
+    request = Request.load(tmp_path, agent_configparser, logger)
     activity = request.activity
     assert activity.reboot_needed == RebootType.COLD
     assert activity.__rich__()

--- a/pkgs/fc/agent/fc/maintenance/reqmanager.py
+++ b/pkgs/fc/agent/fc/maintenance/reqmanager.py
@@ -30,7 +30,6 @@ from .request import Request, RequestMergeResult
 from .state import ARCHIVE, EXIT_POSTPONE, EXIT_TEMPFAIL, State
 
 DEFAULT_SPOOLDIR = "/var/spool/maintenance"
-DEFAULT_CONFIG_FILE = "/etc/fc-agent.conf"
 
 _log = structlog.get_logger()
 
@@ -267,7 +266,7 @@ class ReqManager:
             if not p.isdir(d):
                 continue
             try:
-                req = Request.load(d, self.log)
+                req = Request.load(d, self.config, self.log)
                 req._reqmanager = self
                 self.requests[req.id] = req
             except Exception as exc:
@@ -1013,7 +1012,10 @@ class ReqManager:
         name_matches = self.requestsdir.glob(req_id_prefix + "*")
         if name_matches:
             return sorted(
-                [Request.load(name, self.log) for name in name_matches],
+                [
+                    Request.load(name, self.config, self.log)
+                    for name in name_matches
+                ],
                 key=lambda r: r.added_at
                 or datetime.fromtimestamp(0, tz=timezone.utc),
             )
@@ -1027,7 +1029,10 @@ class ReqManager:
         name_matches = self.archivedir.glob(req_id_prefix + "*")
         if name_matches:
             return sorted(
-                [Request.load(name, self.log) for name in name_matches],
+                [
+                    Request.load(name, self.config, self.log)
+                    for name in name_matches
+                ],
                 key=lambda r: r.added_at
                 or datetime.fromtimestamp(0, tz=timezone.utc),
             )

--- a/pkgs/fc/agent/fc/maintenance/request.py
+++ b/pkgs/fc/agent/fc/maintenance/request.py
@@ -4,7 +4,9 @@ import datetime
 import os
 import os.path as p
 import tempfile
+from configparser import ConfigParser
 from enum import Enum
+from pathlib import Path
 from typing import Optional
 
 import iso8601
@@ -216,7 +218,7 @@ class Request:
         return self.state not in state.ARCHIVE and self.attempts
 
     @classmethod
-    def load(cls, dir, log):
+    def load(cls, dir: str | Path, config: ConfigParser, log):
         # need imports because such objects may be loaded via YAML
         import fc.maintenance.activity.reboot
         import fc.maintenance.activity.update
@@ -256,6 +258,7 @@ class Request:
         if not hasattr(instance, "state"):
             instance.state = State.pending
 
+        instance.config = config
         instance.dir = dir
         instance.set_up_logging(log)
 

--- a/pkgs/fc/agent/fc/maintenance/tests/test_request.py
+++ b/pkgs/fc/agent/fc/maintenance/tests/test_request.py
@@ -1,3 +1,4 @@
+import configparser
 import datetime
 import unittest.mock
 from io import StringIO
@@ -158,7 +159,7 @@ class ExternalStateActivity(Activity):
             print("foo", file=f)
 
 
-def test_external_activity_state(tmpdir, logger):
+def test_external_activity_state(tmpdir, agent_configparser, logger):
     r = Request(ExternalStateActivity(), 1, dir=str(tmpdir))
     r.save()
     extstate = str(tmpdir / "external_state")
@@ -166,7 +167,7 @@ def test_external_activity_state(tmpdir, logger):
         assert "foo\n" == f.read()
     with open(extstate, "w") as f:
         print("bar", file=f)
-    r2 = Request.load(str(tmpdir), logger)
+    r2 = Request.load(str(tmpdir), agent_configparser, logger)
     assert r2.activity.external == "bar\n"
 
 

--- a/pkgs/fc/agent/fc/manage/manage.py
+++ b/pkgs/fc/agent/fc/manage/manage.py
@@ -4,6 +4,7 @@ import os
 import re
 import socket
 import subprocess
+from configparser import ConfigParser
 from pathlib import Path
 
 from fc.util import nixos
@@ -40,7 +41,7 @@ class SwitchFailed(Exception):
     pass
 
 
-def check(log, enc) -> CheckResult:
+def check(log, enc, config: ConfigParser) -> CheckResult:
     errors = []
     warnings = []
     ok_info = []
@@ -132,6 +133,39 @@ def check(log, enc) -> CheckResult:
             ]
             warnings.append(f"NixOS warnings found ({len(nixos_warnings)})")
             warnings.extend(nixos_warnings)
+
+    try:
+        system_size = nixos.system_closure_size(
+            log, Path("/run/current-system")
+        )
+    except Exception:
+        warnings.append("Failed to get closure size of current system.")
+    else:
+        free_disk_gib = nixos.get_free_store_disk_space(log) / 1024**3
+        disk_keep_free = config.getfloat(
+            "limits", "disk_keep_free", fallback=5.0
+        )
+        size_gib = system_size / 1024**3
+        free_space_error_thresh = size_gib + disk_keep_free
+        free_space_warning_thresh = size_gib * 2 + disk_keep_free
+
+        if free_disk_gib < free_space_error_thresh:
+            errors.append(
+                "Not enough free disk space to build a new system. "
+                f"Free: {free_disk_gib:.1f} GiB. "
+                f"Required: {free_space_error_thresh:.1f} GiB "
+                f"({size_gib:.1f} system size + {disk_keep_free:.1f}) "
+                "Automated updates are suspended until more space is available."
+            )
+        elif free_disk_gib < free_space_warning_thresh:
+            warnings.append(
+                f"Free disk space is getting low. "
+                f"Free: {free_disk_gib:.1f} GiB. "
+                f"Required: {free_space_error_thresh:.1f} GiB. "
+                "Building a new system could fail if more disk space is used."
+            )
+        else:
+            ok_info.append(f"System size: {size_gib:.1f} GiB.")
 
     return CheckResult(errors, warnings, ok_info)
 

--- a/pkgs/fc/agent/fc/util/config.py
+++ b/pkgs/fc/agent/fc/util/config.py
@@ -1,0 +1,20 @@
+import configparser
+from pathlib import Path
+
+
+def parse_agent_config(log, config_file: Path):
+    config = configparser.ConfigParser()
+    if config_file:
+        if config_file.is_file():
+            log.debug(
+                "parse-agent-config",
+                config_file=config_file,
+            )
+            config.read(config_file)
+        else:
+            log.warn(
+                "parse-agent-config-not-found",
+                config_file=config_file,
+            )
+
+    return config

--- a/pkgs/fc/agent/fc/util/constants.py
+++ b/pkgs/fc/agent/fc/util/constants.py
@@ -1,0 +1,1 @@
+DEFAULT_AGENT_CONFIG_FILE = "/etc/fc-agent.conf"

--- a/pkgs/fc/agent/fc/util/tests/test_nixos.py
+++ b/pkgs/fc/agent/fc/util/tests/test_nixos.py
@@ -52,6 +52,9 @@ def test_build_system_with_changes(log, monkeypatch):
 
     popen_mock = mock.Mock(return_value=nix_build_fake)
     monkeypatch.setattr("subprocess.Popen", popen_mock)
+    monkeypatch.setattr(
+        "fc.util.nixos.system_closure_size", lambda *args: 2_000_000
+    )
 
     built_system_path = nixos.build_system(
         channel, build_options=["-v"], out_link="/run/fc-agent-test"
@@ -89,6 +92,9 @@ def test_build_system_unchanged(log, monkeypatch):
 
     popen_mock = mock.Mock(return_value=nix_build_fake)
     monkeypatch.setattr("subprocess.Popen", popen_mock)
+    monkeypatch.setattr(
+        "fc.util.nixos.system_closure_size", lambda *args: 2_000_000
+    )
 
     built_system_path = nixos.build_system(channel)
 


### PR DESCRIPTION
request_update now guesses if the system to be prepared will fit on
the Nix store partition. It uses the size of the current system plus
some extra space as worst-case estimation. This should leave at least
some free space after preparing the new system.

Often nixpkgs updates change core dependencies, so adding the size of the
current system when preparing a new one is not uncommon.

This worst-case estimation will also prevent smaller updates from being installed, even though they'd perfectly fit into available disk space. This creates a new challenge for ensuring that a machine does not miss any updates, we have to make sure to watch the fc-agent check
which will become red when there's not enough space.

Additions:

- Successful system builds now show the closure size of the new system.
- `fc-manage check` now:
  - displays current system closure size as info.
  - warns when less than twice the system size plus some extra space is free.
  - errors when less than the system size plus some extra space is free.
  -  now shows system and state version

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

- agent: check free disk space before preparing a system update. At least the size of the current system plus a fixed value must be available. A Sensu check warns before the limit is reached and becomes critical if updates cannot run anymore. The default fixed value of 5 GiB can be configured using the `flyingcircus.agent.diskKeepFree` option (PL-131859).

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting. => min free space (5 GiB) can be configured and set to 0 (but the size of the current system is still considered). If all fails, the system can still be updated manually using fc-manage. 
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well. => document the new option before the release

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Don't fill disks to 100% to prevent downtime and maybe even data corruption
  - Delaying updates for too long is a security risk. The low disk situation must be monitored so that we can identify machines that cannot run updates. 
- [x] Security requirements tested? (EVIDENCE)
  - checked on a test VM that
    - an update is prepare when enough space is available (with default diskKeepFree) 
    - preparing the update is rejected when not enough space available (diskKeepFree = 15, system size 2.6, free space 17.0)
    - sensu check is critical when updates are suspended
    - sensu check warns when disk space is getting low
