### PR TITLE
Update nixpkgs for gitlab 16.7.7

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -26,11 +26,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1708701802,
-        "narHash": "sha256-OvpkuB5Lx8eomwUgUT4s10fzbrDnPCtCsxOlZ63hYFI=",
+        "lastModified": 1709750969,
+        "narHash": "sha256-LDTZ2aRlnXSwYZnUnv6cJ3WQp8LmDYKMtouv2gTQmAA=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "fa9a708e240c6174f9fc4c6eefbc6a89ce01c350",
+        "rev": "e53e5cc77bb6e1073b136ec98a0a9cfbb582c7a8",
         "type": "github"
       },
       "original": {
@@ -76,11 +76,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1706830856,
-        "narHash": "sha256-a0NYyp+h9hlb7ddVz4LUn1vT/PLwqfrWYcHMvFB1xYg=",
+        "lastModified": 1709336216,
+        "narHash": "sha256-Dt/wOWeW6Sqm11Yh+2+t0dfEWxoMxGBvv3JpIocFl9E=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "b253292d9c0a5ead9bc98c4e9a26c6312e27d69f",
+        "rev": "f7b3c975cf067e56e7cda6cb098ebe3fb4d74ca2",
         "type": "github"
       },
       "original": {
@@ -202,11 +202,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1708950291,
-        "narHash": "sha256-oY+aCEmFW2ZBsANm2wZvZfHDTTS5E6kwDs/4Ly2XrE8=",
+        "lastModified": 1709759576,
+        "narHash": "sha256-Xq0MdT8farF5WTKMA1Izy/1VZ4obRh7/9WeTt3eQ5+E=",
         "owner": "flyingcircusio",
         "repo": "nixpkgs",
-        "rev": "5857afb599983e1fbbbc0c5237ee64492f911df4",
+        "rev": "223066281ca570f5be77d351df0d880d21bcc9de",
         "type": "github"
       },
       "original": {
@@ -219,11 +219,11 @@
     "nixpkgs-lib": {
       "locked": {
         "dir": "lib",
-        "lastModified": 1706550542,
-        "narHash": "sha256-UcsnCG6wx++23yeER4Hg18CXWbgNpqNXcHIo5/1Y+hc=",
+        "lastModified": 1709237383,
+        "narHash": "sha256-cy6ArO4k5qTx+l5o+0mL9f5fa86tYUX3ozE1S+Txlds=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "97b17f32362e475016f942bbdfda4a4a72a8a652",
+        "rev": "1536926ef5621b09bba54035ae2bb6d806d72ac8",
         "type": "github"
       },
       "original": {

--- a/release/package-versions.json
+++ b/release/package-versions.json
@@ -215,9 +215,9 @@
     "version": "2.42.0"
   },
   "gitaly": {
-    "name": "gitaly-16.7.6",
+    "name": "gitaly-16.7.7",
     "pname": "gitaly",
-    "version": "16.7.6"
+    "version": "16.7.7"
   },
   "github-runner": {
     "name": "github-runner-2.313.0",
@@ -225,24 +225,24 @@
     "version": "2.313.0"
   },
   "gitlab": {
-    "name": "gitlab-16.7.6",
+    "name": "gitlab-16.7.7",
     "pname": "gitlab",
-    "version": "16.7.6"
+    "version": "16.7.7"
   },
   "gitlab-container-registry": {
-    "name": "gitlab-container-registry-3.88.1",
+    "name": "gitlab-container-registry-3.90.0",
     "pname": "gitlab-container-registry",
-    "version": "3.88.1"
+    "version": "3.90.0"
   },
   "gitlab-ee": {
-    "name": "gitlab-ee-16.7.6",
+    "name": "gitlab-ee-16.7.7",
     "pname": "gitlab-ee",
-    "version": "16.7.6"
+    "version": "16.7.7"
   },
   "gitlab-pages": {
-    "name": "gitlab-pages-16.7.6",
+    "name": "gitlab-pages-16.7.7",
     "pname": "gitlab-pages",
-    "version": "16.7.6"
+    "version": "16.7.7"
   },
   "gitlab-runner": {
     "name": "gitlab-runner-16.7.0",
@@ -250,9 +250,9 @@
     "version": "16.7.0"
   },
   "gitlab-workhorse": {
-    "name": "gitlab-workhorse-16.7.6",
+    "name": "gitlab-workhorse-16.7.7",
     "pname": "gitlab-workhorse",
-    "version": "16.7.6"
+    "version": "16.7.7"
   },
   "glibc": {
     "name": "glibc-2.38-44",

--- a/release/versions.json
+++ b/release/versions.json
@@ -8,9 +8,9 @@
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/"
   },
   "nixpkgs": {
-    "hash": "sha256-oY+aCEmFW2ZBsANm2wZvZfHDTTS5E6kwDs/4Ly2XrE8=",
+    "hash": "sha256-Xq0MdT8farF5WTKMA1Izy/1VZ4obRh7/9WeTt3eQ5+E=",
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "5857afb599983e1fbbbc0c5237ee64492f911df4"
+    "rev": "223066281ca570f5be77d351df0d880d21bcc9de"
   }
 }


### PR DESCRIPTION
- gitlab: 16.7.6 -> 16.7.7 (CVE-2024-0199, CVE-2024-1299)
- gitlab-container-registry: 3.88.1 -> 3.90.0

PL-132277

@flyingcircusio/release-managers

## Release process

Impact:

- \[NixOS 23.11] Gitlab will be restarted.

Changelog:

- Gitlab security update
  - gitlab: 16.7.6 -> 16.7.7 (CVE-2024-0199, CVE-2024-1299)
  - gitlab-container-registry: 3.88.1 -> 3.90.0

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - apply security updates asap 
- [x] Security requirements tested? (EVIDENCE)
  - checked on our Gitlab staging system that Gitlab works using the checklist