### PR TITLE
[21.05] Metrics script for kernel routing table size

### DIFF
--- a/nixos/platform/network.nix
+++ b/nixos/platform/network.nix
@@ -182,7 +182,7 @@ in
       wireguard.enable = true;
 
       firewall.trustedInterfaces =
-        lib.optionals (!isNull fclib.underlay && config.flyingcircus.infrastructureModule == "flyingcircus-physical")
+        lib.optionals (!isNull fclib.underlay && cfg.infrastructureModule == "flyingcircus-physical")
           ([ "brsto" "brstb" ] ++ (attrNames fclib.underlay.interfaces));
     };
 

--- a/nixos/platform/network.nix
+++ b/nixos/platform/network.nix
@@ -207,6 +207,16 @@ in
 
     };
 
+    flyingcircus.services.telegraf.inputs = lib.optionalAttrs (cfg.infrastructureModule == "flyingcircus-physical") {
+      exec = [{
+        commands = [ "${pkgs.fc.telegraf-routes-summary}/bin/telegraf-routes-summary" ];
+        timeout = "10s";
+        data_format = "json";
+        json_name_key = "name";
+        tag_keys = [ "family" "path" ];
+      }];
+    };
+
     services.udev.initrdRules = interfaceRules;
     services.udev.extraRules = interfaceRules;
 

--- a/pkgs/fc/default.nix
+++ b/pkgs/fc/default.nix
@@ -60,5 +60,6 @@ rec {
   userscan = callPackage ./userscan.nix {};
   util-physical = callPackage ./util-physical {};
   telegraf-collect-psi = callPackage ./telegraf-collect-psi {};
+  telegraf-routes-summary = callPackage ./telegraf-routes-summary {};
 
 }

--- a/pkgs/fc/telegraf-routes-summary/default.nix
+++ b/pkgs/fc/telegraf-routes-summary/default.nix
@@ -1,0 +1,26 @@
+{ lib, stdenv, makeWrapper, python3, iproute2 }:
+
+stdenv.mkDerivation rec {
+  version = "1";
+  pname = "fc-telegraf-routes-summary";
+
+  src = ./.;
+  unpackPhase = ":";
+  dontBuild = true;
+  dontConfigure = true;
+  nativeBuildInputs = [ makeWrapper ];
+  propagatedBuildInputs = [ python3 iproute2 ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cd $src
+    install telegraf-routes-summary.py $out/bin/telegraf-routes-summary
+    wrapProgram $out/bin/telegraf-routes-summary --prefix PATH : \
+      ${lib.makeBinPath propagatedBuildInputs}
+  '';
+
+  meta = with lib; {
+    description = "Script for generating Telegraf metrics based on IP routes";
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/fc/telegraf-routes-summary/telegraf-routes-summary.py
+++ b/pkgs/fc/telegraf-routes-summary/telegraf-routes-summary.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Collect information over the number of routes in the kernel.
+
+This script collects information on the number of routes in the
+kernel, separately counting the number of single-path and multi-path
+routes. Unreachable routes are ignored and onlink/device routes are
+considered single-path routes.
+
+"""
+
+import json
+import subprocess
+import sys
+
+
+def count_routes(type_flag):
+    raw = subprocess.check_output(["ip", "-j", type_flag, "route", "show"])
+    data = json.loads(raw.decode("utf-8"))
+
+    multi = 0
+    single = 0
+
+    for route in data:
+        if "type" in route and route["type"] == "unreachable":
+            continue
+        if "nexthops" in route:
+            multi += 1
+        else:
+            single += 1
+
+    return (single, multi)
+
+
+def main():
+    path_labels = ["single", "multi"]
+    family_labels = ["ipv4", "ipv6"]
+    data = (count_routes("-4"), count_routes("-6"))
+
+    result = list()
+    for path_idx, path_label in enumerate(path_labels):
+        for family_idx, family_label in enumerate(family_labels):
+            result.append(
+                {
+                    "name": "routes",
+                    "family": family_label,
+                    "path": path_label,
+                    "count": data[family_idx][path_idx],
+                }
+            )
+
+    print(json.dumps(result))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This change adds a script which exposes a count of routes in the kernel routing table to Telegraf. The script differentiates between single-path routes (routes with only a single nexthop) and multi-path routes (routes with more than one nexthop) -- the generated metrics should hence allow graphing and monitoring of the state of multi-path routing on a given host. Unreachable routes are ignored, and on-link routes are considered single-path routes.

PL-131630

@flyingcircusio/release-managers

## Release process

Impact: internal.

Changelog:

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Core platform network functions should be appropriately monitored.
- [x] Security requirements tested? (EVIDENCE)
  - Telegraf successfully ingests script output and exposes metrics correspondingly on the Prometheus port.
