### PR TITLE
[hotfix] lamp: httpd logs must not be removed by systemd-tmpfiles

### DIFF
--- a/nixos/roles/lamp.nix
+++ b/nixos/roles/lamp.nix
@@ -262,8 +262,12 @@ in {
           }];
         };
 
+        # required for PL-132312 hotfix: httpd needs to be restarted after the update to create new log.
+        # Can be removed again at some point.
+        systemd.services.httpd.restartTriggers = [ "2024-03-14-PL-132312" ];
+
         systemd.tmpfiles.rules = [
-          "D /var/log/httpd 2750 root service"
+          "d /var/log/httpd 2750 root service"
           "a+ /var/log/httpd - - - - default:group::r-X,default:group:sudo-srv:r-X,default:group:service:r-X,default:mask::r-X"
           # recursive is required as well to adjust permissions of existing files
           "A+ /var/log/httpd - - - - group:sudo-srv:r-X,group:service:r-X,group::r-X,mask::r-X"


### PR DESCRIPTION
Fixes a regression in #930 and is thus branched off directly off the production branch as a hotfix. Will still be backported to the normal release flow afterwards.

The changes in the tmpfiles rules accidentally caused the httpd logfiels to be cleaned up at each system switch. This happened by accident due to mixing up d and D.
As httpd continues to log into the still open file descriptors of the log files removed from the fs, it needs a restart (or reload) to re-create logfiles.

PL-132312

@flyingcircusio/release-managers

## Release process

Impact:
- httpd will be restarted

Changelog:
- lamp/httpd: Fix a regression that log files from /var/log/httpd are periodically deleted
### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - fix a regression
  - must not introduce any new known regressions 
  - log files are important for debugging (-> availability), thus the decision to roll this out as a hotfix
- [x] Security requirements tested? (EVIDENCE)
  - [x] automated tests still pass
  - [x] rolled this out to an affected VM, verified the necissity of restarts for recovery of logfiles