### PR TITLE
add a bit of documentation for rate limiting

### DIFF
--- a/doc/src/webgateway.md
+++ b/doc/src/webgateway.md
@@ -6,6 +6,11 @@ This role provides a stack of components that enables you to serve a web
 application via HTTP. In addition, you can do load balancing and configure
 failover support.
 
+```{contents} Table of Contents
+:local: true
+:depth: 2
+```
+
 ## Versions
 
 - HAProxy: 2.8.x
@@ -293,3 +298,30 @@ If you still need them on 23.05/23.11, use the Nginx package which still support
 ~~~
 
 A package alias under the name `nginxLegacyCrypt` is already available in our NixOS 22.11 release, enabling seamless platform upgrades with the same configuration.
+
+
+### Rate limiting
+
+There are a few scenarios where you may need to rate limit connections going
+to nginx. One aspect can be DOS protection against some specific attacks like
+"[rapid reset](https://www.cisa.gov/news-events/alerts/2023/10/10/http2-rapid-reset-vulnerability-cve-2023-44487)". We generally keep nginx updated so that you will benefit from
+general counter measures against those kinds of attacks.
+
+However, in some scenarios rate limiting may be necessary to fend off attackers.
+As rate limits need to be carefully adjusted to your specific application
+we do not enable rate limits on our platform by default.
+
+The options available to control rate limiting in your nginx instance are:
+
+~~~
+# /etc/local/nixos/nginx-rate-limiting.nix
+{ pkgs, ... }:
+{
+  flyingcircus.services.nginx.rateLimit = {
+    enable = true;
+    maxConcurrent = 200;
+    maxRequestsPerSecond = 50;
+    burst = 500;
+  };
+}
+~~~


### PR DESCRIPTION
Fixes PL-132210

@flyingcircusio/release-managers

## Release process

Impact:

none

Changelog:

n/a

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

Document an optional security measure.

- [x] Security requirements tested? (EVIDENCE)

Compiled and proof-read the docs locally.