### PR TITLE
fix? mail in devhost

### DIFF
--- a/doc/src/kubernetes.md
+++ b/doc/src/kubernetes.md
@@ -281,7 +281,7 @@ to generate backends that are dynamically populated with the pod IPs
 automatically when you add/remove pods. By default, up to 10 pods are used by
 HAProxy. You can change the `maxExpectedPods` setting described below.
 
-See {ref}`webgateway` for more details about general HAProxy and nginx
+See {ref}`nixos-webgateway` for more details about general HAProxy and nginx
 configuration.
 
 

--- a/nixos/infrastructure/dev-vm.nix
+++ b/nixos/infrastructure/dev-vm.nix
@@ -93,8 +93,8 @@ in {
 
       flyingcircus.roles.memcached.listenAddresses = [ "0.0.0.0" "[::]" ];
 
-      flyingcircus.roles.mailserver.smtpBind4 = [ "127.0.0.1" ];
-      flyingcircus.roles.mailserver.smtpBind6 = [ "::1" ];
+      flyingcircus.roles.mailserver.smtpBind4 = "127.0.0.1";
+      flyingcircus.roles.mailserver.smtpBind6 = "::1";
       flyingcircus.roles.mailserver.explicitSmtpBind = false;
 
       flyingcircus.roles.mysql.listenAddresses = [ "::" ];
@@ -155,7 +155,8 @@ in {
           ssh_pubkey = [
            "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGc7V2c2zFPRMl8/gmBv1/MEldEuJau8jHjhx+2qziYs root@ct-dir-dev2"
           ];
-          uid = "developer";}
+          uid = "developer";
+          email_addresses = []; }
         { class = "service";
           gid = 100;
           home_directory = "/srv/s-dev";
@@ -165,7 +166,8 @@ in {
           name = "s-dev";
           ssh_pubkey = [] ;
           permissions = { container = []; };
-          uid = "s-dev"; } ];
+          uid = "s-dev";
+          email_addresses = []; } ];
 
       flyingcircus.users.permissions = [
         { description = "commit to VCS repository";


### PR DESCRIPTION
PL-132682

@flyingcircusio/release-managers

## Release process

Impact: -

Changelog:
- `flyingcircus.roles.mailserver` now works in the devhost environment

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - [x] must not introduce known regressions
  - [x] fixes a previously-broken issue in devhosts
- [ ] Security requirements tested? (EVIDENCE)
  - [x] automated NixOS tests still pass
  - [x]  tested by the customer
  - [x] the situation definitely improved compared to the previously broken state