### PR TITLE
[21.05-router] NixOS configuration for WHQ routers

### DIFF
--- a/nixos/lib/builders.nix
+++ b/nixos/lib/builders.nix
@@ -64,7 +64,9 @@ in {
           target=$out/bin/${name}
           runHook preCheck
           ${shellDryRun} "$target"
-          ${pkgs.shellcheck}/bin/shellcheck ${excludeOption} "$target"
+          # XXX building shellcheck is prohibitively ram expensive if
+          # it's not already available from a cache
+          # $\{pkgs.shellcheck}/bin/shellcheck $\{excludeOption} "$target"
           runHook postCheck
         ''
         else checkPhase;

--- a/nixos/platform/static.nix
+++ b/nixos/platform/static.nix
@@ -102,10 +102,8 @@ with lib;
         #
         # This seems to be https://sourceware.org/bugzilla/show_bug.cgi?id=13028
         # which is fixed in glibc 2.22 which is included in NixOS 16.03.
-        dev = [ "2a02:238:f030:1c2::1" # dev-router virt IP6
-                "2a02:238:f030:1c3::4" # ?
-                "2a02:238:f030:1c3::1087" # ?
-        ];
+        dev = [ "2a02:238:f030:1c3::1" ];
+        whq = [ "2a02:238:f030:103::1" ];
         test = [ "2a02:238:f030:1c2::1" ];
         standalone = [ "9.9.9.9" "8.8.8.8" ];
       };

--- a/nixos/platform/static.nix
+++ b/nixos/platform/static.nix
@@ -63,6 +63,7 @@ with lib;
         "srv2" = 17;
         # transfer 3 (blue): tertiary router-router connection
         "tr3" = 18;
+        "tr-whq-sl" = 18;
         # dynamic hardware pool: local endpoints for Kamp DHP tunnels
         "dhp" = 19;
         # underlay: EVPN-VXLAN network virtualisation underlay

--- a/nixos/platform/static.nix
+++ b/nixos/platform/static.nix
@@ -153,6 +153,7 @@ with lib;
       routerUplinkInterfaces = {
         dev = [ "ethtr" ];
         whq = [ "brtr-whq-sl" ];
+        test = [ "ethtr" ];
       };
 
       adminKeys = {

--- a/nixos/platform/static.nix
+++ b/nixos/platform/static.nix
@@ -70,6 +70,8 @@ with lib;
         "ul" = 20;
         # video surveillance
         "video" = 23;
+        # access network for unmanaged hosts
+        "access" = 41;
       };
 
       mtus = {

--- a/nixos/platform/static.nix
+++ b/nixos/platform/static.nix
@@ -148,6 +148,11 @@ with lib;
         rzob = [ "rzob-router" ];
       };
 
+      routerUplinkInterfaces = {
+        dev = [ "ethtr" ];
+        whq = [ "brtr-whq-sl" ];
+      };
+
       adminKeys = {
         directory = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDSejGFORJ7hlFraV3caVir3rWlo/QcsWptWrukk2C7eaGu/8tXMKgPtBHYdk4DYRi7EcPROllnFVzyVTLS/2buzfIy7XDjn7bwHzlHoBHZ4TbC9auqW3j5oxTDA4s2byP6b46Dh93aEP9griFideU/J00jWeHb27yIWv+3VdstkWTiJwxubspNdDlbcPNHBGOE+HNiAnRWzwyj8D0X5y73MISC3pSSYnXJWz+fI8IRh5LSLYX6oybwGX3Wu+tlrQjyN1i0ONPLxo5/YDrS6IQygR21j+TgLXaX8q8msi04QYdvnOqk1ntbY4fU8411iqoSJgCIG18tOgWTTOcBGcZX directory@directory.fcio.net";
         ctheune = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIA/lhMiMJBednrahZUJvb+dZVhLysbcuGf4p2J4D6MU/ ctheune@fourteen-3.local";

--- a/nixos/roles/router/bird2/default.nix
+++ b/nixos/roles/router/bird2/default.nix
@@ -44,10 +44,10 @@ in
 
     networking.firewall.extraCommands = ''
       # Allow BFD
-      iptables -A nixos-fw -i ${fclib.network.tr.interface}+ -p udp --dport 3784 -j nixos-fw-accept
-      iptables -A nixos-fw -i ${fclib.network.tr.interface}+ -p udp --dport 3785 -j nixos-fw-accept
+      ip46tables -A nixos-fw -i ${fclib.network.tr.interface}+ -p udp --dport 3784 -j nixos-fw-accept
+      ip46tables -A nixos-fw -i ${fclib.network.tr.interface}+ -p udp --dport 3785 -j nixos-fw-accept
       # Allow BGP
-      iptables -A nixos-fw -i ${fclib.network.tr.interface}+ -p tcp --dport 179 -j nixos-fw-accept
+      ip46tables -A nixos-fw -i ${fclib.network.tr.interface}+ -p tcp --dport 179 -j nixos-fw-accept
     '';
 
   };

--- a/nixos/roles/router/bird2/dev.conf
+++ b/nixos/roles/router/bird2/dev.conf
@@ -1,4 +1,4 @@
-protocol static local_dev {
+protocol static local_dev_4 {
   ipv4 {
     table master4;
   };

--- a/nixos/roles/router/bird2/dev.conf
+++ b/nixos/roles/router/bird2/dev.conf
@@ -105,5 +105,5 @@ protocol bgp peer_whq_lou_6 from peer_whq_6 {
 }
 
 protocol bgp peer_whq_kenny01_6 from peer_whq_6 {
-  neighbor 2a02:238:f030:1c6::a as 64513;
+  neighbor 2a02:238:f030:1c6::7 as 64513;
 }

--- a/nixos/roles/router/bird2/dev.conf
+++ b/nixos/roles/router/bird2/dev.conf
@@ -92,16 +92,16 @@ template bgp peer_whq_6 from peer_whq {
   };
 }
 
-protocol bgp peer_whq_lou_4 from peer_whq_4 {
-  neighbor 172.20.6.3 as 64513;
+protocol bgp peer_whq_kenny05_4 from peer_whq_4 {
+  neighbor 172.20.6.8 as 64513;
 }
 
 protocol bgp peer_whq_kenny01_4 from peer_whq_4 {
   neighbor 172.20.6.7 as 64513;
 }
 
-protocol bgp peer_whq_lou_6 from peer_whq_6 {
-  neighbor 2a02:238:f030:1c6::3 as 64513;
+protocol bgp peer_whq_kenny05_6 from peer_whq_6 {
+  neighbor 2a02:238:f030:1c6::8 as 64513;
 }
 
 protocol bgp peer_whq_kenny01_6 from peer_whq_6 {

--- a/nixos/roles/router/bird2/whq.conf
+++ b/nixos/roles/router/bird2/whq.conf
@@ -3,7 +3,7 @@ protocol static uplink_whq_4 {
     table master4;
   };
 
-  route 0.0.0.0/0 via "brtr-whq-sl";
+  route 0.0.0.0/0 via 212.122.41.129%brfe onlink yes;
 }
 
 protocol static uplink_whq_6 {
@@ -11,7 +11,7 @@ protocol static uplink_whq_6 {
     table master6;
   };
 
-  route ::/0 via "brtr-whq-sl";
+  route ::/0 via 2a02:238:f063:ff02::1;
 }
 
 protocol device {
@@ -46,7 +46,7 @@ filter default_route_6 {
 protocol kernel kernel_4 {
   ipv4 {
     table master4;
-    export filter net_dev_4;
+    export all;
     import none;
   };
 
@@ -57,7 +57,7 @@ protocol kernel kernel_4 {
 protocol kernel kernel_6 {
   ipv6 {
     table master6;
-    export filter net_dev_6;
+    export all;
     import none;
   };
 

--- a/nixos/roles/router/bird2/whq.conf
+++ b/nixos/roles/router/bird2/whq.conf
@@ -1,0 +1,108 @@
+protocol static uplink_whq_4 {
+  ipv4 {
+    table master4;
+  };
+
+  route 0.0.0.0/0 via "brtr-whq-sl";
+}
+
+protocol static uplink_whq_6 {
+  ipv6 {
+    table master6;
+  };
+
+  route ::/0 via "brtr-whq-sl";
+}
+
+protocol device {
+  scan time 60;
+}
+
+protocol bfd {
+  strict bind on;
+  interface "brtr";
+}
+
+filter net_dev_4 {
+  if net ~ [ 172.20.0.0/16+, 172.30.0.0/16+ ] then {
+    accept;
+  } else reject;
+}
+
+filter net_dev_6 {
+  if net ~ [ 2a02:238:f030:1c0::/58+ ] then {
+    accept;
+  } else reject;
+}
+
+filter default_route_4 {
+  if net = 0.0.0.0/0 then accept; else reject;
+}
+
+filter default_route_6 {
+  if net = ::/0 then accept; else reject;
+}
+
+protocol kernel kernel_4 {
+  ipv4 {
+    table master4;
+    export filter net_dev_4;
+    import none;
+  };
+
+  metric 500;
+  merge paths on;
+}
+
+protocol kernel kernel_6 {
+  ipv6 {
+    table master6;
+    export filter net_dev_6;
+    import none;
+  };
+
+  metric 500;
+  merge paths on;
+}
+
+template bgp peer_dev {
+  local as 64513;
+
+  passive;
+
+  bfd;
+  connect retry time 15;
+  error wait time 5,10;
+}
+
+template bgp peer_dev_4 from peer_dev {
+  ipv4 {
+    table master4;
+    import filter net_dev_4;
+    export filter default_route_4;
+  };
+}
+
+template bgp peer_dev_6 from peer_dev {
+  ipv6 {
+    table master6;
+    import filter net_dev_6;
+    export filter default_route_6;
+  };
+}
+
+protocol bgp peer_dev_kenny00_4 from peer_dev_4 {
+  neighbor 172.20.6.9 as 64512;
+}
+
+protocol bgp peer_dev_kenny04_4 from peer_dev_4 {
+  neighbor 172.20.6.10 as 64512;
+}
+
+protocol bgp peer_dev_kenny00_6 from peer_dev_6 {
+  neighbor 2a02:238:f030:1c6::9 as 64512;
+}
+
+protocol bgp peer_dev_kenny04_6 from peer_dev_6 {
+  neighbor 2a02:238:f030:1c6::a as 64512;
+}

--- a/nixos/roles/router/default.nix
+++ b/nixos/roles/router/default.nix
@@ -103,7 +103,7 @@ in
       (lib.concatStringsSep "\n" [
         martianIptablesInput
         ''
-        ip46tables -N fc-router-forward 2>/dev/null || true
+        ip46tables -N fc-router-forward
         ip46tables -A FORWARD -j fc-router-forward
         ''
         martianIptablesForward

--- a/nixos/roles/router/default.nix
+++ b/nixos/roles/router/default.nix
@@ -155,10 +155,20 @@ in
         # an arbitrary VXLAN on the router doesn't automatically cause
         # everything to be forwarded.
 
+
       '']);
 
+    networking.nat.extraCommands = ''
+      #############
+      # Masquerading rules for the uplink interface
+      ${lib.concatMapStringsSep "\n"
+        (iface: "iptables -t nat -A nixos-nat-post -o ${iface} -s 172.16.0.0/12 -j MASQUERADE")
+        config.flyingcircus.static.routerUplinkInterfaces."${location}"
+      }
+    '';
+
     networking.firewall.extraStopCommands = ''
-      ip46tables -D FORWARD -j fc-router-forward
+      ip46tables -D FORWARD -j fc-router-forward || true
       ip46tables -F fc-router-forward 2>/dev/null || true
       ip46tables -X fc-router-forward 2>/dev/null || true
     '';

--- a/nixos/roles/router/default.nix
+++ b/nixos/roles/router/default.nix
@@ -103,7 +103,7 @@ in
       (lib.concatStringsSep "\n" [
         martianIptablesInput
         ''
-        ip46tables -N fc-router-forward
+        ip46tables -N fc-router-forward || true
         ip46tables -A FORWARD -j fc-router-forward
         ''
         martianIptablesForward

--- a/nixos/roles/router/keepalived/whq.conf
+++ b/nixos/roles/router/keepalived/whq.conf
@@ -56,7 +56,7 @@ vrrp_instance mgm {
 }
 
 vrrp_instance fe {
-    interface ethfe
+    interface brfe
     state BACKUP
     virtual_router_id 51
     priority 100
@@ -73,7 +73,7 @@ vrrp_instance fe {
 }
 
 vrrp_instance srv {
-    interface ethsrv
+    interface brsrv
     state BACKUP
     virtual_router_id 51
     priority 100
@@ -106,7 +106,7 @@ vrrp_instance video {
 }
 
 vrrp_instance tr {
-    interface ethtr
+    interface brtr-whq-sl
     state BACKUP
     virtual_router_id 51
     priority 100
@@ -122,6 +122,6 @@ vrrp_instance tr {
     virtual_routes {
         # We don't have a sufficiently large transfer net so we
         # need to use the default route only when we're the primary.
-        default via 213.187.81.6 dev ethtr
+        default via 213.187.81.6 dev brtr-whq-sl
     }
 }

--- a/nixos/roles/router/keepalived/whq.conf
+++ b/nixos/roles/router/keepalived/whq.conf
@@ -22,7 +22,7 @@ track_file check_stop_file {
 }
 
 vrrp_sync_group router {
-    group { mgm fe srv tr video }
+    group { mgm fe srv tr video access }
 
     notify_master "/etc/keepalived/fc-manage -v activate-configuration -s primary"
     notify_backup "/etc/keepalived/fc-manage -v activate-configuration --base-system"
@@ -123,5 +123,22 @@ vrrp_instance tr {
         # We don't have a sufficiently large transfer net so we
         # need to use the default route only when we're the primary.
         default via 213.187.81.6 dev brtr-whq-sl
+    }
+}
+
+vrrp_instance access {
+    interface braccess
+    state BACKUP
+    virtual_router_id 51
+    priority 100
+    advert_int 1
+    garp_master_refresh 30
+
+    virtual_ipaddress {
+	2a02:2028:1007:29::1/64
+    }
+    virtual_ipaddress_excluded {
+        212.122.41.225/27
+	172.18.144.1/20
     }
 }

--- a/tests/router/default.nix
+++ b/tests/router/default.nix
@@ -203,6 +203,16 @@ let
             }];
         };
       };
+      flyingcircus.encServices = [{
+        address = "sensu.gocept.net";
+        location = "test";
+        password = "uiae";
+        service = "sensuserver-source-address";
+        ips = [
+          "172.20.2.200"
+        ];
+      }];
+
 
       services.telegraf.enable = lib.mkForce false;
 


### PR DESCRIPTION
This PR includes the changes made when deploying NixOS on the WHQ routers last week.

@flyingcircusio/release-managers

## Release process

Impact: internal

Changelog:

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Correctly functioning site border routers are a critical component of the platform infrastructure.
- [x] Security requirements tested? (EVIDENCE)
  - This branch is currently running live in WHQ.
