### PR TITLE
Update nixpkgs (2024-04-29)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -417,11 +417,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1713987743,
-        "narHash": "sha256-2codJoMwnEd4W78yG8jx46BbQ5MaRbsQWh7LpNWsw0U=",
+        "lastModified": 1714379850,
+        "narHash": "sha256-CHq7+yE8zml9Wc6Bralp0cvxXfHVKoQviR5m8eDs2lY=",
         "owner": "flyingcircusio",
         "repo": "nixpkgs",
-        "rev": "c0bcdbf87575a89263497d36a1cb60882cae98e6",
+        "rev": "090f9c669ba86a758a988b98b71bcde4304f3033",
         "type": "github"
       },
       "original": {

--- a/release/package-versions.json
+++ b/release/package-versions.json
@@ -75,9 +75,9 @@
     "version": "123.0.6312.122"
   },
   "chromium": {
-    "name": "chromium-123.0.6312.122",
+    "name": "chromium-124.0.6367.60",
     "pname": "chromium",
-    "version": "123.0.6312.122"
+    "version": "124.0.6367.60"
   },
   "cifs-utils": {
     "name": "cifs-utils-7.0",
@@ -155,9 +155,9 @@
     "version": "2.3.21"
   },
   "element-web": {
-    "name": "element-web-1.11.64",
+    "name": "element-web-1.11.65",
     "pname": "element-web",
-    "version": "1.11.64"
+    "version": "1.11.65"
   },
   "erlang": {
     "name": "erlang-25.3.2.7",
@@ -190,9 +190,9 @@
     "version": "7.17.16"
   },
   "firefox": {
-    "name": "firefox-124.0.2",
+    "name": "firefox-125.0.2",
     "pname": "firefox",
-    "version": "124.0.2"
+    "version": "125.0.2"
   },
   "gcc": {
     "name": "gcc-wrapper-12.3.0",
@@ -435,9 +435,9 @@
     "version": "0.2.5"
   },
   "linux_5_15": {
-    "name": "linux-5.15.155",
+    "name": "linux-5.15.156",
     "pname": "linux",
-    "version": "5.15.155"
+    "version": "5.15.156"
   },
   "logrotate": {
     "name": "logrotate-3.21.0",
@@ -475,9 +475,9 @@
     "version": "4.16.1"
   },
   "matrix-synapse": {
-    "name": "matrix-synapse-wrapped-1.104.0",
+    "name": "matrix-synapse-wrapped-1.105.1",
     "pname": "matrix-synapse-wrapped",
-    "version": "1.104.0"
+    "version": "1.105.1"
   },
   "mcpp": {
     "name": "mcpp-2.7.2.1",
@@ -686,9 +686,9 @@
     "version": "8.3.6"
   },
   "phpPackages.composer": {
-    "name": "composer-2.7.1",
+    "name": "composer-2.7.3",
     "pname": "composer",
-    "version": "2.7.1"
+    "version": "2.7.3"
   },
   "pkg-config": {
     "name": "pkg-config-wrapper-0.29.2",
@@ -1006,9 +1006,9 @@
     "version": "9.0.2116"
   },
   "webkitgtk": {
-    "name": "webkitgtk-2.44.0+abi=4.0",
+    "name": "webkitgtk-2.44.1+abi=4.0",
     "pname": "webkitgtk",
-    "version": "2.44.0"
+    "version": "2.44.1"
   },
   "wget": {
     "name": "wget-1.21.4",

--- a/release/versions.json
+++ b/release/versions.json
@@ -8,9 +8,9 @@
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/"
   },
   "nixpkgs": {
-    "hash": "sha256-2codJoMwnEd4W78yG8jx46BbQ5MaRbsQWh7LpNWsw0U=",
+    "hash": "sha256-CHq7+yE8zml9Wc6Bralp0cvxXfHVKoQviR5m8eDs2lY=",
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "c0bcdbf87575a89263497d36a1cb60882cae98e6"
+    "rev": "090f9c669ba86a758a988b98b71bcde4304f3033"
   }
 }


### PR DESCRIPTION
Pull upstream NixOS changes, security fixes and package updates:

- chromium: 123.0.6312.122 -> 124.0.6367.60
- linux_5_15: 5.15.155 -> 5.15.156
- matrix-synapse: 1.105.0 -> 1.105.1
- php81: add missing patch
- phpPackages.composer: 2.7.1 -> 2.7.3
- webkitgtk: 2.44.0 → 2.44.1

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

### PR release workflow (internal)

- [ ] PR has internal ticket
- [ ] internal issue ID (PL-…) part of branch name
- [ ] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [ ] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [ ] Security requirements tested? (EVIDENCE)
