### PR TITLE
[21.05] network: improve order for link property and frr services

### DIFF
--- a/nixos/platform/network.nix
+++ b/nixos/platform/network.nix
@@ -1,4 +1,4 @@
-{ config, lib, pkgs, ... }:
+{ config, lib, pkgs, utils, ... }:
 
 with builtins;
 
@@ -332,6 +332,7 @@ in
               description = "Ensure link properties for physical interface ${iface.name}";
               wantedBy = [ "network-addresses-${iface.name}.service"
                            "multi-user.target" ];
+              after = [ "sys-subsystem-net-devices-${utils.escapeSystemdPath iface.name}.device" ];
               before = wantedBy;
               path = [ pkgs.nettools pkgs.ethtool pkgs.procps fclib.relaxedIp ];
               script = ''

--- a/nixos/services/frr.nix
+++ b/nixos/services/frr.nix
@@ -184,8 +184,13 @@ in
             daemon = daemonName service;
           in
             nameValuePair daemon ({
-              wantedBy = [ "multi-user.target" ];
-              after = [ "network-pre.target" "systemd-sysctl.service" ] ++ lib.optionals (service != "zebra") [ "zebra.service" ];
+              # Inspired by Cumulus' dependency here. network-online isn't
+              # really intended for this but we need to go between the low level
+              # network setup (network.target) and before actual applications
+              # that need the network to function come up.
+              wantedBy = [ "network-online.target" ];
+              before = [ "network-online.target" ];
+              after = [ "network.target" "systemd-sysctl.service" ] ++ lib.optionals (service != "zebra") [ "zebra.service" ];
               bindsTo = lib.optionals (service != "zebra") [ "zebra.service" ];
               wants = [ "network.target" ] ++ lib.optionals (service == "zebra") (map (svc: "${daemonName svc}.service") (filter isEnabled services));
 


### PR DESCRIPTION
Re PL-131630

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

Improving network stability / predictability in boot and switch processes.

- [x] Security requirements tested? (EVIDENCE)

manually evaluated different setting combinations on cartman06
