### PR TITLE
[21.05-router] Prevent forwarding onto underlay interfaces

### DIFF
--- a/nixos/roles/router/default.nix
+++ b/nixos/roles/router/default.nix
@@ -164,8 +164,21 @@ in
         # an arbitrary VXLAN on the router doesn't automatically cause
         # everything to be forwarded.
 
-
-      '']);
+        ''
+        (lib.optionalString (!isNull fclib.underlay) ''
+        #############
+        # Protect UL
+        # Forwarding should not be permitted onto or out of the underlay network
+        ${lib.concatMapStringsSep "\n"
+          (link: "ip46tables -A fc-router-forward -o ${link.link} -j REJECT")
+          fclib.underlay.links
+         }
+        ${lib.concatMapStringsSep "\n"
+          (link: "ip46tables -A fc-router-forward -i ${link.link} -j REJECT")
+          fclib.underlay.links
+         }
+        '')
+      ]);
 
     networking.nat.extraCommands = ''
       #############


### PR DESCRIPTION
The underlay network is intended to be separate from all other logical networks, and no packets should ever be forwarded onto or out of this network. This change introduces firewall rules which enforce this policy.

@flyingcircusio/release-managers

## Release process

Impact: internal.

Changelog: none.

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - The underlay network has a privileged function in the platform, and access to this logical network should be restricted from normal platform tenants.
- [x] Security requirements tested? (EVIDENCE)
  - Manually verified in dev. Before applying this change, it was possible to connect to port 22 on an underlay IP address from an arbitrary VM in dev. After applying this change, port 22 is no longer reachable.