### PR TITLE
[21.05] ceph: add new `passive` option to disable daemons and timers

### DIFF
--- a/nixos/roles/ceph/mon.nix
+++ b/nixos/roles/ceph/mon.nix
@@ -137,6 +137,8 @@ in
       };
 
       systemd.services.fc-ceph-mon = rec {
+        enable = ! config.flyingcircus.services.ceph.server.passive;
+
         description = "Local Ceph Mon (via fc-ceph)";
         wantedBy = [ "multi-user.target" ];
         # Ceph requires the IPs to be properly attached to interfaces so it
@@ -220,6 +222,8 @@ in
       };
 
       systemd.services.fc-ceph-mgr = rec {
+        enable = ! config.flyingcircus.services.ceph.server.passive;
+
         description = "Local Ceph MGR (via fc-ceph)";
         wantedBy = [ "multi-user.target" ];
         # Ceph requires the IPs to be properly attached to interfaces so it
@@ -304,6 +308,8 @@ in
     (lib.mkIf (role.enable && role.primary) {
 
       systemd.timers.fc-ceph-load-vm-images = {
+        enable = ! config.flyingcircus.services.ceph.server.passive;
+
         description = "Timer for loading new VM base images";
         wantedBy = [ "timers.target" ];
         timerConfig = {
@@ -313,6 +319,8 @@ in
       };
 
       systemd.timers.fc-ceph-purge-old-snapshots = {
+        enable = ! config.flyingcircus.services.ceph.server.passive;
+
         description = "Timer for cleaning old snapshots";
         wantedBy = [ "timers.target" ];
         timerConfig = {
@@ -322,6 +330,8 @@ in
       };
 
       systemd.timers.fc-ceph-clean-deleted-vms = {
+        enable = ! config.flyingcircus.services.ceph.server.passive;
+
         description = "Timer for cleaning deleted VM disks";
         wantedBy = [ "timers.target" ];
         timerConfig = {
@@ -331,6 +341,8 @@ in
       };
 
       systemd.timers.fc-ceph-mon-update-client-keys = {
+        enable = ! config.flyingcircus.services.ceph.server.passive;
+
         description = "Timer for updating client keys and authorization in the monitor database.";
         wantedBy = [ "timers.target" ];
         timerConfig = {

--- a/nixos/roles/ceph/osd.nix
+++ b/nixos/roles/ceph/osd.nix
@@ -195,6 +195,8 @@ in
       flyingcircus.services.ceph.cluster_network = head fclib.network.stb.v4.networks;
 
       systemd.services.fc-ceph-osds-all = rec {
+        enable = ! config.flyingcircus.services.ceph.server.passive;
+
         description = "All locally known Ceph OSDs (via fc-ceph managed units)";
         wantedBy = [ "multi-user.target" ];
 
@@ -223,6 +225,8 @@ in
       } // osdServiceDeps;
 
       systemd.services."fc-ceph-osd@" = rec {
+        enable = ! config.flyingcircus.services.ceph.server.passive;
+
         description = "Ceph OSD %i";
 
         environment = {

--- a/nixos/roles/ceph/rgw.nix
+++ b/nixos/roles/ceph/rgw.nix
@@ -92,6 +92,8 @@ in
       ];
 
       systemd.services.fc-ceph-rgw = rec {
+        enable = ! config.flyingcircus.services.ceph.server.passive;
+
         description = "Start/stop local Ceph Rados Gateway";
         wantedBy = [ "multi-user.target" ];
         # Ceph requires the IPs to be properly attached to interfaces so it
@@ -189,6 +191,8 @@ in
     (lib.mkIf (role.enable && role.primary) {
 
       systemd.timers.fc-ceph-rgw-update-stats = {
+        enable = ! config.flyingcircus.services.ceph.server.passive;
+
         description = "Timer for updating RGW stats";
         wantedBy = [ "timers.target" ];
         timerConfig = {
@@ -198,6 +202,8 @@ in
       };
 
       systemd.timers.fc-ceph-rgw-accounting = {
+        enable = ! config.flyingcircus.services.ceph.server.passive;
+
         description = "Timer for uploading S3 usage data to the Directory";
         wantedBy = [ "timers.target" ];
         timerConfig = {

--- a/nixos/services/ceph/server.nix
+++ b/nixos/services/ceph/server.nix
@@ -35,6 +35,8 @@ in
           Background: We operate our rbd.hdd and rbd.ssd pools under different Ceph crush
           roots to map them to disjoint sets of certain disks.'';
       };
+
+      passive = lib.mkEnableOption "Setup all configuration but disable any daemon units.";
     };
   };
 


### PR DESCRIPTION
This is a knob for operators where we want to temporarily, but reliably disable all Ceph daemons and timers to perform maintenance but do not lose Ceph config and can run reboots and nixos-rebuild without accidentally turning the daemons back on.

Re PL-132400

@flyingcircusio/release-managers

## Release process

Impact:

none

Changelog:

* Add ability to switch Ceph servers into a `passive` mode during manual maintenances to avoid daemons activating automatically on boot and during agent runs. (PL-132400)

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.

This is a feature toggle ;)

- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

Avoid downtimes.

- [x] Security requirements tested? (EVIDENCE)

manually tested
