### PR TITLE
[21.05] fc qemu scrub timeout

### DIFF
--- a/nixos/roles/kvm.nix
+++ b/nixos/roles/kvm.nix
@@ -295,6 +295,7 @@ in
       path = [ pkgs.fc.agent role.package ];
       serviceConfig = {
         Type = "oneshot";
+        TimeoutStartSec = 600; # PL-132323
       };
 
       script = "fc-qemu-scrub";


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

none

Changelog:

* Add a timeout to our KVM host scrubbing mechanism to ensure timely repeated attempts. (PL-132323)

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

ensuring availability is important. ;)

- [ ] Security requirements tested? (EVIDENCE)

not yet, needs double checking in dev