### PR TITLE
Update nixpkgs (2024-05-27)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -57,11 +57,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1715593316,
-        "narHash": "sha256-S7XatU9uV3q9bVBcg/ER0VMQcnPZprrVlN209ne7LDw=",
+        "lastModified": 1716772813,
+        "narHash": "sha256-PLQ5Ap2BJ/EnLTY8KybwuOHDveVaH7Fvh+ItXzLL38M=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "725c90407ef53cc2a1b53701c6d2d0745cf2484f",
+        "rev": "a1290a186b9420e2c0b21700f300b486ad90dcc9",
         "type": "github"
       },
       "original": {
@@ -154,11 +154,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1714641030,
-        "narHash": "sha256-yzcRNDoyVP7+SCNX0wmuDju1NUCt8Dz9+lyUXEI0dbI=",
+        "lastModified": 1715865404,
+        "narHash": "sha256-/GJvTdTpuDjNn84j82cU6bXztE0MSkdnTWClUCRub78=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "e5d10a24b66c3ea8f150e47dfdb0416ab7c3390e",
+        "rev": "8dc45382d5206bd292f9c2768b8058a8fd8311d9",
         "type": "github"
       },
       "original": {
@@ -411,11 +411,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1715763972,
-        "narHash": "sha256-Xf/7fHwIykK+wdF8UjuA4hrzOrf4l3lvUvFVZTWmNyY=",
+        "lastModified": 1716842013,
+        "narHash": "sha256-xe+bTKopBu/5JfCl8B4OIazxLcYG6LoZYkqorqubGNw=",
         "owner": "flyingcircusio",
         "repo": "nixpkgs",
-        "rev": "2b151fba3ac708c04ae98c0bd2e4efd18869e80d",
+        "rev": "c7a78f96557f5ab6144173d69866658973a88b41",
         "type": "github"
       },
       "original": {

--- a/release/package-versions.json
+++ b/release/package-versions.json
@@ -70,14 +70,14 @@
     "version": "18.2.0"
   },
   "chromedriver": {
-    "name": "chromedriver-124.0.6367.201",
+    "name": "chromedriver-125.0.6422.78",
     "pname": "chromedriver",
-    "version": "124.0.6367.201"
+    "version": "125.0.6422.78"
   },
   "chromium": {
-    "name": "chromium-124.0.6367.201",
+    "name": "chromium-125.0.6422.112",
     "pname": "chromium",
-    "version": "124.0.6367.201"
+    "version": "125.0.6422.112"
   },
   "cifs-utils": {
     "name": "cifs-utils-7.0",
@@ -85,9 +85,9 @@
     "version": "7.0"
   },
   "clamav": {
-    "name": "clamav-1.2.2",
+    "name": "clamav-1.2.3",
     "pname": "clamav",
-    "version": "1.2.2"
+    "version": "1.2.3"
   },
   "cmake": {
     "name": "cmake-3.27.7",
@@ -140,9 +140,9 @@
     "version": "2.90"
   },
   "docker": {
-    "name": "docker-24.0.5",
+    "name": "docker-24.0.9",
     "pname": "docker",
-    "version": "24.0.5"
+    "version": "24.0.9"
   },
   "docker-compose": {
     "name": "docker-compose-2.23.1",
@@ -190,9 +190,9 @@
     "version": "7.17.16"
   },
   "firefox": {
-    "name": "firefox-125.0.3",
+    "name": "firefox-126.0",
     "pname": "firefox",
-    "version": "125.0.3"
+    "version": "126.0"
   },
   "gcc": {
     "name": "gcc-wrapper-12.3.0",
@@ -220,9 +220,9 @@
     "version": "2.42.0"
   },
   "gitaly": {
-    "name": "gitaly-16.10.5",
+    "name": "gitaly-16.10.6",
     "pname": "gitaly",
-    "version": "16.10.5"
+    "version": "16.10.6"
   },
   "github-runner": {
     "name": "github-runner-2.316.1",
@@ -230,24 +230,24 @@
     "version": "2.316.1"
   },
   "gitlab": {
-    "name": "gitlab-16.10.5",
+    "name": "gitlab-16.10.6",
     "pname": "gitlab",
-    "version": "16.10.5"
+    "version": "16.10.6"
   },
   "gitlab-container-registry": {
-    "name": "gitlab-container-registry-4.1.0",
+    "name": "gitlab-container-registry-4.2.0",
     "pname": "gitlab-container-registry",
-    "version": "4.1.0"
+    "version": "4.2.0"
   },
   "gitlab-ee": {
-    "name": "gitlab-ee-16.10.5",
+    "name": "gitlab-ee-16.10.6",
     "pname": "gitlab-ee",
-    "version": "16.10.5"
+    "version": "16.10.6"
   },
   "gitlab-pages": {
-    "name": "gitlab-pages-16.10.5",
+    "name": "gitlab-pages-16.10.6",
     "pname": "gitlab-pages",
-    "version": "16.10.5"
+    "version": "16.10.6"
   },
   "gitlab-runner": {
     "name": "gitlab-runner-16.10.0",
@@ -255,9 +255,9 @@
     "version": "16.10.0"
   },
   "gitlab-workhorse": {
-    "name": "gitlab-workhorse-16.10.5",
+    "name": "gitlab-workhorse-16.10.6",
     "pname": "gitlab-workhorse",
-    "version": "16.10.5"
+    "version": "16.10.6"
   },
   "glibc": {
     "name": "glibc-2.38-66",
@@ -435,9 +435,9 @@
     "version": "0.2.5"
   },
   "linux_5_15": {
-    "name": "linux-5.15.158",
+    "name": "linux-5.15.159",
     "pname": "linux",
-    "version": "5.15.158"
+    "version": "5.15.159"
   },
   "logrotate": {
     "name": "logrotate-3.21.0",
@@ -475,9 +475,9 @@
     "version": "4.16.1"
   },
   "matrix-synapse": {
-    "name": "matrix-synapse-wrapped-1.106.0",
+    "name": "matrix-synapse-wrapped-1.107.0",
     "pname": "matrix-synapse-wrapped",
-    "version": "1.106.0"
+    "version": "1.107.0"
   },
   "mcpp": {
     "name": "mcpp-2.7.2.1",
@@ -886,9 +886,9 @@
     "version": "7.2.4"
   },
   "roundcube": {
-    "name": "roundcube-1.6.6",
+    "name": "roundcube-1.6.7",
     "pname": "roundcube",
-    "version": "1.6.6"
+    "version": "1.6.7"
   },
   "rsync": {
     "name": "rsync-3.2.7",
@@ -931,9 +931,9 @@
     "version": "8.11.2"
   },
   "strace": {
-    "name": "strace-6.8",
+    "name": "strace-6.9",
     "pname": "strace",
-    "version": "6.8"
+    "version": "6.9"
   },
   "strongswan": {
     "name": "strongswan-5.9.11",
@@ -1006,9 +1006,9 @@
     "version": "9.0.2116"
   },
   "webkitgtk": {
-    "name": "webkitgtk-2.44.1+abi=4.0",
+    "name": "webkitgtk-2.44.2+abi=4.0",
     "pname": "webkitgtk",
-    "version": "2.44.1"
+    "version": "2.44.2"
   },
   "wget": {
     "name": "wget-1.21.4",

--- a/release/versions.json
+++ b/release/versions.json
@@ -8,9 +8,9 @@
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/"
   },
   "nixpkgs": {
-    "hash": "sha256-Xf/7fHwIykK+wdF8UjuA4hrzOrf4l3lvUvFVZTWmNyY=",
+    "hash": "sha256-xe+bTKopBu/5JfCl8B4OIazxLcYG6LoZYkqorqubGNw=",
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "2b151fba3ac708c04ae98c0bd2e4efd18869e80d"
+    "rev": "c7a78f96557f5ab6144173d69866658973a88b41"
   }
 }


### PR DESCRIPTION
Pull upstream NixOS changes, security fixes and package updates:

- chromedriver: 124.0.6367.201 -> 125.0.6422.112
- chromium: 124.0.6367.201 -> 125.0.6422.112
- clamav: 1.2.2 -> 1.2.3
- docker: 24.0.5 -> docker-24.0.9
- firefox: 125.0.3 -> 126.0
- gitlab: 16.10.5 -> 16.10.6
- libressl: backport to replace expiring certs
- linux_5_15: 5.15.158 -> 5.15.159
- matrix-synapse: 1.106.0 -> 1.107.0
- roundcube: 1.6.6 -> 1.6.7
- strace: 6.8 -> 6.9
- webkitgtk: 2.44.1 → 2.44.2

PL-132631

@flyingcircusio/release-managers

## Release process

Impact:

- reboot

Changelog:
- (include commit msg)

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - pull in upstream security fixes regularly
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still run, works on various test VM, including a Gitlab test system
  - checked commit log for fixed CVEs and possible problems with updates, looked at [synapse/upgrade.md](https://github.com/element-hq/synapse/blob/develop/docs/upgrade.md)