### PR TITLE
[21.05] ceph osds: ensure they come up again after fc-blockdev restarts

### DIFF
--- a/nixos/roles/ceph/osd.nix
+++ b/nixos/roles/ceph/osd.nix
@@ -10,6 +10,14 @@ let
 
   cephPkgs = fclib.ceph.mkPkgs role.cephRelease;
 
+  osdServiceDeps = rec {
+    # Ceph requires the IPs to be properly attached to interfaces so it
+    # knows where to bind to the public and cluster networks.
+    wants = [ "network.target" ];
+    requires = [ "fc-blockdev.service" ];
+    after = wants ++ requires;
+  };
+
   defaultOsdSettings = {
     # Assist speedy but balanced recovery
     osdMaxBackfills = 2;
@@ -190,10 +198,6 @@ in
       systemd.services.fc-ceph-osds-all = rec {
         description = "All locally known Ceph OSDs (via fc-ceph managed units)";
         wantedBy = [ "multi-user.target" ];
-        # Ceph requires the IPs to be properly attached to interfaces so it
-        # knows where to bind to the public and cluster networks.
-        wants = [ "network.target" ];
-        after = wants;
 
         environment = {
           PYTHONUNBUFFERED = "1";
@@ -217,15 +221,10 @@ in
           Type = "oneshot";
           RemainAfterExit = true;
         };
-      };
+      } // osdServiceDeps;
 
       systemd.services."fc-ceph-osd@" = rec {
         description = "Ceph OSD %i";
-        # Ceph requires the IPs to be properly attached to interfaces so it
-        # knows where to bind to the public and cluster networks.
-        wants = [ "network.target" ];
-        requires = [ "fc-blockdev.service" ];
-        after = wants ++ requires;
 
         environment = {
           PYTHONUNBUFFERED = "1";
@@ -249,7 +248,7 @@ in
           TimeoutSec = "15m";
         };
 
-      };
+      } // osdServiceDeps;
 
 
     })

--- a/nixos/roles/ceph/osd.nix
+++ b/nixos/roles/ceph/osd.nix
@@ -203,7 +203,13 @@ in
           PYTHONUNBUFFERED = "1";
         };
 
-        restartIfChanged = false;
+        # Temporary necessary for upgrades from before f2c4dfb8f8f17f5b1c598710ce81ec85e8038e32,
+        # as otherwise the service won't pick up the changes of having to be
+        # restarted based on its newly added requirements.
+        # Can be reverted after successful production rollout.
+        restartTriggers = [ "foo" ];
+        restartIfChanged = true;
+        #restartIfChanged = false;
 
         script = ''
           ${cephPkgs.fc-ceph}/bin/fc-ceph osd activate all


### PR DESCRIPTION
This fixes the issue of all OSD service units being shut down and staying down when fc-blockdev.service was stopped (and started) again by a system switch. The main issue was that stops of fc-blockdev propagated to stop the individual OSD units, but nothing ensured that they come up again. Only fc-ceph-osds-all.service was pulled in by the multi-user.target and stayed active all the time. By adding the fc-blockdev requirement to the osds-all.service, it is ensured that the stopping of OSDs is discovered and they are being activated again after restart.

Stoppping osd services at a system switch is a notable change we've tried to avoid for now. But doing so makes sense, as it allows automatically applying changed blockdevice settings. Doing OSD restarts for further changes like config file or executable changes is out of scope for now and can be revisited at the next ceph update.

Another important consideration to be made: OSDs explicitly stopped won't always stay stopped, as they might be started again when fc-blockdev changes. But this could already happen when a machine had scheduled a reboot, as after boot all OSDs are started.

PL-132304 PL-132303

@flyingcircusio/release-managers

## Release process

Impact:
- internal only

Changelog:
- fix all OSDs being shutdown and staying down when `fc-blockdev.service` changes
- introduce automatic stopping and starting of all OSDs at system switch time in certain cases:
  - only if fc-blockdev.service changes and thus needs to be restarted
  - OSD units explicitly stopped before will get automatically started again when this happens

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - fix an issue that stopped services at unattended upgrades
  - systems have to transition from a functioning state to another functioning state before and after a maintenance upgrade 
  - manually reproduce the underlying cause
    - manual service stops
    - NixOS-triggered service stops
- [ ] Security requirements tested? (EVIDENCE)
  - [ ] automated tests still pass
  - [x] manually verified the system unit behaviour on a dev host with
    - [x] manual start/stops of fc-blockdev
    - [x] NixOS-induced start/stops of fc-blockdev
    - [x] manually verify upgrading from a previous state works
      - disclaimer: mostly looked at the service stops and (re)starts done; the network on dev hosts currently breaks at switch time