### PR TITLE
[21.05] router: only run maintenance in keepalived backup state

### DIFF
--- a/nixos/roles/router/keepalived/default.nix
+++ b/nixos/roles/router/keepalived/default.nix
@@ -54,7 +54,7 @@ lib.mkIf role.enable {
 
   environment.etc."keepalived/check-default-route-v4".source = "${checkDefaultRoute4}/bin/check-default-route-v4";
   environment.etc."keepalived/check-default-route-v6".source = "${checkDefaultRoute6}/bin/check-default-route-v6";
-  environment.etc."keepalived/fc-manage".source = "${pkgs.fc.agent}/bin/fc-manage";
+  environment.etc."keepalived/fc-keepalived".source = "${pkgs.fc.agent}/bin/fc-keepalived";
   environment.etc."keepalived/keepalived.conf".source = keepalivedConf;
 
   environment.systemPackages = with pkgs; [
@@ -63,9 +63,19 @@ lib.mkIf role.enable {
     checkDefaultRoute6
   ];
 
+
+  flyingcircus.passwordlessSudoRules = [
+    {
+      commands = [
+        "${pkgs.fc.agent}/bin/fc-keepalived check"
+      ];
+      groups = [ "admins" "sudo-srv" "service" ];
+    }
+  ];
+
   services.keepalived = {
     enable = true;
-    # XXX: We override the keepalived config file in ExecStart below,
+    # Note: We override the keepalived config file in ExecStart below,
     # using config options here has no effect.
   };
 
@@ -83,6 +93,7 @@ lib.mkIf role.enable {
         + " -p /run/keepalived.pid"
         + " -n");
       StateDirectory = "keepalived";
+      RuntimeDirectory = "keepalived";
     };
   };
 

--- a/nixos/roles/router/keepalived/dev.conf
+++ b/nixos/roles/router/keepalived/dev.conf
@@ -21,13 +21,20 @@ track_file check_stop_file {
   init_file 0
 }
 
+track_file check_maint_file {
+  # Used by fc-keepalived enter-maintenance
+  file /etc/keepalived/fcio_maintenance
+  weight -20
+  init_file 0
+}
+
 vrrp_sync_group router {
     group { mgm srv fe }
 
-    notify_master "/etc/keepalived/fc-manage -v activate-configuration -s primary"
-    notify_backup "/etc/keepalived/fc-manage -v activate-configuration --base-system"
-    notify_fault "/etc/keepalived/fc-manage -v activate-configuration --base-system"
-    notify_stop "/etc/keepalived/fc-manage -v activate-configuration --base-system"
+    notify_master "/etc/keepalived/fc-keepalived notify master"
+    notify_backup "/etc/keepalived/fc-keepalived notify backup"
+    notify_fault "/etc/keepalived/fc-keepalived notify fault"
+    notify_stop "/etc/keepalived/fc-keepalived notify stop"
 
     track_script {
         check_default_route_v4 weight 10
@@ -36,6 +43,7 @@ vrrp_sync_group router {
 
     track_file {
       check_stop_file
+      check_maint_file
     }
 }
 

--- a/nixos/roles/router/keepalived/rzob.conf
+++ b/nixos/roles/router/keepalived/rzob.conf
@@ -21,13 +21,20 @@ track_file check_stop_file {
   init_file 0
 }
 
+track_file check_maint_file {
+  # Used by fc-keepalived enter-maintenance
+  file /etc/keepalived/fcio_maintenance
+  weight -20
+  init_file 0
+}
+
 vrrp_sync_group router {
     group { mgm srv fe dhp }
 
-    notify_master "/etc/keepalived/fc-manage -v activate-configuration -s primary"
-    notify_backup "/etc/keepalived/fc-manage -v activate-configuration --base-system"
-    notify_fault "/etc/keepalived/fc-manage -v activate-configuration --base-system"
-    notify_stop "/etc/keepalived/fc-manage -v activate-configuration --base-system"
+    notify_master "/etc/keepalived/fc-keepalived notify master"
+    notify_backup "/etc/keepalived/fc-keepalived notify backup"
+    notify_fault "/etc/keepalived/fc-keepalived notify fault"
+    notify_stop "/etc/keepalived/fc-keepalived notify stop"
 
     track_script {
         check_default_route_v4 weight 10
@@ -36,6 +43,7 @@ vrrp_sync_group router {
 
     track_file {
       check_stop_file
+      check_maint_file
     }
 }
 

--- a/nixos/roles/router/keepalived/test.conf
+++ b/nixos/roles/router/keepalived/test.conf
@@ -12,6 +12,14 @@ vrrp_script check_default_route_v6 {
       rise 2
 }
 
+track_file check_maint_file {
+  # Used by fc-keepalived enter-maintenance
+  file /etc/keepalived/fcio_maintenance
+  weight -20
+  init_file 0
+}
+
+
 track_file check_stop_file {
   # Allow admins to locally send keepalive into FAIL state by adding
   # a non "0" entry
@@ -24,10 +32,10 @@ track_file check_stop_file {
 vrrp_sync_group router {
     group { mgm srv fe }
 
-    notify_master "/etc/keepalived/fc-manage -v activate-configuration -s primary"
-    notify_backup "/etc/keepalived/fc-manage -v activate-configuration --base-system"
-    notify_fault "/etc/keepalived/fc-manage -v activate-configuration --base-system"
-    notify_stop "/etc/keepalived/fc-manage -v activate-configuration --base-system"
+    notify_master "/etc/keepalived/fc-keepalived notify master"
+    notify_backup "/etc/keepalived/fc-keepalived notify backup"
+    notify_fault "/etc/keepalived/fc-keepalived notify fault"
+    notify_stop "/etc/keepalived/fc-keepalived notify stop"
 
     track_script {
         check_default_route_v4 weight 10
@@ -36,6 +44,7 @@ vrrp_sync_group router {
 
     track_file {
       check_stop_file
+      check_maint_file
     }
 }
 

--- a/nixos/roles/router/keepalived/whq.conf
+++ b/nixos/roles/router/keepalived/whq.conf
@@ -21,13 +21,20 @@ track_file check_stop_file {
   init_file 0
 }
 
+track_file check_maint_file {
+  # Used by fc-keepalived enter-maintenance
+  file /etc/keepalived/fcio_maintenance
+  weight -20
+  init_file 0
+}
+
 vrrp_sync_group router {
     group { mgm fe srv tr video access }
 
-    notify_master "/etc/keepalived/fc-manage -v activate-configuration -s primary"
-    notify_backup "/etc/keepalived/fc-manage -v activate-configuration --base-system"
-    notify_fault "/etc/keepalived/fc-manage -v activate-configuration --base-system"
-    notify_stop "/etc/keepalived/fc-manage -v activate-configuration --base-system"
+    notify_master "/etc/keepalived/fc-keepalived notify master"
+    notify_backup "/etc/keepalived/fc-keepalived notify backup"
+    notify_fault "/etc/keepalived/fc-keepalived notify fault"
+    notify_stop "/etc/keepalived/fc-keepalived notify stop"
 
     track_script {
         check_dev_route_v4 weight 10
@@ -36,6 +43,7 @@ vrrp_sync_group router {
 
     track_file {
       check_stop_file
+      check_maint_file
     }
 }
 

--- a/pkgs/fc/agent/fc/manage/keepalived.py
+++ b/pkgs/fc/agent/fc/manage/keepalived.py
@@ -1,0 +1,183 @@
+import os
+import time
+from pathlib import Path
+from typing import NamedTuple
+
+import fc.manage.manage
+import fc.util.enc
+import fc.util.keepalived
+import fc.util.logging
+import structlog
+from fc.maintenance.state import EXIT_TEMPFAIL
+from fc.util.keepalived import (
+    KEEPALIVED_STATE_FILE,
+    MAINT_MARKER_FILE,
+    KeepalivedState,
+    KeepalivedStateError,
+)
+from fc.util.nixos import Specialisation
+from fc.util.typer_utils import FCTyperApp
+from typer import Argument, Exit, Option
+
+app = FCTyperApp("fc-keepalived")
+
+
+class Context(NamedTuple):
+    logdir: Path
+    lock_dir: Path
+
+
+context: Context
+
+
+@app.callback()
+def fc_keepalived(
+    logdir: Path = Option(
+        exists=True,
+        file_okay=False,
+        writable=True,
+        default="/var/log",
+        help="Directory for log files, expects a fc-agent subdirectory there.",
+    ),
+    lock_dir: Path = Option(
+        exists=True,
+        file_okay=False,
+        writable=True,
+        default="/run/lock",
+        help="Directory where the lock file for exclusive operations should be "
+        "placed.",
+    ),
+):
+    global context
+    context = Context(
+        logdir=logdir,
+        lock_dir=lock_dir,
+    )
+
+    fc.util.logging.init_logging(
+        verbose=True, logdir=logdir, log_to_console=True
+    )
+
+
+@app.command()
+def check():
+    """
+    Checks keepalived maintenance state controlled by this script.
+
+    Two files are checked:
+    - maintenance marker file (is modified by fc-keepalived enter-maintenance
+      and leave-maintenance)
+    - keepalived state file (is modified by fc-keepalived notify).
+
+    XXX: turn this into a real Sensu check. At the moment, it just displays
+    log messages as a side effect of get_state().
+    """
+    log = structlog.get_logger()
+    fc.util.keepalived.get_state(log)
+
+
+@app.command()
+def enter_maintenance():
+    log = structlog.get_logger()
+    log.info("enter-maintenance")
+
+    try:
+        state = fc.util.keepalived.get_state(log)
+    except KeepalivedStateError:
+        log.warn("maint-skip")
+        raise Exit(EXIT_TEMPFAIL)
+
+    # No need to change the maintenance marker when the router is in a fault
+    # or stop state, just skip maintenance and signal a temporary failure.
+    if state in (KeepalivedState.FAULT, KeepalivedState.STOP):
+        log.warn("maint-skip", state=state)
+        raise Exit(EXIT_TEMPFAIL)
+
+    try:
+        # Reduces priority of keepalived by 20, should trigger a switchover to
+        # another router when we are primary here at the moment.
+        MAINT_MARKER_FILE.write_text("1")
+        elapsed = 0
+        while state == KeepalivedState.MASTER:
+            if elapsed > 60:
+                log.warn("switchover-timeout", elapsed=elapsed, state=state)
+                raise Exit(EXIT_TEMPFAIL)
+            log.debug("wait-for-backup-state", state=state, elapsed=elapsed)
+            time.sleep(1)
+            elapsed += 1
+            state_content = KEEPALIVED_STATE_FILE.read_text()
+            try:
+                state = KeepalivedState(state_content)
+            except ValueError:
+                log.error(
+                    "unexpected-state-file-content",
+                    state_content=state_content,
+                )
+                raise Exit(EXIT_TEMPFAIL)
+
+        if state == KeepalivedState.BACKUP:
+            log.debug("backup-state-reached")
+        else:
+            log.warn(
+                "unexpected-state-after-switch",
+                expected=KeepalivedState.BACKUP,
+                actual=state,
+            )
+            raise Exit(EXIT_TEMPFAIL)
+
+    except Exception:
+        MAINT_MARKER_FILE.write_text("0")
+        log.info("exception-reset-maint-marker")
+        raise
+
+    log.info("enter-maintenance-finished")
+
+
+@app.command()
+def leave_maintenance():
+    log = structlog.get_logger()
+    log.debug("leave-maintenance-start")
+    try:
+        state = fc.util.keepalived.get_state(log)
+    except KeepalivedStateError:
+        # get_state() has already logged the error.
+        # There's something wrong with the state/maintenance files, but we can
+        # still go on and leave maintenance.
+        state = None
+    log.info("reset-maint-marker")
+    MAINT_MARKER_FILE.write_text("0")
+    log.info("leave-maintenance-finished", state=state)
+
+
+@app.command()
+def notify(
+    new_state: KeepalivedState = Argument(..., help="New keepalived state"),
+):
+    """
+    Triggers a system switch when keepalived state changes.
+    To be used as keepalived notify script.
+
+
+    """
+    log = structlog.get_logger()
+    log.debug("notify", new_state=new_state)
+
+    if new_state == KeepalivedState.MASTER:
+        specialisation = "primary"
+    else:
+        specialisation = Specialisation.BASE_CONFIG
+
+    fc.manage.manage.switch_to_configuration(
+        log=log,
+        specialisation=specialisation,
+        lock_dir=context.lock_dir,
+        lazy=True,
+    )
+
+    KEEPALIVED_STATE_FILE.write_text(new_state.value)
+
+    log.info("notify-finished")
+
+
+if __name__ == "__main__":
+    app()

--- a/pkgs/fc/agent/fc/util/keepalived.py
+++ b/pkgs/fc/agent/fc/util/keepalived.py
@@ -1,0 +1,67 @@
+from datetime import datetime
+from enum import Enum
+from pathlib import Path
+
+KEEPALIVED_STATE_FILE = Path("/run/keepalived/state")
+MAINT_MARKER_FILE = Path("/etc/keepalived/fcio_maintenance")
+
+
+class KeepalivedState(Enum):
+    MASTER = "master"
+    BACKUP = "backup"
+    FAULT = "fault"
+    STOP = "stop"
+
+
+class KeepalivedStateError(Exception):
+    pass
+
+
+def get_state(log) -> KeepalivedState:
+    if not KEEPALIVED_STATE_FILE.exists():
+        log.error("keepalived-state-file-missing")
+        raise KeepalivedStateError(
+            f"Missing keepalive state file, expected at {KEEPALIVED_STATE_FILE}"
+        )
+
+    state_content = KEEPALIVED_STATE_FILE.read_text()
+    state_last_modified = datetime.fromtimestamp(
+        KEEPALIVED_STATE_FILE.stat().st_mtime
+    )
+    log.debug(
+        "keepalived-state-file",
+        content=state_content,
+        last_modified=state_last_modified.isoformat(),
+        path=str(KEEPALIVED_STATE_FILE),
+    )
+
+    if not MAINT_MARKER_FILE.exists():
+        log.error("maintenance-marker-file-missing")
+        raise KeepalivedStateError(
+            f"Maintenance marker file missing, expected at {MAINT_MARKER_FILE}"
+        )
+
+    maint_file_content = MAINT_MARKER_FILE.read_text()
+
+    maint_last_modified = datetime.fromtimestamp(
+        MAINT_MARKER_FILE.stat().st_mtime
+    )
+    maint = int(maint_file_content)
+
+    log.debug(
+        "maintenance-marker-file",
+        content=maint_file_content,
+        last_modified=maint_last_modified.isoformat(),
+        path=str(MAINT_MARKER_FILE),
+    )
+
+    try:
+        state = KeepalivedState(state_content)
+    except ValueError:
+        log.error("unexpected-state-file-content", content=state_content)
+        raise KeepalivedStateError(
+            f"State file content is not a keepalived state: '{state_content}'"
+        )
+    log.debug("status", state=state, in_maintenance=maint > 0)
+
+    return state

--- a/pkgs/fc/agent/setup.py
+++ b/pkgs/fc/agent/setup.py
@@ -70,6 +70,7 @@ setup(
             "fc-dhcpd=fc.manage.dhcpd:main",
             "fc-directory=fc.util.directory:directory_cli",
             "fc-graylog=fc.manage.graylog:main",
+            "fc-keepalived=fc.manage.keepalived:app",
             "fc-maintenance=fc.maintenance.cli:app",
             "fc-manage=fc.manage.cli:app",
             "fc-qemu-scrub=fc.manage.qemu:main",


### PR DESCRIPTION
- only one router may be in maintenance at the same time
- primary routers are switched to backup state by enter-maintenance (priority -20)
- routers in stop or fault states skip maintenance (tempfail)
- routers in backup state can start maintenance right away

PL-132407

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - routers must not run maintenance activities when they are primary to avoid routing interruptions
- [x] Security requirements tested? (EVIDENCE)
  - verified in dev that 
    - priority is lowered and switchover to other router works when entering maintenance as primary
    - a backup router just run enters maintenance without change and has lower priority during maintenance
    - a router in fault or stop state skips maintenance (without lowering its priority in the process)
    - running a script+update activity works as expected on a primary router
  - automated NixOS test executes a maintenance activity on the primary router and checks that the switchover happens 