### PR TITLE
mailserver: leverage our antivirus role to ensure proper clamav config

### DIFF
--- a/nixos/roles/mailserver.nix
+++ b/nixos/roles/mailserver.nix
@@ -230,6 +230,10 @@ in
       flyingcircus.services.nginx.enable = true;
       flyingcircus.services.redis.enable = true;
 
+      # Ensure we enable our clamav customizations and not run with a
+      # default clamav as enabled by the nixos mailserver package.
+      flyingcircus.roles.antivirus.enable = true;
+
       flyingcircus.passwordlessSudoPackages = [
         {
           commands = [ "bin/postsuper" ];

--- a/tests/mail/default.nix
+++ b/tests/mail/default.nix
@@ -32,6 +32,9 @@ in
           {
             virtualisation.memorySize = 2048;
 
+            # lower limit for allowing the enabling of antivirus
+            flyingcircus.enc.parameters.memory = 3072;
+
             flyingcircus.roles.mailserver = {
               enable = true;
               mailHost = "mail.example.local";


### PR DESCRIPTION
Fixes PL-132286

@flyingcircusio/release-managers

## Release process

Impact:

* ClamAV and other mailserver components will be restarted.

Changelog:

* Integrate our antivirus role into the mailserver role to ensure a consistent production-ready configuration. (PL-132286)

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

Leverage predictable, tested configuration.

- [x] Security requirements tested? (EVIDENCE)

Manually tested and covered in functional tests.