### PR TITLE
[21.05] RadosGW: selectively re-enable connection tracking

### DIFF
--- a/nixos/roles/ceph/osd.nix
+++ b/nixos/roles/ceph/osd.nix
@@ -201,7 +201,8 @@ in
 
         trustedInterfaces = [ fclib.network.stb.interface ];
 
-        extraCommands = ''
+        extraCommands = lib.mkOrder 800 ''
+          # Disable STB connection tracking to reduce kernel connection table overhead
           iptables -t raw -A fc-raw-prerouting -i ${fclib.network.stb.interface} -j CT --notrack
           iptables -t raw -A fc-raw-output -o ${fclib.network.stb.interface} -j CT --notrack
         '';

--- a/nixos/roles/ceph/osd.nix
+++ b/nixos/roles/ceph/osd.nix
@@ -203,8 +203,8 @@ in
 
         extraCommands = lib.mkOrder 800 ''
           # Disable STB connection tracking to reduce kernel connection table overhead
-          iptables -t raw -A fc-raw-prerouting -i ${fclib.network.stb.interface} -j CT --notrack
-          iptables -t raw -A fc-raw-output -o ${fclib.network.stb.interface} -j CT --notrack
+          ip46tables -t raw -A fc-raw-prerouting -i ${fclib.network.stb.interface} -j CT --notrack
+          ip46tables -t raw -A fc-raw-output -o ${fclib.network.stb.interface} -j CT --notrack
         '';
       };
 

--- a/nixos/roles/ceph/rgw.nix
+++ b/nixos/roles/ceph/rgw.nix
@@ -129,30 +129,37 @@ in
       networking.firewall.extraCommands =
         let
           srv = fclib.network.srv;
-        in
-        ''
-          set -x
-          # Accept traffic from S3 gateways from within the SRV network.
-          ip46tables -w -t nat -N fc-nat-pre
+          sto = fclib.network.sto;
+        in lib.mkMerge [
+          (lib.mkOrder 700 ''
+            # Ensure that conntrack is enabled for RGW connections using port redirects
+            iptables -w -t raw -A fc-raw-prerouting -i ${sto.interface} -p tcp --dport 7480 -j RETURN
+            iptables -w -t raw -A fc-raw-output -o ${sto.interface} -p tcp --sport 80 -j RETURN
+          '')
+          (''
+            set -x
+            # Accept traffic from S3 gateways from within the SRV network.
+            ip46tables -w -t nat -N fc-nat-pre
 
-        '' + (lib.concatMapStringsSep "\n"
-          (net: ''
-            iptables -A nixos-fw -i ${srv.interface} -s ${net} -p tcp --dport 80 -j ACCEPT
-            # PL-130368 Fix S3 presigned URLs
-            iptables -t nat -A fc-nat-pre -p tcp --dport 7480 -j REDIRECT --to-port 80
+          '' + (lib.concatMapStringsSep "\n"
+            (net: ''
+              iptables -A nixos-fw -i ${srv.interface} -s ${net} -p tcp --dport 80 -j ACCEPT
+              # PL-130368 Fix S3 presigned URLs
+              iptables -t nat -A fc-nat-pre -p tcp --dport 7480 -j REDIRECT --to-port 80
+            '')
+            srv.v4.networks
+          ) + "\n" +
+          (lib.concatMapStringsSep "\n"
+            (net: ''
+              ip6tables -A nixos-fw -i ${srv.interface} -s ${net} -p tcp --dport 80 -j ACCEPT
+              # PL-130368 Fix S3 presigned URLs
+              ip6tables -t nat -A fc-nat-pre -p tcp --dport 7480 -j REDIRECT --to-port 80
+            '')
+            srv.v6.networks) +
+          ''
+            ip46tables -t nat -A PREROUTING -j fc-nat-pre
           '')
-          srv.v4.networks
-        ) + "\n" +
-        (lib.concatMapStringsSep "\n"
-          (net: ''
-            ip6tables -A nixos-fw -i ${srv.interface} -s ${net} -p tcp --dport 80 -j ACCEPT
-            # PL-130368 Fix S3 presigned URLs
-            ip6tables -t nat -A fc-nat-pre -p tcp --dport 7480 -j REDIRECT --to-port 80
-          '')
-          srv.v6.networks) +
-        ''
-          ip46tables -t nat -A PREROUTING -j fc-nat-pre
-        '';
+        ];
 
       systemd.services.fc-ceph-rgw-update-stats = {
         description = "Update RGW stats";

--- a/nixos/roles/ceph/rgw.nix
+++ b/nixos/roles/ceph/rgw.nix
@@ -133,8 +133,8 @@ in
         in lib.mkMerge [
           (lib.mkOrder 700 ''
             # Ensure that conntrack is enabled for RGW connections using port redirects
-            iptables -w -t raw -A fc-raw-prerouting -i ${sto.interface} -p tcp --dport 7480 -j RETURN
-            iptables -w -t raw -A fc-raw-output -o ${sto.interface} -p tcp --sport 80 -j RETURN
+            ip46tables -w -t raw -A fc-raw-prerouting -i ${sto.interface} -p tcp --dport 7480 -j RETURN
+            ip46tables -w -t raw -A fc-raw-output -o ${sto.interface} -p tcp --sport 80 -j RETURN
           '')
           (''
             set -x

--- a/nixos/services/ceph/client.nix
+++ b/nixos/services/ceph/client.nix
@@ -188,8 +188,8 @@ in
 
       extraCommands = lib.mkOrder 800 ''
         # Disable STO connection tracking to reduce kernel connection table overhead
-        iptables  -t raw -A fc-raw-prerouting -i ${fclib.network.sto.interface} -j CT --notrack
-        iptables  -t raw -A fc-raw-output -o ${fclib.network.sto.interface} -j CT --notrack
+        ip46tables  -t raw -A fc-raw-prerouting -i ${fclib.network.sto.interface} -j CT --notrack
+        ip46tables  -t raw -A fc-raw-output -o ${fclib.network.sto.interface} -j CT --notrack
       '';
 
     };

--- a/nixos/services/ceph/client.nix
+++ b/nixos/services/ceph/client.nix
@@ -186,7 +186,8 @@ in
 
       trustedInterfaces = [ fclib.network.sto.interface ];
 
-      extraCommands = ''
+      extraCommands = lib.mkOrder 800 ''
+        # Disable STO connection tracking to reduce kernel connection table overhead
         iptables  -t raw -A fc-raw-prerouting -i ${fclib.network.sto.interface} -j CT --notrack
         iptables  -t raw -A fc-raw-output -o ${fclib.network.sto.interface} -j CT --notrack
       '';


### PR DESCRIPTION
In #988 and #989 connection tracking was disabled on the STO and STB networks, to reduce the overhead in the kernel connection table. This however breaks RadosGW clients using the STO interface (e.g. the rgw.local reverse proxy on the KVM servers), as the RGW hosts use iptables REDIRECT rules to steer incoming connections on port 7480 to the radosgw process listening on port 80 (as a workaround for another problem). The REDIRECT target relies on conntrack in order to rewrite the port numbers on incoming and outgoing packets correctly, and disabling conntrack renders these rules ineffective.

This commit selectively re-enables conntrack in the RGW role on the STO interface, so that only connections to and from the RGW process are tracked. This allows the REDIRECT rules to function correctly again.

PL-132519

@flyingcircusio/release-managers

## Release process

Impact: internal.

Changelog: none.

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - No specific requirements, this change fixes the integration of Ceph in the platform downstream of other changes made as part of the VXLAN integration.
- [x] Security requirements tested? (EVIDENCE)
  - Manually verified in DEV. Previously non-functional RGW access now works over the STO network from a KVM host again with this change applied to an RGW host.