### PR TITLE
[21.05] nixpkgs-23_05: instantiate with our nixpkgs config

### DIFF
--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -9,7 +9,7 @@ let
   phps = (import ../nix-phps/pkgs/phps.nix) (../nix-phps)
     {} super;
 
-  nixpkgs-23_05 = import versions.nixpkgs-23_05 {};
+  nixpkgs-23_05 = import versions.nixpkgs-23_05 {inherit (self) config;};
 
   inherit (super) fetchpatch fetchurl lib;
 


### PR DESCRIPTION
Pass the same config to the 23.05 nixpkgs instance as used by the rest of the system. This e.g. makes sure that unfree packages are allowed the same way.

In this particular instance, this fixes an eval failure of the nvidia-x11 kernel module.

PL-132105

@flyingcircusio/release-managers

## Release process

Impact:
internal

Changelog:
- bugfix for inclusion of 23.05 nixpkgs

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - must not introduce any known regressions
  - unify config, fix broken system build
- [x] Security requirements tested? (EVIDENCE)
  - [x] automated tests still pass
  - [x] successfully fix build on ike00
