### PR TITLE
sensu + rabbitmq: reduce busy wait, improve user update performance

### DIFF
--- a/nixos/services/rabbitmq.nix
+++ b/nixos/services/rabbitmq.nix
@@ -173,6 +173,8 @@ in {
 
       environment = {
         RABBITMQ_MNESIA_BASE = "${cfg.dataDir}/mnesia";
+        # https://www.rabbitmq.com/docs/runtime#busy-waiting
+        RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS = "+sbwt none +sbwtdcpu none +sbwtdio none";
         RABBITMQ_LOGS = "-";
         SYS_PREFIX = "";
         RABBITMQ_CONFIG_FILE = config_file;

--- a/nixos/services/sensu/server.nix
+++ b/nixos/services/sensu/server.nix
@@ -127,11 +127,10 @@ in {
               ];
             in ''
               # Configure user and permissions for ${node}:
-              rabbitmqctl list_users | grep ^${node} || \
-                rabbitmqctl add_user ${node} ${password}
-
-              rabbitmqctl change_password ${client.node} ${password}
-              rabbitmqctl set_permissions -p /sensu ${node} ${lib.concatMapStringsSep " " (p: "'${p}'") permissions}
+              rabbitmqctl list_users | grep ^${node} || (
+                rabbitmqctl add_user ${node} ${password} ;
+                rabbitmqctl change_password ${client.node} ${password} ;
+                rabbitmqctl set_permissions -p /sensu ${node} ${lib.concatMapStringsSep " " (p: "'${p}'") permissions}
             '')
           sensuClients);
       in

--- a/nixos/services/sensu/server.nix
+++ b/nixos/services/sensu/server.nix
@@ -101,8 +101,8 @@ in {
 
     systemd.services.prepare-rabbitmq-for-sensu = {
       description = "Prepare rabbitmq for sensu-server.";
-      partOf = [ "rabbitmq.service" ];
-      wantedBy = [ "rabbitmq.service" ];
+      wantedBy = [ "multi-user.target" ];
+      requires = ["rabbitmq.service" ];
       after = ["rabbitmq.service" ];
       path = [ config.services.rabbitmq.package ];
       serviceConfig = {


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

* RabbitMQ instances will be restarted

Changelog:

* RabbitMQ: reduce CPU busy waiting to alleviate CPU pressure on neighbour processes (FC-37810)
* Sensu: optimistically add users to reduce load on sensu servers and avoid excessive `rabbitmqctl` calls. (FC-37810)

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

performance impacts availability

- [x] Security requirements tested? (EVIDENCE)

manually tested the rabbitmq settings services14, relying on existing test suite for the sensu user management script