### PR TITLE
Update nixpkgs (2024-03-12)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -26,11 +26,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1709750969,
-        "narHash": "sha256-LDTZ2aRlnXSwYZnUnv6cJ3WQp8LmDYKMtouv2gTQmAA=",
+        "lastModified": 1710144971,
+        "narHash": "sha256-CjTOdoBvT/4AQncTL20SDHyJNgsXZjtGbz62yDIUYnM=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "e53e5cc77bb6e1073b136ec98a0a9cfbb582c7a8",
+        "rev": "6c0bad0045f1e1802f769f7890f6a59504825f4d",
         "type": "github"
       },
       "original": {
@@ -202,11 +202,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1709759576,
-        "narHash": "sha256-Xq0MdT8farF5WTKMA1Izy/1VZ4obRh7/9WeTt3eQ5+E=",
+        "lastModified": 1710241614,
+        "narHash": "sha256-dq+XM6e67EIRmPzy3VJBL/4afhEI7uyHSqxhDelZfXA=",
         "owner": "flyingcircusio",
         "repo": "nixpkgs",
-        "rev": "223066281ca570f5be77d351df0d880d21bcc9de",
+        "rev": "6f99099c456b0793be58ac42c4612df9396d8384",
         "type": "github"
       },
       "original": {

--- a/release/package-versions.json
+++ b/release/package-versions.json
@@ -55,9 +55,9 @@
     "version": "2.4.22"
   },
   "cacert": {
-    "name": "nss-cacert-3.95",
+    "name": "nss-cacert-3.98",
     "pname": "nss-cacert",
-    "version": "3.95"
+    "version": "3.98"
   },
   "calibre": {
     "name": "calibre-7.0.0",
@@ -70,14 +70,14 @@
     "version": "18.2.0"
   },
   "chromedriver": {
-    "name": "chromedriver-122.0.6261.69",
+    "name": "chromedriver-122.0.6261.94",
     "pname": "chromedriver",
-    "version": "122.0.6261.69"
+    "version": "122.0.6261.94"
   },
   "chromium": {
-    "name": "chromium-122.0.6261.69",
+    "name": "chromium-122.0.6261.111",
     "pname": "chromium",
-    "version": "122.0.6261.69"
+    "version": "122.0.6261.111"
   },
   "cifs-utils": {
     "name": "cifs-utils-7.0",
@@ -130,9 +130,9 @@
     "version": "3.2.0.beta1"
   },
   "dnsmasq": {
-    "name": "dnsmasq-2.89",
+    "name": "dnsmasq-2.90",
     "pname": "dnsmasq",
-    "version": "2.89"
+    "version": "2.90"
   },
   "docker": {
     "name": "docker-24.0.5",
@@ -150,9 +150,9 @@
     "version": "2.3.21"
   },
   "element-web": {
-    "name": "element-web-1.11.58",
+    "name": "element-web-1.11.59",
     "pname": "element-web",
-    "version": "1.11.58"
+    "version": "1.11.59"
   },
   "erlang": {
     "name": "erlang-25.3.2.7",
@@ -185,9 +185,9 @@
     "version": "7.17.16"
   },
   "firefox": {
-    "name": "firefox-123.0",
+    "name": "firefox-123.0.1",
     "pname": "firefox",
-    "version": "123.0"
+    "version": "123.0.1"
   },
   "gcc": {
     "name": "gcc-wrapper-12.3.0",
@@ -220,9 +220,9 @@
     "version": "16.7.7"
   },
   "github-runner": {
-    "name": "github-runner-2.313.0",
+    "name": "github-runner-2.314.1",
     "pname": "github-runner",
-    "version": "2.313.0"
+    "version": "2.314.1"
   },
   "gitlab": {
     "name": "gitlab-16.7.7",
@@ -270,9 +270,9 @@
     "version": "2.4.4"
   },
   "go": {
-    "name": "go-1.21.5",
+    "name": "go-1.21.8",
     "pname": "go",
-    "version": "1.21.5"
+    "version": "1.21.8"
   },
   "go_1_19": {
     "name": "go-1.19.13",
@@ -300,9 +300,9 @@
     "version": "2.8.4"
   },
   "imagemagick": {
-    "name": "imagemagick-7.1.1-27",
+    "name": "imagemagick-7.1.1-29",
     "pname": "imagemagick",
-    "version": "7.1.1-27"
+    "version": "7.1.1-29"
   },
   "imagemagick6": {
     "name": "imagemagick-6.9.12-68",
@@ -310,9 +310,9 @@
     "version": "6.9.12-68"
   },
   "imagemagick7": {
-    "name": "imagemagick-7.1.1-27",
+    "name": "imagemagick-7.1.1-29",
     "pname": "imagemagick",
-    "version": "7.1.1-27"
+    "version": "7.1.1-29"
   },
   "inetutils": {
     "name": "inetutils-2.5",
@@ -430,9 +430,9 @@
     "version": "0.2.5"
   },
   "linux_5_15": {
-    "name": "linux-5.15.149",
+    "name": "linux-5.15.151",
     "pname": "linux",
-    "version": "5.15.149"
+    "version": "5.15.151"
   },
   "logrotate": {
     "name": "logrotate-3.21.0",
@@ -470,9 +470,9 @@
     "version": "4.16.1"
   },
   "matrix-synapse": {
-    "name": "matrix-synapse-wrapped-1.101.0",
+    "name": "matrix-synapse-wrapped-1.102.0",
     "pname": "matrix-synapse-wrapped",
-    "version": "1.101.0"
+    "version": "1.102.0"
   },
   "mcpp": {
     "name": "mcpp-2.7.2.1",
@@ -525,24 +525,24 @@
     "version": "2.18.1"
   },
   "nodejs": {
-    "name": "nodejs-18.18.2",
+    "name": "nodejs-18.19.1",
     "pname": "nodejs",
-    "version": "18.18.2"
+    "version": "18.19.1"
   },
   "nodejs_18": {
-    "name": "nodejs-18.18.2",
+    "name": "nodejs-18.19.1",
     "pname": "nodejs",
-    "version": "18.18.2"
+    "version": "18.19.1"
   },
   "nodejs_20": {
-    "name": "nodejs-20.9.0",
+    "name": "nodejs-20.11.1",
     "pname": "nodejs",
-    "version": "20.9.0"
+    "version": "20.11.1"
   },
   "nodejs_21": {
-    "name": "nodejs-21.2.0",
+    "name": "nodejs-21.6.2",
     "pname": "nodejs",
-    "version": "21.2.0"
+    "version": "21.6.2"
   },
   "nspr": {
     "name": "nspr-4.35",
@@ -560,9 +560,9 @@
     "version": "19.0.2+7"
   },
   "openjpeg": {
-    "name": "openjpeg-2.5.0",
+    "name": "openjpeg-2.5.2",
     "pname": "openjpeg",
-    "version": "2.5.0"
+    "version": "2.5.2"
   },
   "openldap": {
     "name": "openldap-2.6.6",
@@ -620,9 +620,9 @@
     "version": "10.42"
   },
   "percona": {
-    "name": "percona-server-8.0.35-27",
+    "name": "percona-server-8.0.36-28",
     "pname": "percona-server",
-    "version": "8.0.35-27"
+    "version": "8.0.36-28"
   },
   "percona-server": {},
   "percona-xtrabackup_8_0": {
@@ -636,9 +636,9 @@
     "version": "5.7.42-45"
   },
   "percona80": {
-    "name": "percona-server-8.0.35-27",
+    "name": "percona-server-8.0.36-28",
     "pname": "percona-server",
-    "version": "8.0.35-27"
+    "version": "8.0.36-28"
   },
   "php72": {
     "name": "php-with-extensions-7.2.34",
@@ -671,9 +671,9 @@
     "version": "8.2.16"
   },
   "phpPackages.composer": {
-    "name": "composer-2.6.5",
+    "name": "composer-2.7.1",
     "pname": "composer",
-    "version": "2.6.5"
+    "version": "2.7.1"
   },
   "pkg-config": {
     "name": "pkg-config-wrapper-0.29.2",
@@ -696,9 +696,9 @@
     "version": "123"
   },
   "postfix": {
-    "name": "postfix-3.8.5",
+    "name": "postfix-3.8.6",
     "pname": "postfix",
-    "version": "3.8.5"
+    "version": "3.8.6"
   },
   "postgresql": {
     "name": "postgresql-15.6",
@@ -741,9 +741,9 @@
     "version": "0.12.4"
   },
   "python3": {
-    "name": "python3-3.11.6",
+    "name": "python3-3.11.8",
     "pname": "python3",
-    "version": "3.11.6"
+    "version": "3.11.8"
   },
   "python310": {
     "name": "python3-3.10.13",
@@ -751,14 +751,14 @@
     "version": "3.10.13"
   },
   "python311": {
-    "name": "python3-3.11.6",
+    "name": "python3-3.11.8",
     "pname": "python3",
-    "version": "3.11.6"
+    "version": "3.11.8"
   },
   "python312": {
-    "name": "python3-3.12.1",
+    "name": "python3-3.12.2",
     "pname": "python3",
-    "version": "3.12.1"
+    "version": "3.12.2"
   },
   "python38": {
     "name": "python3-3.8.18",

--- a/release/versions.json
+++ b/release/versions.json
@@ -8,9 +8,9 @@
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/"
   },
   "nixpkgs": {
-    "hash": "sha256-Xq0MdT8farF5WTKMA1Izy/1VZ4obRh7/9WeTt3eQ5+E=",
+    "hash": "sha256-dq+XM6e67EIRmPzy3VJBL/4afhEI7uyHSqxhDelZfXA=",
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "223066281ca570f5be77d351df0d880d21bcc9de"
+    "rev": "6f99099c456b0793be58ac42c4612df9396d8384"
   }
 }


### PR DESCRIPTION
Pull upstream NixOS changes, security fixes and package updates (PL-132298):

- cacert: 3.95 -> 3.98
- chromedriver: 122.0.6261.69 -> 122.0.6261.94
- chromium: 122.0.6261.69 -> 122.0.6261.111
- dnsmasq: 2.89 -> 2.90 (CVE-2023-50387, CVE-2023-50868)
- element-web: 1.11.58 -> 1.11.59
- firefox: 123.0 -> 123.0.1
- go: 1.21.5 -> 1.21.6
- imagemagick: 7.1.1-27 -> 7.1.1-29
- linux_5_15: 5.15.149 -> 5.15.151
- matrix-synapse: 1.101.0 -> 1.102.0
- nix: patch CVE-2024-27297
- nodejs_18: 18.18.2 -> 18.19.1
- nodejs_20: 20.10.0 -> 20.11.1
- nodejs_20: 20.9.0 -> 20.10.0
- nodejs_21: 21.2.0 -> 21.6.2
- openjpeg: 2.5.0 -> 2.5.2
- phpPackages.composer: 2.6.6 -> 2.7.1 (CVE-2024-24821)
- percona80: 8.0.35-27 -> 8.0.36-28
- postfix: 3.8.5 -> 3.8.6
- python311: 3.11.6 -> 3.11.8
- python312: 3.12.1 -> 3.12.2



@flyingcircusio/release-managers

## Release process

Impact:

- \[NixOS 23.11\] Machines will reboot after the update to activate the changed kernel.

Changelog:

* (include changes from PR description)

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - pull in upstream security fixes regularly
- [x] Security requirements tested? (EVIDENCE)
  - [x] automated tests still run, works on various test VMs, including a mail test server
  - [x] checked commit log for fixed CVEs and possible problems with updates, looked at [synapse/upgrade.md](https://github.com/element-hq/synapse/blob/develop/docs/upgrade.md), [Percona Server for MySQL 8.0.36-28 (2024-03-04) - Percona Server for MySQL](https://docs.percona.com/percona-server/8.0/release-notes/8.0.36-28.html) and [Postfix stable release 3.8.6, ...](https://www.postfix.org/announcements/postfix-3.8.6.html)