### PR TITLE
Update nixpkgs (2024-06-17)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -67,6 +67,7 @@
       "original": {
         "owner": "cachix",
         "repo": "devenv",
+        "rev": "a1290a186b9420e2c0b21700f300b486ad90dcc9",
         "type": "github"
       }
     },
@@ -136,11 +137,11 @@
     "flake-compat_3": {
       "flake": false,
       "locked": {
-        "lastModified": 1668681692,
-        "narHash": "sha256-Ht91NGdewz8IQLtWZ9LCeNXMSXHUss+9COoqu6JLmXU=",
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "009399224d5e398d03b22badca40a37ac85412a1",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
         "type": "github"
       },
       "original": {
@@ -154,11 +155,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1715865404,
-        "narHash": "sha256-/GJvTdTpuDjNn84j82cU6bXztE0MSkdnTWClUCRub78=",
+        "lastModified": 1717285511,
+        "narHash": "sha256-iKzJcpdXih14qYVcZ9QC9XuZYnPc6T8YImb6dX166kw=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "8dc45382d5206bd292f9c2768b8058a8fd8311d9",
+        "rev": "2a55567fcf15b1b1c7ed712a2c6fadaec7412ea8",
         "type": "github"
       },
       "original": {
@@ -329,6 +330,7 @@
       "original": {
         "host": "gitlab.flyingcircus.io",
         "owner": "flyingcircus",
+        "ref": "23.11",
         "repo": "nixos-mailserver",
         "type": "gitlab"
       }
@@ -351,14 +353,14 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1714640452,
-        "narHash": "sha256-QBx10+k6JWz6u7VsohfSw8g8hjdBZEf8CFzXH1/1Z94=",
+        "lastModified": 1717284937,
+        "narHash": "sha256-lIbdfCsf8LMFloheeE6N31+BMIeixqyQWbSr2vk79EQ=",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/50eb7ecf4cd0a5756d7275c8ba36790e5bd53e33.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/eb9ceca17df2ea50a250b6b27f7bf6ab0186f198.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/50eb7ecf4cd0a5756d7275c8ba36790e5bd53e33.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/eb9ceca17df2ea50a250b6b27f7bf6ab0186f198.tar.gz"
       }
     },
     "nixpkgs-regression": {
@@ -411,11 +413,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1716842013,
-        "narHash": "sha256-xe+bTKopBu/5JfCl8B4OIazxLcYG6LoZYkqorqubGNw=",
+        "lastModified": 1718705262,
+        "narHash": "sha256-S2xodELdL3UB/tJ/1Ihijx+PIRBCqPqh0nazvj6JYbA=",
         "owner": "flyingcircusio",
         "repo": "nixpkgs",
-        "rev": "c7a78f96557f5ab6144173d69866658973a88b41",
+        "rev": "c7db71f5e6bbec6d50187b752095c29f749a6a7b",
         "type": "github"
       },
       "original": {
@@ -516,13 +518,31 @@
         "type": "github"
       }
     },
-    "utils": {
+    "systems_3": {
       "locked": {
-        "lastModified": 1605370193,
-        "narHash": "sha256-YyMTf3URDL/otKdKgtoMChu4vfVL3vCMkRqpGifhUn0=",
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "inputs": {
+        "systems": "systems_3"
+      },
+      "locked": {
+        "lastModified": 1709126324,
+        "narHash": "sha256-q6EQdSeUZOG26WelxqkmR7kArjgWCdw5sfJVHPH/7j8=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "5021eac20303a61fafe17224c087f5519baed54d",
+        "rev": "d465f4819400de7c8d874d50b982301f28a84605",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -25,13 +25,13 @@
   inputs = {
     nixpkgs.url = "github:flyingcircusio/nixpkgs/nixos-23.11";
     nixos-mailserver = {
-      url = "gitlab:flyingcircus/nixos-mailserver?host=gitlab.flyingcircus.io";
+      url = "gitlab:flyingcircus/nixos-mailserver/23.11?host=gitlab.flyingcircus.io";
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.nixpkgs-22_11.follows = "nixpkgs";
       inputs.nixpkgs-23_05.follows = "nixpkgs";
     };
     devenv = {
-      url = "github:cachix/devenv";
+      url = "github:cachix/devenv/a1290a186b9420e2c0b21700f300b486ad90dcc9";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     flake-parts.url = "github:hercules-ci/flake-parts";

--- a/release/package-versions.json
+++ b/release/package-versions.json
@@ -10,9 +10,9 @@
     "version": "2.4.59"
   },
   "asterisk": {
-    "name": "asterisk-20.5.2",
+    "name": "asterisk-20.8.1",
     "pname": "asterisk",
-    "version": "20.5.2"
+    "version": "20.8.1"
   },
   "auditbeat7-oss": {
     "name": "auditbeat-oss-7.17.16",
@@ -70,14 +70,14 @@
     "version": "18.2.0"
   },
   "chromedriver": {
-    "name": "chromedriver-125.0.6422.78",
+    "name": "chromedriver-125.0.6422.141",
     "pname": "chromedriver",
-    "version": "125.0.6422.78"
+    "version": "125.0.6422.141"
   },
   "chromium": {
-    "name": "chromium-125.0.6422.112",
+    "name": "chromium-125.0.6422.141",
     "pname": "chromium",
-    "version": "125.0.6422.112"
+    "version": "125.0.6422.141"
   },
   "cifs-utils": {
     "name": "cifs-utils-7.0",
@@ -155,9 +155,9 @@
     "version": "2.3.21"
   },
   "element-web": {
-    "name": "element-web-1.11.66",
+    "name": "element-web-1.11.67",
     "pname": "element-web",
-    "version": "1.11.66"
+    "version": "1.11.67"
   },
   "erlang": {
     "name": "erlang-25.3.2.7",
@@ -190,9 +190,9 @@
     "version": "7.17.16"
   },
   "firefox": {
-    "name": "firefox-126.0",
+    "name": "firefox-127.0",
     "pname": "firefox",
-    "version": "126.0"
+    "version": "127.0"
   },
   "gcc": {
     "name": "gcc-wrapper-12.3.0",
@@ -215,39 +215,39 @@
     "version": "10.02.1"
   },
   "git": {
-    "name": "git-2.42.0",
+    "name": "git-2.42.2",
     "pname": "git",
-    "version": "2.42.0"
+    "version": "2.42.2"
   },
   "gitaly": {
-    "name": "gitaly-16.10.6",
+    "name": "gitaly-16.10.7",
     "pname": "gitaly",
-    "version": "16.10.6"
+    "version": "16.10.7"
   },
   "github-runner": {
-    "name": "github-runner-2.316.1",
+    "name": "github-runner-2.317.0",
     "pname": "github-runner",
-    "version": "2.316.1"
+    "version": "2.317.0"
   },
   "gitlab": {
-    "name": "gitlab-16.10.6",
+    "name": "gitlab-16.10.7",
     "pname": "gitlab",
-    "version": "16.10.6"
+    "version": "16.10.7"
   },
   "gitlab-container-registry": {
-    "name": "gitlab-container-registry-4.2.0",
+    "name": "gitlab-container-registry-4.5.0",
     "pname": "gitlab-container-registry",
-    "version": "4.2.0"
+    "version": "4.5.0"
   },
   "gitlab-ee": {
-    "name": "gitlab-ee-16.10.6",
+    "name": "gitlab-ee-16.10.7",
     "pname": "gitlab-ee",
-    "version": "16.10.6"
+    "version": "16.10.7"
   },
   "gitlab-pages": {
-    "name": "gitlab-pages-16.10.6",
+    "name": "gitlab-pages-16.10.7",
     "pname": "gitlab-pages",
-    "version": "16.10.6"
+    "version": "16.10.7"
   },
   "gitlab-runner": {
     "name": "gitlab-runner-16.10.0",
@@ -255,12 +255,12 @@
     "version": "16.10.0"
   },
   "gitlab-workhorse": {
-    "name": "gitlab-workhorse-16.10.6",
+    "name": "gitlab-workhorse-16.10.7",
     "pname": "gitlab-workhorse",
-    "version": "16.10.6"
+    "version": "16.10.7"
   },
   "glibc": {
-    "name": "glibc-2.38-66",
+    "name": "glibc-2.38-77",
     "pname": "glibc",
     "version": "2.38"
   },
@@ -275,9 +275,9 @@
     "version": "2.4.4"
   },
   "go": {
-    "name": "go-1.21.9",
+    "name": "go-1.21.10",
     "pname": "go",
-    "version": "1.21.9"
+    "version": "1.21.10"
   },
   "go_1_19": {
     "name": "go-1.19.13",
@@ -290,9 +290,9 @@
     "version": "1.20.12"
   },
   "grafana": {
-    "name": "grafana-10.2.6",
+    "name": "grafana-10.2.7",
     "pname": "grafana",
-    "version": "10.2.6"
+    "version": "10.2.7"
   },
   "grub2": {
     "name": "grub-2.12-rc1",
@@ -420,9 +420,9 @@
     "version": "1.3.2"
   },
   "libxml2": {
-    "name": "libxml2-2.11.7",
+    "name": "libxml2-2.11.8",
     "pname": "libxml2",
-    "version": "2.11.7"
+    "version": "2.11.8"
   },
   "libxslt": {
     "name": "libxslt-1.1.38",
@@ -435,9 +435,9 @@
     "version": "0.2.5"
   },
   "linux_5_15": {
-    "name": "linux-5.15.159",
+    "name": "linux-5.15.160",
     "pname": "linux",
-    "version": "5.15.159"
+    "version": "5.15.160"
   },
   "logrotate": {
     "name": "logrotate-3.21.0",
@@ -465,9 +465,9 @@
     "version": "3.3.5"
   },
   "mastodon": {
-    "name": "mastodon-4.2.8",
+    "name": "mastodon-4.2.9",
     "pname": "mastodon",
-    "version": "4.2.8"
+    "version": "4.2.9"
   },
   "matomo": {
     "name": "matomo-4.16.1",
@@ -475,9 +475,9 @@
     "version": "4.16.1"
   },
   "matrix-synapse": {
-    "name": "matrix-synapse-wrapped-1.107.0",
+    "name": "matrix-synapse-wrapped-1.108.0",
     "pname": "matrix-synapse-wrapped",
-    "version": "1.107.0"
+    "version": "1.108.0"
   },
   "mcpp": {
     "name": "mcpp-2.7.2.1",
@@ -488,6 +488,16 @@
     "name": "memcached-1.6.22",
     "pname": "memcached",
     "version": "1.6.22"
+  },
+  "mongodb": {
+    "name": "mongodb-6.0.11",
+    "pname": "mongodb",
+    "version": "6.0.11"
+  },
+  "mongodb-6_0": {
+    "name": "mongodb-6.0.11",
+    "pname": "mongodb",
+    "version": "6.0.11"
   },
   "monitoring-plugins": {
     "name": "monitoring-plugins-2.3.5",
@@ -515,9 +525,9 @@
     "version": "1.24.0"
   },
   "nginxMainline": {
-    "name": "nginx-1.25.4",
+    "name": "nginx-1.25.5",
     "pname": "nginx",
-    "version": "1.25.4"
+    "version": "1.25.5"
   },
   "nginxStable": {
     "name": "nginx-1.24.0",
@@ -555,9 +565,9 @@
     "version": "4.35"
   },
   "nss_latest": {
-    "name": "nss-3.100",
+    "name": "nss-3.101",
     "pname": "nss",
-    "version": "3.100"
+    "version": "3.101"
   },
   "openjdk": {
     "name": "openjdk-19.0.2+7",
@@ -671,24 +681,24 @@
     "version": "8.0.30"
   },
   "php81": {
-    "name": "php-with-extensions-8.1.28",
+    "name": "php-with-extensions-8.1.29",
     "pname": "php-with-extensions",
-    "version": "8.1.28"
+    "version": "8.1.29"
   },
   "php82": {
-    "name": "php-with-extensions-8.2.19",
+    "name": "php-with-extensions-8.2.20",
     "pname": "php-with-extensions",
-    "version": "8.2.19"
+    "version": "8.2.20"
   },
   "php83": {
-    "name": "php-with-extensions-8.3.7",
+    "name": "php-with-extensions-8.3.8",
     "pname": "php-with-extensions",
-    "version": "8.3.7"
+    "version": "8.3.8"
   },
   "phpPackages.composer": {
-    "name": "composer-2.7.6",
+    "name": "composer-2.7.7",
     "pname": "composer",
-    "version": "2.7.6"
+    "version": "2.7.7"
   },
   "pkg-config": {
     "name": "pkg-config-wrapper-0.29.2",
@@ -716,34 +726,34 @@
     "version": "3.8.6"
   },
   "postgresql": {
-    "name": "postgresql-15.6",
+    "name": "postgresql-15.7",
     "pname": "postgresql",
-    "version": "15.6"
+    "version": "15.7"
   },
   "postgresql_12": {
-    "name": "postgresql-12.18",
+    "name": "postgresql-12.19",
     "pname": "postgresql",
-    "version": "12.18"
+    "version": "12.19"
   },
   "postgresql_13": {
-    "name": "postgresql-13.14",
+    "name": "postgresql-13.15",
     "pname": "postgresql",
-    "version": "13.14"
+    "version": "13.15"
   },
   "postgresql_14": {
-    "name": "postgresql-14.11",
+    "name": "postgresql-14.12",
     "pname": "postgresql",
-    "version": "14.11"
+    "version": "14.12"
   },
   "postgresql_15": {
-    "name": "postgresql-15.6",
+    "name": "postgresql-15.7",
     "pname": "postgresql",
-    "version": "15.6"
+    "version": "15.7"
   },
   "postgresql_16": {
-    "name": "postgresql-16.2",
+    "name": "postgresql-16.3",
     "pname": "postgresql",
-    "version": "16.2"
+    "version": "16.3"
   },
   "powerdns": {
     "name": "pdns-4.8.4",
@@ -896,9 +906,9 @@
     "version": "3.2.7"
   },
   "ruby": {
-    "name": "ruby-3.1.4",
+    "name": "ruby-3.1.5",
     "pname": "ruby",
-    "version": "3.1.4"
+    "version": "3.1.5"
   },
   "ruby_2_7": {
     "name": "ruby-2.7.8",
@@ -906,9 +916,9 @@
     "version": "2.7.8"
   },
   "ruby_3_2": {
-    "name": "ruby-3.2.3",
+    "name": "ruby-3.2.4",
     "pname": "ruby",
-    "version": "3.2.3"
+    "version": "3.2.4"
   },
   "runc": {
     "name": "runc-1.1.12",

--- a/release/versions.json
+++ b/release/versions.json
@@ -8,9 +8,9 @@
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/"
   },
   "nixpkgs": {
-    "hash": "sha256-xe+bTKopBu/5JfCl8B4OIazxLcYG6LoZYkqorqubGNw=",
+    "hash": "sha256-S2xodELdL3UB/tJ/1Ihijx+PIRBCqPqh0nazvj6JYbA=",
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "c7a78f96557f5ab6144173d69866658973a88b41"
+    "rev": "c7db71f5e6bbec6d50187b752095c29f749a6a7b"
   }
 }


### PR DESCRIPTION
Update nixpkgs (2024-06-17)

Pull upstream NixOS changes, security fixes and package updates:

- asterisk: 20.5.2 -> 20.6.0 (CVE-2024-35190)
- chromedriver: 125.0.6422.78 -> 125.0.6422.141
- chromium: 125.0.6422.112 -> 125.0.6422.141
- git: 2.42.0 -> 2.42.2 (CVE-2024-32002, CVE-2024-32004, CVE-2024-32465,
  CVE-2024-32020, CVE-2024-32021)
- gitlab: 16.10.6 -> 16.10.7
- glibc: 2.38-66 -> 2.38-77 (CVE-2024-33599, CVE-2024-33600,
  CVE-2024-33601, CVE-2024-33602)
- github-runner: 2.316.1 -> 2.317.0
- go: 1.22.2 -> 1.22.3
- grafana: 10.2.6 -> 10.2.7
- libxml2: 2.11.7 -> 2.11.8 (CVE-2024-34459)
- linux_5_15: 5.15.159 -> 5.15.160
- mastodon: 4.2.8 -> 4.2.9
- matrix-synapse: 1.107.0 -> 1.108.0
- nginxMainline: 1.25.4 -> 1.25.5 (CVE-2024-32760, CVE-2024-31079,
  CVE-2024-35200, CVE-2024-34161)
- nss_latest: 3.100 -> 3.101
- php81: 8.1.28 -> 8.1.29 (CVE-2024-4577, CVE-2024-5458, CVE-2024-2408,
  CVE-2024-5585)
- php82: 8.2.19 -> 8.2.20 (CVE-2024-4577, CVE-2024-5458, CVE-2024-2408,
  CVE-2024-5585)
- php83: 8.3.7 -> 8.3.8 (CVE-2024-4577, CVE-2024-5458, CVE-2024-2408,
  CVE-2024-5585)
- phpPackages.composer: 2.7.6 -> 2.7.7 (CVE-2024-35241, CVE-2024-3524)
- postgresql: 12.18 -> 12.19, 13.14 -> 13.15, 14.11 -> 14.12, 15.6 -> 15.7, 16.2 -> 16.3 (CVE-2024-4317)
- ruby_3_2: 3.2.3 -> 3.2.4
- util-linux: backport patch for CVE-2024-28085

PL-132692

@flyingcircusio/release-managers

## Release process

Impact:

* reboot

Changelog:

* see description

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - pull in upstream security fixes regularly
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still run, works on various test VM, including a Gitlab test system
  - checked commit log for fixed CVEs and possible problems with updates, looked at [synapse/upgrade.md](https://github.com/element-hq/synapse/blob/develop/docs/upgrade.md) and [Grafana changelog](https://github.com/grafana/grafana/blob/main/CHANGELOG.md)

