### PR TITLE
[21.05] add 24.05 images

### DIFF
--- a/pkgs/fc/ceph/src/fc/ceph/maintenance/images_nautilus.py
+++ b/pkgs/fc/ceph/src/fc/ceph/maintenance/images_nautilus.py
@@ -36,6 +36,10 @@ RELEASES = [
     "fc-23.11-dev",
     "fc-23.11-staging",
     "fc-23.11-production",
+    "fc-24.05-dev",
+    "fc-24.05-staging",
+    "fc-24.05-production",
+    "pre-fc-24.05",
     "ts-test",
 ]
 CEPH_CONF = "/etc/ceph/ceph.conf"

--- a/pkgs/fc/ceph/src/fc/ceph/maintenance/nautilus.py
+++ b/pkgs/fc/ceph/src/fc/ceph/maintenance/nautilus.py
@@ -167,8 +167,8 @@ class MaintenanceTasks(object):
         else:
             return False
 
-    def load_vm_images(self):
-        load_vm_images_task()
+    def load_vm_images(self) -> int:
+        return load_vm_images_task()
 
     def purge_old_snapshots(self) -> int:
         status_code = 0


### PR DESCRIPTION
Adds the 24.05 release images the old way, hopefully for the last time.

Currently, all images put pre-fc-24.05 are placeholders still pointing to 23.11, to avoid bogus failures of the image loading job.
The failures that happened before adding the placeholder jobs also inspired me to rework the error handling of individual jobs to not block following image pull jobs.

PL-132686

@flyingcircusio/release-managers

## Release process

Impact: internal

Changelog:
- fc-ceph-load-vm-images:
  - add all 24.05 images to list of images to pull
  - improve error handling: individual job failures do not block other jobs

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - improve locality of error handling to prevent jobs from becoming unnecessary stale
  - must not introduce new known regressions
  - change needs to be tested 
- [x] Security requirements tested? (EVIDENCE)
  - [x] automated tests still pass
  - [x] manually tested on a dev host
    - continuing after known-broken pull jobs
    - status code evaluation
    - default case without errors tested as well 