### PR TITLE
[21.05] Router configuration for RZOB

### DIFF
--- a/nixos/roles/router/bird2/rzob.conf
+++ b/nixos/roles/router/bird2/rzob.conf
@@ -1,0 +1,116 @@
+protocol static local_rzob_4 {
+  ipv4 {
+    table master4;
+  };
+
+  route 185.105.252.0/24 unreachable;
+  route 195.62.125.0/24 unreachable;
+  route 195.62.126.0/24 unreachable;
+}
+
+protocol static local_rzob_6 {
+  ipv6 {
+    table master6;
+  };
+
+  route 2a02:248:101::/48 unreachable;
+}
+
+protocol device {
+  scan time 60;
+}
+
+protocol bfd {
+  strict bind on;
+  interface "ethtr-kamp-a", "ethtr-kamp-b";
+}
+
+filter net_rzob_4 {
+  if net ~ [ 195.62.125.0/24+, 195.62.126.0/24+ ]
+    then bgp_community.add((65535, 65281));  # No export because those are KAMP-owned
+
+  if net ~ [ 185.105.252.0/24+, 195.62.125.0/24+, 195.62.126.0/24+ ] then {
+    bgp_med = UPLINK_MED;
+    accept;
+  } else reject;
+}
+
+filter net_rzob_6 {
+  if net ~ [ 2a02:248:101::/48+ ]
+    then bgp_community.add((65535, 65281));  # No export because those are KAMP-owned
+
+  if net ~ [ 2a02:248:101::/48+ ] then {
+    bgp_med = UPLINK_MED;
+    accept;
+  } else reject;
+}
+
+filter default_route_4 {
+  if net = 0.0.0.0/0 then accept; else reject;
+}
+
+filter default_route_6 {
+  if net = ::/0 then accept; else reject;
+}
+
+protocol kernel kernel_4 {
+  ipv4 {
+    table master4;
+    export all;
+    import none;
+  };
+
+  metric 500;
+  merge paths on;
+}
+
+protocol kernel kernel_6 {
+  ipv6 {
+    table master6;
+    export all;
+    import none;
+  };
+
+  metric 500;
+  merge paths on;
+}
+
+template bgp peer_kamp {
+  local as 64514;
+
+  bfd;
+  connect retry time 15;
+  error wait time 5,10;
+}
+
+template bgp peer_kamp_4 from peer_kamp {
+  ipv4 {
+    table master4;
+    import filter default_route_4;
+    export filter net_rzob_4;
+  };
+}
+
+template bgp peer_kamp_6 from peer_kamp {
+  ipv6 {
+    table master6;
+    import filter default_route_6;
+    export filter net_rzob_6;
+  };
+}
+
+protocol bgp peer_kamp_bbr_ob_01_4 from peer_kamp_4 {
+  neighbor 195.62.112.81 as 8648;
+}
+
+protocol bgp peer_kamp_bbr_ob_02_4 from peer_kamp_4 {
+  neighbor 195.62.112.89 as 8648;
+}
+
+protocol bgp peer_kamp_bbr_ob_01_6 from peer_kamp_6 {
+  neighbor 2a02:248:0:1040::1 as 8648;
+}
+
+protocol bgp peer_kamp_bbr_ob_02_6 from peer_kamp_6 {
+  neighbor 2a02:248:0:1041::1 as 8648;
+}

--- a/nixos/roles/router/keepalived/rzob.conf
+++ b/nixos/roles/router/keepalived/rzob.conf
@@ -24,10 +24,10 @@ track_file check_stop_file {
 vrrp_sync_group router {
     group { mgm srv fe dhp }
 
-    notify_master "/nix/var/nix/profiles/system/specialisation/primary/bin/switch-to-configuration test"
-    notify_backup "/nix/var/nix/profiles/system/bin/switch-to-configuration test"
-    notify_fault "/nix/var/nix/profiles/system/bin/switch-to-configuration test"
-    notify_stop '/nix/var/nix/profiles/system/bin/switch-to-configuration test'
+    notify_master "/etc/keepalived/fc-manage -v activate-configuration -s primary"
+    notify_backup "/etc/keepalived/fc-manage -v activate-configuration --base-system"
+    notify_fault "/etc/keepalived/fc-manage -v activate-configuration --base-system"
+    notify_stop "/etc/keepalived/fc-manage -v activate-configuration --base-system"
 
     track_script {
         check_default_route_v4 weight 10
@@ -56,7 +56,7 @@ vrrp_instance mgm {
 }
 
 vrrp_instance fe {
-    interface ethfe
+    interface brfe
     state BACKUP
     virtual_router_id 51
     priority 100
@@ -75,7 +75,7 @@ vrrp_instance fe {
 }
 
 vrrp_instance srv {
-    interface ethsrv
+    interface brsrv
     state BACKUP
     virtual_router_id 51
     priority 100
@@ -94,7 +94,7 @@ vrrp_instance srv {
 }
 
 vrrp_instance dhp {
-    interface ethtr.679
+    interface ethtr-kamp-dhp
     state BACKUP
     virtual_router_id 51
     priority 100


### PR DESCRIPTION
Port the BGP config to Bird 2 and adjust the keepalived configuration for deployment in RZOB.

@flyingcircusio/release-managers

## Release process

Impact: internal

Changelog: none

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - This change is an update of configuration which will be first deployed when the routers in RZOB are redeployed with NixOS
- [x] Security requirements tested? (EVIDENCE)
  - The Bird configuration passes a syntax check. The config will first be tested when we get to the rollout in a few weeks.