### PR TITLE
[23.05] Fix nameservers, use floating service IPs. Remove retired IPs.

### DIFF
--- a/nixos/platform/static.nix
+++ b/nixos/platform/static.nix
@@ -72,9 +72,9 @@ with lib;
         #
         # This seems to be https://sourceware.org/bugzilla/show_bug.cgi?id=13028
         # which is fixed in glibc 2.22 which is included in NixOS 16.03.
-        dev = [ "172.20.2.1" "172.20.3.7" "172.20.3.57" ];
-        whq = [ "212.122.41.129" "212.122.41.173" "212.122.41.169" ];
-        rzob = [ "195.62.125.1" "195.62.126.130" "195.62.126.131" ];
+        dev = [ "172.20.2.1" ];
+        whq = [ "172.16.48.1" ];
+        rzob = [ "172.22.48.1" ];
         standalone = [ "9.9.9.9" "8.8.8.8" ];
       };
 


### PR DESCRIPTION
Re PL-132679

@flyingcircusio/release-managers

## Release process

Impact:

none

Changelog:

* Update our DNS resolver IPs and limit to redundant, floating service IPs to avoid intermittent DNS issues caused by clients with unpredictable behaviour. (PL-132679)

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

* Reliability
* decouple services from individual machine configurations

- [x] Security requirements tested? (EVIDENCE)

 same settings as on 23.11