### PR TITLE
[21.05] firewall log ratelimit to prevent kernel crashes

### DIFF
--- a/nixos/platform/default.nix
+++ b/nixos/platform/default.nix
@@ -181,7 +181,7 @@ in {
   config = {
 
     boot = {
-      consoleLogLevel = mkDefault 7;
+      consoleLogLevel = mkDefault 6;
 
       initrd.kernelModules = [
         "bfq"

--- a/nixos/platform/firewall.nix
+++ b/nixos/platform/firewall.nix
@@ -4,6 +4,7 @@ with builtins;
 
 let
   cfg = config.flyingcircus;
+  cfgUpstream = config.networking.firewall;
 
   fclib = config.fclib;
 
@@ -55,6 +56,22 @@ let
 
 in
 {
+  options.flyingcircus.firewall = {
+    logRateLimit = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = "10/second";
+      description = "average rate limit to use for logging refused IPtables matches,"
+        + " see `--limit` in `man 8 iptables-extensions`.\n"
+        "Disabled when `null`.";
+    };
+    logBurstLimit = lib.mkOption {
+      type = lib.types.ints.positive;
+      default = 5;
+      description = "burst limit to use for logging refused IPtables matches,"
+        + " see `--limit-burst` in `man 8 iptables-extensions`.\n"
+        "Only enabled when `logRateLimit` is enabled.";
+    };
+  };
   config = {
 
     environment.etc."local/firewall/README".text = ''
@@ -109,6 +126,35 @@ in
 
         extraCommands =
           let
+            # As we flush the full chain defined in upstream NixOS, we need to
+            # recreate the parts we'd like to keep. Thus, this is mainly copied
+            # over, just modified by adding the option for rate-limiting the
+            # LOGs.
+            # Flushing and recreating the full chain is deemed more resilient
+            # than replacing single rules of a chain.
+            logLimits = lib.optionalString (! isNull cfg.firewall.logRateLimit)
+                "-m limit --limit ${cfg.firewall.logRateLimit} --limit-burst ${toString cfg.firewall.logBurstLimit} ";
+            fcChainMods = ''
+              ${lib.optionalString cfgUpstream.logRefusedConnections ''
+                ip46tables -A nixos-fw-log-refuse ${logLimits}-p tcp --syn -j LOG --log-level info --log-prefix "refused connection: "
+              ''}
+              ${lib.optionalString (cfgUpstream.logRefusedPackets && !cfgUpstream.logRefusedUnicastsOnly) ''
+                ip46tables -A nixos-fw-log-refuse -m pkttype --pkt-type broadcast \
+                  ${logLimits}\
+                  -j LOG --log-level info --log-prefix "refused broadcast: "
+                ip46tables -A nixos-fw-log-refuse -m pkttype --pkt-type multicast \
+                  ${logLimits}\
+                  -j LOG --log-level info --log-prefix "refused broadcast: "
+                  -j LOG --log-level info --log-prefix "refused multicast: "
+              ''}
+              ip46tables -A nixos-fw-log-refuse -m pkttype ! --pkt-type unicast -j nixos-fw-refuse
+              ${lib.optionalString cfgUpstream.logRefusedPackets ''
+                ip46tables -A nixos-fw-log-refuse \
+                  ${logLimits}\
+                  -j LOG --log-level info --log-prefix "refused packet: "
+              ''}
+              ip46tables -A nixos-fw-log-refuse -j nixos-fw-refuse
+            '';
             rg = lib.optionalString
               (rgRules != "")
               "# Accept traffic within the same resource group.\n${rgRules}\n\n";
@@ -117,7 +163,7 @@ in
               set -v
               ${readFile filteredRules}
             '';
-          in lib.mkAfter (rg + local);
+          in lib.mkAfter (fcChainMods + rg + local);
       };
 
     flyingcircus.passwordlessSudoRules =


### PR DESCRIPTION
This works around a kernel issue where logging storms being printk-ed out to a slow serial console can cause crashes, see the individual commit messages for details.

Just rate-limiting the refusal logs unfortunately did not suffice to get of NMI kernel trace messages, so additionally firewall logs are not printed to the serial console anymore. This turned out to be sufficient in a test setup, and still allows keeping the refusal logs verbose enough to potentially use them for later processing stages.

PL-132397 

@flyingcircusio/release-managers

## Release process

Impact:
internal only

Changelog:
- firewall refusal log messages are now rate-limited to 10 per second at most by default, adjustable with `flyingcircus.firewall.logRateLimit` and `logBurstLimit`
- firewall refusal logs are not printed to the console by default, this can be adjusted by decreasing the `flyingcircus.firewall.logLevel`
  - in general only messages of log level 6 (info) are printed to the console anymore

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
  - yes, the rate limits and log levels are configurable 
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
  - not user-facing

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - prevent a known kernel issue from being triggered remotely
  - must not introduce any known regressions
  - thoroughly verify the effects in dev 
- [x] Security requirements tested? (EVIDENCE)
  - [x] nixos tests still pass
  - [x] verified with a SYN portscan as a trigger that the rate-limiting is not sufficient to prevent kernel NMI trace messages, but not logging the messages out to the console resolves this