### PR TITLE
[21.05] silence warnings when swap isn't there anymore

### DIFF
--- a/nixos/infrastructure/flyingcircus-physical.nix
+++ b/nixos/infrastructure/flyingcircus-physical.nix
@@ -49,7 +49,9 @@ mkIf (cfg.infrastructureModule == "flyingcircus-physical") {
     flyingcircus.activationScripts = {
       disableSwap = ''
         swapoff -a
-        wipefs -af /dev/disk/by-label/swap || true
+        if [[ -e /dev/disk/by-label/swap ]]; then
+          wipefs  -af /dev/disk/by-label/swap || true
+        fi
       '';
     };
     systemd.targets.swap.enable = false;  # implicitly mask the unit to prevent pulling in existing `*.swap` units


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

none

Changelog:

none

### PR release workflow (internal)

- [ ] PR has internal ticket
- [ ] internal issue ID (PL-…) part of branch name
- [ ] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

reduce log noise, making logs more readable

- [ ] Security requirements tested? (EVIDENCE)
