### PR TITLE
[21.05] devhost: replace hydra eval with metadata endpoint, various improvements (PL-132065)

### DIFF
--- a/nixos/roles/devhost/fc-devhost.py
+++ b/nixos/roles/devhost/fc-devhost.py
@@ -108,6 +108,177 @@ class Manager:
         shutil.rmtree(self.data_dir, ignore_errors=True)
         run("fc-manage", "-v", "-b")
 
+    def provision(self, cpu, memory, image_url, channel_url, aliases, location):
+        fcntl.flock(self.lockfile, fcntl.LOCK_EX)
+
+        if os.path.isfile(self.config_file):
+            self.cfg = json.load(open(self.config_file))
+
+        self.cfg["cpu"] = cpu
+        self.cfg["name"] = self.name
+        self.cfg["memory"] = memory
+        # self.cfg["hydra_eval"] = hydra_eval
+        self.cfg["aliases"] = aliases
+        self.cfg["location"] = location
+
+        if "user" not in self.cfg:
+            self.cfg["user"] = os.getlogin()
+        if "creation-date" not in self.cfg:
+            self.cfg["creation-date"] = datetime.datetime.utcnow().isoformat()
+
+        if "id" not in self.cfg:
+            known_ids = set(vm["id"] for vm in list_all_vm_configs())
+            for candidate in range(MAX_VM_ID):
+                if candidate not in known_ids:
+                    self.cfg["id"] = candidate
+                    break
+            else:
+                raise RuntimeError("Could not find free VM ID.")
+
+        # The MAC address is calculated every time deterministically
+        srv_mac = f"0203{self.cfg['id']:08x}"
+        self.cfg["srv-mac"] = ":".join(
+            srv_mac[i : i + 2] for i in range(0, 12, 2)
+        )
+
+        if "srv-ip" not in self.cfg:
+            known_ips = set(
+                ipaddress.ip_address(vm["srv-ip"])
+                for vm in list_all_vm_configs()
+            )
+            known_ips.add(NETWORK.broadcast_address)
+            known_ips.add(NETWORK.network_address)
+            known_ips.add(NETWORK[1])  # gateway
+            for candidate in NETWORK:
+                if candidate not in known_ips:
+                    self.cfg["srv-ip"] = candidate.exploded
+                    break
+            else:
+                raise RuntimeError("Could not find free SRV IP address.")
+
+        vm_nix_file_existed = os.path.isfile(self.nix_file)
+        try:
+            with open(self.config_file, mode="w") as f:
+                f.write(json.dumps(self.cfg))
+
+            nix_aliases = " ".join(map(lambda x: f'"{x}"', self.cfg["aliases"]))
+            with open(self.nix_file, mode="w") as f:
+                f.write(
+                    textwrap.dedent(
+                        f"""\
+                # DO NOT TOUCH!
+                # Managed by fc-devhost
+                {{ ... }}: {{
+                  flyingcircus.roles.devhost.virtualMachines = {{
+                    "{self.cfg['name']}" = {{
+                      id = {self.cfg['id']};
+                      memory = "{self.cfg['memory']}";
+                      cpu = {self.cfg['cpu']};
+                      srvIp = "{self.cfg['srv-ip']}";
+                      srvMac = "{self.cfg['srv-mac']}";
+                      aliases = [ {nix_aliases} ];
+                    }};
+                  }};
+                }}
+                """
+                    )
+                )
+
+            os.makedirs(self.data_dir, exist_ok=True)
+            os.makedirs(VM_BASE_IMAGE_DIR, exist_ok=True)
+
+            if not os.path.isfile(self.image_file):
+                vm_base_image_path = VM_BASE_IMAGE_DIR / "vm.qcow2"
+                if not os.path.isfile(vm_base_image_path):
+                    vm_base_image_path_tmp = VM_BASE_IMAGE_DIR / "vm.qcow2.tmp"
+
+                    r = requests.get(image_url)
+                    with open(vm_base_image_path_tmp, "wb") as f:
+                        f.write(r.content)
+                    os.rename(vm_base_image_path_tmp, vm_base_image_path)
+                run(
+                    "cp",
+                    "--reflink=auto",
+                    vm_base_image_path,
+                    self.image_file_tmp,
+                )
+
+                with tempfile.TemporaryDirectory() as image_mount_directory:
+                    # the 10 is the number of max. nbd devices provided by the kernel
+                    nbd_number = None
+                    for i in range(8):
+                        if check_if_nbd_device_is_used(i):
+                            nbd_number = i
+                            break
+                    if nbd_number is None:
+                        raise RuntimeError("There is no unused nbd device.")
+                    try:
+                        run(
+                            "qemu-nbd",
+                            f"--connect=/dev/nbd{nbd_number}",
+                            self.image_file_tmp,
+                        )
+                        while True:
+                            if check_if_nbd_device_is_used(nbd_number):
+                                time.sleep(0.5)
+                                break
+
+                        new_fs_uuid = str(uuid.uuid4())
+                        run(
+                            "xfs_admin",
+                            "-U",
+                            new_fs_uuid,
+                            f"/dev/nbd{nbd_number}p1",
+                        )
+
+                        run(
+                            "mount",
+                            f"/dev/nbd{nbd_number}p1",
+                            image_mount_directory,
+                        )
+
+                        enc_file_path = (
+                            Path(image_mount_directory) / "etc/nixos/enc.json"
+                        )
+                        with open(enc_file_path, mode="w") as f:
+                            f.write(generate_enc_json(self.cfg, channel_url))
+                    finally:
+                        run("umount", image_mount_directory)
+                        run("qemu-nbd", "--disconnect", f"/dev/nbd{nbd_number}")
+                os.rename(self.image_file_tmp, self.image_file)
+            else:
+                with tempfile.NamedTemporaryFile(mode="w") as f:
+                    f.write(generate_enc_json(self.cfg, channel_url))
+                    f.flush()
+                    run(
+                        "rsync",
+                        "-e",
+                        "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i /var/lib/devhost/ssh_bootstrap_key",
+                        "--rsync-path=sudo rsync",
+                        f.name,
+                        f"developer@{self.name}:/etc/nixos/enc.json",
+                    )
+
+            run("fc-manage", "-v", "-b")
+
+            fcntl.flock(self.lockfile, fcntl.LOCK_UN)
+            # We need to wait for the VM to get online
+            while True:
+                response = os.system(f"ping -c 1 {self.cfg['srv-ip']}")
+                if response == 0:
+                    break
+                else:
+                    time.sleep(0.5)
+
+        except Exception as e:
+            # We want the script to end in a state, where other VMs can be started without a problem.
+            # So mainly, if the VM is started for the first time, we just destroy it.
+            # If a VM is new, is determined by the existence of their nix file, as it controls the
+            # associated systemd unit.
+            if not vm_nix_file_existed:
+                self.destroy()
+            raise e
+
     def ensure(self, cpu, memory, hydra_eval, aliases, location):
         fcntl.flock(self.lockfile, fcntl.LOCK_EX)
         # Nixify the alias list
@@ -382,10 +553,35 @@ def main():
     p.add_argument("name", help="name of the VM")
     p.add_argument("--location", help="location the VMs live in")
 
+    # ---------------------------------
+
+    p = sub.add_parser(
+        "provision", help="provision a devhost vm with a provided image"
+    )
+    p.set_defaults(func="provision")
+    p.add_argument("--cpu", type=int, help="number of cores")
+    p.add_argument("--memory", type=int, help="amount of memory")
+    p.add_argument("--image-url", type=str, help="url to an image for the vm")
+    p.add_argument(
+        "--channel-url", type=str, help="url to the nix channel for the vm"
+    )
+    p.add_argument(
+        "--aliases",
+        type=space_separated_list,
+        default=[],
+        help="aliases for the nginx",
+    )
+    p.add_argument("name", help="name of the VM")
+    p.add_argument("--location", help="location the VMs live in")
+
+    # ---------------------------------
+
     p = sub.add_parser("destroy", help="Destroy a given VM.")
     p.set_defaults(func="destroy")
     p.add_argument("name", help="name of the VM")
     p.add_argument("--location", help="location the VMs live in")
+
+    # ---------------------------------
 
     p = sub.add_parser(
         "list",
@@ -402,12 +598,16 @@ def main():
     )
     p.add_argument("--location", help="location the VMs live in")
 
+    # ---------------------------------
+
     p = sub.add_parser(
         "cleanup",
         help="Cleanup. This is an automated task. In this process old base images will be deleted.",
     )
     p.set_defaults(func="cleanup")
     p.add_argument("--location", help="location the VMs live in")
+
+    # ---------------------------------
 
     p = sub.add_parser(
         "login",

--- a/nixos/roles/devhost/fc-devhost.py
+++ b/nixos/roles/devhost/fc-devhost.py
@@ -528,7 +528,9 @@ class Manager:
 
 
 def main():
-    a = argparse.ArgumentParser(description="Manage DevHost VMs.")
+    a = argparse.ArgumentParser(
+        prog="fc-devhost", description="Manage DevHost VMs."
+    )
     a.set_defaults(func="print_usage")
     sub = a.add_subparsers(title="subcommands")
 

--- a/nixos/roles/devhost/fc-devhost.py
+++ b/nixos/roles/devhost/fc-devhost.py
@@ -576,9 +576,13 @@ def main():
 
     # ---------------------------------
 
-    p = sub.add_parser("destroy", help="Destroy a given VM.")
+    p = sub.add_parser("destroy", aliases=["rm"], help="Destroy provided VMs.")
     p.set_defaults(func="destroy")
-    p.add_argument("name", help="name of the VM")
+    p.add_argument(
+        "name",
+        nargs="+",
+        help="name(s) of the VMs to be destroyed",
+    )
     p.add_argument("--location", help="location the VMs live in")
 
     # ---------------------------------
@@ -628,6 +632,12 @@ def main():
 
     name = getattr(args, "name", None)
     kwargs = dict(args._get_kwargs())
+
+    if func == "destroy":
+        for name in args.name:
+            manager = Manager(name)
+            manager.destroy()
+
     del kwargs["func"]
     if "name" in kwargs:
         del kwargs["name"]


### PR DESCRIPTION
@flyingcircusio/release-managers

relates to [PL-132065]

## Release process

Impact:

This PR implements a new subcommand "provision" for `fc-devhost` that takes a channel url and an image url instead of a hydra eval (see subcommand "ensure") to provision a new devhost vm. Functionally, the new subcommand is identical to the existing subcommand "ensure".
Additionally, it changes the destroy subcommand to accept an arbitrary number of vm names that will all be deleted.
The `destroy` subcommand is also aliased to `rm` similarly to `list` being aliased to `ls`.

Changelog:

- implement a new subcommand "provision" for `fc-devhost` that takes a channel url and an image url instead of a hydra eval (see subcommand "ensure") to provision a new devhost vm
- change the `destroy` subcommand to take an arbitrary (n >= 1) amount of vm names to destroy
- set the program name in `argparse` for more readable error messages that don't include a nix store hash

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE) 

We now allow users to provide explicit image URLs to bootstrap VMs from. Theoretically those could be arbitrary OS images including Windows, memtest, or some malware that then get access to the internet via NAT.

However, the VM architecture itself already provides similar vectors, like becoming root and spawning custom kernels. This is the whole point of running VMs anyway.

- [x] Security requirements tested? (EVIDENCE)

Functionality tested manually with @leona-ya on largo00. 