### PR TITLE
ceph: fix sto/stb separation on the roles. mons do not need stb.

### DIFF
--- a/nixos/roles/ceph/osd.nix
+++ b/nixos/roles/ceph/osd.nix
@@ -194,6 +194,19 @@ in
 
       flyingcircus.services.ceph.cluster_network = head fclib.network.stb.v4.networks;
 
+      # Ceph OSDs are using a lot of ports so we're being gratuitous here about
+      # the firewall and we want to avoid spamming the connection tracking
+      # table.
+      networking.firewall = {
+
+        trustedInterfaces = [ fclib.network.stb.interface ];
+
+        extraCommands = ''
+          iptables -t raw -A fc-raw-prerouting -i ${fclib.network.stb.interface} -j CT --notrack
+          iptables -t raw -A fc-raw-output -o ${fclib.network.stb.interface} -j CT --notrack
+        '';
+      };
+
       systemd.services.fc-ceph-osds-all = rec {
         enable = ! config.flyingcircus.services.ceph.server.passive;
 

--- a/nixos/services/ceph/client.nix
+++ b/nixos/services/ceph/client.nix
@@ -187,8 +187,8 @@ in
       trustedInterfaces = [ fclib.network.sto.interface ];
 
       extraCommands = ''
-        iptables  -t raw -A fc-raw-prerouting -i brsto -j CT --notrack
-        iptables  -t raw -A fc-raw-output -o brsto -j CT --notrack
+        iptables  -t raw -A fc-raw-prerouting -i ${fclib.network.sto.interface} -j CT --notrack
+        iptables  -t raw -A fc-raw-output -o ${fclib.network.sto.interface} -j CT --notrack
       '';
 
     };

--- a/nixos/services/ceph/server.nix
+++ b/nixos/services/ceph/server.nix
@@ -68,18 +68,6 @@ in
       "d /srv/ceph 0755"
     ];
 
-    # Ceph is using a lot of ports so we're being gratuitous here about
-    # the firewall and we want to avoid spamming the connection tracking table.
-    networking.firewall = {
-
-      trustedInterfaces = [ fclib.network.stb.interface ];
-
-      extraCommands = ''
-        iptables -t raw -A fc-raw-prerouting -i brstb -j CT --notrack
-        iptables -t raw -A fc-raw-output -o brstb -j CT --notrack
-      '';
-    };
-
     flyingcircus.services.sensu-client.expectedConnections = {
       warning = 20000;
       critical = 25000;


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

### PR release workflow (internal)

- [ ] PR has internal ticket
- [ ] internal issue ID (PL-…) part of branch name
- [ ] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

Keep things working, fix bugs.

- [x] Security requirements tested? (EVIDENCE)

Extended automated testing.