### PR TITLE
[21.05] Port qol ipmitool from gentoo

### DIFF
--- a/nixos/platform/ipmi.nix
+++ b/nixos/platform/ipmi.nix
@@ -37,7 +37,7 @@ in {
 
   config = mkIf cfg.ipmi.enable {
 
-    environment.systemPackages = [ pkgs.ipmitool ];
+    environment.systemPackages = [ pkgs.ipmitool pkgs.fc.ipmitool ];
 
     boot.blacklistedKernelModules = [ "wdat_wdt" ];
     boot.kernelModules = [ "ipmi_watchdog" ];

--- a/pkgs/fc/default.nix
+++ b/pkgs/fc/default.nix
@@ -5,13 +5,7 @@ rec {
 
   agent = pythonPackages.callPackage ./agent {};
 
-  check-age = callPackage ./check-age {};
-  check-ceph-nautilus = callPackage ./check-ceph/nautilus {inherit (pkgs.ceph-nautilus) ceph-client;};
-  check-haproxy = callPackage ./check-haproxy {};
-  check-journal = callPackage ./check-journal.nix {};
-  check-link-redundancy = callPackage ./check-link-redundancy {};
-  check-mongodb = callPackage ./check-mongodb {};
-  check-postfix = callPackage ./check-postfix {};
+  blockdev = callPackage ./blockdev {};
 
   # fc-ceph does not need to be versioned on the Nix-package level as
   # it can be parametrized via config file for each individual subsystem.
@@ -19,18 +13,24 @@ rec {
     inherit agent blockdev;
   };
 
+  check-age = callPackage ./check-age {};
+  check-ceph-nautilus = callPackage ./check-ceph/nautilus {inherit (pkgs.ceph-nautilus) ceph-client;};
+  check-haproxy = callPackage ./check-haproxy {};
+  check-journal = callPackage ./check-journal.nix {};
+  check-link-redundancy = callPackage ./check-link-redundancy {};
+  check-mongodb = callPackage ./check-mongodb {};
+  check-postfix = callPackage ./check-postfix {};
   check-xfs-broken = callPackage ./check-xfs-broken {};
-  blockdev = callPackage ./blockdev {};
   collectdproxy = callPackage ./collectdproxy {};
-  roundcube-chpasswd = callPackage ./roundcube-chpasswd {};
   fix-so-rpath = callPackage ./fix-so-rpath {};
+  ipmitool = callPackage ./ipmitool {};
+
   ledtool = pkgs.writers.writePython3Bin "fc-ledtool"
     {} (builtins.readFile ./ledtool/led.py);
   lldp-to-altname = callPackage ./lldp-to-altname {};
   logcheckhelper = callPackage ./logcheckhelper { };
   megacli = callPackage ./megacli { };
   multiping = callPackage ./multiping.nix {};
-
   qemu-nautilus = callPackage ./qemu rec {
     version = "1.4.3";
     src = pkgs.fetchFromGitHub {
@@ -42,7 +42,6 @@ rec {
     qemu_ceph = pkgs.qemu-ceph-nautilus;
     ceph_client = pkgs.ceph-nautilus.ceph-client;
   };
-
   # Enable this temporarily during development, but DO NOT commit this as
   # it will break hydra and we can't cleanly filter it out of the automatic
   # test discovery at the moment.
@@ -55,12 +54,13 @@ rec {
   #   ceph_client = pkgs.ceph-nautilus.ceph-client;
   # };
 
+  roundcube-chpasswd = callPackage ./roundcube-chpasswd {};
   secure-erase = callPackage ./secure-erase {};
   sensuplugins = callPackage ./sensuplugins {};
   sensusyntax = callPackage ./sensusyntax {};
-  userscan = callPackage ./userscan.nix {};
-  util-physical = callPackage ./util-physical {};
   telegraf-collect-psi = callPackage ./telegraf-collect-psi {};
   telegraf-routes-summary = callPackage ./telegraf-routes-summary {};
+  userscan = callPackage ./userscan.nix {};
+  util-physical = callPackage ./util-physical {};
 
 }

--- a/pkgs/fc/ipmitool/default.nix
+++ b/pkgs/fc/ipmitool/default.nix
@@ -1,0 +1,31 @@
+{ lib, stdenv, python3Full, ipmitool, makeWrapper }:
+
+
+stdenv.mkDerivation rec {
+  version = "0.1";
+  name = "fc-ipmitool";
+
+  src = ./fc-ipmitool.py;
+  unpackPhase = ":";
+  dontBuild = true;
+  dontConfigure = true;
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ python3Full ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp ${src} $out/bin/fc-ipmitool
+    chmod +x $out/bin/fc-ipmitool
+    patchShebangs $out/bin
+    wrapProgram $out/bin/fc-ipmitool \
+      --prefix PATH : "${lib.makeBinPath [ ipmitool ]}"
+  '';
+
+  meta = with lib; {
+    description = "fc-ipmitool";
+    maintainers = [ maintainers.theuni ];
+    platforms = platforms.unix;
+  };
+
+}

--- a/pkgs/fc/ipmitool/fc-ipmitool.py
+++ b/pkgs/fc/ipmitool/fc-ipmitool.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+
+"""A convenience wrapper around ipmitool."""
+
+import argparse
+import os
+import shutil
+
+a = argparse.ArgumentParser(description=__doc__)
+a.add_argument(
+    "--user",
+    "-U",
+    default="ADMIN",
+    help="User to connect with",
+)
+a.add_argument(
+    "host",
+    help="host to connect with",
+)
+a.add_argument(
+    "args",
+    nargs="*",
+    help="host to connect with",
+)
+
+args = a.parse_args()
+
+host = args.host
+if "." not in args.host:
+    location = os.environ["FCIO_LOCATION"]
+    host = f"{host}.ipmi.{location}.gocept.net"
+
+exec_args = [
+    "ipmitool",
+    "-4",
+    "-U",
+    args.user,
+    "-I",
+    "lanplus",
+    "-H",
+    host,
+    *args.args,
+]
+
+exec_path = shutil.which("ipmitool")
+print(exec_path, " ".join(exec_args))
+os.execve(exec_path, exec_args, os.environ)

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -165,6 +165,13 @@ in {
 
   innotop = super.callPackage ./percona/innotop.nix { };
 
+  ipmitool = super.ipmitool.overrideAttrs(a: a // {
+    buildInputs = a.buildInputs ++ [ super.ncurses super.readline ];
+    configureFlags = a.configureFlags ++ [
+      "--enable-ipmishell"
+    ];
+  });
+
   jibri = super.callPackage ./jibri { jre_headless = super.jre8_headless; };
 
   jicofo = super.jicofo.overrideAttrs(oldAttrs: rec {


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

n/a

Changelog:

invisible, porting the internal QoL state form gentoo

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

no specific requirements

- [x] Security requirements tested? (EVIDENCE)

functionality tested manually on kenny04
