### PR TITLE
[21.05] ceph: workaround for 8ab330b2d48dc88a5b9698d191b75e0086fdcc0d

### DIFF
--- a/nixos/services/ceph/server.nix
+++ b/nixos/services/ceph/server.nix
@@ -124,6 +124,16 @@ in
       environment = {
         PYTHONUNBUFFERED = "1";
       };
+
+      # workaround for properly getting rid of the RequiredBy = fc-ceph-osd@…
+      # done in 8ab330b2d48dc88a5b9698d191b75e0086fdcc0d without stopping these
+      # dependant units one last time at switch-to-configuration time based on
+      # the *previous* unit state. This *restarts* fc-blockdev already with its
+      # current dependency declarations.
+      #
+      # The main purpose of this is to manage the transition from before the
+      # mentioned commit, this *may* be removed in the future at some point again.
+      stopIfChanged = false;  # do a restart with the new unit file instead of stop-start
     };
 
     boot.kernel.sysctl = {


### PR DESCRIPTION
Unfortunately the changes in 8ab330b2d48dc88a5b9698d191b75e0086fdcc0d are not sufficient for preventing the shutdown of OSDs, as the decision
at switch-to-configuration time on which dependent units to stop when
fc-blockdev is stopped relies on the unit state _before_ the switch. As
long as the `requires` relation between OSDs and fc-blockdev is still
there in that state, OSDs will still be stopped and do not come up again
automatically.

This utilises a trick of using a `systemctl restart` instead of a stop
and start in switch-to-configuration, as the restart is already done
based on the new unit file and its dependency structures.
Also, changing this modifies the unit file itself and already triggers a
restart of fc-blockdev.service by itself, making sure the changes are
persisted.

This _might_ be removed in the future again, as its main purpose is
making sure the transition of fc-ceph-osd@.service dependencies happens
cleanly without pulling down the osds.

PL-132304

@flyingcircusio/release-managers

## Release process

Impact:
- internal only

Changelog:
- *prevents* automatical restarts of fc-blockdev, causing changed blockdev setting to only be applied at the next boot

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - analysed system behaviour during rollout for regression
  - design workaround to keep ceph OSDs available
  - must not introduce any new known new regressions 
- [x] Security requirements tested? (EVIDENCE)
  - [x] manually tested on a host
  - [x] automated tests still pass
  - [x] manually tested direct update from de4b8e543cc02d6f1106918417ee22bf2316c149 (prev commit of the `requires` change)  to this commit in staging
