### PR TITLE
[21.05] FDE: admin fingerprint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,4 +22,4 @@ repos:
 - hooks:
   - id: black
   repo: https://github.com/psf/black
-  rev: 22.3.0
+  rev: 24.4.2

--- a/pkgs/fc/agent/fc/maintenance/activity/__init__.py
+++ b/pkgs/fc/agent/fc/maintenance/activity/__init__.py
@@ -1,4 +1,5 @@
 """Base class for maintenance activities."""
+
 from enum import Enum
 from pathlib import Path
 from typing import NamedTuple, Optional

--- a/pkgs/fc/agent/fc/maintenance/activity/vm_change.py
+++ b/pkgs/fc/agent/fc/maintenance/activity/vm_change.py
@@ -1,5 +1,6 @@
 """Handle VM changes that need a cold reboot.
 """
+
 from typing import Optional
 
 import fc.util.dmi_memory

--- a/pkgs/fc/agent/fc/maintenance/maintenance.py
+++ b/pkgs/fc/agent/fc/maintenance/maintenance.py
@@ -5,6 +5,7 @@ system state. All maintenance activities start their life here in this module.
 TODO: better logging for created activites.
 
 """
+
 import os.path
 import shutil
 import typing

--- a/pkgs/fc/agent/fc/maintenance/reqmanager.py
+++ b/pkgs/fc/agent/fc/maintenance/reqmanager.py
@@ -250,9 +250,11 @@ class ReqManager:
                 req.comment,
                 format_datetime(req.added_at) if req.added_at else "-",
                 format_datetime(req.updated_at) if req.updated_at else "-",
-                format_datetime(req.last_scheduled_at)
-                if req.last_scheduled_at
-                else "-",
+                (
+                    format_datetime(req.last_scheduled_at)
+                    if req.last_scheduled_at
+                    else "-"
+                ),
             )
 
         return table
@@ -1349,9 +1351,9 @@ class ReqManager:
             metrics["requests_pending"] = num_requests_pending
             metrics["requests_running"] = num_requests_running
             metrics["requests_scheduled"] = num_requests_scheduled
-            metrics[
-                "requests_waiting_for_schedule"
-            ] = num_requests_waiting_for_schedule
+            metrics["requests_waiting_for_schedule"] = (
+                num_requests_waiting_for_schedule
+            )
 
             metrics["request_longest_in_queue_duration"] = (
                 now.timestamp() - oldest_added_at.timestamp()

--- a/pkgs/fc/agent/fc/maintenance/tests/test_reqmanager.py
+++ b/pkgs/fc/agent/fc/maintenance/tests/test_reqmanager.py
@@ -133,9 +133,11 @@ def test_add_do_merge_compatible_request(connect, significant, log, reqmanager):
         # Should be merged
         assert rm.add(to_be_merged_request) is second_request
         assert log.has(
-            "requestmanager-merge-significant"
-            if significant
-            else "requestmanager-merge-update",
+            (
+                "requestmanager-merge-significant"
+                if significant
+                else "requestmanager-merge-update"
+            ),
             request=to_be_merged_request.id,
             merged=second_request.id,
         )

--- a/pkgs/fc/agent/fc/manage/dhcpd.py
+++ b/pkgs/fc/agent/fc/manage/dhcpd.py
@@ -1,6 +1,5 @@
 """Create dhcpd configuration based on directory data."""
 
-
 import optparse
 import os.path as p
 import sys

--- a/pkgs/fc/agent/fc/util/dhcp.py
+++ b/pkgs/fc/agent/fc/util/dhcp.py
@@ -1,6 +1,5 @@
 """Model entities commonly found in DHCP configuration files."""
 
-
 import collections
 import itertools
 

--- a/pkgs/fc/agent/fc/util/directory.py
+++ b/pkgs/fc/agent/fc/util/directory.py
@@ -1,4 +1,5 @@
 """Unified client access to fc.directory."""
+
 import contextlib
 import functools
 import json

--- a/pkgs/fc/ceph/default.nix
+++ b/pkgs/fc/ceph/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, python3Full, python3Packages, cryptsetup, lz4, blockdev, lvm2, agent }:
+{ lib, stdenv, python3Full, python3Packages, cryptsetup, lz4, blockdev, lvm2, agent, py_pytest_patterns }:
 
 let
   py = python3Packages;
@@ -20,6 +20,7 @@ py.buildPythonApplication rec {
   checkInputs = [
     python3Packages.mock
     python3Packages.freezegun
+    py_pytest_patterns
   ];
 
   nativeCheckInputs = [

--- a/pkgs/fc/ceph/src/fc/ceph/luks/__init__.py
+++ b/pkgs/fc/ceph/src/fc/ceph/luks/__init__.py
@@ -1,25 +1,32 @@
 import getpass
+import hashlib
+import os
 import shutil
+from base64 import standard_b64encode
+from functools import wraps
 from pathlib import Path
 from socket import gethostname
+from typing import Optional
 
-from fc.ceph.util import console, mlockall, run
+from fc.ceph.util import console, default_false_prompt, mlockall, run
 
 
-def get_password(prompt):
-    pw1 = pw2 = None
-    while not pw1:
-        pw1 = getpass.getpass(f"{prompt}: ")
-        pw2 = getpass.getpass(f"{prompt}, repeated: ")
-        if pw1 != pw2:
-            console.print("Keys do not match. Try again.", style="red")
-            pw1 = pw2 = None
-    return pw1
+def memoize(func):
+    """Caches the result of a memeber method invocation in an attribute of the
+    called function name prefixed with '__'
+    """
+
+    @wraps(func)
+    def wrapper(self, *args, **kw):
+        attr_name = "__" + func.__name__
+        if not hasattr(self, attr_name):
+            setattr(self, attr_name, func(self, *args, **kw))
+        return getattr(self, attr_name)
+
+    return wrapper
 
 
 class LUKSKeyStore(object):
-    __admin_key = None
-
     slots = {"admin": "1", "local": "0"}
     local_key_dir: Path = Path("/mnt/keys/")
 
@@ -30,13 +37,56 @@ class LUKSKeyStore(object):
     def local_key_path(self) -> str:
         return str(self.local_key_dir / f"{gethostname()}.key")
 
-    def admin_key_for_input(self) -> str:
-        if not self.__admin_key:
-            self.__admin_key = get_password("LUKS admin key for this location")
-        return self.__admin_key.encode("ascii")
+    @memoize
+    def admin_key_for_input(
+        self, prompt: str = "LUKS admin key for this location"
+    ) -> bytes:
+        while True:
+            admin_key = getpass.getpass(f"{prompt}: ").encode("ascii")
+
+            fingerprint_path = self.local_key_dir / "admin.fprint"
+            persisted_fingerprint: str = ""
+            if fingerprint_path.exists():
+                persisted_fingerprint = (
+                    open(fingerprint_path, "rt").read().strip()
+                )
+
+            fingerprint = hashlib.sha256(admin_key).hexdigest()
+
+            if fingerprint == persisted_fingerprint:
+                break
+
+            if not persisted_fingerprint:
+                console.print("No admin key fingerprint stored.\n")
+            else:
+                console.print(
+                    "Error: fingerprint mismatch:\n\n"
+                    f"fingerprint for your entry: '{fingerprint}'\n"
+                    f"fingerprint stored locally: '{persisted_fingerprint}'\n"
+                )
+
+            if not default_false_prompt(
+                f"Is '{fingerprint}' the correct new fingerprint?\nRetry otherwise."
+            ):
+                console.print("Retrying.")
+                continue
+
+            console.print(
+                f"Updating persisted fingerprint to {fingerprint_path!s}"
+            )
+
+            # Make a ticket: keep a history of the previously known fingerprints.
+            with open(fingerprint_path, "wt") as f:
+                f.write(fingerprint)
+            break
+
+        console.print(
+            f"Using admin key with matching fingerprint '{fingerprint}'."
+        )
+        return admin_key
 
     def backup_external_header(self, headerfile: Path):
-        # assumption: all external volume headers of a mchine have distinct names
+        # assumption: all external volume headers of a machine have distinct names
         shutil.copy(headerfile, self.local_key_dir)
 
 
@@ -71,8 +121,10 @@ class Cryptsetup:
     # tunables that apply when (re)creating a LUKS volume header
     _tunables_luks_header = (
         # fmt: off
-        "--pbkdf", "argon2id",
-        "--type", "luks2",
+        "--pbkdf",
+        "argon2id",
+        "--type",
+        "luks2",
         # fmt: on
     )
 

--- a/pkgs/fc/ceph/src/fc/ceph/luks/manage.py
+++ b/pkgs/fc/ceph/src/fc/ceph/luks/manage.py
@@ -180,23 +180,15 @@ class LUKSKeyStoreManager(object):
         For `verify`, compare with stored fingerprint and return a status code
         1 at mismatch"""
 
-        input_phrase: Optional[bytes] = None
+        while True:
+            input_phrase = getpass.getpass("Enter passphrase to fingerprint: ")
+            if not confirm:
+                break
+            if getpass.getpass("Confirm passphrase again: ") == input_phrase:
+                break
+            print("Mismatching passphrases entered, please retry.")
 
-        while not input_phrase:
-            input_phrase = getpass.getpass(
-                "Enter passphrase to fingerprint: "
-            ).encode("ascii")
-            if (
-                confirm
-                and getpass.getpass("Confirm passphrase again: ").encode(
-                    "ascii"
-                )
-                != input_phrase
-            ):
-                print("Mismatching passphrases entered, please retry.")
-                input_phrase = None
-
-        fingerprint = hashlib.sha256(input_phrase).hexdigest()
+        fingerprint = hashlib.sha256(input_phrase.encode("ascii")).hexdigest()
         console.print(fingerprint)
 
         if verify:

--- a/pkgs/fc/ceph/src/fc/ceph/luks/manage.py
+++ b/pkgs/fc/ceph/src/fc/ceph/luks/manage.py
@@ -1,4 +1,6 @@
 import fnmatch
+import getpass
+import hashlib
 import os
 import secrets
 import shutil
@@ -170,3 +172,49 @@ class LUKSKeyStoreManager(object):
 
         if header:
             self._KEYSTORE.backup_external_header(Path(header))
+
+    def fingerprint(self, verify: bool, confirm: bool) -> int:
+        """
+        Ask for passphrase and print its fingerprint.
+
+        For `verify`, compare with stored fingerprint and return a status code
+        1 at mismatch"""
+
+        input_phrase: Optional[bytes] = None
+
+        while not input_phrase:
+            input_phrase = getpass.getpass(
+                "Enter passphrase to fingerprint: "
+            ).encode("ascii")
+            if (
+                confirm
+                and getpass.getpass("Confirm passphrase again: ").encode(
+                    "ascii"
+                )
+                != input_phrase
+            ):
+                print("Mismatching passphrases entered, please retry.")
+                input_phrase = None
+
+        fingerprint = hashlib.sha256(input_phrase).hexdigest()
+        console.print(fingerprint)
+
+        if verify:
+            fingerprint_path = self._KEYSTORE.local_key_dir / "admin.fprint"
+            persisted_fingerprint = (
+                open(fingerprint_path, "rt").read().strip()
+                if fingerprint_path.exists()
+                else ""
+            )
+            if not persisted_fingerprint:
+                console.print("No admin key fingerprint stored.\n")
+                return 1
+            elif persisted_fingerprint != fingerprint:
+                console.print(
+                    "Error: fingerprint mismatch:\n\n"
+                    f"fingerprint for your entry: '{fingerprint}'\n"
+                    f"fingerprint stored locally: '{persisted_fingerprint}'\n"
+                )
+                return 1
+
+        return 0

--- a/pkgs/fc/ceph/src/fc/ceph/luks/manage.py
+++ b/pkgs/fc/ceph/src/fc/ceph/luks/manage.py
@@ -97,13 +97,18 @@ class LUKSKeyStoreManager(object):
 
         if slot == "local":
             console.print("Updating local machine key ...", style="bold")
+            # Ensure to request the admin key early on.
+            self._KEYSTORE.admin_key_for_input(
+                "Current LUKS admin key for unlocking this location"
+            )
         elif slot == "admin":
             console.print("Updating admin key ...", style="bold")
+            # Ensure to request the admin key early on.
+            self._KEYSTORE.admin_key_for_input(
+                "New LUKS admin key to be set for this location"
+            )
         else:
             raise ValueError(f"slot={slot}")
-
-        # Ensure to request the admin key early on.
-        self._KEYSTORE.admin_key_for_input()
 
         candidates = lsblk_to_cryptdevices(
             run.json.lsblk("-s", "-o", "NAME,PATH,TYPE,MOUNTPOINT")

--- a/pkgs/fc/ceph/src/fc/ceph/luks/manage.py
+++ b/pkgs/fc/ceph/src/fc/ceph/luks/manage.py
@@ -109,21 +109,21 @@ class LUKSKeyStoreManager(object):
             run.json.lsblk("-s", "-o", "NAME,PATH,TYPE,MOUNTPOINT")
         )
         for candidate in candidates:
+            this_header = header
             if not fnmatch.fnmatch(candidate.name, name_glob):
                 continue
             console.print(f"Replacing key for {candidate.name}")
 
             if (
-                (not header)
+                (not this_header)
                 and (mp := candidate.mountpoint)
                 and os.path.exists(headerfile := f"{mp}.luks")
             ):
-                header = headerfile
-            # TODO: nixos test?
+                this_header = headerfile
             self._do_rekey(
                 slot=slot,
                 device=candidate.base_blockdev,
-                header=header,
+                header=this_header,
             )
 
         console.print("Key updated.", style="bold green")

--- a/pkgs/fc/ceph/src/fc/ceph/lvm.py
+++ b/pkgs/fc/ceph/src/fc/ceph/lvm.py
@@ -192,11 +192,9 @@ class AutomountActivationMixin:
                 time.sleep(1)
         if not mount_device:
             run.mount(
-                # fmt: off
                 "-t", self.FSTYPE, "-o", self.MOUNT_OPTS,
                 self.device, self.mountpoint,
-                # fmt: on
-            )
+            )  # fmt: skip
         elif mount_device != self.lv.expected_mapper_name:
             raise RuntimeError(
                 f"Mountpoint is using unexpected device `{mount_device}`."
@@ -367,12 +365,10 @@ class LogicalVolume(GenericLogicalVolume):
             # -L1g
             size = f"-L{size}"
         run.lvcreate(
-            # fmt: off
             "-W", "y", "-y",
             size, f"-n{self.name}",
             vg_name,
-            # fmt: on
-        )
+        )  # fmt: skip
 
     @staticmethod
     def ensure_vg(vg_name: str, base_device: Optional[GenericBlockDevice]):
@@ -480,24 +476,20 @@ class EncryptedLogicalVolume(GenericLogicalVolume):
 
         print(f"Encrypting volume {self.name} ...")
         Cryptsetup.luksFormat(
-            # fmt: off
             "--key-slot", str(fc.ceph.luks.KEYSTORE.slots["local"]),
             "-d", fc.ceph.luks.KEYSTORE.local_key_path(),
             self.underlay.device,
-            # fmt: on
-        )
+        )  # fmt: skip
 
         admin_key = fc.ceph.luks.KEYSTORE.admin_key_for_input()
 
         Cryptsetup.luksAddKey(
-            # fmt: off
             "-d", fc.ceph.luks.KEYSTORE.local_key_path(),
             self.underlay.device,
             "--key-slot", str(fc.ceph.luks.KEYSTORE.slots["admin"]),
             "-",
             input=admin_key,
-            # fmt: on
-        )
+        )  # fmt: skip
 
     @property
     def encrypted(self):
@@ -507,14 +499,12 @@ class EncryptedLogicalVolume(GenericLogicalVolume):
         self.underlay.activate()
         if not os.path.exists(self.device_path):
             Cryptsetup.cryptsetup(
-                # fmt: off
-                "--allow-discards",  # pass throught TRIM commands to disk
+                "--allow-discards",  # pass through TRIM commands to disk
                 "open",
                 "-d", fc.ceph.luks.KEYSTORE.local_key_path(),
                 self.underlay.device,
                 self.name,
-                # fmt: on
-            )
+            )  # fmt: skip
         self._ready = True
 
     def deactivate(self):
@@ -617,13 +607,11 @@ class XFSVolume(AutomountActivationMixin, GenericCephVolume):
         )
         # Create OSD filesystem
         run.mkfs_xfs(
-            # fmt: off
             "-f",
             "-L", self.name,
             *self.MKFS_OPTS,
             self.device,
-            # fmt: on
-        )
+        )  # fmt: skip
         run.sync()
         self.activate()
 

--- a/pkgs/fc/ceph/src/fc/ceph/lvm.py
+++ b/pkgs/fc/ceph/src/fc/ceph/lvm.py
@@ -65,8 +65,8 @@ class MdraidDevice(GenericBlockDevice):
             raise RuntimeError(
                 f"MdraidDevice: at least {cls.RAID_MIN_DISKS} disks required. Aborting."
             )
-        main_disks = blockdevices[:-1]
-        spare_disk = blockdevices[-1]
+        main_disks = blockdevices[: -cls.RAID_SPARE]
+        spare_disk = blockdevices[-cls.RAID_SPARE]
         obj = cls(name)
         run.mdadm(
             "--create",

--- a/pkgs/fc/ceph/src/fc/ceph/main.py
+++ b/pkgs/fc/ceph/src/fc/ceph/main.py
@@ -457,6 +457,24 @@ def luks(args=sys.argv[1:]):
     )
     parser_rekey.set_defaults(action="rekey")
 
+    parser_fingerprint = keystore_sub.add_parser(
+        "fingerprint", help="Compute a fingerprint of an admin passphrase."
+    )
+    parser_fingerprint.add_argument(
+        "--confirm",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Request the passphrase twice to avoid accidental typos.",
+    )
+    parser_fingerprint.add_argument(
+        "--verify",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Verify if the entered passphrase confirms to the fingerprint "
+        "already stored. On mismatch, returns exitcode 1",
+    )
+    parser_fingerprint.set_defaults(action="fingerprint")
+
     backup = subparsers.add_parser("backup", help="Manage backup volumes.")
     backup.set_defaults(
         subsystem=fc.ceph.backup.BackupManager, action=backup.print_usage
@@ -517,5 +535,5 @@ def luks(args=sys.argv[1:]):
     action_statuscode = action(**args)
 
     # optionally allow actions to return a statuscode
-    if isinstance(action_statuscode, int):
+    if isinstance(action_statuscode, int) and action_statuscode != 0:
         sys.exit(action_statuscode)

--- a/pkgs/fc/ceph/src/fc/ceph/main.py
+++ b/pkgs/fc/ceph/src/fc/ceph/main.py
@@ -83,7 +83,7 @@ def ceph(args=sys.argv[1:]):
         "--encrypt",
         action=argparse.BooleanOptionalAction,
         default=True,
-        help="(Experimental) Set up OSD disk volumes with encryption",
+        help="Set up OSD disk volumes with encryption",
     )
     parser_create_bs.set_defaults(action="create_bluestore")
 
@@ -203,7 +203,7 @@ def ceph(args=sys.argv[1:]):
         "--encrypt",
         action=argparse.BooleanOptionalAction,
         default=True,
-        help="(Experimental) Set up manager volumes with encryption",
+        help="Set up manager volumes with encryption",
     )
     parser_create.set_defaults(action="create")
 
@@ -248,7 +248,7 @@ def ceph(args=sys.argv[1:]):
         "--encrypt",
         action=argparse.BooleanOptionalAction,
         default=True,
-        help="(Experimental) Set up manager volumes with encryption",
+        help="Set up manager volumes with encryption",
     )
     parser_create.set_defaults(action="create")
 

--- a/pkgs/fc/ceph/src/fc/ceph/main.py
+++ b/pkgs/fc/ceph/src/fc/ceph/main.py
@@ -534,6 +534,7 @@ def luks(args=sys.argv[1:]):
     action = getattr(subsystem, action)
     action_statuscode = action(**args)
 
-    # optionally allow actions to return a statuscode
+    # Help testing by avoiding superfluous SystemExit exceptions in the happy
+    # case.
     if isinstance(action_statuscode, int) and action_statuscode != 0:
         sys.exit(action_statuscode)

--- a/pkgs/fc/ceph/src/fc/ceph/tests/test_luks.py
+++ b/pkgs/fc/ceph/src/fc/ceph/tests/test_luks.py
@@ -553,11 +553,7 @@ def test_keystore_admin_key_fingerprint_existing_update(
     assert p == captured.out
     pe = patterns.fpdialog_getpass
     pe.optional("Warning: Password input may be echoed.")
-    pe.in_order(
-        # fmt: off
-        "LUKS admin key for this location: "
-        # fmt: on
-    )
+    pe.in_order("LUKS admin key for this location: ")
     assert pe == captured.err
 
 
@@ -620,12 +616,10 @@ def test_luks_fingerprint_mismatch_retry(
     pe = patterns.fpdialog_getpass
     pe.optional("Warning: Password input may be echoed.")
     pe.in_order(
-        # fmt: off
         "Enter passphrase to fingerprint: \n"
         "Confirm passphrase again: \n"
         "Enter passphrase to fingerprint: \n"
         "Confirm passphrase again: "
-        # fmt: on
     )
     assert pe == captured.err
 
@@ -661,29 +655,23 @@ def test_luks_fingerprint_verify(
     p = patterns.fpdialog
     p.optional("<empty-line>")
     p.in_order(
-        # fmt: off
-      # 1sr invocation
-      "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae\n"
-      "No admin key fingerprint stored.\n"
-
-      # 2nd invocation
-      "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae\n"
-      "fingerprint for your entry: \n"
-      "'2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae'\n"
-      "fingerprint stored locally: \n"
-      "'28b0289d1cceb110614259333e64a77ea39e87ec9add8af435c1271f8d2e9e13'\n"
-
-      # 3rd invocation
-      "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae"
-        # fmt: on
+        # 1st invocation
+        "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae\n"
+        "No admin key fingerprint stored.\n"
+        # 2nd invocation
+        "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae\n"
+        "fingerprint for your entry: \n"
+        "'2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae'\n"
+        "fingerprint stored locally: \n"
+        "'28b0289d1cceb110614259333e64a77ea39e87ec9add8af435c1271f8d2e9e13'\n"
+        # 3rd invocation
+        "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae"
     )
     pe = patterns.fpdialog_getpass
     pe.optional("Warning: Password input may be echoed.")
     pe.in_order(
-        # fmt: off
         "Enter passphrase to fingerprint: \n"
         "Enter passphrase to fingerprint: \n"
         "Enter passphrase to fingerprint: "
-        # fmt: on
     )
     assert pe == captured.err

--- a/pkgs/fc/ceph/src/fc/ceph/util.py
+++ b/pkgs/fc/ceph/src/fc/ceph/util.py
@@ -193,37 +193,23 @@ def mlockall():
         raise Exception("cannot lock memory, errno=%s" % ctypes.get_errno())
 
 
-def default_true_prompt(msg: str) -> bool:
-    choice = True
-    print(msg, "[y]/n:", end=" ")
+def prompt_bool(msg: str, default) -> bool:
+    choice = default
+    prompt = "[y]/n:" if default else "y/[n]:"
+    print(msg, prompt, end=" ")
     while True:
         resp = input()
         match resp:
             case "n":
                 choice = False
                 break
-            case "y" | "":
-                break
-            case _:
-                print(f"Invalid input '{resp}', retry.")
-                continue
-
-    return choice
-
-
-def default_false_prompt(msg: str) -> bool:
-    choice = False
-    print(msg, "y/[n]:", end=" ")
-    while True:
-        resp = input()
-        match resp:
             case "y":
                 choice = True
                 break
-            case "n" | "":
+            case "":
+                choice = default
                 break
             case _:
                 print(f"Invalid input '{resp}', retry.")
                 continue
-
     return choice

--- a/pkgs/fc/ceph/src/fc/ceph/util.py
+++ b/pkgs/fc/ceph/src/fc/ceph/util.py
@@ -191,3 +191,39 @@ def mlockall():
     result = libc.mlockall(MCL_CURRENT | MCL_FUTURE)
     if result != 0:
         raise Exception("cannot lock memory, errno=%s" % ctypes.get_errno())
+
+
+def default_true_prompt(msg: str) -> bool:
+    choice = True
+    print(msg, "[y]/n:", end=" ")
+    while True:
+        resp = input()
+        match resp:
+            case "n":
+                choice = False
+                break
+            case "y" | "":
+                break
+            case _:
+                print(f"Invalid input '{resp}', retry.")
+                continue
+
+    return choice
+
+
+def default_false_prompt(msg: str) -> bool:
+    choice = False
+    print(msg, "y/[n]:", end=" ")
+    while True:
+        resp = input()
+        match resp:
+            case "y":
+                choice = True
+                break
+            case "n" | "":
+                break
+            case _:
+                print(f"Invalid input '{resp}', retry.")
+                continue
+
+    return choice

--- a/pkgs/fc/default.nix
+++ b/pkgs/fc/default.nix
@@ -11,6 +11,7 @@ rec {
   # it can be parametrized via config file for each individual subsystem.
   ceph = pythonPackages.callPackage ./ceph {
     inherit agent blockdev;
+    py_pytest_patterns = pkgs.py_pytest_patterns.override {python3Packages = pythonPackages;};
   };
 
   check-age = callPackage ./check-age {};
@@ -20,6 +21,7 @@ rec {
   check-link-redundancy = callPackage ./check-link-redundancy {};
   check-mongodb = callPackage ./check-mongodb {};
   check-postfix = callPackage ./check-postfix {};
+
   check-xfs-broken = callPackage ./check-xfs-broken {};
   collectdproxy = callPackage ./collectdproxy {};
   fix-so-rpath = callPackage ./fix-so-rpath {};

--- a/pkgs/fc/qemu/clean-logs.py
+++ b/pkgs/fc/qemu/clean-logs.py
@@ -14,6 +14,7 @@ So this script deletes log files, iff:
 2. it is older than 14 days.
 
 """
+
 import datetime
 import pathlib
 import re

--- a/pkgs/fc/qemu/default.nix
+++ b/pkgs/fc/qemu/default.nix
@@ -76,7 +76,7 @@ in
       py.setuptools
       (py.toPythonModule ceph_client)
       # note: this is not really appropriate in theory, as test-only tooling
-      #should be part of *checkInputs instead. checkInputs vs. nativeCheckInputs
+      # should be part of *checkInputs instead. checkInputs vs. nativeCheckInputs
       # needs some adaptions in more recent NixOS releases anyways, so keeping this for now.
       py_pytest_patterns
     ];

--- a/pkgs/fc/qemu/default.nix
+++ b/pkgs/fc/qemu/default.nix
@@ -15,7 +15,8 @@
   parted,
   xfsprogs,
   procps,
-  systemd
+  systemd,
+  py_pytest_patterns
 }:
 
 let
@@ -44,25 +45,7 @@ let
     };
   };
 
-  py_pytest_patterns = py.buildPythonPackage rec {
-    pname = "pytest_patterns";
-    version = "0.1.0";
 
-    src = py.fetchPypi {
-      inherit pname version;
-      hash = "sha256-guKexrkDP4Ovqc87M7s8qFtW1FuVcf2PiDwh+QHcp6A=";
-      format = "wheel";
-      python = "py3";
-    };
-
-    format = "wheel";
-    propagatedBuildInputs = [ py.pytest ];
-
-    meta = with lib; {
-      description = "pytest plugin to make testing complicated long string output easy to write and easy to debug";
-      homepage = "https://pypi.org/project/pytest-patterns/";
-    };
-  };
 
 in
   # We use buildPythonPackage instead of buildPythonApplication
@@ -92,6 +75,9 @@ in
       py.pyyaml
       py.setuptools
       (py.toPythonModule ceph_client)
+      # note: this is not really appropriate in theory, as test-only tooling
+      #should be part of *checkInputs instead. checkInputs vs. nativeCheckInputs
+      # needs some adaptions in more recent NixOS releases anyways, so keeping this for now.
       py_pytest_patterns
     ];
 

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -525,6 +525,7 @@ in {
 
   prometheus-elasticsearch-exporter = super.callPackage ./prometheus-elasticsearch-exporter.nix { };
 
+  py_pytest_patterns = self.callPackage ./python/pytest-patterns { };
   # python27 with several downgrades to make required modules work under python27 again
   python27-ceph-downgrades = let thisPy = self.python27-ceph-downgrades;
   in

--- a/pkgs/python/pytest-patterns/default.nix
+++ b/pkgs/python/pytest-patterns/default.nix
@@ -1,0 +1,20 @@
+{ python3Packages }:
+python3Packages.buildPythonPackage rec {
+  pname = "pytest_patterns";
+  version = "0.1.0";
+
+  src = python3Packages.fetchPypi {
+    inherit pname version;
+    hash = "sha256-guKexrkDP4Ovqc87M7s8qFtW1FuVcf2PiDwh+QHcp6A=";
+    format = "wheel";
+    python = "py3";
+  };
+
+  format = "wheel";
+  propagatedBuildInputs = [ python3Packages.pytest ];
+
+  meta = {
+    description = "pytest plugin to make testing complicated long string output easy to write and easy to debug";
+    homepage = "https://pypi.org/project/pytest-patterns/";
+  };
+}

--- a/tests/backy_volumes.nix
+++ b/tests/backy_volumes.nix
@@ -30,7 +30,7 @@ let
     virtualisation.fileSystems."/mnt/keys" = config.flyingcircus.infrastructure.fullDiskEncryption.fsOptions;
     virtualisation.fileSystems."/srv/backy" = config.flyingcircus.roles.backyserver.fsOptions;
     # Cotherwise fc-luks OOMs
-    virtualisation.memorySize = 1000;
+    virtualisation.memorySize = 1200;
   };
 
 in
@@ -93,7 +93,7 @@ in
       legacyBacky.succeed("${migrationScript}")
       legacyBacky.wait_for_unit("backy-reencrypt.service")
       print(legacyBacky.execute('systemctl status backy-reencrypt.service')[1])
-      legacyBacky.succeed('echo -e "newphrase\nnewphrase" | setsid -w fc-luks keystore rekey --slot=admin backy > /dev/kmsg 2>&1')
+      legacyBacky.succeed('echo -e "newphrase\ny\n" | setsid -w fc-luks keystore rekey --slot=admin backy > /dev/kmsg 2>&1')
       legacyBacky.succeed("${pkgs.util-linux}/bin/findmnt /srv/backy > /dev/kmsg 2>&1")
       legacyBacky.succeed("grep FOOTEST /srv/backy/testfile")
 
@@ -106,7 +106,7 @@ in
     setupKeystore(newBacky)
 
     with subtest("Creating new backy volume from scratch"):
-      newBacky.succeed('echo -e "adminphrase\nadminphrase" | setsid -w fc-luks backup create /dev/vdb /dev/vdc /dev/vdd /dev/vde /dev/vdf > /dev/kmsg 2>&1')
+      newBacky.succeed('echo -e "adminphrase\ny\n" | setsid -w fc-luks backup create /dev/vdb /dev/vdc /dev/vdd /dev/vde /dev/vdf > /dev/kmsg 2>&1')
       newBacky.succeed("${pkgs.util-linux}/bin/findmnt /srv/backy > /dev/kmsg 2>&1")
 
     test_reboot_automount(newBacky)

--- a/tests/ceph-nautilus.nix
+++ b/tests/ceph-nautilus.nix
@@ -258,7 +258,7 @@ in
 
     with subtest("Initialize first mon"):
       host1.succeed('fc-ceph osd prepare-journal /dev/vdb > /dev/kmsg 2>&1')
-      host1.succeed('echo -e "adminphrase\nadminphrase" | setsid -w fc-ceph mon create --encrypt --size 500m --bootstrap-cluster > /dev/kmsg 2>&1')
+      host1.succeed('echo -e "adminphrase\ny\n" | setsid -w fc-ceph mon create --encrypt --size 500m --bootstrap-cluster > /dev/kmsg 2>&1')
       show(host1, "ls -l /dev/disk/by-label")
       show(host1, 'lsblk')
       show(host1, 'journalctl -u fc-ceph-mon')
@@ -281,7 +281,7 @@ in
       show(host1, 'ceph mon dump')
 
       # mgr keys rely on 'fc-ceph keys' to be executed first
-      host1.execute('echo -e "adminphrase\nadminphrase" | setsid -w fc-ceph mgr create --encrypt --size 500m > /dev/kmsg 2>&1')
+      host1.execute('echo -e "adminphrase\n" | setsid -w fc-ceph mgr create --encrypt --size 500m > /dev/kmsg 2>&1')
       show(host1, 'journalctl -u fc-ceph-mgr')
       show(host1, 'ceph mgr module ls')
 
@@ -291,7 +291,7 @@ in
 
     with subtest("Initialize first OSD (bluestore)"):
       host1.execute('systemctl status fc-ceph-osd@0.service > /dev/kmsg 2>&1')
-      host1.execute('echo -e "adminphrase\nadminphrase" | setsid -w fc-ceph osd create-bluestore --encrypt /dev/vdc > /dev/kmsg 2>&1')
+      host1.execute('echo -e "adminphrase\n" | setsid -w fc-ceph osd create-bluestore --encrypt /dev/vdc > /dev/kmsg 2>&1')
       host1.execute('systemctl status fc-ceph-osd@0.service > /dev/kmsg 2>&1')
 
     with subtest("Initialize second MON and OSD (bluestore, internal WAL)"):
@@ -348,8 +348,8 @@ in
 
       assert_clean_cluster(host2, 2, 3, 2, 320)
 
-      host1.succeed('echo -e "adminphrase\nadminphrase" | setsid -w fc-ceph mon create --size 500m > /dev/kmsg 2>&1')
-      host1.execute('echo -e "adminphrase\nadminphrase" | setsid -w fc-ceph mgr create --size 500m > /dev/kmsg 2>&1')
+      host1.succeed('echo -e "adminphrase\n" | setsid -w fc-ceph mon create --size 500m > /dev/kmsg 2>&1')
+      host1.execute('echo -e "adminphrase\n" | setsid -w fc-ceph mgr create --size 500m > /dev/kmsg 2>&1')
       host1.sleep(5)
       show(host1, 'tail -n 500 /var/log/ceph/*mon*')
       show(host1, 'tail -n 500 /var/log/ceph/*mgr*')
@@ -374,7 +374,7 @@ in
       host1.sleep(5)
       assert_clean_cluster(host2, 3, (4, 3), 3, 320)
       # then rebuild
-      host1.succeed('echo -e "adminphrase\nadminphrase" | setsid -w fc-ceph osd rebuild --no-encrypt --strict-safety-check 3 > /dev/kmsg 2>&1')
+      host1.succeed('echo -e "adminphrase\n" | setsid -w fc-ceph osd rebuild --no-encrypt --strict-safety-check 3 > /dev/kmsg 2>&1')
       # and set the osds in again
       host1.execute('ceph osd in $(ceph osd ls-tree host1)')
       show(host1, "lsblk")
@@ -383,7 +383,7 @@ in
       assert_clean_cluster(host2, 3, 4, 3, 320)
 
     with subtest("Rebuild all OSDs on host 1 and ensure encryption is enabled"):
-      host1.succeed('echo -e "adminphrase\nadminphrase" | setsid -w fc-ceph osd rebuild --encrypt --no-safety-check all > /dev/kmsg 2>&1')
+      host1.succeed('echo -e "adminphrase\n" | setsid -w fc-ceph osd rebuild --encrypt --no-safety-check all > /dev/kmsg 2>&1')
       assert_clean_cluster(host2, 3, 4, 3, 320)
 
     with subtest("Destroy the 2nd OSD on host 1 without redundancy loss"):
@@ -400,9 +400,9 @@ in
     with subtest("Destroy and re-create the keystore, rekey the OSD"):
       host1.succeed("fc-luks keystore destroy --no-overwrite > /dev/kmsg 2>&1")
       host1.succeed("fc-luks keystore create /dev/vde > /dev/kmsg 2>&1")
-      host1.succeed('echo -e "adminphrase\nadminphrase" | setsid -w fc-luks keystore rekey "*" > /dev/kmsg 2>&1')
-      host1.succeed('echo -e "newphrase\nnewphrase" | setsid -w fc-luks keystore rekey --slot=admin "*" > /dev/kmsg 2>&1')
-      host1.succeed('echo -e "newphrase\nnewphrase" | setsid -w fc-luks keystore rekey "ceph-osd-0" > /dev/kmsg 2>&1')
+      host1.succeed('echo -e "adminphrase\ny\n" | setsid -w fc-luks keystore rekey "*" > /dev/kmsg 2>&1')
+      host1.succeed('echo -e "newphrase\ny\n" | setsid -w fc-luks keystore rekey --slot=admin "*" > /dev/kmsg 2>&1')
+      host1.succeed('echo -e "newphrase\n" | setsid -w fc-luks keystore rekey "ceph-osd-0" > /dev/kmsg 2>&1')
       host1.succeed("fc-ceph osd reactivate all")
       assert_clean_cluster(host2, 3, 3, 3, 320)
 


### PR DESCRIPTION
@flyingcircusio/release-managers

Compute and display a hash fingerprint of the LUKS admin passphrase entered and store it alongside the key file on the keystore USB stick.
This helps discovering accidentally wrong keys entered into a system and debug unknown/ corrupted passphrase states.

Missing fingerprints or mismatches are displayed and resolved interactively.

Includes subcommand `fc-luks keystore fingerprint` for calculating the fingerprint of a passphrase and then storing it in a vault of your choice.

PL-131325

## Release process

Impact: internal

Changelog:
- fc-ceph/ fc-luks: entering an admin key now displays a fingerprint of the correct key on mismatches
- `fc-luks keystore fingerprint`

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - [x] improve handling and discoverability of passphrase mismatches for operators
  - [x] extend automated tests
  - [x] fine-grained unit tests for all common input flows
  - [x] must not introduce known regressions
  - [x] must work on existing encrypted hosts and update them with a fingerprint
- [x] Security requirements tested? (EVIDENCE)
  - [x] automated tests pass
  - [x] extended unit tests
  - [x] manually tested in dev cluster
  - [x] manually initialised the fingerprint on host while maintaining the same passphrase (migration scenario)
