### PR TITLE
[21.05] Router: fix WHQ gateway address for access network

### DIFF
--- a/nixos/roles/router/keepalived/whq.conf
+++ b/nixos/roles/router/keepalived/whq.conf
@@ -135,7 +135,7 @@ vrrp_instance access {
     garp_master_refresh 30
 
     virtual_ipaddress {
-	2a02:2028:1007:29::1/64
+        2a02:238:f030:129::1/64
     }
     virtual_ipaddress_excluded {
         212.122.41.225/27


### PR DESCRIPTION
We renumbered the access network in WHQ, this change updates the keepalived config with the new gateway address.

PL-132416

@flyingcircusio/release-managers

## Release process

Impact: internal.

Changelog: none.

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - No special requirements, an IP address has been changed.
- [x] Security requirements tested? (EVIDENCE)
  - No special requirements.
