### PR TITLE
networking: reduce connection tracking usage

### DIFF
--- a/nixos/services/ceph/client.nix
+++ b/nixos/services/ceph/client.nix
@@ -180,9 +180,18 @@ in
 
     services.udev.extraRules = builtins.readFile "${cfg.client.package}/etc/udev/50-rbd.rules";
 
-    # We want this trusted on this level, to avoid filling up the connection
-    # tracking tables.
-    networking.firewall.trustedInterfaces = [ fclib.network.sto.interface ];
+    # Ceph is using a lot of ports so we're being gratuitous here about
+    # the firewall and we want to avoid spamming the connection tracking table.
+    networking.firewall = {
+
+      trustedInterfaces = [ fclib.network.sto.interface ];
+
+      extraCommands = ''
+        iptables  -t raw -A fc-raw-prerouting -i brsto -j CT --notrack
+        iptables  -t raw -A fc-raw-output -o brsto -j CT --notrack
+      '';
+
+    };
 
     flyingcircus.services.ceph.allMergedSettings = (
         lib.recursiveUpdate

--- a/nixos/services/ceph/server.nix
+++ b/nixos/services/ceph/server.nix
@@ -68,9 +68,17 @@ in
       "d /srv/ceph 0755"
     ];
 
-    # We want this trusted on this level, to avoid filling up the connection
-    # tracking tables.
-    networking.firewall.trustedInterfaces = [ fclib.network.stb.interface ];
+    # Ceph is using a lot of ports so we're being gratuitous here about
+    # the firewall and we want to avoid spamming the connection tracking table.
+    networking.firewall = {
+
+      trustedInterfaces = [ fclib.network.stb.interface ];
+
+      extraCommands = ''
+        iptables -t raw -A fc-raw-prerouting -i brstb -j CT --notrack
+        iptables -t raw -A fc-raw-output -o brstb -j CT --notrack
+      '';
+    };
 
     flyingcircus.services.sensu-client.expectedConnections = {
       warning = 20000;


### PR DESCRIPTION
We have a lot of connections (Ceph, VXLAN) that are allowed in the firewall without having to keep track of state but will have a high number of flows/combinations associated.

To avoid the connection tracking table to explode, we exclude Ceph on the client and replication network, as well as the VXLAN underlay traffic.

@flyingcircusio/release-managers

We're skipping a bit of process (ticket etc) here as this was detected during the recent router PR merge and we wanted to get this in quickly to get dev/staging moved forward quickly.

## Release process

Impact:

Changelog:

### PR release workflow (internal)

- [ ] PR has internal ticket
- [ ] internal issue ID (PL-…) part of branch name
- [ ] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.

This is bound to various roles as a feature toggle and allows adding more rules flexibly.

- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

not customer facing per se

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

Avoid DOS due to conntrack table overflow. (We did experience this years ago when Ceph accidentally ended up in connection tracking limits)

- [x] Security requirements tested? (EVIDENCE)

Manually verified on cartman06.