### PR TITLE
[21.05] router: traffic accounting

### DIFF
--- a/nixos/roles/router/default.nix
+++ b/nixos/roles/router/default.nix
@@ -67,7 +67,9 @@ in
     ./keepalived
     ./chrony.nix
     ./dhcpd.nix
+    ./pmacctd.nix
     ./radvd.nix
+    ./trafficclient.nix
   ];
 
   config = lib.mkIf role.enable {
@@ -110,7 +112,6 @@ in
 
     environment.systemPackages = with pkgs; [
       kickInterfaces
-      pmacct
     ];
 
     environment.shellAliases = {

--- a/nixos/roles/router/pmacctd.nix
+++ b/nixos/roles/router/pmacctd.nix
@@ -1,0 +1,53 @@
+{ config, pkgs, lib, ... }:
+
+with builtins;
+
+let
+  inherit (config) fclib;
+  role = config.flyingcircus.roles.router;
+  mkConfig = interface:
+    pkgs.writeText "pmacctd-${interface}.conf" ''
+      interface: ${interface}
+      aggregate: src_host,dst_host
+
+      plugins: print
+
+      print_refresh_time: 60
+      print_output: csv
+      print_output_file: /var/spool/pmacctd/${interface}-%Y%m%d-%H%M-%s.txt
+      print_history: 1m
+      print_output_file_append: true
+    '';
+
+  mkService = interface: lib.nameValuePair "pmacctd-${interface}" {
+    description = "Collect traffic accounting data";
+    wantedBy = [ "multi-user.target" ];
+    requires = [ "network-addresses-${interface}.service" ];
+    stopIfChanged = false;
+    script = ''
+      ${pkgs.pmacct}/bin/pmacctd -f ${mkConfig interface}
+    '';
+    serviceConfig = {
+      Restart = "always";
+      RestartSec = "1s";
+    };
+  };
+in
+lib.mkIf role.enable {
+  environment.systemPackages = with pkgs; [
+    pmacct
+  ];
+
+  environment.etc."pmacctd-${fclib.network.fe.interface}".source = mkConfig fclib.network.fe.interface;
+  environment.etc."pmacctd-${fclib.network.srv.interface}".source = mkConfig fclib.network.srv.interface;
+
+  systemd.services =
+    lib.listToAttrs [
+      (mkService fclib.network.fe.interface)
+      (mkService fclib.network.srv.interface)
+    ];
+
+  systemd.tmpfiles.rules = [
+    "d /var/spool/pmacctd 0700 root root 5d"
+  ];
+}

--- a/nixos/roles/router/trafficclient.nix
+++ b/nixos/roles/router/trafficclient.nix
@@ -1,0 +1,51 @@
+{ config, pkgs, lib, ... }:
+
+with builtins;
+
+let
+  inherit (config) fclib;
+  inherit (config.flyingcircus) location;
+  role = config.flyingcircus.roles.router;
+  configFile =
+    pkgs.writeText "trafficclient.conf" ''
+      [trafficclient]
+      dbdir = /var/db/trafficclient
+      location = ${location}
+      ignored-ips = 2a02:238:f030:102::103b
+        212.122.41.135
+        46.237.250.54
+        80.147.225.83
+        2a02:248:0::/48
+        195.62.121.0/24
+        195.62.122.0/24
+        195.62.123.0/24
+        195.62.127.0/24
+        82.141.39.0/24
+    '';
+in
+lib.mkIf role.enable {
+  environment.etc."trafficclient.conf".source = configFile;
+
+  systemd.services.fc-trafficclient = {
+    description = "Measure traffic and report it to the traffic server";
+    requires = [ "network-online.target" ];
+    after = [ "network-online.service" "pmacctd.service" ];
+    script = ''
+      ${pkgs.fc.trafficclient}/bin/fc-trafficclient ${configFile}
+    '';
+    serviceConfig = {
+      StateDirectory = "trafficclient";
+      TimeoutStartSec = "10m";
+    };
+  };
+
+  systemd.timers.fc-trafficclient = {
+    description = "Timer for fc-trafficclient";
+    wantedBy = [ "timers.target" ];
+    requires = [ "network-online.target" ];
+    timerConfig = {
+      OnActiveSec = "1m";
+      OnUnitInactiveSec = "2m";
+    };
+  };
+}

--- a/pkgs/fc/default.nix
+++ b/pkgs/fc/default.nix
@@ -60,6 +60,7 @@ rec {
   sensusyntax = callPackage ./sensusyntax {};
   telegraf-collect-psi = callPackage ./telegraf-collect-psi {};
   telegraf-routes-summary = callPackage ./telegraf-routes-summary {};
+  trafficclient = pythonPackages.callPackage ./trafficclient.nix {};
   userscan = callPackage ./userscan.nix {};
   util-physical = callPackage ./util-physical {};
 

--- a/pkgs/fc/trafficclient.nix
+++ b/pkgs/fc/trafficclient.nix
@@ -1,0 +1,80 @@
+{ lib
+, stdenv
+, fetchPypi
+, fetchFromGitHub
+, dmidecode
+, gitMinimal
+, gptfdisk
+, libyaml
+, multipath-tools
+, nix
+, buildPythonApplication
+, pythonPackages
+, python
+, util-linux
+, xfsprogs
+, pytest
+, structlog
+}:
+
+let
+  py = pythonPackages;
+
+  stamina = py.buildPythonPackage rec {
+    pname = "stamina";
+    version = "23.1.0";
+    format = "pyproject";
+
+    src = fetchPypi {
+      inherit pname version;
+      hash = "sha256-sWzj1S1liqdduBP8amZht3Cr/qkV9yzaSOMl8qeFR4Y=";
+    };
+
+    nativeBuildInputs = with py; [ hatchling hatch-vcs hatch-fancy-pypi-readme ];
+    propagatedBuildInputs = with py; [ structlog tenacity typing-extensions ];
+  };
+in
+buildPythonApplication rec {
+  name = "fc-trafficclient-${version}";
+  version = "1.0";
+  namePrefix = "";
+
+  src = fetchFromGitHub {
+    owner = "flyingcircusio";
+    repo = "trafficclient";
+    rev = "68d5ae84ebcbb4787de92a6de917da7284f80f4b";
+    hash = "sha256-dp91sPzcoq4QF/odkWZ96a3y4ZctQoWQjgcVmaDcw5M=";
+  };
+
+  checkInputs = [
+    py.pytest
+    py.pytest-cov
+    py.pytest-timeout
+  ];
+  nativeBuildInputs = [
+    py.setuptools
+    py.pip
+  ];
+  nativeCheckInputs = [
+    py.pytestCheckHook
+  ];
+  propagatedBuildInputs = [
+    py.ipy
+    py.persistent
+    py.pyyaml
+    py.transaction
+    py.zodb
+    stamina
+  ];
+  dontStrip = true;
+  doCheck = true;
+  disabledTests = [
+    # Fails with: Permission denied: '/homeless-shelter
+    "test_tilde_is_expanded_to_home_dir"
+  ];
+
+  passthru.pythonDevEnv = python.withPackages (_:
+    checkInputs ++ [ py.pytest ] ++ propagatedBuildInputs
+  );
+
+}


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - traffic accounting is an internal service on our routers, talking to the directory. Functionality is still the same as on our old platform. 
- [x] Security requirements tested? (EVIDENCE)
  - Python tests for trafficclient are clean
  - NixOS test checks that pmacctd is running for fe and srv interfaces and that the timer is active
  - verified in dev (kenny04) that pmacctd is collecting data and trafficclient is sending data to the directory every two minutes