### PR TITLE
[21.05] Prepare BGP configuration for cross-tenant shared overlays

### DIFF
--- a/nixos/platform/network.nix
+++ b/nixos/platform/network.nix
@@ -236,7 +236,6 @@ in
           router bgp ${toString fclib.underlay.asNumber}
            bgp router-id ${fclib.underlay.loopback}
            bgp bestpath as-path multipath-relax
-           no bgp ebgp-requires-policy
            neighbor switches peer-group
            neighbor switches remote-as external
            neighbor switches capability extended-nexthop
@@ -250,14 +249,27 @@ in
             redistribute connected
             neighbor switches prefix-list underlay-import in
             neighbor switches prefix-list underlay-export out
+            neighbor switches route-map accept-all-routes in
+            neighbor switches route-map accept-local-routes out
            exit-address-family
            !
            address-family l2vpn evpn
             neighbor switches activate
+            neighbor switches route-map accept-all-routes in
+            neighbor switches route-map accept-local-routes out
             advertise-all-vni
             advertise-svi-ip
            exit-address-family
           !
+          exit
+          !
+          bgp as-path access-list local-origin seq 1 permit ^$
+          !
+          route-map accept-local-routes permit 1
+           match as-path local-origin
+          exit
+          !
+          route-map accept-all-routes permit 1
           exit
           !
           ip prefix-list underlay-export seq 1 permit ${fclib.underlay.loopback}/32
@@ -269,8 +281,6 @@ in
             fclib.underlay.subnets
            }
           !
-          route-map accept-routes permit 1
-          exit
         '';
       };
     };

--- a/nixos/platform/network.nix
+++ b/nixos/platform/network.nix
@@ -259,6 +259,16 @@ in
             neighbor switches route-map accept-local-routes out
             advertise-all-vni
             advertise-svi-ip
+            ${ # Workaround for FRR not advertising SVI IP when
+               # globally configured
+              lib.concatMapStringsSep "\n  "
+                (iface: concatStringsSep "\n  " [
+                  ("vni " + (toString iface.vlanId))
+                  " advertise-svi-ip"
+                  "exit-vni"
+                ])
+                vxlanInterfaces
+            }
            exit-address-family
           !
           exit

--- a/nixos/platform/network.nix
+++ b/nixos/platform/network.nix
@@ -422,15 +422,22 @@ in
               before = wantedBy;
               after = [ "network-link-properties-ul-loopback-virt.service" ];
               path = [ fclib.relaxedIp ];
+              # https://docs.frrouting.org/en/stable-8.5/zebra.html#administrative-distance
+              #
+              # Due to how zebra calculates administrative distance
+              # for routes learned from the kernel, we need to set a
+              # very high metric on these routes (i.e. very low
+              # preference) so that routes learned from BGP can
+              # override these statically configured routes.
               script = ''
                 ${lib.concatMapStringsSep "\n"
-                  (net: "ip route add unreachable " + net)
+                  (net: "ip route add unreachable " + net + " metric 335544321")
                   fclib.underlay.subnets
                  }
               '';
               preStop = ''
                 ${lib.concatMapStringsSep "\n"
-                  (net: "ip route del unreachable " + net)
+                  (net: "ip route del unreachable " + net + " metric 335544321")
                   fclib.underlay.subnets
                  }
               '';


### PR DESCRIPTION
This change includes some required config changes related to BGP in order to support VXLAN overlays shared between hardware tenants. FRR now only advertises routes which are locally originated, in order to avoid re-advertising routes learned from one switch to another, and some route preferences have been adjusted to allow them to be overridden by routes learned through BGP.

PL-131630

@flyingcircusio/release-managers

## Release process

Impact: internal

Changelog:

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Hosts participating in the VXLAN overlay should not re-advertised routes originating from other hosts. This increases the size of the RIB (routing information base), and may inhibit debugging in the case of faults.
  - Underlay subnets belonging to other tenants in the same location should be unroutable by default in order to prevent traffic leakage through a default route, but should be reachable when routes to other tenants are present in the control plane.
- [x] Security requirements tested? (EVIDENCE)
  - Verified on development hardware.
  - After applying this change, the connected switches only receive routes directly advertised from the connected host (with an AS path length of one).
  - Unreachable routes for other tenants are correctly overridden with dynamically learned routes from BGP.