### PR TITLE
Remove deprecated postgresql ensurePermissions

### DIFF
--- a/nixos/roles/k3s/server.nix
+++ b/nixos/roles/k3s/server.nix
@@ -307,7 +307,7 @@ in {
       } ];
     };
 
-    systemd.services.kubernetes-ensure-db-permissions = {
+    systemd.services.fc-k3s-ensure-db-permissions = {
       description = "Ensure the root user has all permissions on kubernetes db";
       wantedBy = [ "k3s.service" ];
       before = [ "k3s.service" ];
@@ -324,6 +324,7 @@ in {
         fi
         done
           $PSQL -tAc 'GRANT ALL PRIVILEGES ON DATABASE kubernetes TO "root"'
+          $PSQL kubernetes -tAc 'GRANT CREATE ON SCHEMA public TO "root"'
       '';
       serviceConfig = {
         type = "oneshot";


### PR DESCRIPTION
Replaces deprecated option `postgresql.ensureUsers.*.ensurePermissions` with a custom systemd unit that ensures database privileges for k3s. This was the only place where we used the option.

PL-132355

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - This test should not change the behaviour compared to previous releases.
- [x] Security requirements tested? (EVIDENCE)
  - I locally changed the postgress-version for k3s to 16 and ran the test cases. All tests passed.
