### PR TITLE
[21.05-router] Prepare VLANs for uplinks in RZOB

### DIFF
--- a/nixos/platform/static.nix
+++ b/nixos/platform/static.nix
@@ -72,12 +72,18 @@ with lib;
         "video" = 23;
         # access network for unmanaged hosts
         "access" = 41;
+        # uplink vlans for kamp in rzob
+        "tr-kamp-a" = 639;
+        "tr-kamp-b" = 640;
+        # uplink vlan for kamp DHP
+        "tr-kamp-dhp" = 679;
       };
 
       mtus = {
         "sto" = 9000;
         "stb" = 9000;
         "ul" = 9216;
+        "tr-kamp-dhp" = 1600;
       };
 
       nameservers = {
@@ -151,6 +157,7 @@ with lib;
       routerUplinkNetworks = {
         dev = [ "tr" ];
         whq = [ "tr-whq-sl" ];
+        rzob = [ "tr-kamp-a" "tr-kamp-b" ];
         test = [ "tr" ];
       };
 


### PR DESCRIPTION
This change is in two parts. The first commit adds VLAN definitions which will be used in RZOB, including the two uplink VLANs and the VLAN for accessing KAMP's dynamic hardware pool.

The second commit ensures that the MTU on physical links are set correctly when the link is shared by multiple interfaces with different MTUs. The MTU of dependent interfaces may not be greater than the MTU of the physical link, so the physical link must be configured to accommodate the MTUs required by its dependent interfaces. Example: FE has an MTU of 1500, and STO has an MTU of 9000. If the interfaces for both of these networks should be configured using tagged VLANs on the same physical link device, then the link device must also have an MTU of 9000 in order to accommodate the STO network's requirements.

Previously, the network configuration code would prepare a list of interfaces backed by hardware links (i.e. a cable plugged into the host) as `ethernetInterfaces`. (This name is a slight misnomer, as we were mixing `physicalInterfaces`, a list of *interfaces*, with a list of *links* used for the VXLAN underlay.) As multiple interfaces may share the same link, this means that a list of unique Interfaces does not necessarily correspond to a list of unique links. The systemd `-netdev` units corresponding to hardware-backed links are generated based on a list of interfaces, which means that the units for links with more than one dependent interface will be generated from the configuration for an arbitrary associated interface. The selected interface may not have the greatest MTU out of all interfaces associated with a given link, which may result in the wrong MTU being set on the link.

The correct(er) approach when generating the `-netdev` units for physical links is to determine which dependent interface has the greatest required MTU, and then use that MTU when configuring the shared link.

@flyingcircusio/release-managers

## Release process

Impact: internal

Changelog: none

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - The platform should deliver functioning network configuration.
  - There's no specific security requirement, this is basically porting and refactoring working configuration we had on Gentoo for years.
- [x] Security requirements tested? (EVIDENCE)
  - Manually verified on a physical host in DEV.