### PR TITLE
Update nixpkgs and nixos-mailserver (2024-04-03)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -16,25 +16,81 @@
         "type": "gitlab"
       }
     },
-    "devenv": {
+    "cachix": {
       "inputs": {
-        "flake-compat": "flake-compat",
-        "nix": "nix",
+        "devenv": "devenv_2",
+        "flake-compat": "flake-compat_2",
         "nixpkgs": [
+          "devenv",
           "nixpkgs"
         ],
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1710144971,
-        "narHash": "sha256-CjTOdoBvT/4AQncTL20SDHyJNgsXZjtGbz62yDIUYnM=",
+        "lastModified": 1710475558,
+        "narHash": "sha256-egKrPCKjy/cE+NqCj4hg2fNX/NwLCf0bRDInraYXDgs=",
         "owner": "cachix",
-        "repo": "devenv",
-        "rev": "6c0bad0045f1e1802f769f7890f6a59504825f4d",
+        "repo": "cachix",
+        "rev": "661bbb7f8b55722a0406456b15267b5426a3bda6",
         "type": "github"
       },
       "original": {
         "owner": "cachix",
+        "repo": "cachix",
+        "type": "github"
+      }
+    },
+    "devenv": {
+      "inputs": {
+        "cachix": "cachix",
+        "flake-compat": "flake-compat_4",
+        "nix": "nix_2",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "pre-commit-hooks": "pre-commit-hooks_2"
+      },
+      "locked": {
+        "lastModified": 1712143604,
+        "narHash": "sha256-Qab376PfQGND+xx2DHCWAz6v5gtt6ux1jkzNvFrY33s=",
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "6b274c61bc67e44885920c4c99389ee777bbce71",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "devenv",
+        "type": "github"
+      }
+    },
+    "devenv_2": {
+      "inputs": {
+        "flake-compat": [
+          "devenv",
+          "cachix",
+          "flake-compat"
+        ],
+        "nix": "nix",
+        "nixpkgs": "nixpkgs",
+        "poetry2nix": "poetry2nix",
+        "pre-commit-hooks": [
+          "devenv",
+          "cachix",
+          "pre-commit-hooks"
+        ]
+      },
+      "locked": {
+        "lastModified": 1708704632,
+        "narHash": "sha256-w+dOIW60FKMaHI1q5714CSibk99JfYxm0CzTinYWr+Q=",
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "2ee4450b0f4b95a1b90f2eb5ffea98b90e48c196",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "ref": "python-rewrite",
         "repo": "devenv",
         "type": "github"
       }
@@ -58,6 +114,70 @@
     "flake-compat_2": {
       "flake": false,
       "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_6": {
+      "flake": false,
+      "locked": {
         "lastModified": 1668681692,
         "narHash": "sha256-Ht91NGdewz8IQLtWZ9LCeNXMSXHUss+9COoqu6JLmXU=",
         "owner": "edolstra",
@@ -76,11 +196,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1709336216,
-        "narHash": "sha256-Dt/wOWeW6Sqm11Yh+2+t0dfEWxoMxGBvv3JpIocFl9E=",
+        "lastModified": 1712014858,
+        "narHash": "sha256-sB4SWl2lX95bExY2gMFG5HIzvva5AVMJd4Igm+GpZNw=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "f7b3c975cf067e56e7cda6cb098ebe3fb4d74ca2",
+        "rev": "9126214d0a59633752a136528f5f3b9aa8565b7d",
         "type": "github"
       },
       "original": {
@@ -94,11 +214,47 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1685518550,
-        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
+        "lastModified": 1689068808,
+        "narHash": "sha256-6ixXo3wt24N/melDWjq70UuHQLxGV8jZvooRanIHXw0=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
+        "rev": "919d646de7be200f3bf08cb76ae1f09402b6f9b4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_3": {
+      "inputs": {
+        "systems": "systems_3"
+      },
+      "locked": {
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
         "type": "github"
       },
       "original": {
@@ -111,16 +267,17 @@
       "inputs": {
         "nixpkgs": [
           "devenv",
+          "cachix",
           "pre-commit-hooks",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1660459072,
-        "narHash": "sha256-8DFJjXG8zqoONA1vXtgeKXy68KdJL5UaXR8NtVMUbx8=",
+        "lastModified": 1703887061,
+        "narHash": "sha256-gGPa9qWNc6eCXT/+Z5/zMkyYOuRZqeFZBDbopNZQkuY=",
         "owner": "hercules-ci",
         "repo": "gitignore.nix",
-        "rev": "a20de23b925fd8264fd7fad6454652e142fd7f73",
+        "rev": "43e1aa1308018f37118e34d3a9cb4f5e75dc11d5",
         "type": "github"
       },
       "original": {
@@ -129,42 +286,98 @@
         "type": "github"
       }
     },
-    "lowdown-src": {
-      "flake": false,
+    "gitignore_2": {
+      "inputs": {
+        "nixpkgs": [
+          "devenv",
+          "pre-commit-hooks",
+          "nixpkgs"
+        ]
+      },
       "locked": {
-        "lastModified": 1633514407,
-        "narHash": "sha256-Dw32tiMjdK9t3ETl5fzGrutQTzh2rufgZV4A/BbxuD4=",
-        "owner": "kristapsdz",
-        "repo": "lowdown",
-        "rev": "d2c2b44ff6c27b936ec27358a2653caaef8f73b8",
+        "lastModified": 1703887061,
+        "narHash": "sha256-gGPa9qWNc6eCXT/+Z5/zMkyYOuRZqeFZBDbopNZQkuY=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "43e1aa1308018f37118e34d3a9cb4f5e75dc11d5",
         "type": "github"
       },
       "original": {
-        "owner": "kristapsdz",
-        "repo": "lowdown",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
         "type": "github"
       }
     },
     "nix": {
       "inputs": {
-        "lowdown-src": "lowdown-src",
+        "flake-compat": "flake-compat",
         "nixpkgs": [
+          "devenv",
+          "cachix",
           "devenv",
           "nixpkgs"
         ],
         "nixpkgs-regression": "nixpkgs-regression"
       },
       "locked": {
-        "lastModified": 1676545802,
-        "narHash": "sha256-EK4rZ+Hd5hsvXnzSzk2ikhStJnD63odF7SzsQ8CuSPU=",
+        "lastModified": 1708577783,
+        "narHash": "sha256-92xq7eXlxIT5zFNccLpjiP7sdQqQI30Gyui2p/PfKZM=",
         "owner": "domenkozar",
         "repo": "nix",
-        "rev": "7c91803598ffbcfe4a55c44ac6d49b2cf07a527f",
+        "rev": "ecd0af0c1f56de32cbad14daa1d82a132bf298f8",
         "type": "github"
       },
       "original": {
         "owner": "domenkozar",
-        "ref": "relaxed-flakes",
+        "ref": "devenv-2.21",
+        "repo": "nix",
+        "type": "github"
+      }
+    },
+    "nix-github-actions": {
+      "inputs": {
+        "nixpkgs": [
+          "devenv",
+          "cachix",
+          "devenv",
+          "poetry2nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1688870561,
+        "narHash": "sha256-4UYkifnPEw1nAzqqPOTL2MvWtm3sNGw1UTYTalkTcGY=",
+        "owner": "nix-community",
+        "repo": "nix-github-actions",
+        "rev": "165b1650b753316aa7f1787f3005a8d2da0f5301",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nix-github-actions",
+        "type": "github"
+      }
+    },
+    "nix_2": {
+      "inputs": {
+        "flake-compat": "flake-compat_5",
+        "nixpkgs": [
+          "devenv",
+          "nixpkgs"
+        ],
+        "nixpkgs-regression": "nixpkgs-regression_2"
+      },
+      "locked": {
+        "lastModified": 1710500156,
+        "narHash": "sha256-zvCqeUO2GLOm7jnU23G4EzTZR7eylcJN+HJ5svjmubI=",
+        "owner": "domenkozar",
+        "repo": "nix",
+        "rev": "c5bbf14ecbd692eeabf4184cc8d50f79c2446549",
+        "type": "github"
+      },
+      "original": {
+        "owner": "domenkozar",
+        "ref": "devenv-2.21",
         "repo": "nix",
         "type": "github"
       }
@@ -172,7 +385,7 @@
     "nixos-mailserver": {
       "inputs": {
         "blobs": "blobs",
-        "flake-compat": "flake-compat_2",
+        "flake-compat": "flake-compat_6",
         "nixpkgs": [
           "nixpkgs"
         ],
@@ -186,11 +399,11 @@
       },
       "locked": {
         "host": "gitlab.flyingcircus.io",
-        "lastModified": 1701453570,
-        "narHash": "sha256-2ai0rYD6o8fQgweO3zKqPbbQBy/SQC8Hs+ZTf+GeXuU=",
+        "lastModified": 1711404790,
+        "narHash": "sha256-8zLBr6NNLZYirvuFL1bVNU8pAzEv3Z0BBjcU8tK6aH8=",
         "owner": "flyingcircus",
         "repo": "nixos-mailserver",
-        "rev": "b3d6e950b71f7f9a29268beb9de03003705765e8",
+        "rev": "871e767a7450630ce0180ac68846dcd2d6981ed9",
         "type": "gitlab"
       },
       "original": {
@@ -202,16 +415,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1710241614,
-        "narHash": "sha256-dq+XM6e67EIRmPzy3VJBL/4afhEI7uyHSqxhDelZfXA=",
-        "owner": "flyingcircusio",
+        "lastModified": 1692808169,
+        "narHash": "sha256-x9Opq06rIiwdwGeK2Ykj69dNc2IvUH1fY55Wm7atwrE=",
+        "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6f99099c456b0793be58ac42c4612df9396d8384",
+        "rev": "9201b5ff357e781bf014d0330d18555695df7ba8",
         "type": "github"
       },
       "original": {
-        "owner": "flyingcircusio",
-        "ref": "nixos-23.11",
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -219,11 +432,11 @@
     "nixpkgs-lib": {
       "locked": {
         "dir": "lib",
-        "lastModified": 1709237383,
-        "narHash": "sha256-cy6ArO4k5qTx+l5o+0mL9f5fa86tYUX3ozE1S+Txlds=",
+        "lastModified": 1711703276,
+        "narHash": "sha256-iMUFArF0WCatKK6RzfUJknjem0H9m4KgorO/p3Dopkk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1536926ef5621b09bba54035ae2bb6d806d72ac8",
+        "rev": "d8fe5e6c92d0d190646fb9f1056741a229980089",
         "type": "github"
       },
       "original": {
@@ -250,42 +463,141 @@
         "type": "github"
       }
     },
-    "nixpkgs-stable": {
+    "nixpkgs-regression_2": {
       "locked": {
-        "lastModified": 1685801374,
-        "narHash": "sha256-otaSUoFEMM+LjBI1XL/xGB5ao6IwnZOXc47qhIgJe8U=",
+        "lastModified": 1643052045,
+        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c37ca420157f4abc31e26f436c1145f8951ff373",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-23.05",
         "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      }
+    },
+    "nixpkgs-stable": {
+      "locked": {
+        "lastModified": 1704874635,
+        "narHash": "sha256-YWuCrtsty5vVZvu+7BchAxmcYzTMfolSPP5io8+WYCg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "3dc440faeee9e889fe2d1b4d25ad0f430d449356",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-23.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-stable_2": {
+      "locked": {
+        "lastModified": 1704874635,
+        "narHash": "sha256-YWuCrtsty5vVZvu+7BchAxmcYzTMfolSPP5io8+WYCg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "3dc440faeee9e889fe2d1b4d25ad0f430d449356",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-23.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1712173322,
+        "narHash": "sha256-XpKp+f9eyFGPIUuyW7xsBjTAYpaw/XaitfE0C3IF5jA=",
+        "owner": "flyingcircusio",
+        "repo": "nixpkgs",
+        "rev": "828c9768fa53d526b1828854a59b1f74eff51f16",
+        "type": "github"
+      },
+      "original": {
+        "owner": "flyingcircusio",
+        "ref": "nixos-23.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "poetry2nix": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nix-github-actions": "nix-github-actions",
+        "nixpkgs": [
+          "devenv",
+          "cachix",
+          "devenv",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1692876271,
+        "narHash": "sha256-IXfZEkI0Mal5y1jr6IRWMqK8GW2/f28xJenZIPQqkY0=",
+        "owner": "nix-community",
+        "repo": "poetry2nix",
+        "rev": "d5006be9c2c2417dafb2e2e5034d83fabd207ee3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "poetry2nix",
         "type": "github"
       }
     },
     "pre-commit-hooks": {
       "inputs": {
-        "flake-compat": [
-          "devenv",
-          "flake-compat"
-        ],
-        "flake-utils": "flake-utils",
+        "flake-compat": "flake-compat_3",
+        "flake-utils": "flake-utils_2",
         "gitignore": "gitignore",
         "nixpkgs": [
           "devenv",
+          "cachix",
           "nixpkgs"
         ],
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1704725188,
-        "narHash": "sha256-qq8NbkhRZF1vVYQFt1s8Mbgo8knj+83+QlL5LBnYGpI=",
+        "lastModified": 1708018599,
+        "narHash": "sha256-M+Ng6+SePmA8g06CmUZWi1AjG2tFBX9WCXElBHEKnyM=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "ea96f0c05924341c551a797aaba8126334c505d2",
+        "rev": "5df5a70ad7575f6601d91f0efec95dd9bc619431",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
+    "pre-commit-hooks_2": {
+      "inputs": {
+        "flake-compat": [
+          "devenv",
+          "flake-compat"
+        ],
+        "flake-utils": "flake-utils_3",
+        "gitignore": "gitignore_2",
+        "nixpkgs": [
+          "devenv",
+          "nixpkgs"
+        ],
+        "nixpkgs-stable": "nixpkgs-stable_2"
+      },
+      "locked": {
+        "lastModified": 1708018599,
+        "narHash": "sha256-M+Ng6+SePmA8g06CmUZWi1AjG2tFBX9WCXElBHEKnyM=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "5df5a70ad7575f6601d91f0efec95dd9bc619431",
         "type": "github"
       },
       "original": {
@@ -299,10 +611,40 @@
         "devenv": "devenv",
         "flake-parts": "flake-parts",
         "nixos-mailserver": "nixos-mailserver",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs_2"
       }
     },
     "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_3": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/release/package-versions.json
+++ b/release/package-versions.json
@@ -70,14 +70,14 @@
     "version": "18.2.0"
   },
   "chromedriver": {
-    "name": "chromedriver-122.0.6261.94",
+    "name": "chromedriver-123.0.6312.86",
     "pname": "chromedriver",
-    "version": "122.0.6261.94"
+    "version": "123.0.6312.86"
   },
   "chromium": {
-    "name": "chromium-122.0.6261.111",
+    "name": "chromium-123.0.6312.86",
     "pname": "chromium",
-    "version": "122.0.6261.111"
+    "version": "123.0.6312.86"
   },
   "cifs-utils": {
     "name": "cifs-utils-7.0",
@@ -150,9 +150,9 @@
     "version": "2.3.21"
   },
   "element-web": {
-    "name": "element-web-1.11.59",
+    "name": "element-web-1.11.61",
     "pname": "element-web",
-    "version": "1.11.59"
+    "version": "1.11.61"
   },
   "erlang": {
     "name": "erlang-25.3.2.7",
@@ -185,9 +185,9 @@
     "version": "7.17.16"
   },
   "firefox": {
-    "name": "firefox-123.0.1",
+    "name": "firefox-124.0.1",
     "pname": "firefox",
-    "version": "123.0.1"
+    "version": "124.0.1"
   },
   "gcc": {
     "name": "gcc-wrapper-12.3.0",
@@ -215,44 +215,44 @@
     "version": "2.42.0"
   },
   "gitaly": {
-    "name": "gitaly-16.7.7",
+    "name": "gitaly-16.9.3",
     "pname": "gitaly",
-    "version": "16.7.7"
+    "version": "16.9.3"
   },
   "github-runner": {
-    "name": "github-runner-2.314.1",
+    "name": "github-runner-2.315.0",
     "pname": "github-runner",
-    "version": "2.314.1"
+    "version": "2.315.0"
   },
   "gitlab": {
-    "name": "gitlab-16.7.7",
+    "name": "gitlab-16.9.3",
     "pname": "gitlab",
-    "version": "16.7.7"
+    "version": "16.9.3"
   },
   "gitlab-container-registry": {
-    "name": "gitlab-container-registry-3.90.0",
+    "name": "gitlab-container-registry-3.91.0",
     "pname": "gitlab-container-registry",
-    "version": "3.90.0"
+    "version": "3.91.0"
   },
   "gitlab-ee": {
-    "name": "gitlab-ee-16.7.7",
+    "name": "gitlab-ee-16.9.3",
     "pname": "gitlab-ee",
-    "version": "16.7.7"
+    "version": "16.9.3"
   },
   "gitlab-pages": {
-    "name": "gitlab-pages-16.7.7",
+    "name": "gitlab-pages-16.9.3",
     "pname": "gitlab-pages",
-    "version": "16.7.7"
+    "version": "16.9.3"
   },
   "gitlab-runner": {
-    "name": "gitlab-runner-16.7.0",
+    "name": "gitlab-runner-16.9.1",
     "pname": "gitlab-runner",
-    "version": "16.7.0"
+    "version": "16.9.1"
   },
   "gitlab-workhorse": {
-    "name": "gitlab-workhorse-16.7.7",
+    "name": "gitlab-workhorse-16.9.3",
     "pname": "gitlab-workhorse",
-    "version": "16.7.7"
+    "version": "16.9.3"
   },
   "glibc": {
     "name": "glibc-2.38-44",
@@ -285,9 +285,9 @@
     "version": "1.20.12"
   },
   "grafana": {
-    "name": "grafana-10.2.4",
+    "name": "grafana-10.2.6",
     "pname": "grafana",
-    "version": "10.2.4"
+    "version": "10.2.6"
   },
   "grub2": {
     "name": "grub-2.12-rc1",
@@ -330,24 +330,24 @@
     "version": "17.0.7-b829.16"
   },
   "jetty": {
-    "name": "jetty-12.0.5",
+    "name": "jetty-12.0.7",
     "pname": "jetty",
-    "version": "12.0.5"
+    "version": "12.0.7"
   },
   "jicofo": {
-    "name": "jicofo-1.0-1059",
+    "name": "jicofo-1.0-1075",
     "pname": "jicofo",
-    "version": "1.0-1059"
+    "version": "1.0-1075"
   },
   "jitsi-meet": {
-    "name": "jitsi-meet-1.0.7712",
+    "name": "jitsi-meet-1.0.7790",
     "pname": "jitsi-meet",
-    "version": "1.0.7712"
+    "version": "1.0.7790"
   },
   "jitsi-videobridge": {
-    "name": "jitsi-videobridge2-2.3-64-g719465d1",
+    "name": "jitsi-videobridge2-2.3-92-g64f9f34f",
     "pname": "jitsi-videobridge2",
-    "version": "2.3-64-g719465d1"
+    "version": "2.3-92-g64f9f34f"
   },
   "jq": {
     "name": "jq-1.7.1",
@@ -430,9 +430,9 @@
     "version": "0.2.5"
   },
   "linux_5_15": {
-    "name": "linux-5.15.151",
+    "name": "linux-5.15.152",
     "pname": "linux",
-    "version": "5.15.151"
+    "version": "5.15.152"
   },
   "logrotate": {
     "name": "logrotate-3.21.0",
@@ -470,9 +470,9 @@
     "version": "4.16.1"
   },
   "matrix-synapse": {
-    "name": "matrix-synapse-wrapped-1.102.0",
+    "name": "matrix-synapse-wrapped-1.103.0",
     "pname": "matrix-synapse-wrapped",
-    "version": "1.102.0"
+    "version": "1.103.0"
   },
   "mcpp": {
     "name": "mcpp-2.7.2.1",
@@ -550,9 +550,9 @@
     "version": "4.35"
   },
   "nss_latest": {
-    "name": "nss-3.98",
+    "name": "nss-3.99",
     "pname": "nss",
-    "version": "3.98"
+    "version": "3.99"
   },
   "openjdk": {
     "name": "openjdk-19.0.2+7",
@@ -666,9 +666,9 @@
     "version": "8.1.27"
   },
   "php82": {
-    "name": "php-with-extensions-8.2.16",
+    "name": "php-with-extensions-8.2.17",
     "pname": "php-with-extensions",
-    "version": "8.2.16"
+    "version": "8.2.17"
   },
   "phpPackages.composer": {
     "name": "composer-2.7.1",
@@ -731,9 +731,9 @@
     "version": "4.8.4"
   },
   "prometheus": {
-    "name": "prometheus-2.49.0",
+    "name": "prometheus-2.49.1",
     "pname": "prometheus",
-    "version": "2.49.0"
+    "version": "2.49.1"
   },
   "prosody": {
     "name": "prosody-0.12.4",
@@ -761,14 +761,14 @@
     "version": "3.12.2"
   },
   "python38": {
-    "name": "python3-3.8.18",
+    "name": "python3-3.8.19",
     "pname": "python3",
-    "version": "3.8.18"
+    "version": "3.8.19"
   },
   "python39": {
-    "name": "python3-3.9.18",
+    "name": "python3-3.9.19",
     "pname": "python3",
-    "version": "3.9.18"
+    "version": "3.9.19"
   },
   "python3Packages.boto3": {
     "name": "python3.11-boto3-1.28.57",
@@ -911,9 +911,9 @@
     "version": "8.11.2"
   },
   "strace": {
-    "name": "strace-6.7",
+    "name": "strace-6.8",
     "pname": "strace",
-    "version": "6.7"
+    "version": "6.8"
   },
   "strongswan": {
     "name": "strongswan-5.9.11",
@@ -956,14 +956,14 @@
     "version": "3.3a"
   },
   "tomcat10": {
-    "name": "apache-tomcat-10.1.18",
+    "name": "apache-tomcat-10.1.20",
     "pname": "apache-tomcat",
-    "version": "10.1.18"
+    "version": "10.1.20"
   },
   "tomcat9": {
-    "name": "apache-tomcat-9.0.85",
+    "name": "apache-tomcat-9.0.87",
     "pname": "apache-tomcat",
-    "version": "9.0.85"
+    "version": "9.0.87"
   },
   "unzip": {
     "name": "unzip-6.0",
@@ -976,9 +976,9 @@
     "version": "2.39.2"
   },
   "varnish": {
-    "name": "varnish-7.4.2",
+    "name": "varnish-7.4.3",
     "pname": "varnish",
-    "version": "7.4.2"
+    "version": "7.4.3"
   },
   "vim": {
     "name": "vim-9.0.2116",

--- a/release/versions.json
+++ b/release/versions.json
@@ -2,15 +2,15 @@
   "nixos-mailserver": {
     "deepClone": false,
     "fetchSubmodules": false,
-    "hash": "sha256-2ai0rYD6o8fQgweO3zKqPbbQBy/SQC8Hs+ZTf+GeXuU=",
+    "hash": "sha256-8zLBr6NNLZYirvuFL1bVNU8pAzEv3Z0BBjcU8tK6aH8=",
     "leaveDotGit": false,
-    "rev": "b3d6e950b71f7f9a29268beb9de03003705765e8",
+    "rev": "871e767a7450630ce0180ac68846dcd2d6981ed9",
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/"
   },
   "nixpkgs": {
-    "hash": "sha256-dq+XM6e67EIRmPzy3VJBL/4afhEI7uyHSqxhDelZfXA=",
+    "hash": "sha256-XpKp+f9eyFGPIUuyW7xsBjTAYpaw/XaitfE0C3IF5jA=",
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "6f99099c456b0793be58ac42c4612df9396d8384"
+    "rev": "828c9768fa53d526b1828854a59b1f74eff51f16"
   }
 }


### PR DESCRIPTION
Update nixpkgs (2024-04-03)

Pull upstream NixOS changes, security fixes and package updates:

- chromedriver: 122.0.6261.94 -> 123.0.6312.86
- chromium: 122.0.6261.111 -> 123.0.6312.86
- element-web: 1.11.59 -> 1.11.61
- firefox: 123.0.1 -> 124.0.1
- github-runner: 2.314.1 -> 2.315.0
- gitlab-runner: 16.7.0 -> 16.9.1
- gitlab-container-registry: 3.90.0 -> 3.91.0
- gitlab: 16.7.7 -> 16.9.3
- grafana: 10.2.4 -> 10.2.6 (CVE-2024-1442)
- jetty: 12.0.5 -> 12.0.7
- jicofo: 1.0-1059 -> 1.0-1075
- jitsi-meet: 1.0.7712 -> 1.0.7790
- jitsi-videobridge: 2.3-64-g719465d1 -> 2.3-92-g64f9f34f
- linux_5_15: 5.15.151 -> 5.15.152
- matrix-synapse: 1.102.0 -> 1.103.0
- nss_latest: 3.98 -> 3.99
- php82: 8.2.16 -> 8.2.17
- prometheus: 2.49.0 -> 2.49.1
- python38: 3.8.18 -> 3.8.19 (CVE-2023-52425, CVE-2024-0450, CVE-2023-6597)
- python39: 3.9.18 -> 3.9.19 (CVE-2023-52425, CVE-2024-0450, CVE-2023-6597)
- strace: 6.7 -> 6.8
- tomcat10: 10.1.18 -> 10.1.20
- tomcat9: 9.0.85 -> 9.0.87
- varnish: 7.4.2 -> 7.4.3 (CVE-2023-44487)

(Cherry-picked jitsi-videobridge, jitsi-meet and jicofo from
nixos-unstable to our nixpkgs fork. Also ran the update script myself to get the Gitlab 16.9.2 -> 16.9.3 security fix. Upstream has already merged 16.10.1 but that was too late for nixos-23.11 where we pull from and I don't want Gitlab major versions that are "too fresh". Better wait for 16.10.2+)

PL-132333

Also updates the nixos-mailserver dependency, with the following change:

- rspamd: fix duplicate and syntactically wrong header settings (PL-132289)


@flyingcircusio/release-managers

## Release process

Impact:

- \[NixOS 23.11\] Machines will reboot after the update to activate the changed kernel.

Changelog:

(include changed packages from commit msg)

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - pull in upstream security fixes regularly
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still run, works on various test VM, including Gitlab and Jitsi test systems
  - checked commit log for fixed CVEs and possible problems with updates, looked at [synapse/upgrade.md](https://github.com/element-hq/synapse/blob/develop/docs/upgrade.md) and [Grafana changelog](https://github.com/grafana/grafana/blob/main/CHANGELOG.md)
