### PR TITLE
services.percona: fix initialScript execution

### DIFF
--- a/doc/src/mysql.md
+++ b/doc/src/mysql.md
@@ -17,7 +17,7 @@ which provides useful improvements over the standard Oracle MySQL/MariaDB implem
 
 MySQL works out-of-the box without configuration.
 
-You can change the password for the mysql root user in {file}`/etc/local/mysql/mysql.passwd`.
+You can change the password for the mysql *root* user in {file}`/etc/local/mysql/mysql.passwd`.
 The MySQL service must be restarted to pick up the new password:
 
 ```
@@ -36,11 +36,11 @@ to activate the new configuration.
 
 ## Interaction
 
-You can find the password for the MySQL root user in {file}`/etc/local/mysql.passwd`.
+You can find the password for the MySQL *root* user in {file}`/etc/local/mysql.passwd`.
 Service users can read the password file.
 
 Service users can use {command}`sudo -iu mysql` to access the
-MySQL super user account to perform administrative commands
+MySQL *root* account to perform administrative commands
 and log files in {file}`/var/log/mysql`.
 To connect to the local MySQL server, run {command}`mysql` as *mysql* user:
 

--- a/doc/src/mysql.md
+++ b/doc/src/mysql.md
@@ -70,3 +70,18 @@ permission for executing xtrabackup from the service user as root.
 The default monitoring setup checks that the MySQL server process is
 running and that it responds to connection attempts to the standard MySQL
 port.
+
+## Populating with Initial Data
+
+For populating the database with data or executing other custom SQL commands at
+first startup, the NixOS option `services.percona.initialScript` can be set to a
+file containing such SQL commands.
+
+:::{caution}
+This is mainly useful for {ref}`nixos-devhost` deployments, as the script will only
+be executed at first startup and is ignored afterwards.
+
+Enabling a Percona role first and only setting an initial script later won't have
+any effect anymore.
+% hidden note as of 20240711: It is possible to re-trigger db initialisation by `touch /run/mysql_init`, but we have decided not to expose this as an official stable API.
+:::

--- a/nixos/services/percona.nix
+++ b/nixos/services/percona.nix
@@ -64,6 +64,7 @@ let
     user = root
     __EOT__
     chmod 440 /root/.my.cnf
+    # allow convenient logins as db `root` user for unix users `mysql` and `root
     cp -p /root/.my.cnf /srv/mysql/.my.cnf
     chown mysql:mysql /srv/mysql/.my.cnf
 
@@ -113,6 +114,8 @@ in
         description = "Port of MySQL";
       };
 
+      # FIXME: this cannot be configurable for us, we hard-code the `mysql`
+      # user home dir and its permissions later in the mysqlPreStart file
       user = mkOption {
         default = "mysql";
         description = "User account under which MySQL runs";
@@ -161,6 +164,7 @@ in
       };
 
       initialScript = mkOption {
+        type = with lib.types; nullOr path;
         default = null;
         description = ''
           A file containing SQL statements to be executed on the first startup.
@@ -288,7 +292,7 @@ in
               ${optionalString (cfg.initialScript != null)
                 ''
                   # Execute initial script
-                  cat ${cfg.initialScript} | ${mysql}/bin/mysql -u root -N
+                  cat ${cfg.initialScript} | ${mysql}/bin/mysql --defaults-extra-file=/root/.my.cnf -u root -N
                 ''}
 
             rm /run/mysql_init

--- a/nixos/services/percona.nix
+++ b/nixos/services/percona.nix
@@ -168,7 +168,13 @@ in
         default = null;
         description = ''
           A file containing SQL statements to be executed on the first startup.
-          Can be used for granting certain permissions on the database
+          Can be used for granting certain permissions on the database.
+
+          ::: {.caution}
+          The script will only be executed at first startup and is ignored afterwards.
+          Enabling the service first and only etting an `initialScript` later
+          won't have any effect.
+          :::
         '';
       };
 

--- a/nixos/services/percona.nix
+++ b/nixos/services/percona.nix
@@ -249,7 +249,7 @@ in
           do
               if [ $count -eq 300 ]
               then
-                  echo "Tried 300 seconds, giving up..."
+                  echo "Tried 900 seconds, giving up..."
                   exit 1
               fi
 


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact: mysql will be restarted

Changelog:
- services.percona: fix initialScript execution

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
  - n/a 
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
  - slightly adapted docs to clarify super user and root role

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - [x] must not introduce any known regressions
  - [x] extended automated NixOS tests to include executing an initial script? Exact use case is still unclear.
  - [x] fix a provided feature that was broken
  - [x] unexpected restrictions/ behaviour needs to be documented
- [x] Security requirements tested? (EVIDENCE)
  - [x] automated tests still pass
  - [x] manually tested the execution of the initialScript in a testvm with mysql57, can be re-triggered by `touch /run/mysql_init`
  - [x] looked at rendered doc changes