### PR TITLE
gitlab: Increase default HSTS max-age to 2 years

### DIFF
--- a/nixos/roles/gitlab.nix
+++ b/nixos/roles/gitlab.nix
@@ -79,10 +79,9 @@ in
         maxAge = lib.mkOption {
           type = types.ints.positive;
           description = "Expiration time of HSTS caching in browser (unit: seconds)";
-          default = 3600;
+          default = 63072000;
           defaultText = ''
-            3600 seconds (1 hour)
-            Note: We intend to massively increase that value in a following release.
+            63072000 seconds (2 years)
           '';
         };
         preload = lib.mkOption {

--- a/tests/gitlab.nix
+++ b/tests/gitlab.nix
@@ -102,7 +102,7 @@ import ./make-test-python.nix ({ pkgs, lib, testlib, ...} : with lib; {
       # So just check for the header.
       request_headers = gitlab.succeed("curl http://gitlab/users/sign_in -I | cat").split('\n')
       print(request_headers)
-      assert 'Strict-Transport-Security: max-age=3600; includeSubDomains' in map(lambda s: s.strip(), request_headers)
+      assert 'Strict-Transport-Security: max-age=63072000; includeSubDomains' in map(lambda s: s.strip(), request_headers)
       assert any(header.startswith("Content-Security-Policy: base-uri 'self';") for header in request_headers)
 
     with subtest("test basic Gitlab REST API actions"):


### PR DESCRIPTION
After successfully testing HSTS headers for our gitlab deployments with cautiously short validity times, we can now increase this period to the recommended value of 2 years (see https://infosec.mozilla.org/guidelines/web_security.html#http-strict-transport-security) A period of at least one year is necessary for preloading to work, anyways.

@flyingcircusio/release-managers

## Release process

Impact:
- None, the nginx config will only reload without connections being dropped

Changelog:
- gitlab: Increase default max-age validity period of HTTP Strict Transport Security to 2 years
  - this functionality has proven to be unproblematic during its initial rollout phase with a much shorter period

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
  - just chages a default value that is configurable 
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - must not introduce any known regressions
  - adapt tests to changed values 
  - after successful but cautious initial feature rollout, increase validity period to recommended value of 2 years
- [ ] Security requirements tested? (EVIDENCE)
  - [x] adapted test accordingly
  - [x] all NixOS tests still pass 
