### PR TITLE
[FC-36891] fix varnish monitoring

### DIFF
--- a/nixos/roles/webproxy.nix
+++ b/nixos/roles/webproxy.nix
@@ -63,9 +63,26 @@ in
           command = "${cfg.package}/bin/varnishadm status";
           timeout = 180;
         };
-        varnish_http = {
-          notification = "varnish port 8008 HTTP response";
-          command = "check_http -H localhost -p 8008 -c 10 -w 3 -t 20 -e HTTP";
+        varnish_http = let
+          # remove the optional protocol option at the end
+          address = builtins.elemAt (lib.splitString "," cfg.http_address) 0;
+          ip-port = lib.splitString ":" address;
+          # default (empty) host and "*" are equivalent to 0.0.0.0
+          # so the check can be run on localhost
+          host = let
+            tmp = builtins.elemAt ip-port 0;
+          in
+            if builtins.stringLength tmp > 0 && tmp != "*"
+            then tmp
+            else "127.0.0.1";
+          # default port is 80 and can be omitted
+          port =
+            if builtins.length ip-port == 2
+            then builtins.elemAt ip-port 1
+            else 80;
+        in {
+          notification = "varnish port ${port} HTTP response";
+          command = "check_http -H ${host} -p ${port} -c 10 -w 3 -t 20 -e HTTP";
         };
       };
 

--- a/nixos/services/varnish/default.nix
+++ b/nixos/services/varnish/default.nix
@@ -76,9 +76,18 @@ in {
     http_address = mkOption {
       type = types.str;
       default = "*:8008";
+      description = ''
+        The http address for the varnish service to listen on.
+        Unix sockets can technically be used for varnish, but are not currently supported on the FCIO platform due to monitoring constraints.
+        See `varnishd(1)` for details.
+      '';
     };
     virtualHosts = mkOption {
-      type = types.attrsOf (types.submodule ({ name, config, ... }: {
+      type = types.attrsOf (types.submodule ({
+        name,
+        config,
+        ...
+      }: {
         options = {
           host = mkOption {
             type = types.str;


### PR DESCRIPTION
The default monitoring check for the varnish service relied on Varnish to run on a specific address.
Since this address can be changed through nix, the monitoring check needs to be adjusted to correctly infer the host and port that varnish is running on.

@flyingcircusio/release-managers

FC-36891

## Release process

Impact: -

Changelog:
- varnish: monitoring checks now support customised listening addresses and ports

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - [x] the varnish monitors the correct address when not using the default
- [x] Security requirements tested? (EVIDENCE)

```
phil@test01 ~ $ sensu-client-show-config | jq '.checks.varnish_http'
{
  "command": "check_http -H 172.22.57.135 -p 8080 -c 10 -w 3 -t 20 -e HTTP",
  "interval": 60,
  "notification": "varnish port 8080 HTTP response",
  "standalone": true,
  "timeout": null,
  "ttl": null,
  "warnIsCritical": false
}

phil@test01 ~ $ cat /etc/local/nixos/varnish_http.nix
{ lib, ... }:
{
  services.varnish.http_address = lib.mkForce "172.22.57.135:8080";
}

phil@test01 ~ $
```
