### PR TITLE
[21.05] Reload keepalived when interfaces change

### DIFF
--- a/nixos/platform/static.nix
+++ b/nixos/platform/static.nix
@@ -179,6 +179,14 @@ with lib;
         host = {};
       };
 
+      # Networks which have floating gateways shared between routers
+      floatingGatewayNetworks = {
+        test = [ "mgm" "srv" "fe" ];
+        dev = [ "mgm" "srv" "fe" ];
+        whq = [ "mgm" "srv" "fe" "tr-whq-sl" "video" "access" ];
+        rzob = [ "mgm" "srv" "fe" "tr-kamp-dhp" ];
+      };
+
       adminKeys = {
         directory = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDSejGFORJ7hlFraV3caVir3rWlo/QcsWptWrukk2C7eaGu/8tXMKgPtBHYdk4DYRi7EcPROllnFVzyVTLS/2buzfIy7XDjn7bwHzlHoBHZ4TbC9auqW3j5oxTDA4s2byP6b46Dh93aEP9griFideU/J00jWeHb27yIWv+3VdstkWTiJwxubspNdDlbcPNHBGOE+HNiAnRWzwyj8D0X5y73MISC3pSSYnXJWz+fI8IRh5LSLYX6oybwGX3Wu+tlrQjyN1i0ONPLxo5/YDrS6IQygR21j+TgLXaX8q8msi04QYdvnOqk1ntbY4fU8411iqoSJgCIG18tOgWTTOcBGcZX directory@directory.fcio.net";
         ctheune = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIA/lhMiMJBednrahZUJvb+dZVhLysbcuGf4p2J4D6MU/ ctheune@fourteen-3.local";


### PR DESCRIPTION
Some changes between system configurations will cause virtual kernel network devices such as bridge and VXLAN devices to be destroyed and recreated (in particular, changing nameservers will result in network-setup.service being restarted, which brings the whole house of cards down). keepalived only resolves interface names to interface indices when it starts and reloads, which means that it won't automatically notice if an interface it's meant to be managing gets taken away and recreated. Attempting to send to the network using old and no longer valid interface indices causes a lot of log spam, and might also mean that keepalived is no longer correctly monitoring interfaces which have been recreated.

This change introduces a sidecar unit which will reload keepalived if network interfaces are changed, and adjusts the dependencies so that keepalived will be stopped before interfaces are brought down at shutdown time.

@flyingcircusio/release-managers

## Release process

Impact: internal

Changelog: none

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - This change improves reliability and interoperability between keepalived and the NixOS platform.
- [x] Security requirements tested? (EVIDENCE)
  - Manually verified in DEV. keepalived no longer gets into a state where it receives an error from the kernel when attempting to send VRRP packets on an interface which has been restarted since its last reload.