### PR TITLE
[21.05] router ssh startup

### DIFF
--- a/nixos/roles/router/default.nix
+++ b/nixos/roles/router/default.nix
@@ -115,6 +115,14 @@ in
       "net.netfilter.nf_conntrack_buckets" = 32768;
     };
 
+    services.openssh.extraConfig = ''
+      # Protect routers more aggressively against DOS on the MaxStartup settings.
+      # We do not support password logins, so a small login grace time helps
+      # reducing unauthenticated sessions piling up.
+      LoginGraceTime 10
+      MaxStartups 100:30:500
+    '';
+
     environment.etc."specialisation".text = lib.mkDefault "";
 
     environment.systemPackages = with pkgs; [


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Adjust ssdh login protections (LoginGraceTime and MaxStartups) on Routers to balance the protections against internet noise. (PL-132611)
* 
### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

dos protection, balance different contradictory goals: availability vs. resource exhaustion

- [x] Security requirements tested? (EVIDENCE)

tested on kenny04 and verified the thresholds with nc