### PR TITLE
mailserver: do not use the nixos-mailserver default knot resolver

### DIFF
--- a/nixos/services/mail/default.nix
+++ b/nixos/services/mail/default.nix
@@ -212,7 +212,7 @@ in {
         enableManageSieve = true;
         # FC-38677 - we have a properly configured local resolver in our
         # platform, so a bland unconfigured kresd is counterproductive.
-        mailserver.localDnsResolver = false;
+        localDnsResolver = false;
         lmtpSaveToDetailMailbox = "no";
         mailDirectory = vmailDir;
         mailboxes = {
@@ -235,6 +235,11 @@ in {
         vmailGroupName = "vmail";
         vmailUserName = "vmail";
       };
+
+      # See https://gitlab.com/simple-nixos-mailserver/nixos-mailserver/-/issues/289
+      systemd.services.postfix.restartTriggers = [ config.mailserver.localDnsResolver  ];
+      systemd.services.rspamd.restartTriggers = [ config.mailserver.localDnsResolver ];
+      systemd.services.opendkim.restartTriggers = [ config.mailserver.localDnsResolver ];
 
       services.dovecot2.extraConfig = ''
         passdb {

--- a/nixos/services/mail/default.nix
+++ b/nixos/services/mail/default.nix
@@ -210,6 +210,9 @@ in {
         certificateScheme = 3;
         enableImapSsl = true;
         enableManageSieve = true;
+        # FC-38677 - we have a properly configured local resolver in our
+        # platform, so a bland unconfigured kresd is counterproductive.
+        mailserver.localDnsResolver = false;
         lmtpSaveToDetailMailbox = "no";
         mailDirectory = vmailDir;
         mailboxes = {


### PR DESCRIPTION
Our platform provides properly maintained resolvers on the local network so the dangers of using a provider's generic resolver do not apply here.

The unconfigured resolver is actually more harmful in our case.

Fixes FC-38677

@flyingcircusio/release-managers

## Release process

Impact:

* postfix, opendkim and rspamd will be restarted.

Changelog:

* Mailservers were running with an implicit local resolver (knot resolver, kresd) that was not properly configured and caused issues for customers. Our platform provides well-configured resolvers that should be used instead. (FC-38677)

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

no specific requirements

- [x] Security requirements tested? (EVIDENCE)

manually tested the code, general test coverage is already there 