### PR TITLE
k3s: monitor pods and check for pod state "Pending"

### DIFF
--- a/nixos/roles/k3s/server.nix
+++ b/nixos/roles/k3s/server.nix
@@ -110,7 +110,7 @@ let
         metadata.name = "flyingcircus:sensu-client";
         rules = [{
           apiGroups = [""];
-          resources = ["nodes"];
+          resources = ["nodes" "pods"];
           verbs = ["get" "list"];
         }];
       })

--- a/nixos/roles/k3s/server.nix
+++ b/nixos/roles/k3s/server.nix
@@ -274,7 +274,7 @@ let
       Restart = "on-failure";
       RestartSec = 10;
       ExecStart = "${authTokenScript}/bin/kubernetes-write-auth-token ${user} ${secret}";
-      ExecCondition = "${pkgs.coreutils}/bin/test ! -s /var/lib/k3s/tokens/${user}";
+      ExecCondition = "${pkgs.coreutils}/bin/test ! -s /var/lib/k3s/tokens/${user} -o ! -s /var/lib/k3s/tokens/${user}.cfg";
     };
   };
 


### PR DESCRIPTION
This change introduces a new sensu check script which checks for Kubernetes pods which have been in the Pending state for more than 10 minutes. Pods may normally be in the Pending state while the host machine is allocating resources or downloading container images for the pod which are not cached locally, however if pods are stuck in this state for an extended period of time this is often a symptom of a problem.

As a pre-requisite, this change also grants the Kubernetes access token for sensu-client additional permissions so that it can enumerate the list of currently running pods. Additionally, the access tokens for sensu-client and telegraf are now also provided as kubeconfig files, as some tools (such as kubectl) do not support reading a raw bearer token from a file

PL-132666

@flyingcircusio/release-managers

## Release process

Impact:

Changelog: The k3s-server role now includes a Sensu check which checks for pods which have been stuck in the "Pending" state for more than 10 minutes (PL-132666).

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Authentication tokens for host services are now provided additionally in kubeconfig files. Some tools, such as kubectl, only support the use of bearer tokens in the process's argument vector (instead of reading them from a file), which means authentication material would be visible in the process list.
- [x] Security requirements tested? (EVIDENCE)
  - Upgrading a system with this change applied causes the additional kubeconfig files to be generated from the existing bearer tokens.
  - The check script has been tested manually on a dev machine.