### PR TITLE
Pl 127635 stabilize network reconfiguration

### DIFF
--- a/.pre-commit-config-local.yaml
+++ b/.pre-commit-config-local.yaml
@@ -1,1 +1,1 @@
-exclude: "pkgs/fc/sensusyntax/fixtures/(syntaxerror|empty).json|(nixos/infrastructure/container.nix|tests/testlib.nix|nixos/roles/devhost/vm.nix)"
+exclude: "pkgs/fc/sensusyntax/fixtures/(syntaxerror|empty).json|(nixos/infrastructure/container.nix|tests/testlib.nix|nixos/roles/devhost/vm.nix|tests/physical-installer.nix)"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-exclude: ^secrets/|^appenv$|pkgs/fc/sensusyntax/fixtures/(syntaxerror|empty).json|(nixos/infrastructure/container.nix|tests/testlib.nix|nixos/roles/devhost/vm.nix)
+exclude: ^secrets/|^appenv$|pkgs/fc/sensusyntax/fixtures/(syntaxerror|empty).json|(nixos/infrastructure/container.nix|tests/testlib.nix|nixos/roles/devhost/vm.nix|tests/physical-installer.nix)
 repos:
 - hooks:
   - exclude: "(?x)^(\n  secrets/|environments/.*/secret.*|\n  .*\\.patch\n)$\n"

--- a/nixos/infrastructure/flyingcircus-physical.nix
+++ b/nixos/infrastructure/flyingcircus-physical.nix
@@ -120,6 +120,12 @@ mkIf (cfg.infrastructureModule == "flyingcircus-physical") {
         '';
     };
 
+    services.journald.extraConfig = ''
+      SystemMaxUse=8G
+      MaxLevelConsole=err
+      ForwardToWall=no
+    '';
+
     systemd.services.lvm-upgrade-metadata = {
         wantedBy = [ "multi-user.target" ];
         serviceConfig.Type = "oneshot";

--- a/nixos/infrastructure/flyingcircus-virtual.nix
+++ b/nixos/infrastructure/flyingcircus-virtual.nix
@@ -84,6 +84,12 @@ mkIf (cfg.infrastructureModule == "flyingcircus") {
     '';
   };
 
+  services.journald.extraConfig = ''
+    SystemMaxUse=2G
+    MaxLevelConsole=notice
+    ForwardToWall=no
+  '';
+
   systemd = {
     ctrlAltDelUnit = "poweroff.target";
 

--- a/nixos/lib/network.nix
+++ b/nixos/lib/network.nix
@@ -332,7 +332,7 @@ rec {
           else if policy == "tagged" then "${buildComplexInterfaceName "eth-" (builtins.head interface'.nics).external_label or "vlan"}"
           else taggedLink;
 
-        externalLabel = if (length (interface' ? nics or 0) > 0) then (builtins.head interface'.nics).external_label else null;
+        externalLabel = if (length (interface'.nics or 0) > 0) then (builtins.head interface'.nics).external_label else null;
 
         linkStack = lib.unique (filter (l: l != null) [
           link

--- a/nixos/lib/network.nix
+++ b/nixos/lib/network.nix
@@ -332,7 +332,7 @@ rec {
           else if policy == "tagged" then "${buildComplexInterfaceName "eth-" (builtins.head interface'.nics).external_label or "vlan"}"
           else taggedLink;
 
-        externalLabel = (builtins.head interface'.nics).external_label;
+        externalLabel = if (length (interface' ? nics or 0) > 0) then (builtins.head interface'.nics).external_label else null;
 
         linkStack = lib.unique (filter (l: l != null) [
           link

--- a/nixos/lib/network.nix
+++ b/nixos/lib/network.nix
@@ -332,7 +332,7 @@ rec {
           else if policy == "tagged" then "${buildComplexInterfaceName "eth-" (builtins.head interface'.nics).external_label or "vlan"}"
           else taggedLink;
 
-        externalLabel = if (length (interface'.nics or 0) > 0) then (builtins.head interface'.nics).external_label else null;
+        externalLabel = if (length (interface'.nics or []) > 0) then (builtins.head interface'.nics).external_label else null;
 
         linkStack = lib.unique (filter (l: l != null) [
           link

--- a/nixos/lib/network.nix
+++ b/nixos/lib/network.nix
@@ -186,7 +186,7 @@ rec {
   # exists) to make it idempotent.
   relaxedIp = pkgs.writeScriptBin "ip" ''
     #! ${pkgs.stdenv.shell} -e
-    echo ip "$@"
+    echo ip "$@" >&2
     rc=0
     ${pkgs.iproute}/bin/ip "$@" || rc=$?
     if ((rc == 2)); then

--- a/nixos/platform/network.nix
+++ b/nixos/platform/network.nix
@@ -99,6 +99,8 @@ in
       # -> #PL-129549
       hosts = lib.mkOverride 90 {};
 
+      tempAddresses = "disabled";
+
       nameservers =
         if (hasAttr location cfg.static.nameservers)
         then cfg.static.nameservers.${location}
@@ -778,7 +780,7 @@ in
       "vm.min_free_kbytes" = "513690";
 
       "net.core.netdev_max_backlog" = "300000";
-      "net.core.optmem" = "40960";
+      "net.core.optmem_max" = "65536";
       "net.core.wmem_default" = "16777216";
       "net.core.wmem_max" = "16777216";
       "net.core.rmem_default" = "8388608";
@@ -795,7 +797,6 @@ in
       "net.ipv4.tcp_wmem" = "1048576 8388608 16777216";
       "net.ipv4.tcp_rmem" = "1048576 8388608 16777216";
 
-      "net.ipv4.tcp_tw_recycle" = "1";
       "net.ipv4.tcp_tw_reuse" = "1";
 
       # Supposedly this doesn't do much good anymore, but in one of my tests

--- a/nixos/platform/network.nix
+++ b/nixos/platform/network.nix
@@ -427,6 +427,9 @@ in
                 # Ensure MTU
                 ip l set ${iface.link} mtu ${toString iface.mtu}
 
+                ''
+
+             + (lib.optionalString (iface.externalLabel != null) ''
                 # Add long alternative names according to the external label
                 if ip l show dev ${quoteLabel iface.externalLabel} > /dev/null; then
                   # XXX There is an edge case we don't cover here:
@@ -437,9 +440,9 @@ in
                 fi
                 ip l property add altname ${quoteLabel iface.externalLabel} dev ${iface.link}
 
+              '') + ''
                 echo "Releasing lock"
                 exec 4>&-
-
               '';
               preStop = ''
                 set -e

--- a/nixos/platform/systemd.nix
+++ b/nixos/platform/systemd.nix
@@ -27,12 +27,6 @@ in
       "admins"
     ];
 
-    services.journald.extraConfig = ''
-      SystemMaxUse=2G
-      MaxLevelConsole=notice
-      ForwardToWall=no
-    '';
-
     services.journald.forwardToSyslog = lib.mkOverride 90 false;
 
     flyingcircus.activationScripts = {

--- a/nixos/roles/ceph/rgw.nix
+++ b/nixos/roles/ceph/rgw.nix
@@ -151,6 +151,7 @@ in
         description = "Update RGW stats";
         serviceConfig.Type = "oneshot";
         path = [ cephPkgs.ceph pkgs.jq ];
+        requires = [ "network-addresses-${fclib.network.sto.interface}.service" ];
         script = ''
           for uid in $(radosgw-admin metadata list user | jq -r '.[]'); do
             echo $uid
@@ -163,6 +164,7 @@ in
         description = "Upload S3 usage data to the Directory";
         path = [ cephPkgs.ceph ];
         serviceConfig.Type = "oneshot";
+        requires = [ "network-addresses-${fclib.network.sto.interface}.service" ];
         script = "${pkgs.fc.agent}/bin/fc-s3accounting --enc ${config.flyingcircus.encPath}";
       };
 

--- a/nixos/roles/external_net/vxlan-client.nix
+++ b/nixos/roles/external_net/vxlan-client.nix
@@ -40,10 +40,8 @@ in
         description = "Custom routing rules for external networks";
         after = [ "network-addresses-${netdev}.service" "firewall.service" ];
         requires = after;
-        wantedBy = [ "network.target" ];
-        # XXX quoting
-        bindsTo = [ "sys-subsystem-net-devices-${fclib.network.srv.interface}.device" ];
-        path = [ pkgs.gawk pkgs.iproute pkgs.glibc pkgs.iptables ];
+        wantedBy = [ "network.target" "multi-user.target" ];
+        path = [ pkgs.gawk fclib.relaxedIp pkgs.glibc pkgs.iptables ];
 
         serviceConfig = {
           Type = "oneshot";

--- a/nixos/roles/external_net/vxlan.nix
+++ b/nixos/roles/external_net/vxlan.nix
@@ -18,13 +18,12 @@ let
   vxlanRole = config.flyingcircus.roles.vxlan;
   extnet = cfg.roles.external_net;
   parameters = lib.attrByPath [ "enc" "parameters" ] {} cfg;
-  interfaces = lib.attrByPath [ "interfaces" ] {} parameters;
   resource_group = lib.attrByPath [ "resource_group" ] null parameters;
 
   net4 = extnet.vxlan4;
   net6 = extnet.vxlan6;
   dev = "nx0";
-  realdev = "ethfe";
+  interface = fclib.network.fe.interface;
   port = 8472;
 
   exampleConfig = ''
@@ -137,10 +136,9 @@ in
 
       systemd.services."vxlan-${dev}" = rec {
         description = "VxLAN tunnel ${dev}";
-        after = [ "network-addresses-${realdev}.service" ];
+        after = [ "network-addresses-${interface}.service" ];
         wantedBy = [ "dnsmasq.service" ];
         before = wantedBy;
-        bindsTo = [ "sys-subsystem-net-devices-${realdev}.device" ];
 
         serviceConfig = let
           ip = "${pkgs.iproute}/bin/ip";
@@ -154,7 +152,7 @@ in
             echo "adding link ${dev}"
             ${ip} link del ${dev} 2>/dev/null || true
             ${ip} link add ${dev} type vxlan id ${toString vid} \
-              dev ${realdev} local ${local} remote ${remote} \
+              dev ${interface} local ${local} remote ${remote} \
               dstport ${toString port}
             ${ip} link set up mtu ${toString mtu} dev ${dev}
             ${ip} -4 addr add ${gw4} dev ${dev}

--- a/nixos/roles/router/dhcpd.nix
+++ b/nixos/roles/router/dhcpd.nix
@@ -64,7 +64,11 @@ in
   config = lib.mkIf (role.enable && role.isPrimary) {
     services.dhcpd4 = {
       enable = true;
-      interfaces = [ "brfe" "brsrv" "ethmgm" ];
+      interfaces = [
+        fclib.network.fe.interface
+        fclib.network.srv.interface
+        fclib.network.mgm.interface
+      ];
       configFile = pkgs.writeText "dhcpd4.conf" ''
         ${baseConf}
         ${dhcpd4Conf}
@@ -74,7 +78,11 @@ in
 
     services.dhcpd6 = {
       enable = true;
-      interfaces = [ "brfe" "brsrv" "ethmgm" ];
+      interfaces = [
+        fclib.network.fe.interface
+        fclib.network.srv.interface
+        fclib.network.mgm.interface
+      ];
       configFile = pkgs.writeText "dhcpd6.conf" ''
         ${baseConf}
         ${dhcpd6Conf}

--- a/nixos/roles/webdata_blackbee.nix
+++ b/nixos/roles/webdata_blackbee.nix
@@ -64,8 +64,7 @@ in
       after = [ "network-addresses-${netdev}.service" "firewall.service" ];
       requires = after;
       wantedBy = [ "multi-user.target" ];
-      # quoting
-      bindsTo = [ "sys-subsystem-net-devices-${fclib.network.srv.interface}.device" ];
+      bindsTo = [ "network-addresses-${fclib.network.srv.interface}.service" ];
       path = with pkgs; [ gawk iproute glibc iptables ];
 
       serviceConfig =

--- a/pkgs/fc/lldp-to-altname/fc-lldp-to-altname.py
+++ b/pkgs/fc/lldp-to-altname/fc-lldp-to-altname.py
@@ -34,7 +34,7 @@ class Runner(object):
                     ),
                     file=sys.stderr,
                 )
-                sys.exit(1)
+                continue
             indices.add(index)
 
         interfaces = set()
@@ -48,7 +48,7 @@ class Runner(object):
                     ),
                     file=sys.stderr,
                 )
-                sys.exit(1)
+                continue
             interfaces.add(iface)
 
         # sort to ensure stable renames in case of altname collisions

--- a/tests/mail/default.nix
+++ b/tests/mail/default.nix
@@ -1,4 +1,8 @@
-import ../make-test-python.nix ({pkgs, lib, ...}:
+import ../make-test-python.nix ({ pkgs, lib, testlib, ... }:
+
+with lib;
+with testlib;
+
 let
   commonConfig = {
     networking.domain = "example.local";
@@ -21,7 +25,10 @@ in
   nodes = {
     mail =
       { lib, ... }: {
-        imports = [ ../../nixos ../../nixos/roles ];
+        imports = [
+          (fcConfig { id = 3; })
+        ];
+
         config = lib.mkMerge [
           commonConfig
           {
@@ -36,30 +43,6 @@ in
                 };
               };
               rootAlias = "user2@example.local";
-            };
-
-            virtualisation.vlans = [ 1 3 ];
-
-            flyingcircus.enc.parameters = {
-              resource_group = "test";
-              interfaces.srv = {
-                mac = "52:54:00:12:03:03";
-                bridged = false;
-                networks = {
-                  "192.168.3.0/24" = [ "192.168.3.3" ];
-                  "2001:db8:3::/64" = [ "2001:db8:3::3" ];
-                };
-                gateways = {};
-              };
-              interfaces.fe = {
-                mac = "52:54:00:12:01:03";
-                bridged = false;
-                networks = {
-                  "192.168.1.0/24" = [ "192.168.1.3" ];
-                  "2001:db8:1::/64" = [ "2001:db8:1::3" ];
-                };
-                gateways = {};
-              };
             };
 
             mailserver.certificateScheme = lib.mkOverride 50 2;
@@ -106,33 +89,11 @@ in
       };
     client =
       { lib, ... }: {
-        imports = [ ../../nixos ../../nixos/roles ];
+        imports = [ (fcConfig { id = 1; }) ];
         config = lib.mkMerge [
           commonConfig
           {
             flyingcircus.services.nullmailer.enable = true;
-
-            virtualisation.vlans = [ 1 3 ];
-
-            flyingcircus.enc.parameters.interfaces.srv = {
-              mac = "52:54:00:12:03:01";
-              bridged = false;
-              networks = {
-                "192.168.3.0/24" = [ "192.168.3.1" ];
-                "2001:db8:3::/64" = [ "2001:db8:3::1" ];
-              };
-              gateways = {};
-            };
-
-            flyingcircus.enc.parameters.interfaces.fe = {
-              mac = "52:54:00:12:01:01";
-              bridged = false;
-              networks = {
-                "192.168.1.0/24" = [ "192.168.1.1" ];
-                "2001:db8:1::/64" = [ "2001:db8:1::1" ];
-              };
-              gateways = {};
-            };
 
             flyingcircus.encServices = [
               {
@@ -145,6 +106,8 @@ in
       };
     ext =
       { pkgs, ... }: {
+        imports = [ (fcConfig { id = 2; }) ];
+
         config = lib.mkMerge [
           commonConfig
           {

--- a/tests/network/default.nix
+++ b/tests/network/default.nix
@@ -117,11 +117,11 @@ in {
           flyingcircus.encAddresses = [
             {
               name = "machine";
-              ip = "10.51.2.11";
+              ip = "10.51.3.11";
             }
             {
               name = "other";
-              ip = "10.51.2.12";
+              ip = "10.51.3.12";
             }
           ];
 

--- a/tests/network/default.nix
+++ b/tests/network/default.nix
@@ -2,44 +2,18 @@ import ../make-test-python.nix ({ pkgs, ... }:
 let
   router =
     { config, pkgs, ... }:
-    with pkgs.lib;
-    let
-      vlanIfs = range 1 (length config.virtualisation.vlans);
-    in {
-      environment.systemPackages = with pkgs; [ iptables curl ];
-      virtualisation.vlans = [ 1 2 3 ];  # fe srv tr
-      boot.kernel.sysctl."net.ipv6.conf.all.forwarding" = true;
-      networking = {
-        useDHCP = false;
-        firewall.allowPing = true;
-        firewall.checkReversePath = true;
-        interfaces = mkForce (listToAttrs (flip map vlanIfs (n:
-          nameValuePair "eth${toString n}" {
-            ipv4.addresses = [
-              { address = "10.51.${toString n}.1"; prefixLength = 24; }
-            ];
-            ipv6.addresses = [
-              { address = "2001:db8:${toString n}::1"; prefixLength = 64; }
-            ];
-          })));
-      };
+    with pkgs.lib; {
+      imports = [ ../../nixos ../../nixos/roles ];
 
+      environment.systemPackages = with pkgs; [ iptables curl ];
+      virtualisation.vlans = [ 2 3 6 ];  # fe srv tr
+      boot.kernel.sysctl."net.ipv6.conf.all.forwarding" = true;
+
+      flyingcircus.enc.parameters.interfaces = encInterfaces "1";
     };
 
   encInterfaces = id: {
-    fe = {  # VLAN 1
-      mac = "52:54:00:12:01:0${id}";
-      bridged = false;
-      networks = {
-        "10.51.1.0/24" = [ "10.51.1.1${id}" "10.51.1.2${id}" ];
-        "2001:db8:1::/64" = [ "2001:db8:1::1${id}" "2001:db8:1::2${id}" ];
-      };
-      gateways = {
-        "10.51.1.0/24" = "10.51.1.1";
-        "2001:db8:1::/64" = "2001:db8:1::1";
-      };
-    };
-    srv = {  # VLAN 2
+    fe = {  # VLAN 2
       mac = "52:54:00:12:02:0${id}";
       bridged = false;
       networks = {
@@ -50,6 +24,27 @@ let
         "10.51.2.0/24" = "10.51.2.1";
         "2001:db8:2::/64" = "2001:db8:2::1";
       };
+      nics = [
+        {"mac" = "52:54:00:12:02:0${id}";
+         "external_label" = "fenic${id}"; }
+      ];
+
+    };
+    srv = {  # VLAN 3
+      mac = "52:54:00:12:03:0${id}";
+      bridged = false;
+      networks = {
+        "10.51.3.0/24" = [ "10.51.3.1${id}" "10.51.3.2${id}" ];
+        "2001:db8:3::/64" = [ "2001:db8:3::1${id}" "2001:db8:3::2${id}" ];
+      };
+      gateways = {
+        "10.51.3.0/24" = "10.51.3.1";
+        "2001:db8:3::/64" = "2001:db8:3::1";
+      };
+      nics = [
+        {"mac" = "52:54:00:12:03:0${id}";
+         "external_label" = "srvnic${id}"; }
+      ];
     };
   };
 
@@ -117,7 +112,7 @@ in {
         { pkgs, ... }:
         {
           imports = [ ../../nixos ../../nixos/roles ];
-          virtualisation.vlans = [ 1 2 ];
+          virtualisation.vlans = [ 2 3 ];
           flyingcircus.enc.parameters.interfaces = encInterfaces "1";
           flyingcircus.encAddresses = [
             {
@@ -144,64 +139,67 @@ in {
         machine.wait_for_unit("network.target")
         with subtest("'machine' should resolve to own srv address"):
           ip = machine.succeed("${gethostbyname} machine")
-          assert ip == "10.51.2.11", f"resolved to {ip}"
+          assert ip == "10.51.3.11", f"resolved to {ip}"
 
         with subtest("'machine.fcio.net' should resolve to own srv address"):
           ip = machine.succeed("${gethostbyname} machine.fcio.net")
-          assert ip == "10.51.2.11", f"resolved to {ip}"
+          assert ip == "10.51.3.11", f"resolved to {ip}"
 
         with subtest("'other' should resolve to foreign srv address"):
           ip = machine.succeed("${gethostbyname} other")
-          assert ip == "10.51.2.12", f"resolved to {ip}"
+          assert ip == "10.51.3.12", f"resolved to {ip}"
 
         with subtest("'other.fcio.net' should resolve to foreign srv address"):
           ip = machine.succeed("${gethostbyname} other.fcio.net")
-          assert ip == "10.51.2.12", f"resolved to {ip}"
+          assert ip == "10.51.3.12", f"resolved to {ip}"
       '';
     };
 
     ping-vlans = {
       name = "ping-vlans";
-      nodes.client =
-        { pkgs, ... }:
+      # n1/n2 to ensure ordering.
+      nodes.n1_router = router; # id 1
+      nodes.n2_client =
+        { ... }:
         {
           imports = [ ../../nixos ../../nixos/roles ];
-          virtualisation.vlans = [ 1 2 ];
-          flyingcircus.enc.parameters.interfaces = encInterfaces "1";
+          virtualisation.vlans = [ 2 3 ];
+          flyingcircus.enc.parameters.interfaces = encInterfaces "2";
         };
-      nodes.router = router;
       testScript = ''
         start_all()
-        client.wait_for_unit("network-online.target")
-        router.wait_for_unit("network-online.target")
+        n2_client.wait_for_unit("network-online.target")
+        n1_router.wait_for_unit("network-online.target")
 
-        print("\n* Router network overview\n")
-        print(router.succeed("ip a"))
-        print("\n* Client network overview\n")
-        print(client.succeed("ip a"))
+        print("\n* n1_router network overview\n")
+        print(n1_router.succeed("ip a"))
+        print("\n* n2_client network overview\n")
+        print(n2_client.succeed("ip a"))
         # ipv6 needs more time, wait until self-ping works
-        router.wait_until_succeeds("ping -c1 2001:db8:1::1")
-        client.wait_until_succeeds("ping -c1 2001:db8:1::11")
+        n1_router.wait_until_succeeds("ping -c1 2001:db8:2::11")
+        n2_client.wait_until_succeeds("ping -c1 2001:db8:2::12")
 
         with subtest("ping fe"):
-          client.succeed("ping -I ethfe -c1 10.51.1.1")
-          client.succeed("ping -I ethfe -c1 2001:db8:1::1")
-          router.succeed("ping -c1 10.51.1.11")
-          router.succeed("ping -c1 10.51.1.21")
-          router.succeed("ping -c1 2001:db8:1::11")
-          router.succeed("ping -c1 2001:db8:1::21")
+          n2_client.succeed("ping -I ethfe -c1 10.51.2.11")
+          n2_client.succeed("ping -I ethfe -c1 2001:db8:2::11")
+          n1_router.succeed("ping -c1 10.51.2.12")
+          n1_router.succeed("ping -c1 10.51.2.22")
+          n1_router.succeed("ping -c1 2001:db8:2::12")
+          n1_router.succeed("ping -c1 2001:db8:2::22")
 
         with subtest("ping srv"):
-          client.succeed("ping -I ethsrv -c1 10.51.2.1")
-          client.succeed("ping -I ethsrv -c1 2001:db8:2::1")
-          router.succeed("ping -c1 10.51.2.11")
-          router.succeed("ping -c1 10.51.2.21")
-          router.succeed("ping -c1 2001:db8:2::11")
-          router.succeed("ping -c1 2001:db8:2::21")
+          n2_client.succeed("ping -I ethsrv -c1 10.51.3.11")
+          n2_client.succeed("ping -I ethsrv -c1 2001:db8:3::11")
+          n1_router.succeed("ping -c1 10.51.3.12")
+          n1_router.succeed("ping -c1 10.51.3.22")
+          n1_router.succeed("ping -c1 2001:db8:3::12")
+          n1_router.succeed("ping -c1 2001:db8:3::22")
 
         with subtest("ping default gateway"):
-          client.succeed("ping -c1 10.51.3.1")
-          client.succeed("ping -c1 2001:db8:3::1")
+          n2_client.succeed("ping -c1 10.51.2.11")
+          n2_client.succeed("ping -c1 2001:db8:2::11")
+          n2_client.succeed("ping -c1 10.51.3.11")
+          n2_client.succeed("ping -c1 2001:db8:3::11")
       '';
     };
 
@@ -211,20 +209,24 @@ in {
         { pkgs, ... }:
         {
           imports = [ ../../nixos ../../nixos/roles ];
-          virtualisation.vlans = [ 2 ];
+          virtualisation.vlans = [ 3 ];
           flyingcircus.enc.parameters.interfaces = {
-            srv = {  # VLAN 2
-              mac = "52:54:00:12:02:01";
+            srv = {  # VLAN 3
+              mac = "52:54:00:12:03:01";
               bridged = false;
               networks = {
-                "10.51.2.0/24" = [ "10.51.2.11" ];
-                "10.51.3.0/24" = [ ];
-                "2001:db8:2::/64" = [ "2001:db8:2::11" ];
-                "2001:db8:3::/64" = [ ];
+                "10.51.3.0/24" = [ "10.51.3.11" ];
+                "10.51.99.0/24" = [ ];
+                "2001:db8:3::/64" = [ "2001:db8:3::11" ];
+                "2001:db8:99::/64" = [ ];
               };
+              nics = [
+                {"mac" = "52:54:00:12:03:01";
+                 "external_label" = "srvnic1"; }
+              ];
               gateways = {
-                "10.51.2.0/24" = "10.51.2.1";
-                "2001:db8:2::/64" = "2001:db8:2::1";
+                "10.51.3.0/24" = "10.51.3.1";
+                "2001:db8:3::/64" = "2001:db8:3::1";
               };
             };
           };
@@ -233,20 +235,24 @@ in {
         { pkgs, ... }:
         {
           imports = [ ../../nixos ../../nixos/roles ];
-          virtualisation.vlans = [ 2 ];
+          virtualisation.vlans = [ 3 ];
           flyingcircus.enc.parameters.interfaces = {
-            srv = {  # VLAN 2
-              mac = "52:54:00:12:02:02";
+            srv = {  # VLAN 3
+              mac = "52:54:00:12:03:02";
               bridged = false;
               networks = {
-                "10.51.2.0/24" = [ ];
-                "10.51.3.0/24" = [ "10.51.3.12" ];
-                "2001:db8:2::/64" = [ ];
-                "2001:db8:3::/64" = [ "2001:db8:3::12" ];
+                "10.51.3.0/24" = [ ];
+                "10.51.99.0/24" = [ "10.51.99.12" ];
+                "2001:db8:3::/64" = [ ];
+                "2001:db8:99::/64" = [ "2001:db8:99::12" ];
               };
+              nics = [
+                {"mac" = "52:54:00:12:03:02";
+                 "external_label" = "srvnic2"; }
+              ];
               gateways = {
-                "10.51.3.0/24" = "10.51.3.1";
-                "2001:db8:3::/64" = "2001:db8:3::1";
+                "10.51.99.0/24" = "10.51.99.1";
+                "2001:db8:99::/64" = "2001:db8:99::1";
               };
             };
           };
@@ -264,20 +270,20 @@ in {
         print(machine2.succeed("ip -6 r"))
 
         with subtest("machine1 should be able to ping machine2 via srv v4"):
-          machine1.succeed("ping -c1 -w1 10.51.3.12")
+          machine1.succeed("ping -c1 -w1 10.51.99.12")
 
         with subtest("machine2 should be able to ping machine1 via srv v4"):
-          machine2.succeed("ping -c1 -w1 10.51.2.11")
+          machine2.succeed("ping -c1 -w1 10.51.3.11")
 
         # ipv6 needs more time, wait until self-ping works
-        machine1.wait_until_succeeds("ping -c1 -w1 2001:db8:2::11")
-        machine2.wait_until_succeeds("ping -c1 -w1 2001:db8:3::12")
+        machine1.wait_until_succeeds("ping -c1 -w1 2001:db8:3::11")
+        machine2.wait_until_succeeds("ping -c1 -w1 2001:db8:99::12")
 
         with subtest("machine1 should be able to ping machine2 via srv v6"):
-          machine1.succeed("ping -c3 -w3 2001:db8:3::12")
+          machine1.succeed("ping -c3 -w3 2001:db8:99::12")
 
         with subtest("machine2 should be able to ping machine1 via srv v6"):
-          machine2.succeed("ping -c1 -w1 2001:db8:2::11")
+          machine2.succeed("ping -c1 -w1 2001:db8:3::11")
     '';
   };
 
@@ -289,7 +295,7 @@ in {
             {
               networking.hostName = "srv${hostId}";
               imports = [ ../../nixos ../../nixos/roles ];
-              virtualisation.vlans = [ 1 2 ];
+              virtualisation.vlans = [ 2 3 ];
               flyingcircus.infrastructureModule = "flyingcircus";
               flyingcircus.enc.parameters.interfaces = encInterfaces hostId;
               flyingcircus.localConfigPath = localConfigPath;
@@ -302,8 +308,7 @@ in {
             };
       in {
         name = "firewall";
-        # encInterfaces defines MAC addresses for the first node
-        nodes.router = router;
+        nodes.client = router;
         nodes.srv2 = firewalledServer { hostId = "2"; };
         nodes.srv3 = firewalledServer {
           hostId = "3";
@@ -311,22 +316,44 @@ in {
         };
         testScript = ''
           start_all()
-          router.wait_for_unit("network-online.target")
+          client.wait_for_unit("network-online.target")
+
+          print("client")
+          print(client.execute("ip a")[1])
+          print(client.execute("ip -4 a")[1])
+          print(client.execute("iptables -L -n -v")[1])
+          print(client.execute("ip6tables -L -n -v")[1])
+          print(client.execute("ip route")[1])
 
           srv2.wait_for_unit("nginx.service")
 
+          print("srv2")
+          print(srv2.execute("ip -4 a")[1])
+          print(srv2.execute("iptables -L -n -v")[1])
+          print(srv2.execute("ip6tables -L -n -v")[1])
+          print(srv2.execute("ip route")[1])
+
           with subtest("default firewall"):
-            router.fail("curl http://10.51.1.12/default.nix")
-            router.fail("curl http://[2001:db8:1::12]/default.nix")
-            router.fail("curl http://10.51.2.12/default.nix")
-            router.fail("curl http://[2001:db8:2::12]/default.nix")
+            client.fail("curl http://10.51.2.12/default.nix")
+            client.fail("curl http://[2001:db8:2::12]/default.nix")
+            client.fail("curl http://10.51.3.12/default.nix")
+            client.fail("curl http://[2001:db8:3::2]/default.nix")
+
+          print(srv2.execute("ip6tables -L -n -v")[1])
+
+          print("srv3")
+          print(srv3.execute("ip -4 a")[1])
+          print(srv3.execute("iptables -L -n -v")[1])
+          print(srv3.execute("ip6tables -L -n -v")[1])
+          print(srv3.execute("ip route")[1])
 
           srv3.wait_for_unit("nginx.service");
           with subtest("firewall opens FE"):
-            router.succeed("curl http://10.51.1.13/default.nix")
-            router.succeed("curl http://[2001:db8:1::13]/default.nix")
-            router.fail("curl http://10.51.2.13/default.nix")
-            router.fail("curl http://[2001:db8:2::13]/default.nix")
+            client.succeed("ping -c 3 10.51.2.13")
+            client.succeed("curl http://10.51.2.13/default.nix")
+            client.succeed("curl http://[2001:db8:2::13]/default.nix")
+            client.fail("curl http://10.51.3.13/default.nix")
+            client.fail("curl http://[2001:db8:3::13]/default.nix")
 
           # service user should be able to write to its local config dir
           srv2.succeed('sudo -u s-test touch /etc/local/firewall/test')

--- a/tests/nfs.nix
+++ b/tests/nfs.nix
@@ -1,4 +1,7 @@
-import ./make-test-python.nix ({ pkgs, ... }:
+import ./make-test-python.nix ({ pkgs, lib, testlib, ... }:
+
+with lib;
+with testlib;
 
 let
   user = {
@@ -37,7 +40,10 @@ in {
     client =
       { lib, ... }:
       {
-        imports = [ ../nixos ../nixos/roles ];
+        imports = [
+          (fcConfig { id = 1; })
+        ];
+
         config = {
           flyingcircus.roles.nfs_rg_client.enable = true;
           flyingcircus.roles.lamp.enable = true;
@@ -68,8 +74,8 @@ in {
                 "nfsvers=4"
               ];
             noCheck = true;
+            };
           };
-        };
 
           users.users.u = user;
         };
@@ -79,7 +85,10 @@ in {
     server =
       { ... }:
       {
-        imports = [ ../nixos ../nixos/roles ];
+        imports = [
+          (fcConfig { id = 2; })
+        ];
+
         config = {
           flyingcircus.roles.nfs_rg_share.enable = true;
           flyingcircus.encServiceClients = encServiceClients;

--- a/tests/physical-installer.nix
+++ b/tests/physical-installer.nix
@@ -2,7 +2,7 @@ import ./make-test-python.nix ({ nixpkgs, ... }:
 {
   name = "physical-installer";
   machine =
-    { pkgs, ... }:
+    { pkgs, config, ... }:
     {
       virtualisation.emptyDiskImages = [ 120000 100 ];
       imports = [
@@ -22,6 +22,12 @@ import ./make-test-python.nix ({ nixpkgs, ... }:
 
   testScript = ''
     machine.wait_for_unit('multi-user.target')
+
+    print(machine.execute("cat /proc/cmdline")[1])
+    print(machine.execute("ps auxf")[1])
+    print(machine.execute("systemctl cat dhcpcd")[1])
+    print(machine.execute("cat /nix/store/qadpv1yrn8d73bigcqyicbc15ylq3inj-dhcpcd.conf")[1])
+
     machine.succeed("systemctl status lldpd")
     result = machine.succeed("show-interfaces")
     print(result)
@@ -30,7 +36,7 @@ import ./make-test-python.nix ({ nixpkgs, ... }:
     INTERFACE           | MAC               | SWITCH               | ADDRESSES
     --------------------+-------------------+----------------------+-----------------------------------
     eth0                | 52:54:00:12:34:56 | None/None            | 10.0.2.15
-    eth1                | 52:54:00:12:01:01 | None/None            | 192.168.1.1
+    eth1                | 52:54:00:12:01:01 | None/None            | 
 
     NOTE: If you are missing interface data, wait 30s and run `show-interfaces` again.
 

--- a/tests/router/default.nix
+++ b/tests/router/default.nix
@@ -162,6 +162,9 @@ let
             "172.20.1.0/24" = "172.20.1.1";
             "2a02:238:f030:1c1::/64" = "2a02:238:f030:1c1::1";
           };
+          nics = [{"mac"= "52:54:00:12:01:0${toString id}";
+                   "external_label" = "label-management";
+            }];
         };
         interfaces.fe = {
           mac = "52:54:00:12:02:0${toString id}";
@@ -174,6 +177,9 @@ let
             "172.20.2.0/24" = "172.20.2.1";
             "2a02:238:f030:1c2::/64" = "2a02:238:f030:1c2::1";
           };
+          nics = [{"mac"= "52:54:00:12:02:0${toString id}";
+                   "external_label" = "label-fe";
+            }];
         };
         interfaces.srv = {
           mac = "52:54:00:12:03:0${toString id}";
@@ -187,6 +193,9 @@ let
             "172.20.3.0/24" = "172.20.3.1";
             "2a02:238:f030:1c3::/64" = "2a02:238:f030:1c3::1";
           };
+          nics = [{"mac"= "52:54:00:12:03:0${toString id}";
+                   "external_label" = "label-srv";
+            }];
         };
         interfaces.tr = {
           mac = "52:54:00:12:06:0${toString id}";
@@ -199,6 +208,9 @@ let
             "172.20.6.0/24" = "172.20.6.1";
             "2a02:238:f030:1c6::/124" = "2a02:238:f030:1c6::1";
           };
+          nics = [{"mac"= "52:54:00:12:03:0${toString id}";
+                   "external_label" = "label-tr";
+            }];
         };
       };
 
@@ -325,6 +337,9 @@ in
         primary.wait_for_unit("bind")
 
       with subtest("dhcpd4 is running"):
+        import time
+        time.sleep(10)
+        print(primary.execute("journalctl -u dhcpd4")[1])
         primary.wait_for_unit("dhcpd4")
 
       with subtest("dhcpd6 is running"):

--- a/tests/testlib.nix
+++ b/tests/testlib.nix
@@ -93,7 +93,7 @@ rec {
     ];
 
     config = {
-      virtualisation.vlans = map (vlan: vlans.${vlan}) (attrNames config.flyingcircus.enc.parameters.interfaces);
+      virtualisation.vlans = map (vlan: vlans.${vlan}) (attrNames (trace config.flyingcircus.enc config.flyingcircus.enc.parameters.interfaces));
 
       flyingcircus.enc.parameters = (lib.recursiveUpdate {
         inherit resource_group location secrets;
@@ -106,6 +106,12 @@ rec {
             "2001:db8:${toString vid}::/64" = [ "2001:db8:${toString vid}::${toString id}" ];
           };
           gateways = {};
+          nics = [
+            {
+              "mac" = "52:54:00:12:0${toString vid}:0${toString id}"; 
+              "external_label" = "${name}nic${toString id}";
+            }
+          ];
         })
           (filterAttrs (name: vid: (!(net ? ${name}) && (name == "srv" || name == "fe")) || net ? ${name} && net.${name}) vlans);
       } extraEncParameters);

--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "6e3cc0a811b4a4d4b4df0fa860a7e706b220a742",
-    "sha256": "sha256-w+nm/vk/2jqhjMhf6cbidifO4ZZRznMKcJan0rxQt50="
+    "rev": "3566c920708cfa9eaa7306eee82204bfff9956fe",
+    "sha256": "sha256:0r70zkpz7lgh7y0xgw0y8w7r544psb6gh705km71xfz8r53gnr35"
   },
   "nixpkgs-23.05": {
     "owner": "flyingcircusio",

--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "205fbcbbc8c1d07acf377758e52774db6425d1be",
-    "sha256": "sha256:09ay21zcd52d94cz96lmf0lhdn8pzcy4ilmj02gkyj5jk7n8siq7"
+    "rev": "ac16a2cf6697c7acec2deac4e1a0dda7b446ebb9",
+    "sha256": "sha256:0qggp84mi73b229k8da75pla7nxp26ghwlqf299hpd75dldy8z0x"
   },
   "nixpkgs-23.05": {
     "owner": "flyingcircusio",

--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "3566c920708cfa9eaa7306eee82204bfff9956fe",
-    "sha256": "sha256:0r70zkpz7lgh7y0xgw0y8w7r544psb6gh705km71xfz8r53gnr35"
+    "rev": "205fbcbbc8c1d07acf377758e52774db6425d1be",
+    "sha256": "sha256:09ay21zcd52d94cz96lmf0lhdn8pzcy4ilmj02gkyj5jk7n8siq7"
   },
   "nixpkgs-23.05": {
     "owner": "flyingcircusio",


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

* All network interfaces will be restarted, causing a short service interruption of a few seconds. (PL-127635)

Changelog:

* We have rebuilt a major part of the network configuration logic to allow more fine grained online network reconfiguration in the future and to make it a lot more robust when making changes like changing IP addresses, renaming interfaces  and shifting between more complex architectures like tagged networks, bridge setups and even EVPN-VXLAN environments.

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

Ensure availability by improving robustness.

- [x] Security requirements tested? (EVIDENCE)

Relying on the existing automated tests. Also extensively tested on cartman06 (Ceph) while developing and tested on cartman37 and kyle05 and tstest21 to check production rollout impact. In online scenarios this causes about 10-15 seconds of interruption in EVPN-VXLAN situations, less than 5 seconds in non-EVPN-VXLAN setups and VMs.
