### PR TITLE
[21.05] router/firewall: reopen port 80/443 as we need Let's Encrypt.

### DIFF
--- a/nixos/roles/router/default.nix
+++ b/nixos/roles/router/default.nix
@@ -167,6 +167,8 @@ in
         #############
         # Protect SRV
         ip46tables -A fc-router-forward -o ${fclib.network.srv.interface} -p tcp --dport 22 -j ACCEPT
+        ip46tables -A fc-router-forward -o ${fclib.network.srv.interface} -p tcp --dport 80 -j ACCEPT
+        ip46tables -A fc-router-forward -o ${fclib.network.srv.interface} -p tcp --dport 443 -j ACCEPT
         ip46tables -A fc-router-forward -o ${fclib.network.srv.interface} -p tcp --dport 8140 -j ACCEPT
         ip46tables -A fc-router-forward -o ${fclib.network.srv.interface} -j REJECT
 


### PR DESCRIPTION
Those ports were turned off during the router migration to NixOS because we thought they were only there for historical reasons when we used to present awstats on this port. Nowadays, we do leverage let's encrypt for internal names in many places and this breaks certificate generation/renewal.

VMs protect themselves on 80/443 anyway, so this is safe.

Re PL-132680

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

- Reopen port 80/443 on our border routers for SRV to allow VMs to interact with Let's Encrypt for internal names.

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x]  [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

General network security has been thought through here and we need those ports to remain functional and ensure availability.

- [x] Security requirements tested? (EVIDENCE)

manually rolled out the change as a quick fix via directory enc nixos configs on all nixos routers