### PR TITLE
[21.05] Add fd, lnav packages

### DIFF
--- a/nixos/platform/packages.nix
+++ b/nixos/platform/packages.nix
@@ -17,6 +17,7 @@
         dnsutils
         dstat
         ethtool
+        fd
         file
         fc.logcheckhelper
         fio
@@ -40,6 +41,7 @@
         libxslt
         links
         lsof
+        lnav
         lynx
         magic-wormhole
         mailutils


### PR DESCRIPTION
Cherry-pick from a modern platform release. fd and lnav are currently available via nix-shell as well, but are not available in binary cache and thus need to be built locally.

[Lnav](https://lnav.org/) is very useful for navigationg logs, [fd](https://github.com/sharkdp/fd) is a small utility for finding files fast

(cherry picked from commit 4e2cd2c2e7c9c31b5065e67ff8bb7ec2c0f7f765)

@flyingcircusio/release-managers

## Release process

Impact: internal

Changelog:
- platform default packages: add lnav, fd

### PR release workflow (internal)

- [ ] PR has internal ticket
- [ ] internal issue ID (PL-…) part of branch name
- [ ] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - default packages shall not provide significant additional attack surface
  - useful tooling for debugging present on all hosts
- [x] Security requirements tested? (EVIDENCE)
  - [x] automated regression tests still pass
  - [x] both packages are CLI tools that are __not__ continually running and do not have any active networking attack surface