### PR TITLE
[24.05] pull in latest nixpkgs to update and unbreak imagemagick6

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -57,11 +57,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1716283962,
-        "narHash": "sha256-7uR/kbcILAcVh8WQH3rNIoKJUxK2JL6AEv5v5XFVUd0=",
+        "lastModified": 1716847473,
+        "narHash": "sha256-Sn3PpgNAmV9pLr8pefvVAiHzBebq23nFf5QeHqMfVGk=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "493a90dce3d276fb976f872bdbaa1af422b05b62",
+        "rev": "60ed3dba92ed027bb886611b53cf9b9d1e7f149e",
         "type": "github"
       },
       "original": {
@@ -411,11 +411,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1716293225,
-        "narHash": "sha256-pU9ViBVE3XYb70xZx+jK6SEVphvt7xMTbm6yDIF4xPs=",
+        "lastModified": 1716509168,
+        "narHash": "sha256-4zSIhSRRIoEBwjbPm3YiGtbd8HDWzFxJjw5DYSDy1n8=",
         "owner": "flyingcircusio",
         "repo": "nixpkgs",
-        "rev": "3eaeaeb6b1e08a016380c279f8846e0bd8808916",
+        "rev": "bfb7a882678e518398ce9a31a881538679f6f092",
         "type": "github"
       },
       "original": {

--- a/nixpkgs-config.nix
+++ b/nixpkgs-config.nix
@@ -9,7 +9,7 @@
   ];
 
   permittedInsecurePackages = [
-    "imagemagick-6.9.12-68" # Legacy, but gets updates. Customer still needs it.
+    "imagemagick-6.9.13-10" # Legacy, but gets updates. Customer still needs it.
     "openssl-1.1.1w" # EOL 2023-09-11, needed for Percona and older PHP versions.
     "python-2.7.18.8" # Needed for some legacy customer applications.
     "ruby-2.7.8" # EOL 2023-03-31, needed for Sensu checks

--- a/release/important_packages.json
+++ b/release/important_packages.json
@@ -62,6 +62,7 @@
   "grub2",
   "haproxy",
   "imagemagick",
+  "imagemagick6",
   "imagemagick7",
   "inetutils",
   "jdk",

--- a/release/package-versions.json
+++ b/release/package-versions.json
@@ -10,9 +10,9 @@
     "version": "2.4.59"
   },
   "asterisk": {
-    "name": "asterisk-20.6.0",
+    "name": "asterisk-20.8.1",
     "pname": "asterisk",
-    "version": "20.6.0"
+    "version": "20.8.1"
   },
   "auditbeat7-oss": {
     "name": "auditbeat-oss-7.17.16",
@@ -70,14 +70,14 @@
     "version": "18.2.1"
   },
   "chromedriver": {
-    "name": "chromedriver-125.0.6422.60",
+    "name": "chromedriver-125.0.6422.76",
     "pname": "chromedriver",
-    "version": "125.0.6422.60"
+    "version": "125.0.6422.76"
   },
   "chromium": {
-    "name": "chromium-125.0.6422.60",
+    "name": "chromium-125.0.6422.76",
     "pname": "chromium",
-    "version": "125.0.6422.60"
+    "version": "125.0.6422.76"
   },
   "cifs-utils": {
     "name": "cifs-utils-7.0",
@@ -215,14 +215,14 @@
     "version": "10.02.1"
   },
   "git": {
-    "name": "git-2.44.0",
+    "name": "git-2.44.1",
     "pname": "git",
-    "version": "2.44.0"
+    "version": "2.44.1"
   },
   "gitaly": {
-    "name": "gitaly-16.10.5",
+    "name": "gitaly-16.10.6",
     "pname": "gitaly",
-    "version": "16.10.5"
+    "version": "16.10.6"
   },
   "github-runner": {
     "name": "github-runner-2.316.1",
@@ -230,9 +230,9 @@
     "version": "2.316.1"
   },
   "gitlab": {
-    "name": "gitlab-16.10.5",
+    "name": "gitlab-16.10.6",
     "pname": "gitlab",
-    "version": "16.10.5"
+    "version": "16.10.6"
   },
   "gitlab-container-registry": {
     "name": "gitlab-container-registry-4.1.0",
@@ -240,14 +240,14 @@
     "version": "4.1.0"
   },
   "gitlab-ee": {
-    "name": "gitlab-ee-16.10.5",
+    "name": "gitlab-ee-16.10.6",
     "pname": "gitlab-ee",
-    "version": "16.10.5"
+    "version": "16.10.6"
   },
   "gitlab-pages": {
-    "name": "gitlab-pages-16.10.5",
+    "name": "gitlab-pages-16.10.6",
     "pname": "gitlab-pages",
-    "version": "16.10.5"
+    "version": "16.10.6"
   },
   "gitlab-runner": {
     "name": "gitlab-runner-16.11.1",
@@ -255,12 +255,12 @@
     "version": "16.11.1"
   },
   "gitlab-workhorse": {
-    "name": "gitlab-workhorse-16.10.5",
+    "name": "gitlab-workhorse-16.10.6",
     "pname": "gitlab-workhorse",
-    "version": "16.10.5"
+    "version": "16.10.6"
   },
   "glibc": {
-    "name": "glibc-2.39-31",
+    "name": "glibc-2.39-52",
     "pname": "glibc",
     "version": "2.39"
   },
@@ -275,9 +275,9 @@
     "version": "2.4.5"
   },
   "go": {
-    "name": "go-1.22.2",
+    "name": "go-1.22.3",
     "pname": "go",
-    "version": "1.22.2"
+    "version": "1.22.3"
   },
   "go_1_19": {},
   "go_1_20": {},
@@ -377,9 +377,9 @@
     "version": "1.10.3"
   },
   "libjpeg": {
-    "name": "libjpeg-turbo-3.0.2",
+    "name": "libjpeg-turbo-3.0.3",
     "pname": "libjpeg-turbo",
-    "version": "3.0.2"
+    "version": "3.0.3"
   },
   "libmodsecurity": {
     "name": "libmodsecurity-3.0.12",
@@ -407,9 +407,9 @@
     "version": "1.4.0"
   },
   "libxml2": {
-    "name": "libxml2-2.12.6",
+    "name": "libxml2-2.12.7",
     "pname": "libxml2",
-    "version": "2.12.6"
+    "version": "2.12.7"
   },
   "libxslt": {
     "name": "libxslt-1.1.39",
@@ -718,9 +718,9 @@
     "version": "1.8.3"
   },
   "polkit": {
-    "name": "polkit-123",
+    "name": "polkit-124",
     "pname": "polkit",
-    "version": "123"
+    "version": "124"
   },
   "postfix": {
     "name": "postfix-3.9.0",
@@ -728,34 +728,34 @@
     "version": "3.9.0"
   },
   "postgresql": {
-    "name": "postgresql-15.6",
+    "name": "postgresql-15.7",
     "pname": "postgresql",
-    "version": "15.6"
+    "version": "15.7"
   },
   "postgresql_12": {
-    "name": "postgresql-12.18",
+    "name": "postgresql-12.19",
     "pname": "postgresql",
-    "version": "12.18"
+    "version": "12.19"
   },
   "postgresql_13": {
-    "name": "postgresql-13.14",
+    "name": "postgresql-13.15",
     "pname": "postgresql",
-    "version": "13.14"
+    "version": "13.15"
   },
   "postgresql_14": {
-    "name": "postgresql-14.11",
+    "name": "postgresql-14.12",
     "pname": "postgresql",
-    "version": "14.11"
+    "version": "14.12"
   },
   "postgresql_15": {
-    "name": "postgresql-15.6",
+    "name": "postgresql-15.7",
     "pname": "postgresql",
-    "version": "15.6"
+    "version": "15.7"
   },
   "postgresql_16": {
-    "name": "postgresql-16.2",
+    "name": "postgresql-16.3",
     "pname": "postgresql",
-    "version": "16.2"
+    "version": "16.3"
   },
   "powerdns": {
     "name": "pdns-4.9.0",
@@ -960,9 +960,9 @@
     "version": "12.7.4"
   },
   "systemd": {
-    "name": "systemd-255.4",
+    "name": "systemd-255.6",
     "pname": "systemd",
-    "version": "255.4"
+    "version": "255.6"
   },
   "tcpdump": {
     "name": "tcpdump-4.99.4",
@@ -970,9 +970,9 @@
     "version": "4.99.4"
   },
   "telegraf": {
-    "name": "telegraf-1.30.2",
+    "name": "telegraf-1.30.3",
     "pname": "telegraf",
-    "version": "1.30.2"
+    "version": "1.30.3"
   },
   "tmux": {
     "name": "tmux-3.4",
@@ -995,9 +995,9 @@
     "version": "6.0"
   },
   "util-linux": {
-    "name": "util-linux-2.39.3",
+    "name": "util-linux-2.40.1",
     "pname": "util-linux",
-    "version": "2.39.3"
+    "version": "2.40.1"
   },
   "varnish": {
     "name": "varnish-7.4.3",
@@ -1010,9 +1010,9 @@
     "version": "9.1.0377"
   },
   "webkitgtk": {
-    "name": "webkitgtk-2.44.1+abi=4.0",
+    "name": "webkitgtk-2.44.2+abi=4.0",
     "pname": "webkitgtk",
-    "version": "2.44.1"
+    "version": "2.44.2"
   },
   "wget": {
     "name": "wget-1.21.4",
@@ -1025,9 +1025,9 @@
     "version": "1.0.20210914"
   },
   "xfsprogs": {
-    "name": "xfsprogs-6.6.0",
+    "name": "xfsprogs-6.8.0",
     "pname": "xfsprogs",
-    "version": "6.6.0"
+    "version": "6.8.0"
   },
   "xorg.libX11": {
     "name": "libX11-1.8.9",

--- a/release/update-nixpkgs.py
+++ b/release/update-nixpkgs.py
@@ -27,7 +27,8 @@ class NixOSVersion(StrEnum):
     NIXOS_2211 = "nixos-22.11"
     NIXOS_2305 = "nixos-23.05"
     NIXOS_2311 = "nixos-23.11"
-    NIXOS_UNSTABLE = "nixos-24.05"
+    NIXOS_2405 = "nixos-24.05"
+    NIXOS_UNSTABLE = "nixos-24.11"
 
     @property
     def upstream_branch(self) -> str:

--- a/release/versions.json
+++ b/release/versions.json
@@ -8,9 +8,9 @@
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/"
   },
   "nixpkgs": {
-    "hash": "sha256-pU9ViBVE3XYb70xZx+jK6SEVphvt7xMTbm6yDIF4xPs=",
+    "hash": "sha256-4zSIhSRRIoEBwjbPm3YiGtbd8HDWzFxJjw5DYSDy1n8=",
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "3eaeaeb6b1e08a016380c279f8846e0bd8808916"
+    "rev": "bfb7a882678e518398ce9a31a881538679f6f092"
   }
 }


### PR DESCRIPTION
@flyingcircusio/release-managers

PL-132541

Pull upstream NixOS changes, security fixes and package updates:

- chromedriver: 125.0.6422.60 -> 125.0.6422.76
- chromium: 125.0.6422.60 -> 125.0.6422.76
- git: 2.44.0 -> 2.44.1
- gitlab: 16.10.5 -> 16.10.6, (#313641)
- glibc: 2.39-31 -> 2.39-52
- go: 1.22.2 -> 1.22.3
- imagemagick6: 6.9.12-68 -> 6.9.13-10
- libjpeg: 3.0.2 -> 3.0.3
- libxml2: 2.12.6 -> 2.12.7
- polkit: 123 -> 124
- polkit: move patch from archived upstream to local
- polkit: upstream moved to github
- postgresql: drop obsolete musl checkPhase fix
- postgresql_12: 12.18 -> 12.19
- postgresql_13: 13.14 -> 13.15
- postgresql_14: 14.11 -> 14.12, fix https://github.com/advisories/GHSA-37xw-rpjg-xxfx
- postgresql_15: 15.6 -> 15.7, fix https://github.com/advisories/GHSA-37xw-rpjg-xxfx
- postgresql_16: 16.2 -> 16.3, fix https://github.com/advisories/GHSA-37xw-rpjg-xxfx
- qemu: enable canokey by default
- sgx-ssl: openssl: 3.0.12 -> 3.0.13
- systemd: 255.4 -> 255.6
- systemd: fix disabling seccomp
- telegraf: 1.30.2 -> 1.30.3
- telegraf: only run nixosTests on linux
- util-linux: 2.39.3 -> 2.39.4, (except 64-bit linux for now)
- util-linux: also downgrade static builds already
- util-linux: try to fix parallel build failures
- webkitgtk: 2.44.1 → 2.44.2
- xfsprogs: 6.6.0 -> 6.8.0
- zlib: link with --undefined-version on lld

## Release process

Impact:

Changelog:

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - this pre-branch will be reviewed separately as a PR again
  - pull in software updates
  - imagemagick6 has known CVEs, but is deliberately still allowed as some customers require it 
- [x] Security requirements tested? (EVIDENCE)
  - all tests still pass