### PR TITLE
Reimplement HTTP service check program in Python for better redirect handling

### DIFF
--- a/nixos/roles/servicecheck.nix
+++ b/nixos/roles/servicecheck.nix
@@ -26,6 +26,8 @@ in
       interval = 300;
     };
 
+    flyingcircus.services.sensu-client.checkEnvPackages = [ pkgs.fc.sensuplugins ];
+
     systemd.services.fc-servicecheck = {
       description = "Flying Circus global Service Checks";
       # Run this *before* fc-manage rebuilds the system. This service loads

--- a/nixos/roles/servicecheck.nix
+++ b/nixos/roles/servicecheck.nix
@@ -5,6 +5,16 @@
 let
   cfg = config.flyingcircus.roles.servicecheck;
   fclib = config.fclib;
+
+  # we need check_http_service from fc-sensuplugins, however this
+  # package contains commands which collide with monitoring-plugins,
+  # so extract check_http_service into a separate package first.
+  envPackage = pkgs.linkFarm "fc-sensuplugins-check_http_service" [
+    {
+      name = "bin/check_http_service";
+      path = "${pkgs.fc.sensuplugins}/bin/check_http_service" ;
+    }
+  ];
 in
 {
 
@@ -26,7 +36,7 @@ in
       interval = 300;
     };
 
-    flyingcircus.services.sensu-client.checkEnvPackages = [ pkgs.fc.sensuplugins ];
+    flyingcircus.services.sensu-client.checkEnvPackages = [ envPackage ];
 
     systemd.services.fc-servicecheck = {
       description = "Flying Circus global Service Checks";

--- a/pkgs/fc/agent/fc/manage/monitor.py
+++ b/pkgs/fc/agent/fc/manage/monitor.py
@@ -32,24 +32,13 @@ def get_sensucheck_configuration(servicechecks):
             rg=servicecheck["resource_group"], id=servicecheck["id"]
         )
 
-        url = urllib.parse.urlsplit(servicecheck["url"])
-        path = "?".join([p for p in [url.path, url.query] if p])
-
-        command = ["check_http", "-4", "-H", shlex.quote(url.hostname)]
-        if url.port:
-            command.extend(["-p", str(url.port)])
-        if path:
-            command.extend(["-u", shlex.quote(path)])
-        if url.scheme == "https":
-            command.append("-S")
-            command.append("--sni")
-        if url.username:
-            auth_pair = ":".join([url.username, url.password or ""])
-            command.extend(["-a", auth_pair])
+        command = ["check_http_service", "-4"]
         if servicecheck["redirect"]:
-            command.extend(["-f", "follow"])
+            command.append("-f")
         if len(servicecheck["acceptable"]) > 0:
-            command.extend(["-e", ",".join(servicecheck["acceptable"])])
+            for code in servicecheck["acceptable"]:
+                command.extend(["-e", str(code)])
+        command.append(shlex.quote(servicecheck["url"]))
         checks[name] = dict(
             command=" ".join(command),
             interval=120,

--- a/pkgs/fc/sensuplugins/default.nix
+++ b/pkgs/fc/sensuplugins/default.nix
@@ -16,6 +16,7 @@ in
       megacli
       py.nagiosplugin
       py.requests
+      py.requests_toolbelt
       py.psutil
       py.pyyaml
     ];

--- a/pkgs/fc/sensuplugins/fc/sensuplugins/http.py
+++ b/pkgs/fc/sensuplugins/fc/sensuplugins/http.py
@@ -87,7 +87,10 @@ def main():
         err("empty hostname in URL")
 
     session = requests.Session()
-    # match monitoring-plugins defaults
+    # default redirect depth limit is 10, which matches
+    # monitoring-plugins -- chrome and firefox have default limits of
+    # 20. the browsers also perform redirection loop detection,
+    # however we don't implement this yet.
     session.max_redirects = 10
 
     if url.username is not None:

--- a/pkgs/fc/sensuplugins/fc/sensuplugins/http.py
+++ b/pkgs/fc/sensuplugins/fc/sensuplugins/http.py
@@ -109,7 +109,7 @@ def main():
     except requests.ConnectionError as ex:
         critical(f"could not connect to remote host: {ex}")
     except requests.TooManyRedirects as ex:
-        warning("maximum redirection depth exceeded")
+        critical("maximum redirection depth exceeded")
     except requests.Timeout as ex:
         critical("request to remote host exceeded timeout: 10s")
 
@@ -119,7 +119,7 @@ def main():
                 f"request returned server error status code: {resp.status_code}"
             )
         elif resp.status_code >= 400:
-            warning(
+            critical(
                 f"request returned client error status code: {resp.status_code}"
             )
     elif resp.status_code not in args.expect:

--- a/pkgs/fc/sensuplugins/fc/sensuplugins/http.py
+++ b/pkgs/fc/sensuplugins/fc/sensuplugins/http.py
@@ -102,13 +102,13 @@ def main():
         session.mount("https://", SourceAddressAdapter(source_address))
 
     try:
-        resp = session.get(target, allow_redirects=args.follow)
+        resp = session.get(target, allow_redirects=args.follow, timeout=10)
     except requests.ConnectionError as ex:
         critical("could not connect to remote host")
     except requests.TooManyRedirects as ex:
         warning("maximum redirection depth exceeded")
     except requests.Timeout as ex:
-        critical("request to remote host timed out")
+        critical("request to remote host exceeded timeout: 10s")
 
     if args.expect is None:
         if resp.status_code >= 500:

--- a/pkgs/fc/sensuplugins/fc/sensuplugins/http.py
+++ b/pkgs/fc/sensuplugins/fc/sensuplugins/http.py
@@ -16,12 +16,12 @@ from requests_toolbelt.adapters.source import SourceAddressAdapter
 
 def err(msg):
     print(msg, file=sys.stderr)
-    sys.exit(1)
+    sys.exit(2)
 
 
 def unknown(msg):
     print(f"HTTP UNKNOWN - {msg}")
-    sys.exit(1)
+    sys.exit(3)
 
 
 def warning(msg):
@@ -31,7 +31,7 @@ def warning(msg):
 
 def critical(msg):
     print(f"HTTP CRITICAL - {msg}")
-    sys.exit(1)
+    sys.exit(2)
 
 
 def ok(msg):

--- a/pkgs/fc/sensuplugins/fc/sensuplugins/http.py
+++ b/pkgs/fc/sensuplugins/fc/sensuplugins/http.py
@@ -104,7 +104,7 @@ def main():
     try:
         resp = session.get(target, allow_redirects=args.follow, timeout=10)
     except requests.ConnectionError as ex:
-        critical("could not connect to remote host")
+        critical(f"could not connect to remote host: {ex}")
     except requests.TooManyRedirects as ex:
         warning("maximum redirection depth exceeded")
     except requests.Timeout as ex:

--- a/pkgs/fc/sensuplugins/fc/sensuplugins/http.py
+++ b/pkgs/fc/sensuplugins/fc/sensuplugins/http.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""HTTP status check.
+
+Check the status code from an HTTP request, with options for following
+redirects or not.
+"""
+
+import argparse
+import os
+import sys
+import urllib.parse
+
+import requests
+from requests_toolbelt.adapters.source import SourceAddressAdapter
+
+
+def err(msg):
+    print(msg, file=sys.stderr)
+    sys.exit(1)
+
+
+def unknown(msg):
+    print(f"HTTP UNKNOWN - {msg}")
+    sys.exit(1)
+
+
+def warning(msg):
+    print(f"HTTP WARNING - {msg}")
+    sys.exit(1)
+
+
+def critical(msg):
+    print(f"HTTP CRITICAL - {msg}")
+    sys.exit(1)
+
+
+def ok(msg):
+    print(f"HTTP OK - {msg}")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-4", "--ipv4", action="store_true", help="Only use IPv4"
+    )
+    parser.add_argument(
+        "-6", "--ipv6", action="store_true", help="Only use IPv6"
+    )
+    parser.add_argument(
+        "-e",
+        "--expect",
+        type=int,
+        action="append",
+        help="Expected status codes",
+    )
+    parser.add_argument(
+        "-f", "--follow", action="store_true", help="Follow HTTP redirects"
+    )
+    parser.add_argument("URL", help="URL to be fetched")
+
+    args = parser.parse_args()
+
+    # forcing a specific address family by binding to its wildcard
+    # address works on linux, but does not seem to work on darwin.
+    source_address = None
+    if args.ipv4 and args.ipv6:
+        err("conflicting arguments, -4 and -6 cannot be specified together")
+    elif args.ipv4:
+        source_address = "0.0.0.0"
+    elif args.ipv6:
+        source_address = "::"
+
+    if args.expect is not None and any(
+        map(lambda n: n < 100 or n > 599, args.expect)
+    ):
+        err("invalid expected status code")
+
+    try:
+        url = urllib.parse.urlsplit(args.URL)
+    except ValueError as ex:
+        err(f"could not parse URL: {ex}")
+
+    if url.scheme != "http" and url.scheme != "https":
+        err(f"unsupported url scheme: {url.scheme}")
+
+    if url.hostname is None:
+        err("empty hostname in URL")
+
+    session = requests.Session()
+    # match monitoring-plugins defaults
+    session.max_redirects = 10
+
+    if url.username is not None:
+        session.auth = (url.username, url.password)
+
+    target = urllib.parse.urlunsplit(
+        (url.scheme, url.hostname, url.path, url.query, "")
+    )
+
+    if source_address is not None:
+        session.mount("http://", SourceAddressAdapter(source_address))
+        session.mount("https://", SourceAddressAdapter(source_address))
+
+    try:
+        resp = session.get(target, allow_redirects=args.follow)
+    except requests.ConnectionError as ex:
+        critical("could not connect to remote host")
+    except requests.TooManyRedirects as ex:
+        warning("maximum redirection depth exceeded")
+    except requests.Timeout as ex:
+        critical("request to remote host timed out")
+
+    if args.expect is None:
+        if resp.status_code >= 500:
+            critical(
+                f"request returned server error status code: {resp.status_code}"
+            )
+        elif resp.status_code >= 400:
+            warning(
+                f"request returned client error status code: {resp.status_code}"
+            )
+    elif resp.status_code not in args.expect:
+        critical(
+            f"request returned unexpected status code: {resp.status_code}"
+        )
+
+    ok(f"request returned status code: {resp.status_code}")
+
+
+if __name__ == "__main__":
+    main()

--- a/pkgs/fc/sensuplugins/setup.py
+++ b/pkgs/fc/sensuplugins/setup.py
@@ -25,6 +25,7 @@ setup(
             "check_writable=fc.sensuplugins.writable:main",
             "check_interfaces=fc.sensuplugins.interfaces:main",
             "check_psi=fc.sensuplugins.pressure_stall_information:main",
+            "check_http_service=fc.sensuplugins.http:main",
         ],
     },
 )


### PR DESCRIPTION
The `check_http` program in monitoring-plugins which is used for executing customer-provided HTTP service checks does not provide a way to check for specific status codes after following redirects. The only available behaviour is: (a) follow redirects, but then evaluate the resulting status code using the default built-in behaviour; (b) check the status code against the specified list of expected status codes, but do not follow redirects.

This change provides a minimal Python reimplementation of the HTTP check program in fc-sensuplugins. This script supports checking the status codes against an explicitly specified list both with and without following any redirects first.

The `fc-monitor` script has correspondingly been updated to generate sensu checks which use the Python script instead of the monitoring-plugins program.

PL-132208

@flyingcircusio/release-managers

## Release process

Impact: internal

Changelog:

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - The redirect handling for customer-provided HTTP checks should observe the principle of least astonishment when combined with an explicit list of expected status codes.
- [x] Security requirements tested? (EVIDENCE)
  - Tested under global maintenance on services15. The script runs properly and check results are populated correctly in Sensu.