### PR TITLE
mongodb: add to important packages

### DIFF
--- a/release/important_packages.json
+++ b/release/important_packages.json
@@ -98,6 +98,8 @@
   "matrix-synapse",
   "mcpp",
   "memcached",
+  "mongodb",
+  "mongodb-6_0",
   "monitoring-plugins",
   "mysql",
   "mysql80",


### PR DESCRIPTION
To ensure that mongodb binaries are available in our cache, readilyl availble for customers to build their own deployments without having to compile the package on the VM, the package is marked as important.

`mongodb-6_0` because this is the version currently interesting, and `mongodb` to see when there's a major version change in the package version diff.

FC-38101

@flyingcircusio/release-managers

## Release process

Impact: none

Changelog:
- mongodb-6_0: ensure availability in binary cache by adding it as important package

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (FC-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board: no, because it is an AppOps ticket
- [ ] ticket state set to *Pull request ready*: no, because AppOps ticket
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
  - n/a
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
  -n/a
## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - none, except that `tested` jobset still needs to build 
- [ ] Security requirements tested? (EVIDENCE)
