### PR TITLE
nixos/dev-vm: use sha512crypt for developer password

### DIFF
--- a/nixos/infrastructure/container.nix
+++ b/nixos/infrastructure/container.nix
@@ -147,7 +147,7 @@ in
           login_shell = "/bin/bash";
           name = "Developer";
           # password: vagrant
-          password = "$5$xS9kX8R5VNC0g$ZS7QkUYTk/61dUyUgq9r0jLAX1NbiScBT5v1PODz4UC";
+          password = "$6$wOGPiYC.CCUnRIix$HcY4OtrjjOWGsKTvdG4fj6zNcJlhfban2nof3vQxo4CIE3f.rLqrBfsR84KMiGAlyqRul.MYJfNm3f15h/x7w1";
           permissions = { container = [ "admins" "login" "manager" "sudo-srv" ]; };
           ssh_pubkey = [
            "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGc7V2c2zFPRMl8/gmBv1/MEldEuJau8jHjhx+2qziYs root@ct-dir-dev2"

--- a/nixos/infrastructure/dev-vm.nix
+++ b/nixos/infrastructure/dev-vm.nix
@@ -150,7 +150,7 @@ in {
           login_shell = "/bin/bash";
           name = "Developer";
           # password: vagrant
-          password = "$5$xS9kX8R5VNC0g$ZS7QkUYTk/61dUyUgq9r0jLAX1NbiScBT5v1PODz4UC";
+          password = "$6$wOGPiYC.CCUnRIix$HcY4OtrjjOWGsKTvdG4fj6zNcJlhfban2nof3vQxo4CIE3f.rLqrBfsR84KMiGAlyqRul.MYJfNm3f15h/x7w1";
           permissions = { container = [ "admins" "login" "manager" "sudo-srv" ]; };
           ssh_pubkey = [
            "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGc7V2c2zFPRMl8/gmBv1/MEldEuJau8jHjhx+2qziYs root@ct-dir-dev2"


### PR DESCRIPTION
That way, it can be checked using `crypt(3)` provided by the default `libxcrypt` from `nixpkgs` which only enables strong hashes. `$5$` (a.k.a sha256crypt) is not part of that[1].

[1] https://github.com/besser82/libxcrypt/blob/72f75aa370ae96ccd2cc44ea3cf4182d8679ffbe/lib/hashes.conf#L50

PL-132549

@flyingcircusio/release-managers

## Release process

Impact: 

Changelog:

- devhost: upgrade password hash for the `developer` user to sha512crypt.


### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - [x] Be able to use the same, secure defaults NixOS provides (here: supported hashes of `pkgs.libxcrypt`) in dev environments.
    It's not about the hash, the cleartext value is right above in a comment.
- [x] Security requirements tested? (EVIDENCE)
  - [x] Confirmed on the devhost where I initially noticed this that I no longer need `pkgs.libxcrypt-legacy`.