### PR TITLE
gitlab: 16.10.2 -> 16.10.4

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -57,11 +57,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1713442308,
-        "narHash": "sha256-GuObD2FgY3S9jY1FKVZC5qNVMn491OewNtQS3+idS+8=",
+        "lastModified": 1713968789,
+        "narHash": "sha256-Gue8iwW3ZtCQs3EZKhk/i0uLaoUDfW1dpnaZ67MH64o=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "3e601bedf5455f4d8eba783afbcac93c333e04de",
+        "rev": "b26b52a4dac68bdc305f6b9df948c97f49b2c3ee",
         "type": "github"
       },
       "original": {
@@ -237,11 +237,11 @@
         "nixpkgs-regression": "nixpkgs-regression"
       },
       "locked": {
-        "lastModified": 1708577783,
-        "narHash": "sha256-92xq7eXlxIT5zFNccLpjiP7sdQqQI30Gyui2p/PfKZM=",
+        "lastModified": 1712911606,
+        "narHash": "sha256-BGvBhepCufsjcUkXnEEXhEVjwdJAwPglCC2+bInc794=",
         "owner": "domenkozar",
         "repo": "nix",
-        "rev": "ecd0af0c1f56de32cbad14daa1d82a132bf298f8",
+        "rev": "b24a9318ea3f3600c1e24b4a00691ee912d4de12",
         "type": "github"
       },
       "original": {
@@ -417,11 +417,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1713435004,
-        "narHash": "sha256-4fe+i4o1A2Sv21RRgx1FI2xNZXpYVaWGmiOVW1pNYfQ=",
+        "lastModified": 1713987743,
+        "narHash": "sha256-2codJoMwnEd4W78yG8jx46BbQ5MaRbsQWh7LpNWsw0U=",
         "owner": "flyingcircusio",
         "repo": "nixpkgs",
-        "rev": "a7d730a3346ec321b47f36094d315a8d97e34bf8",
+        "rev": "c0bcdbf87575a89263497d36a1cb60882cae98e6",
         "type": "github"
       },
       "original": {
@@ -471,11 +471,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1712897695,
-        "narHash": "sha256-nMirxrGteNAl9sWiOhoN5tIHyjBbVi5e2tgZUgZlK3Y=",
+        "lastModified": 1713775815,
+        "narHash": "sha256-Wu9cdYTnGQQwtT20QQMg7jzkANKQjwBD9iccfGKkfls=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "40e6053ecb65fcbf12863338a6dcefb3f55f1bf8",
+        "rev": "2ac4dcbf55ed43f3be0bae15e181f08a57af24a4",
         "type": "github"
       },
       "original": {

--- a/release/package-versions.json
+++ b/release/package-versions.json
@@ -220,9 +220,9 @@
     "version": "2.42.0"
   },
   "gitaly": {
-    "name": "gitaly-16.10.2",
+    "name": "gitaly-16.10.4",
     "pname": "gitaly",
-    "version": "16.10.2"
+    "version": "16.10.4"
   },
   "github-runner": {
     "name": "github-runner-2.315.0",
@@ -230,24 +230,24 @@
     "version": "2.315.0"
   },
   "gitlab": {
-    "name": "gitlab-16.10.2",
+    "name": "gitlab-16.10.4",
     "pname": "gitlab",
-    "version": "16.10.2"
+    "version": "16.10.4"
   },
   "gitlab-container-registry": {
-    "name": "gitlab-container-registry-3.92.0",
+    "name": "gitlab-container-registry-3.93.0",
     "pname": "gitlab-container-registry",
-    "version": "3.92.0"
+    "version": "3.93.0"
   },
   "gitlab-ee": {
-    "name": "gitlab-ee-16.10.2",
+    "name": "gitlab-ee-16.10.4",
     "pname": "gitlab-ee",
-    "version": "16.10.2"
+    "version": "16.10.4"
   },
   "gitlab-pages": {
-    "name": "gitlab-pages-16.10.2",
+    "name": "gitlab-pages-16.10.4",
     "pname": "gitlab-pages",
-    "version": "16.10.2"
+    "version": "16.10.4"
   },
   "gitlab-runner": {
     "name": "gitlab-runner-16.10.0",
@@ -255,9 +255,9 @@
     "version": "16.10.0"
   },
   "gitlab-workhorse": {
-    "name": "gitlab-workhorse-16.10.2",
+    "name": "gitlab-workhorse-16.10.4",
     "pname": "gitlab-workhorse",
-    "version": "16.10.2"
+    "version": "16.10.4"
   },
   "glibc": {
     "name": "glibc-2.38-44",

--- a/release/versions.json
+++ b/release/versions.json
@@ -8,9 +8,9 @@
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/"
   },
   "nixpkgs": {
-    "hash": "sha256-4fe+i4o1A2Sv21RRgx1FI2xNZXpYVaWGmiOVW1pNYfQ=",
+    "hash": "sha256-2codJoMwnEd4W78yG8jx46BbQ5MaRbsQWh7LpNWsw0U=",
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "a7d730a3346ec321b47f36094d315a8d97e34bf8"
+    "rev": "c0bcdbf87575a89263497d36a1cb60882cae98e6"
   }
 }


### PR DESCRIPTION
PL-132474

@flyingcircusio/release-managers

## Release process

Impact:

- \[NixOS 23.11] Gitlab will be restarted.

Changelog:

- gitlab: 16.10.2 -> 16.10.4 (PL-132474).

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - apply security updates asap 
- [x] Security requirements tested? (EVIDENCE)
  - checked on our Gitlab staging system that Gitlab works
