### PR TITLE
[21.05] Test for firewall differences between specialisations in router role

### DIFF
--- a/tests/router/default.nix
+++ b/tests/router/default.nix
@@ -448,6 +448,14 @@ in
         router.execute("sed -i 'c 1' /etc/keepalived/stop")
         router.wait_until_succeeds("cat /tmp/agent-mock-called")
 
+      with subtest("Firewall configuration should not differ between primary and secondary"):
+        primary_system = router.r.primary_system
+        secondary_system = router.r.secondary_system
+
+        primary_firewall = router.execute(f"cat {primary_system}/etc/systemd/system/firewall.service")
+        secondary_firewall = router.execute(f"cat {secondary_system}/etc/systemd/system/firewall.service")
+        assert primary_firewall[1] == secondary_firewall[1], "firewall configuration differs between primary and secondary system"
+
       print(router.succeed("journalctl -xb -u keepalived"))
     '';
   };


### PR DESCRIPTION
This change adds a test for the router role which checks if the firewall service unit is the same between specialisations. Differences in the unit file will cause a reload when switching specialisations, which causes interruptions to connectivity, as established in #1003.

PL-132482

@flyingcircusio/release-managers

## Release process

Impact: internal.

Changelog: none.

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Regression test for previously fixed issue in the router role.
- [x] Security requirements tested? (EVIDENCE)
  - The test passes on the current state of the dev branch, and partially reverting the fix for the TFTP firewall rules causes the test to fail.
