### PR TITLE
[21.05] Checks for underlay connectivity redundancy

### DIFF
--- a/nixos/platform/network.nix
+++ b/nixos/platform/network.nix
@@ -596,6 +596,14 @@ in
           ])
         )));
 
+    flyingcircus.services.sensu-client.checks = lib.optionalAttrs (!isNull fclib.underlay) {
+      uplink_redundancy = {
+        notification = "Host has redundant switch connectivity";
+        interval = 600;
+        command = "${pkgs.fc.check-link-redundancy}/bin/check_link_redundancy ${lib.concatStringsSep " " (attrNames fclib.underlay.interfaces)}";
+      };
+    };
+
     systemd.timers.fc-lldp-to-altnames = lib.mkIf (!isNull fclib.underlay) {
       description = "Timer for updating interface altnames based on peer hostname advertised in LLDP";
       wantedBy = [ "timers.target" ];

--- a/pkgs/fc/check-link-redundancy/check_link_redundancy.py
+++ b/pkgs/fc/check-link-redundancy/check_link_redundancy.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Check that two or more host network interfaces are connected to
+different switches.
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+
+
+def lldpctl(iface):
+    data = subprocess.check_output(["lldpctl", "-f", "json", iface])
+    return json.loads(data.decode("utf-8"))
+
+
+def main():
+    parser = argparse.ArgumentParser(prog="check_link_redundancy")
+    parser.add_argument(
+        "interfaces", metavar="IFACES", nargs="+", help="Interfaces to check"
+    )
+
+    args = parser.parse_args()
+    switches_all = list()
+    switches_unique = set()
+
+    for iface in args.interfaces:
+        data = lldpctl(iface)
+        data = data["lldp"]
+        if (
+            "interface" in data
+            and iface in data["interface"]
+            and "chassis" in data["interface"][iface]
+        ):
+            data = data["interface"][iface]["chassis"]
+            switches_all.append(data.keys())
+            switches_unique.update(data.keys())
+
+    if len(switches_all) != len(switches_unique):
+        print("CRITICAL - multiple interfaces are connected to the same switch")
+        sys.exit(2)
+    else:
+        print("OK - interfaces are connected to different switches")
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/pkgs/fc/check-link-redundancy/default.nix
+++ b/pkgs/fc/check-link-redundancy/default.nix
@@ -1,0 +1,26 @@
+{ lib, stdenv, makeWrapper, python3, lldpd }:
+
+stdenv.mkDerivation rec {
+  version = "1";
+  pname = "check-link-redundancy";
+
+  src = ./.;
+  unpackPhase = ":";
+  dontBuild = true;
+  dontConfigure = true;
+  nativeBuildInputs = [ makeWrapper ];
+  propagatedBuildInputs = [ python3 lldpd ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cd $src
+    install check_link_redundancy.py $out/bin/check_link_redundancy
+    wrapProgram $out/bin/check_link_redundancy --prefix PATH : \
+      ${lib.makeBinPath propagatedBuildInputs}
+  '';
+
+  meta = with lib; {
+    description = "Sensu check script to ensure that physical interfaces are not connected to the same switch";
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/fc/default.nix
+++ b/pkgs/fc/default.nix
@@ -9,6 +9,7 @@ rec {
   check-ceph-nautilus = callPackage ./check-ceph/nautilus {inherit (pkgs.ceph-nautilus) ceph-client;};
   check-haproxy = callPackage ./check-haproxy {};
   check-journal = callPackage ./check-journal.nix {};
+  check-link-redundancy = callPackage ./check-link-redundancy {};
   check-mongodb = callPackage ./check-mongodb {};
   check-postfix = callPackage ./check-postfix {};
 


### PR DESCRIPTION
This change adds a new sensu check script which uses LLDP to determine if the VXLAN underlay interfaces are all connected to different switches, with the case where more than one interface is connected to the same switch being considered a error condition, causing a critical failure.

PL-131630

@flyingcircusio/release-managers

## Release process

Impact: internal.

Changelog:

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Core network functions should be appropriately monitored -- redundant connectivity should be actually redundant.
- [x] Security requirements tested? (EVIDENCE)
  - Manually verified that the script exits cleanly when passed interfaces on different switches (e.g. non-VXLAN SRV and STO in DEV) and raises an error when passed interfaces on the same switch (e.g. non-VXLAN FE and SRV and in DEV).