### PR TITLE
[21.05] Disable rgw in maintenance

### DIFF
--- a/nixos/roles/ceph/rgw.nix
+++ b/nixos/roles/ceph/rgw.nix
@@ -113,6 +113,11 @@ in
         };
       };
 
+      flyingcircus.agent.maintenance.rgw = {
+        enter = "systemctl stop fc-ceph-rgw";
+        leave = "systemctl start fc-ceph-rgw";
+      };
+
       networking.firewall.extraStopCommands = ''
         ip46tables -w -t nat -D PREROUTING -j fc-nat-pre 2>/dev/null|| true
         ip46tables -w -t nat -F fc-nat-pre 2>/dev/null || true

--- a/pkgs/fc/agent/fc/maintenance/cli.py
+++ b/pkgs/fc/agent/fc/maintenance/cli.py
@@ -140,7 +140,9 @@ def schedule():
 
 @app.command()
 @requires_sudo
-def run(run_all_now: bool = False, force_run: bool = False):
+def run(
+    run_all_now: bool = False, force_run: bool = False, online: bool = True
+):
     """[sudo] Run all maintenance activity requests that are due.
 
     Note that this does not schedule pending requests like running the script without
@@ -169,6 +171,9 @@ def run(run_all_now: bool = False, force_run: bool = False):
     The --force-run flag also runs requests in state 'success' again when they are still
     in the queue after a recent system reboot.
 
+    The --online flag (enabled by default) causes interaction with outside
+    systems like the directory. Use --no-online to avoid outside interaction.
+
     After executing all runnable requests, requests that want to be postponed
     are postponed (they get a new execution time) and finished requests
     (successful or failed permanently) moved from the current request to the
@@ -177,9 +182,9 @@ def run(run_all_now: bool = False, force_run: bool = False):
     log.info("fc-maintenance-run-start")
     with rm:
         rm.update_states()
-        rm.execute(run_all_now, force_run)
-        rm.postpone()
-        rm.archive()
+        rm.execute(run_all_now, force_run, online)
+        rm.postpone(online)
+        rm.archive(online)
     log.info("fc-maintenance-run-finished")
 
 

--- a/pkgs/fc/agent/fc/maintenance/tests/test_reqmanager.py
+++ b/pkgs/fc/agent/fc/maintenance/tests/test_reqmanager.py
@@ -277,7 +277,7 @@ def test_execute_postpone(log, reqmanager):
     req.state = State.due
     req.execute = Mock()
 
-    def enter_maintenance_postpone():
+    def enter_maintenance_postpone(online: bool = True):
         raise PostponeMaintenance()
 
     reqmanager._runnable = lambda run_all_now, force_run: [req]
@@ -420,8 +420,9 @@ def test_schedule_run_end_to_end(connect, request_population):
                     }
                 }
             ),
-        ]
-    ), "unexpected end maintenance calls"
+        ],
+        "unexpected end maintenance calls",
+    )
     assert postp.call_count == 1, "unexpected postpone call count"
 
 

--- a/pkgs/fc/agent/fc/util/typer_utils.py
+++ b/pkgs/fc/agent/fc/util/typer_utils.py
@@ -26,7 +26,7 @@ class FCTyperApp(typer.Typer):
                         command=self.command_name,
                         _log_settings=dict(console_ignore=True),
                     )
-                except:
+                except:  # noqa
                     # Raise the original exception when logging fails.
                     print("WARNING: logging an unhandled exception failed.")
                     raise e


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

none

Changelog:

* Ceph daemons that provide live services (OSDs, RadosGW) are now stopped during maintenances. (PL-132401)

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

Ensure availability of the cluster during maintenance.

- [x] Security requirements tested? (EVIDENCE)

Manually tested and added automated tests.