### PR TITLE
[21.05] routers: ensure we restart bind when it crashes.

### DIFF
--- a/nixos/roles/router/bind/default.nix
+++ b/nixos/roles/router/bind/default.nix
@@ -105,14 +105,18 @@ lib.mkIf role.enable {
     configFile = ./named.conf;
   };
 
-  systemd.services.bind.restartTriggers = [
+  systemd.services.bind = {
+    serviceConfig.Restart = "always";
+
+    restartTriggers = [
       config.environment.etc."bind/acl.conf".source
       config.environment.etc."bind/pri/127.zone".source
       config.environment.etc."bind/pri/localhost.zone".source
       config.environment.etc."bind/pri/gocept.net-internal.zone.static".source
       config.environment.etc."bind/pri/gocept.net.zone.static".source
       config.environment.etc."bind/pri/1.0.1.0.8.4.2.0.2.0.a.2.zone".source
-  ];
+    ];
+  };
 
   networking.firewall.extraCommands = ''
     ip46tables -A nixos-fw -p tcp --dport 53 -j nixos-fw-accept


### PR DESCRIPTION
Fixes PL-131214

@flyingcircusio/release-managers

## Release process

Impact:

none

Changelog:

* Ensure bind gets restarted automatically on crashes. (PL-131214)

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

availability

- [x] Security requirements tested? (EVIDENCE)

relying on automated tests
