### PR TITLE
[21.05-router] Use static uplink network definitions to generate firewall rules

### DIFF
--- a/nixos/platform/static.nix
+++ b/nixos/platform/static.nix
@@ -150,10 +150,26 @@ with lib;
         rzob = [ "rzob-router" ];
       };
 
-      routerUplinkInterfaces = {
-        dev = [ "ethtr" ];
-        whq = [ "brtr-whq-sl" ];
-        test = [ "ethtr" ];
+      # VLANs on which we accept connectivity to the outside world
+      routerUplinkNetworks = {
+        dev = [ "tr" ];
+        whq = [ "tr-whq-sl" ];
+        test = [ "tr" ];
+      };
+
+      # VLANs on which we provide connectivity to the outside world to others
+      routerDownlinkNetworks = {
+        whq = [ "tr" ];
+      };
+
+      # Derivation of router IDs for BGP, either the first IPv4
+      # address on given network, or per-host overrides
+      routerIdSources = {
+        location = {
+          dev = "tr";
+          whq = "tr";
+          test = "tr";
+        };
       };
 
       adminKeys = {

--- a/nixos/platform/static.nix
+++ b/nixos/platform/static.nix
@@ -162,14 +162,17 @@ with lib;
         whq = [ "tr" ];
       };
 
-      # Derivation of router IDs for BGP, either the first IPv4
-      # address on given network, or per-host overrides
+      # Derivation of router IDs for BGP.
       routerIdSources = {
+        # Either the first IPv4 addrress on a given network in a
+        # location
         location = {
           dev = "tr";
           whq = "tr";
           test = "tr";
         };
+        # Or a per-host override
+        host = {};
       };
 
       adminKeys = {


### PR DESCRIPTION
We have firewall rules to drop incoming traffic on the routers' uplink interfaces from invalid network ranges. However, a wildcard match on the ingress interface in the firewall caused the WHQ routers to incorrectly treat IPv4 traffic originating from DEV, which uses an RFC 1918 address range, as martian traffic.

This change refactors the platform to remove hard-coded assumptions about the `tr` VLAN being the sole uplink interface, and uses the statically defined uplink networks (and downlink networks, where applicable) to generate configuration. In particular this removes a lot of wildcard matches in the firewall configuration, and removes some assumptions about transfer networks which are true in WHQ and DEV but which are not true in RZOB.

@flyingcircusio/release-managers

## Release process

Impact: internal.

Changelog: none.

Manual deployment on the WHQ routers required in order to restore outgoing IPv4 connectivity in DEV.

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - The platform-provided firewall should not filter legitimate traffic.
  - The platform should be suitably flexible to accommodate the network topology of all locations.
- [x] Security requirements tested? (EVIDENCE)
  - Manually tested in DEV. The firewall configuration starts and reloads without any errors, and does not introduce any obvious new problems.
  - Switching to this configuration from the current state of the router branch results in only the firewall scripts being rebuilt. This suggests that other host configuration is left unmodified by this change.