### PR TITLE
[21.05] Improve resilience of system network state under upgrade conditions

### DIFF
--- a/nixos/platform/network.nix
+++ b/nixos/platform/network.nix
@@ -466,7 +466,9 @@ in
               reload = ''
                 IFACE=${iface.layer2device}
 
-                # Set underlay address for virtual interface ${iface.layer2device}
+                # Set underlay address for virtual interface ${iface.layer2device}.
+                # Note that changing the VNI or destination port after the interface
+                # has been created is not supported.
                 ip link set $IFACE type vxlan local ${fclib.underlay.loopback}
 
                 # Set MTU and layer 2 address

--- a/nixos/platform/network.nix
+++ b/nixos/platform/network.nix
@@ -393,8 +393,10 @@ in
             "ul-loopback-netdev"
             rec {
               description = "Dummy Interface ul-loopback";
-              wantedBy = [ "multi-user.target" ];
+              wantedBy = [ "network-setup.service" "multi-user.target" ];
               before = wantedBy;
+              after = [ "network-pre.service" ];
+              partOf = [ "network-setup.service" ];
               path = [ pkgs.nettools pkgs.procps fclib.relaxedIp ];
               reloadIfChanged = true;
               script = ''
@@ -435,11 +437,11 @@ in
             "${iface.layer2device}-netdev"
             rec {
               description = "VXLAN Interface ${iface.layer2device}";
-              wantedBy = [ "multi-user.target" ];
+              wantedBy = [ "network-setup.service" "multi-user.target" ];
               before = wantedBy;
               requires = [ "network-addresses-ul-loopback.service" ];
-              after = requires;
-              partOf = requires;
+              after = requires ++ [ "network-pre.target" ];
+              partOf = requires ++ [ "network-setup.service" ];
               reloadIfChanged = true;
               path = [ pkgs.nettools pkgs.procps fclib.relaxedIp ];
               script = ''

--- a/nixos/platform/network.nix
+++ b/nixos/platform/network.nix
@@ -558,6 +558,15 @@ in
                 script = "${pkgs.fc.lldp-to-altname}/bin/fc-lldp-to-altname -q ${lib.concatStringsSep " " (attrNames fclib.underlay.interfaces)}";
               }
             )
+            # ensure that restarts of ul-loopback are propagated to zebra
+            (lib.nameValuePair
+              "zebra"
+              rec {
+                requires = [ "network-addresses-ul-loopback.service" ];
+                after = requires;
+                partOf = requires;
+              }
+            )
           ])
         )));
 


### PR DESCRIPTION
This change refactors the configuration for setting up VXLAN interfaces (once again), and ensures that systemd unit dependencies are correctly set in platform-provided units upon units provided by NixOS's scripted interface configuration automation. This should ensure that the host network configuration is more resilient under some upgrade conditions which have previously led to the loss of network connectivity. 

In particular, channel updates may cause a large number of network-related systemd units to be rebuilt, especially if some core system dependency has changed in the new channel version. When activating the first configuration based upon the new channel, units related to setup of the VXLAN overlay may be indirectly stopped due to dependencies on other units, particularly `PartOf=` dependencies. If these units are not explicitly picked up by switch-to-configuration, then they may not be restarted and leave the network in a broken state. Upstream-provided units for virtual network interfaces (e.g. bridge interfaces) have a number of dependencies set to ensure that they are properly restarted during upgrades, so the solution is to ensure that corresponding/matching dependencies are set on the platform-provided units for configuration of dummy and VXLAN interfaces.

Additionally, the unit for zebra has been updated to ensure that it is restarted when the addresses assigned to the `ul-loopback` interface are changed. The addresses on this interface are used as source addresses for routes inserted into the kernel by zebra, and if these addresses disappear then zebra will remove the routes and will not try to reinsert them without manual intervention.

PL-132305

@flyingcircusio/release-managers

## Release process

Impact:

Changelog: internal

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - The upgrade process in and of itself should not break the host network configuration as a side-effect.
- [x] Security requirements tested? (EVIDENCE)
  - Manually verified on a dev host by toggling the most recent 23.05 channel update and then ensuring that the network doesn't break on the next switch-to-configuration.