### PR TITLE
Update libmodsecurity to the latest upstream version

### DIFF
--- a/pkgs/libmodsecurity/default.nix
+++ b/pkgs/libmodsecurity/default.nix
@@ -1,29 +1,29 @@
 { lib, stdenv, fetchFromGitHub
 , autoreconfHook, bison, flex, pkg-config
-, curl, geoip, libmaxminddb, libxml2, lua, pcre
-, ssdeep, valgrind, yajl
+, curl, geoip, libmaxminddb, libxml2, lua, pcre, ssdeep, yajl
 , nixosTests
 }:
 
 stdenv.mkDerivation rec {
   pname = "libmodsecurity";
-  version = "3.0.8";
+  version = "3.0.12";
 
   src = fetchFromGitHub {
     owner = "SpiderLabs";
     repo = "ModSecurity";
     rev = "v${version}";
-    sha256 = "sha256-Xqg7Y6i5pG1WGDLE7Zry+6ZN5o1LpmpOwEL67LlzIDk=";
+    sha256 = "sha256-WIFAg9LvKAC8e3gpcIxtNHT53AIfPtUTyrv30woxP4M=";
     fetchSubmodules = true;
   };
 
   nativeBuildInputs = [ autoreconfHook bison flex pkg-config ];
-  buildInputs = [ curl geoip libmaxminddb libxml2 lua pcre ssdeep valgrind yajl ];
+  buildInputs = [ curl geoip libmaxminddb libxml2 lua pcre ssdeep yajl ];
 
   outputs = [ "out" "dev" ];
 
   configureFlags = [
     "--enable-parser-generation"
+    "--disable-doxygen-doc"
     "--with-curl=${curl.dev}"
     "--with-libxml=${libxml2.dev}"
     "--with-maxmind=${libmaxminddb}"
@@ -67,5 +67,6 @@ stdenv.mkDerivation rec {
     license = licenses.asl20;
     platforms = platforms.all;
     maintainers = with maintainers; [ izorkin ];
+    mainProgram = "modsec-rules-check";
   };
 }


### PR DESCRIPTION
This change updates libmodsecurity to the latest upstream version, as recent versions have a number of fixes for memory leaks which we suspect we're encountering.

Unfortunately, the compile flags for libmodsecurity used by default in Nixpkgs still seem to cause nginx to segfault in our Hydra tests, though the segfault seemed to occur in libpcre2 rather than in lmdb as they supposedly have previously. Nonetheless, this change retains the locally vendored version of the package, with pcre2 and lmdb turned off.

PL-132307

@flyingcircusio/release-managers

## Release process

Impact:

Changelog: libmodsecurity has been updated to the latest upstream version 3.0.12 (PL-132307).

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Performance and efficiency improvements in third-party packages.
- [x] Security requirements tested? (EVIDENCE)
  - Hydra tests pass.