### PR TITLE
[21.05] devhost: allow nat from dev vms to any interface

### DIFF
--- a/nixos/platform/firewall.nix
+++ b/nixos/platform/firewall.nix
@@ -125,7 +125,7 @@ in
     # configuration on the NixOS side. Users may set additional networking.nat.*
     # options in /etc/local/nixos.
     networking.nat.enable = true;
-    networking.nat.externalInterface = fclib.network.fe.interface;
+    networking.nat.externalInterface = fclib.mkPlatform fclib.network.fe.interface;
 
     networking.firewall =
       # our code generally assumes IPv6

--- a/nixos/roles/devhost/vm.nix
+++ b/nixos/roles/devhost/vm.nix
@@ -164,6 +164,8 @@ in {
         enable = true;
         enableIPv6 = true;
         internalInterfaces = [ "br-vm-srv" ];
+        # We need to NAT to brsrv and brfe
+        externalInterface = null;
       };
     };
     # Maybe switch to kea long-term, but it's not available in 21.05


### PR DESCRIPTION
PL-132532

@flyingcircusio/release-managers

## Release process

Impact: None

Changelog:

* devhost: allow nat from dev vms to any interface to fix bootstrap

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Dev VMs should be able to bootstrap and reach location DNS server
- [x] Security requirements tested? (EVIDENCE)
  - tested bootstrap on largo00

