### PR TITLE
opensearch: fix maintenance enter check

### DIFF
--- a/nixos/roles/opensearch.nix
+++ b/nixos/roles/opensearch.nix
@@ -38,6 +38,7 @@ let
 
   waitForGreenCluster = pkgs.writeShellApplication {
     name = "opensearch-wait-for-green-cluster";
+    runtimeInputs = [ pkgs.curl ];
     text = ''
       echo "Checking if the OpenSearch cluster is green..." >&2
       echo "(timeout 60s, connect timeout 20s)" >&2


### PR DESCRIPTION
curl has to be added as runtime dependency of the check script explicitly as curl is not in the PATH used by the fc-agent service.

Manually running maintenances was not affected because curl is in our global env.

PL-132247

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* opensearch: fix the maintenance pre-check introduced in release 2024_009. The error prevented machines using the *opensearch* role from running any maintenance activities automatically (PL-132247).

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - just a bugfix to allow opensearch machines to run maintenance activities automatically again.
- [x] Security requirements tested? (EVIDENCE)
  -  checked on a test VM that `fc-agent.service` is able to run maintenance activities successfully when the opensearch cluster is green.
