### PR TITLE
Clean up location nameserver addresses (port to 23.11)

### DIFF
--- a/nixos/platform/static.nix
+++ b/nixos/platform/static.nix
@@ -65,16 +65,14 @@ with lib;
       };
 
       nameservers = {
-        # ns.$location.gocept.net, ns2.$location.gocept.net
+        # The virtual router SRV IP which acts as the location-wide resolver.
+        #
         # We are currently not using IPv6 resolvers as we have seen obscure bugs
         # when enabling them, like weird search path confusion that results in
         # arbitrary negative responses, combined with the rotate flag.
-        #
-        # This seems to be https://sourceware.org/bugzilla/show_bug.cgi?id=13028
-        # which is fixed in glibc 2.22 which is included in NixOS 16.03.
-        dev = [ "172.20.2.1" "172.20.3.7" "172.20.3.57" ];
-        whq = [ "212.122.41.129" "212.122.41.173" "212.122.41.169" ];
-        rzob = [ "195.62.125.1" "195.62.126.130" "195.62.126.131" ];
+        dev = [ "172.20.3.1" ];
+        whq = [ "172.16.48.1" ];
+        rzob = [ "172.22.48.1" ];
         standalone = [ "9.9.9.9" "8.8.8.8" ];
       };
 


### PR DESCRIPTION
This was found as we noticed that the static old specific IPs in DEV caused telemetry outages as nginx would try to resolve using the dead IPs.

Those IPs are now independent of any specific hardware life cycle and consistently use SRV which is available to all nodes directly.

Fixes PL-132394

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Clean up the location-specific nameservers: instead of using multiple machine-specific addresses, we now only select a single IP which corresponds to a highly available virtual IP on our routers. This reduces the potential for inconsistent settings that may result in sub-optimal performance on some applications, like nginx resolvers. (PL-132394)

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

Availability.

- [x] Security requirements tested? (EVIDENCE)

Manually tested for the desired effects on services12.
