### PR TITLE
[21.05] Disable resource group firewall rules on routers

### DIFF
--- a/nixos/platform/firewall.nix
+++ b/nixos/platform/firewall.nix
@@ -192,7 +192,7 @@ in
              then (lib.optionalString (rgRules != "")
                "# Accept traffic within the same resource group.\n${rgRules}\n\n")
              else ''
-               # Accept traffic on the SRV interface
+               # Accept traffic on the SRV interface, but disallow arbitrary access to Telegraf
                ip46tables -A nixos-fw -i ${fclib.network.srv.interface} -p tcp --dport 9126 -j nixos-fw-refuse
                ip46tables -A nixos-fw -i ${fclib.network.srv.interface} -j nixos-fw-accept
              ''

--- a/nixos/roles/router/default.nix
+++ b/nixos/roles/router/default.nix
@@ -213,6 +213,8 @@ in
       ip46tables -X fc-router-forward 2>/dev/null || true
     '';
 
+    flyingcircus.firewall.enableSrvRgFirewall = false;
+
     systemd.services = listToAttrs
       (lib.forEach (filter (iface: iface.policy == "vxlan") gatewayInterfaces)
         (iface: lib.nameValuePair


### PR DESCRIPTION
Normally, hosts will rebuild and reload their firewall rules when the SRV addresses in ENC for other hosts in the same resource group change -- this is intended to ensure that only hosts in the same resource group may reach each other over SRV. This is however less desirable on routers, as firewall reloads briefly cause all incoming packets to be dropped, which interrupts connectivity for other hosts.

This commit introduces a new NixOS option to allow the firewall rules restricting access to only the hosts in the same resource group to be disabled, replacing it with rules which allow all connections on the SRV interface. This rule is then enabled in the router role to ensure that new IP addresses in ENC does not cause firewall reloads. In the case where the RG rules are disabled, I've added a hard-coded exception to deny access to Telegraf, as the location statshost is already whitelisted, and Telegraf should not otherwise be world-readable.

PL-132581

@flyingcircusio/release-managers

## Release process

Impact: internal.

Changelog: none.

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
  - This option is for internal platform use only, and is hence only lightly documented.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Reducing frequency of firewall reloads on routers improves service availability.
  - Potentially sensitive metrics endpoints of platform-internal infrastructure should not be world-readable.
- [x] Security requirements tested? (EVIDENCE)
  - Tested with a test KVM server and test router in DEV.
  - No changes in the KVM host firewall; router firewall is left open on the SRV interface, however Telegraf port remains protected.