### PR TITLE
[24.05] fix trace output of evals

### DIFF
--- a/doc/src/base.md
+++ b/doc/src/base.md
@@ -55,7 +55,7 @@ You can look up packages and their descriptions via the [NixOS Package Search](h
 - netcat
 - ngrep
 - nix-top
-- nixfmt
+- nixfmt-rfc-style
 - nmap
 - nvd
 - openssl

--- a/nixos/infrastructure/testing.nix
+++ b/nixos/infrastructure/testing.nix
@@ -6,7 +6,6 @@
     boot.loader.grub.device = "/dev/sda";
     fileSystems."/".device = "/dev/disk/by-label/nixos";
     networking.useDHCP = lib.mkForce false;
-    users.users.root.password = "";
 
     flyingcircus.agent.enable = lib.mkOverride 200 false;
     flyingcircus.enc = config.fclib.mkPlatform {

--- a/nixos/platform/packages.nix
+++ b/nixos/platform/packages.nix
@@ -42,7 +42,7 @@
         netcat
         ngrep
         nix-top
-        nixfmt
+        nixfmt-rfc-style
         nmap
         nvd
         openssl

--- a/nixos/services/postgresql/default.nix
+++ b/nixos/services/postgresql/default.nix
@@ -265,7 +265,6 @@ in {
         dataDir = "/srv/postgresql/${cfg.majorVersion}";
         extraPlugins = extensions;
         initialScript = ./postgresql-init.sql;
-        logLinePrefix = "user=%u,db=%d ";
         package = postgresqlPkg;
 
         ensureDatabases = [ "fcio_monitoring" ];
@@ -323,6 +322,7 @@ in {
           #------------------------------------------------------------------------------
           # ERROR REPORTING AND LOGGING
           #------------------------------------------------------------------------------
+          log_line_prefix = "user=%u,db=%d ";
           log_min_duration_statement = 100;
           log_checkpoints = true;
           log_connections = true;

--- a/tests/ferretdb.nix
+++ b/tests/ferretdb.nix
@@ -42,7 +42,7 @@ in {
       with subtest("killing the ferretdb process should trigger an automatic restart"):
         _, out = machine.systemctl("show ferretdb --property MainPID --value")
         previous_pid = int(out.strip())
-        machine.succeed("systemctl kill -s KILL ferretdb")
+        machine.succeed("systemctl kill -s KILL --kill-whom main ferretdb")
         machine.wait_until_succeeds('test $(systemctl show ferretdb --property NRestarts --value) -eq "1"')
         machine.wait_until_succeeds("${sensuCheck "ferretdb"}")
         _, out = machine.systemctl("show ferretdb --property MainPID --value")

--- a/tests/mongodb.nix
+++ b/tests/mongodb.nix
@@ -53,7 +53,7 @@ in {
       with subtest("killing the opensearch process should trigger an automatic restart"):
         _, out = machine.systemctl("show mongodb --property MainPID --value")
         previous_pid = int(out.strip())
-        machine.succeed("systemctl kill -s KILL mongodb")
+        machine.succeed("systemctl kill -s KILL --kill-whom main mongodb")
         machine.wait_until_succeeds('test $(systemctl show mongodb --property NRestarts --value) -eq "1"')
         machine.wait_until_succeeds("${sensuCheck "mongodb"}")
         _, out = machine.systemctl("show mongodb --property MainPID --value")


### PR DESCRIPTION
@flyingcircusio/release-managers

[PL-132612](https://yt.flyingcircus.io/issue/PL-132612/fix-trace-output-of-evals)

## Release process

Impact:

Changelog:

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - This should fix warnings from upstream changes in order to match closer to upstream.
  - Users shouldn't be bothered by these warnings
  - Our tests should become less noisy
- [x] Security requirements tested? (EVIDENCE)
  - ran a sample test (ferretdb in my case) locally
  - also built a vm from these changes
  - all warnings are now gone, only trace output remaining is `Obsolete option `flyingcircus.roles.statshost.enable' is used. It was renamed to `flyingcircus.roles.statshost-global.enable'.`, which isn't related to the nixos release iirc.
