### PR TITLE
[21.05] Patch FRR to make bgpd output less noisy

### DIFF
--- a/pkgs/frr/0001-zebra-re-install-nhg-on-interface-up.patch
+++ b/pkgs/frr/0001-zebra-re-install-nhg-on-interface-up.patch
@@ -1,7 +1,7 @@
 From 2af4eb5a55225975d721dafdd1015dd50d2b820b Mon Sep 17 00:00:00 2001
 From: Ashwini Reddy <ashred@nvidia.com>
 Date: Wed, 19 Apr 2023 11:35:25 -0700
-Subject: [PATCH 1/3] zebra: re-install nhg on interface up
+Subject: [PATCH 1/4] zebra: re-install nhg on interface up
 
 Intermittently zebra and kernel are out of sync
 when interface flaps and the add's/dels are in
@@ -149,5 +149,5 @@ index 9b925bf10..18914b785 100644
  /* Forward ref of dplane update context type */
  struct zebra_dplane_ctx;
 -- 
-2.39.3 (Apple Git-145)
+2.39.3 (Apple Git-146)
 

--- a/pkgs/frr/0002-zebra-re-install-dependent-nhgs-on-interface-up.patch
+++ b/pkgs/frr/0002-zebra-re-install-dependent-nhgs-on-interface-up.patch
@@ -1,7 +1,7 @@
 From f6feefc2d6829ab81c3e81ab913a3c39ececba2c Mon Sep 17 00:00:00 2001
 From: Chirag Shah <chirag@nvidia.com>
 Date: Fri, 28 Apr 2023 19:09:55 -0700
-Subject: [PATCH 2/3] zebra:re-install dependent nhgs on interface up
+Subject: [PATCH 2/4] zebra:re-install dependent nhgs on interface up
 
 Upon interface up associated singleton NHG's
 dependent NHGs needs to be reinstalled as
@@ -101,5 +101,5 @@ index 78fa22de7..b17167540 100644
  	}
  }
 -- 
-2.39.3 (Apple Git-145)
+2.39.3 (Apple Git-146)
 

--- a/pkgs/frr/0003-zebra-fix-nhg-out-of-sync-between-zebra-and-kernel.patch
+++ b/pkgs/frr/0003-zebra-fix-nhg-out-of-sync-between-zebra-and-kernel.patch
@@ -1,7 +1,7 @@
 From 18042874ba5de1873e4dc312ef628c1f54255716 Mon Sep 17 00:00:00 2001
 From: anlan_cs <vic.lan@pica8.com>
 Date: Mon, 24 Jul 2023 14:40:22 +0800
-Subject: [PATCH 3/3] zebra: fix nhg out of sync between zebra and kernel
+Subject: [PATCH 3/4] zebra: fix nhg out of sync between zebra and kernel
 
 PR#13413 introduces reinstall mechanism, but there is problem with the route
 leak scenario.
@@ -87,5 +87,5 @@ index b17167540..5a5daecf5 100644
  					zlog_debug(
  						"%s: %pNHv given ifindex does not match nexthops ifindex found: %pNHv",
 -- 
-2.39.3 (Apple Git-145)
+2.39.3 (Apple Git-146)
 

--- a/pkgs/frr/0004-lib-add-missing-debug-guards-for-route-map.patch
+++ b/pkgs/frr/0004-lib-add-missing-debug-guards-for-route-map.patch
@@ -1,0 +1,39 @@
+From 136865918a96631ea95e099572208cf2b6dc2cad Mon Sep 17 00:00:00 2001
+From: Molly Miller <mm@flyingcircus.io>
+Date: Wed, 22 May 2024 16:23:07 +0200
+Subject: [PATCH 4/4] lib: add missing debug guards for route-map
+
+Upstream commit: 2336d279e083648e02034d54514b4a0a15b15f3f
+---
+ lib/routemap.c | 14 ++++++++------
+ 1 file changed, 8 insertions(+), 6 deletions(-)
+
+diff --git a/lib/routemap.c b/lib/routemap.c
+index 683943eb6..ee5f2f9f4 100644
+--- a/lib/routemap.c
++++ b/lib/routemap.c
+@@ -2579,13 +2579,15 @@ route_map_result_t route_map_apply_ext(struct route_map *map,
+ 	 */
+ 	if (prefix->family == AF_EVPN) {
+ 		if (evpn_prefix2prefix(prefix, &conv) != 0) {
+-			zlog_debug(
+-				"Unable to convert EVPN prefix %pFX into IPv4/IPv6 prefix. Falling back to non-optimized route-map lookup",
+-				prefix);
++			if (rmap_debug)
++				zlog_debug(
++					   "Unable to convert EVPN prefix %pFX into IPv4/IPv6 prefix. Falling back to non-optimized route-map lookup",
++					   prefix);
+ 		} else {
+-			zlog_debug(
+-				"Converted EVPN prefix %pFX into %pFX for optimized route-map lookup",
+-				prefix, &conv);
++			if (rmap_debug)
++				zlog_debug(
++					   "Converted EVPN prefix %pFX into %pFX for optimized route-map lookup",
++					   prefix, &conv);
+ 
+ 			prefix = &conv;
+ 		}
+-- 
+2.39.3 (Apple Git-146)
+

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -146,6 +146,7 @@ in {
       ./frr/0001-zebra-re-install-nhg-on-interface-up.patch
       ./frr/0002-zebra-re-install-dependent-nhgs-on-interface-up.patch
       ./frr/0003-zebra-fix-nhg-out-of-sync-between-zebra-and-kernel.patch
+      ./frr/0004-lib-add-missing-debug-guards-for-route-map.patch
     ];
   });
 


### PR DESCRIPTION
Currently bgpd outputs a lot of spurious log messages about optimised route lookups for EVPN routes, which makes reading through FRR logs cumbersome. These messages appear to come from debug print statements which should only be executed when route-map debugging has been requested by the operator, however they are incorrectly guarded and unconditionally executed as a result. This has been fixed upstream in newer versions of FRR.

This change introduces a new patch in our overlay to ensure that route-map debugging prints are only enabled when the appropriate configuration flag has been activated.

PL-132609

@flyingcircusio/release-managers

## Release process

Impact: internal

Changelog: none

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - This is a backport of an upstream fix, which makes the default logging output of FRR easier to process.
- [x] Security requirements tested? (EVIDENCE)
  - Tested manually on a host in DEV. After applying this patch, no log messages about optimised route-map lookups are printed unless the operator specifies `debug route-map` in the bgpd configuration.