### PR TITLE
[24.05] fix ACME account reregistration, update nixpkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -57,11 +57,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1717507522,
-        "narHash": "sha256-yE/djn0anGdWQ2yfiE8m82VXvWwB0+CIgEvjW8GfGlc=",
+        "lastModified": 1718001032,
+        "narHash": "sha256-kaL1/ruHEEm5+4OCaFfspCyaguUVrbmkad7A3fXaGF0=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "8485851fadfce27d394fabbc4ccb679c84f8c0dc",
+        "rev": "50e981f8a08cc06553ac591c658f347f6087d836",
         "type": "github"
       },
       "original": {
@@ -408,11 +408,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1717281328,
-        "narHash": "sha256-evZPzpf59oNcDUXxh2GHcxHkTEG4fjae2ytWP85jXRo=",
+        "lastModified": 1717696253,
+        "narHash": "sha256-1+ua0ggXlYYPLTmMl3YeYYsBXDSCqT+Gw3u6l4gvMhA=",
         "owner": "flyingcircusio",
         "repo": "nixpkgs",
-        "rev": "b3b2b28c1daa04fe2ae47c21bb76fd226eac4ca1",
+        "rev": "9b5328b7f761a7bbdc0e332ac4cf076a3eedb89b",
         "type": "github"
       },
       "original": {

--- a/nixos/platform/acme.nix
+++ b/nixos/platform/acme.nix
@@ -42,4 +42,7 @@ in
     # fallback ACME settings
     security.acme.acceptTerms = true;
     security.acme.defaults.email = "admin@flyingcircus.io";
+    # get back ACME account hash generation of <= NixOS 23.11 to avoid forced
+    # re-registration, see https://github.com/NixOS/nixpkgs/issues/316608
+    security.acme.defaults.server = null;
 }

--- a/release/package-versions.json
+++ b/release/package-versions.json
@@ -225,9 +225,9 @@
     "version": "16.10.6"
   },
   "github-runner": {
-    "name": "github-runner-2.316.1",
+    "name": "github-runner-2.317.0",
     "pname": "github-runner",
-    "version": "2.316.1"
+    "version": "2.317.0"
   },
   "gitlab": {
     "name": "gitlab-16.10.6",
@@ -327,9 +327,9 @@
     "version": "17.0.8-b1000.8"
   },
   "jetty": {
-    "name": "jetty-12.0.8",
+    "name": "jetty-12.0.9",
     "pname": "jetty",
-    "version": "12.0.8"
+    "version": "12.0.9"
   },
   "jicofo": {
     "name": "jicofo-1.0-1078",
@@ -357,6 +357,16 @@
     "version": "21+35"
   },
   "k3s": {
+    "name": "k3s-1.30.1+k3s1",
+    "pname": "k3s",
+    "version": "1.30.1+k3s1"
+  },
+  "k3s_1_27": {
+    "name": "k3s-1.27.14+k3s1",
+    "pname": "k3s",
+    "version": "1.27.14+k3s1"
+  },
+  "k3s_1_30": {
     "name": "k3s-1.30.1+k3s1",
     "pname": "k3s",
     "version": "1.30.1+k3s1"
@@ -502,19 +512,19 @@
     "version": "2.6.2"
   },
   "nginx": {
-    "name": "nginx-1.26.0",
+    "name": "nginx-1.26.1",
     "pname": "nginx",
-    "version": "1.26.0"
+    "version": "1.26.1"
   },
   "nginxMainline": {
-    "name": "nginx-1.25.4",
+    "name": "nginx-1.27.0",
     "pname": "nginx",
-    "version": "1.25.4"
+    "version": "1.27.0"
   },
   "nginxStable": {
-    "name": "nginx-1.26.0",
+    "name": "nginx-1.26.1",
     "pname": "nginx",
-    "version": "1.26.0"
+    "version": "1.26.1"
   },
   "nix": {
     "name": "nix-2.18.2",

--- a/release/versions.json
+++ b/release/versions.json
@@ -8,9 +8,9 @@
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/"
   },
   "nixpkgs": {
-    "hash": "sha256-evZPzpf59oNcDUXxh2GHcxHkTEG4fjae2ytWP85jXRo=",
+    "hash": "sha256-1+ua0ggXlYYPLTmMl3YeYYsBXDSCqT+Gw3u6l4gvMhA=",
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "b3b2b28c1daa04fe2ae47c21bb76fd226eac4ca1"
+    "rev": "9b5328b7f761a7bbdc0e332ac4cf076a3eedb89b"
   }
 }


### PR DESCRIPTION
Set the ACME server URL to a value that enforces the creation of the same account hashes as in 23.11 and earlier, to avoid a forced mass re-registration.
Pulls in the latest nixpkgs that allows to do that. This is the main reason of decoupling this into a PR first.

PL-132659

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - updating from 23.11 to 24.05 must not trigger an account re-registration for Let's Encrypt
- [x] Security requirements tested? (EVIDENCE)
  - [x] manually tested that update on a test vm
  - [x] automated tests still pass (except for known-broken rich-rst opensearch dashboard test)
