### PR TITLE
lamp: support for php83

### DIFF
--- a/doc/src/lamp.md
+++ b/doc/src/lamp.md
@@ -201,6 +201,7 @@ Supported packages:
 - `pkgs.lamp_php80`
 - `pkgs.lamp_php81`
 - `pkgs.lamp_php82` (default)
+- `pkgs.lamp_php83`
 
 The `lamp_php_*` packages provided by our platform include commonly used
 PHP extensions, currently:

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -21,7 +21,7 @@ builtins.mapAttrs (_: patchPhps phpLogPermissionPatch) {
 
   # Import old php versions from nix-phps.
   inherit (phps) php72 php73 php74 php80;
-  inherit (super) php81 php82;
+  inherit (super) php81 php82 php83;
 }
 //
 {
@@ -176,6 +176,14 @@ builtins.mapAttrs (_: patchPhps phpLogPermissionPatch) {
               ]);
 
   lamp_php82 = self.php82.withExtensions ({ enabled, all }:
+              enabled ++ [
+                all.bcmath
+                all.imagick
+                all.memcached
+                all.redis
+              ]);
+
+  lamp_php83 = self.php83.withExtensions ({ enabled, all }:
               enabled ++ [
                 all.bcmath
                 all.imagick

--- a/pkgs/tideways/module.nix
+++ b/pkgs/tideways/module.nix
@@ -2,7 +2,7 @@
 
 assert stdenv.hostPlatform.system == "x86_64-linux";
 
-let version = "5.5.14"; in
+let version = "5.7.4"; in
 
 stdenv.mkDerivation {
   name = "tideways-php-module-${version}";
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "https://s3-eu-west-1.amazonaws.com/tideways/extension/${version}/tideways-php-${version}-x86_64.tar.gz";
-    sha256 = "sha256-KH6mKvyYNMPor656so4oEdU6aobxXwU9H7cHAYJulKI=";
+    hash = "sha256-44NAfOFNhjzT6CUYKLAVVmx1PKG3EZI4w6tcwvCMirI=";
   };
 
   meta = {

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -62,11 +62,14 @@ in {
   lampVm81_tideways = callTest ./lamp/vm-test.nix { version = "lamp_php81"; tideways = "1234"; };
   lampVm82 = callTest ./lamp/vm-test.nix { version = "lamp_php82"; };
   lampVm82_tideways = callTest ./lamp/vm-test.nix { version = "lamp_php82"; tideways = "1234"; };
+  lampVm83 = callTest ./lamp/vm-test.nix { version = "lamp_php83"; };
+  lampVm83_tideways = callTest ./lamp/vm-test.nix { version = "lamp_php83"; tideways = "1234"; };
 
   lampPackage74 = callTest ./lamp/package-test.nix { version = "lamp_php74"; };
   lampPackage80 = callTest ./lamp/package-test.nix { version = "lamp_php80"; };
   lampPackage81 = callTest ./lamp/package-test.nix { version = "lamp_php81"; };
   lampPackage82 = callTest ./lamp/package-test.nix { version = "lamp_php82"; };
+  lampPackage83 = callTest ./lamp/package-test.nix { version = "lamp_php83"; };
 
   locale = callTest ./locale.nix {};
   login = callTest ./login.nix {};


### PR DESCRIPTION
@flyingcircusio/release-managers

PL-132390

## Release process

Impact: none

Changelog:
- lamp role: support for php-8.3
  - introduces new `pkgs.lamp_php83`
- tideways_module: 5.5.14 -> 5.7.4 for php-8.3 support

### PR release workflow (internal)

- [x] PR has internal ticket
- [ ] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
  - is a new optional package
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
  - new package mentioned in public role docs

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - provide more recent software releases
  - must not introduce known regressions
  - check with a smoke test
- [x] Security requirements tested? (EVIDENCE)
  - [x] automated tests still pass, tests expanded to new package
  - [x] set up a small lamp example serving a phpinfo call