### PR TITLE
Fix deprecation warnings in tests

### DIFF
--- a/nixos/roles/k3s/server.nix
+++ b/nixos/roles/k3s/server.nix
@@ -313,7 +313,7 @@ in {
       before = [ "k3s.service" ];
       requires = [ "postgresql.service" ];
       script = ''
-        PSQL="${config.services.postgresql.package}/bin/psql --port=${toString config.services.postgresql.port}"
+        PSQL="${config.services.postgresql.package}/bin/psql --port=${toString config.services.postgresql.settings.port}"
         for i in {1..10}; do
           $PSQL -d postgres -c "" 2> /dev/null && break
           sleep 0.5

--- a/tests/backyserver.nix
+++ b/tests/backyserver.nix
@@ -3,7 +3,7 @@ import ./make-test-python.nix ({ pkgs, lib, testlib, ... }:
 {
   name = "backyserver";
 
-  machine = {
+  nodes.machine = {
     imports = [
       ../nixos
       ../nixos/roles

--- a/tests/channel.nix
+++ b/tests/channel.nix
@@ -10,7 +10,7 @@ let
 in {
   name = "channel";
 
-  machine = {
+  nodes.machine = {
     imports = [ ../nixos ../nixos/roles ];
 
     flyingcircus.enc.parameters = {

--- a/tests/collect-garbage.nix
+++ b/tests/collect-garbage.nix
@@ -10,7 +10,7 @@ import ./make-test-python.nix (
   in
   {
     name = "collect-garbage";
-    machine =
+    nodes.machine =
       { ... }:
       {
         imports = [ ../nixos ../nixos/roles ];

--- a/tests/coturn.nix
+++ b/tests/coturn.nix
@@ -107,7 +107,7 @@ in {
 
   testScript = { nodes, ... }:
   let
-    config = nodes.turnserver.config;
+    config = nodes.turnserver;
     sensuChecks = config.flyingcircus.services.sensu-client.checks;
     coturnCheck = lib.replaceChars ["\n"] [" "] sensuChecks.coturn.command;
   in ''

--- a/tests/coturn.nix
+++ b/tests/coturn.nix
@@ -109,7 +109,7 @@ in {
   let
     config = nodes.turnserver;
     sensuChecks = config.flyingcircus.services.sensu-client.checks;
-    coturnCheck = lib.replaceChars ["\n"] [" "] sensuChecks.coturn.command;
+    coturnCheck = lib.replaceStrings ["\n"] [" "] sensuChecks.coturn.command;
   in ''
     start_all()
     turnserver.wait_for_unit("coturn.service")

--- a/tests/docker.nix
+++ b/tests/docker.nix
@@ -4,7 +4,10 @@ let
   redisImage = pkgs.dockerTools.buildImage {
     name = "redis";
     tag = "latest";
-    contents = [ pkgs.redis ];
+    copyToRoot = pkgs.buildEnv {
+      name = "image-root";
+      paths = [ pkgs.redis ];
+    };
     config.Cmd = [ "/bin/redis-server" "--protected-mode no" ];
   };
 in

--- a/tests/fcagent.nix
+++ b/tests/fcagent.nix
@@ -4,7 +4,7 @@ import ./make-test-python.nix ({ pkgs, testlib, ... }:
   testCases = {
     prod = {
       name = "prod";
-      machine =
+      nodes.machine =
         { config, lib, ... }:
         {
           imports = [
@@ -18,7 +18,7 @@ import ./make-test-python.nix ({ pkgs, testlib, ... }:
     };
     nonprod = {
       name = "nonprod";
-      machine =
+      nodes.machine =
         { config, lib, ... }:
         {
           imports = [

--- a/tests/ffmpeg.nix
+++ b/tests/ffmpeg.nix
@@ -3,7 +3,7 @@ import ./make-test-python.nix ({ pkgs, lib, ... }:
 {
   name = "ffmpeg";
 
-  machine = {
+  nodes.machine = {
     imports = [ ../nixos ../nixos/roles ];
 
     environment.systemPackages = with pkgs; [

--- a/tests/k3s/airgapped-k3s-images.nix
+++ b/tests/k3s/airgapped-k3s-images.nix
@@ -3,24 +3,24 @@
 [
 {
   imageName = "docker.io/rancher/klipper-helm";
-  imageDigest = "sha256:3cd71ccc3cce5010865d9ab3548788a3a8cf5e9cfc5b48cc54b5b815675dd121";
-  sha256 = "02xs21ijd8japjmyjdw8q1il4vp722dyp7vf41ww5a34zq8awn26";
+  imageDigest = "sha256:87db3ad354905e6d31e420476467aefcd8f37d071a8f1c8a904f4743162ae546";
+  sha256 = "03qilngaxzv4l0yb7cvvfhb32ll3ajx5lrf53ma186dv6xzwl2ph";
   finalImageName = "docker.io/rancher/klipper-helm";
-  finalImageTag = "v0.7.7-build20230403";
+  finalImageTag = "v0.8.3-build20240228";
 }
 {
   imageName = "docker.io/rancher/klipper-lb";
-  imageDigest = "sha256:2b963c02974155f7e9a51c54b91f09099e48b4550689aadb595e62118e045c10";
-  sha256 = "09gx9chmzizmjv05db65rwz9wx70lq914ydr5mhbdbpiisgxsarr";
+  imageDigest = "sha256:558dcf96bf0800d9977ef46dca18411752618cd9dd06daeb99460c0a301d0a60";
+  sha256 = "1lqayby3yj7ivcr7v9awrcz9wfv2r5b3bd3k2q89gwkc2ivnyagp";
   finalImageName = "docker.io/rancher/klipper-lb";
-  finalImageTag = "v0.4.3";
+  finalImageTag = "v0.4.7";
 }
 {
   imageName = "docker.io/rancher/local-path-provisioner";
-  imageDigest = "sha256:5bb33992a4ec3034c28b5e0b3c4c2ac35d3613b25b79455eb4b1a95adc82cdc0";
-  sha256 = "1lvashw7rdh4skkfgrkl0znzpl5j0zg8vzdaqxnp6f8lvb7aqffv";
+  imageDigest = "sha256:aee53cadc62bd023911e7f077877d047c5b3c269f9bba25724d558654f43cea0";
+  sha256 = "15vvqqf3s8kpv8drdvaykyqadcss90b8kxwbl9ifiq5qvgkxza4v";
   finalImageName = "docker.io/rancher/local-path-provisioner";
-  finalImageTag = "v0.0.24";
+  finalImageTag = "v0.0.26";
 }
 {
   imageName = "docker.io/rancher/mirrored-coredns-coredns";
@@ -31,24 +31,24 @@
 }
 {
   imageName = "docker.io/rancher/mirrored-library-busybox";
-  imageDigest = "sha256:125dfcbe72a0158c16781d3ad254c0d226a6534b59cc7c2bf549cdd50c6e8989";
-  sha256 = "17vhp0khhrx716gz5m0b3pp0yp4qrbbcl11n45ac0manszlgh9mi";
+  imageDigest = "sha256:f9bd56486743d20ed2c148cdef23fd2e9c3e9dc1377df303e777dad288e0e17d";
+  sha256 = "185m58pqc0j39yvjilwa9jcpgzapg9dynqi5xv08vr6sf53rm8mn";
   finalImageName = "docker.io/rancher/mirrored-library-busybox";
-  finalImageTag = "1.34.1";
+  finalImageTag = "1.36.1";
 }
 {
   imageName = "docker.io/rancher/mirrored-library-traefik";
-  imageDigest = "sha256:0842af6afcdf4305d17e862bad4eaf379d0817c987eedabeaff334e2273459c1";
-  sha256 = "09wd68as4fg42n7c7y4m5wa5fqzd8p9aisyi87g0181897pl9w4m";
+  imageDigest = "sha256:606c4c924d9edd6d028a010c8f173dceb34046ed64fabdbce9ff29b2cf2b3042";
+  sha256 = "1r4kmk9wn84b9s89a4gc5anys9hnrjjlzcj0b3cv6mimlc7al9n6";
   finalImageName = "docker.io/rancher/mirrored-library-traefik";
-  finalImageTag = "2.9.4";
+  finalImageTag = "2.10.7";
 }
 {
   imageName = "docker.io/rancher/mirrored-metrics-server";
-  imageDigest = "sha256:16185c0d4d01f8919eca4779c69a374c184200cd9e6eded9ba53052fd73578df";
-  sha256 = "0ydwa51g3mim0b3jxjxrizk1ixxsarcim8nhkir6a6k5jbkdhp75";
+  imageDigest = "sha256:20b8b36f8cac9e25aa2a0ff35147b13643bfec603e7e7480886632330a3bbc59";
+  sha256 = "1ykkhx85q0556in6nvncikrhnxwgs5msf4vjxns9qk74dqrvchxb";
   finalImageName = "docker.io/rancher/mirrored-metrics-server";
-  finalImageTag = "v0.6.2";
+  finalImageTag = "v0.7.0";
 }
 {
   imageName = "docker.io/rancher/mirrored-pause";

--- a/tests/k3s/redis.nix
+++ b/tests/k3s/redis.nix
@@ -5,7 +5,10 @@ rec {
   image = pkgs.dockerTools.buildImage {
     name = "redis";
     tag = "latest";
-    contents = [ pkgs.redis ];
+    copyToRoot = pkgs.buildEnv {
+      name = "image-root";
+      paths = [ pkgs.redis ];
+    };
     config.Entrypoint = ["/bin/redis-server"];
   };
 

--- a/tests/kernelconfig.nix
+++ b/tests/kernelconfig.nix
@@ -154,7 +154,7 @@ let
 in
  rec {
   name = "kernel-config";
-  machine =
+  nodes.machine =
     { config, ... }:
     {
       imports = [ ../nixos ../nixos/roles ];
@@ -197,7 +197,7 @@ in
             opts[key] = value
         return cfg, opts
 
-    expectedRaw, expectedConfig = parseConfigDef("""${toString nodes.machine.config.flyingcircus.kernelOptions}\n${additionalExpectedConfig}""")
+    expectedRaw, expectedConfig = parseConfigDef("""${toString nodes.machine.flyingcircus.kernelOptions}\n${additionalExpectedConfig}""")
 
     duplicateOptions = []
     # Ensure the expected config has no double entries

--- a/tests/locale.nix
+++ b/tests/locale.nix
@@ -1,7 +1,7 @@
 import ./make-test-python.nix ({ ... }:
 {
   name = "locale";
-  machine =
+  nodes.machine =
     { ... }:
     {
       imports = [ ../nixos ../nixos/roles ];

--- a/tests/login.nix
+++ b/tests/login.nix
@@ -2,7 +2,7 @@ import ./make-test-python.nix ({ pkgs, ... }:
 
 {
   name = "login";
-  machine =
+  nodes.machine =
     { pkgs, lib, config, ... }:
     {
       imports = [ ../nixos ../nixos/roles ];

--- a/tests/logrotate.nix
+++ b/tests/logrotate.nix
@@ -5,7 +5,7 @@ import ./make-test-python.nix (
   { pkgs, ... }:
   {
     name = "user-logrotate";
-    machine =
+    nodes.machine =
       { ... }:
       {
         imports = [ ../nixos ../nixos/roles ];

--- a/tests/memcached.nix
+++ b/tests/memcached.nix
@@ -4,7 +4,7 @@ let
   ipv6 = "2001:db8:f030:1c3::1";
 in {
   name = "memcached";
-  machine =
+  nodes.machine =
     { ... }:
     {
       imports = [ ../nixos ../nixos/roles ];

--- a/tests/mysql.nix
+++ b/tests/mysql.nix
@@ -31,7 +31,7 @@ in
 
   testScript = { nodes, ... }:
   let
-    config = nodes.master.config;
+    config = nodes.master;
     sensuChecks = config.flyingcircus.services.sensu-client.checks;
     mysqlCheck = "sudo -u sensuclient " + sensuChecks.mysql.command;
     version = config.services.percona.package.version;

--- a/tests/network/default.nix
+++ b/tests/network/default.nix
@@ -59,7 +59,7 @@ in {
 
     loopback = {
       name = "loopback";
-      machine = {
+      nodes.machine = {
           imports = [ ../../nixos ../../nixos/roles ];
       };
       testScript = ''
@@ -71,7 +71,7 @@ in {
 
     wireguard = {
       name = "wireguard";
-      machine = {
+      nodes.machine = {
         imports = [ ../../nixos ../../nixos/roles ];
       };
       testScript = ''
@@ -111,7 +111,7 @@ in {
 
 
     name-resolution = {
-      machine =
+      nodes.machine =
         { pkgs, ... }:
         {
           imports = [ ../../nixos ../../nixos/roles ];

--- a/tests/prometheus.nix
+++ b/tests/prometheus.nix
@@ -1,7 +1,7 @@
 import ./make-test-python.nix ({ ... }:
 {
   name = "prometheus";
-  machine =
+  nodes.machine =
     { config, ... }:
     {
       imports = [ ../nixos ../nixos/roles ];

--- a/tests/psi.nix
+++ b/tests/psi.nix
@@ -4,7 +4,7 @@ import ./make-test-python.nix ({ testlib, ... }:
   testCases = {
     justpsi = {
       name = "justpsi";
-      machine = { lib, ... }:
+      nodes.machine = { lib, ... }:
       {
         imports = [ (testlib.fcConfig { net.fe = false; }) ];
         services.telegraf.enable = true;
@@ -19,7 +19,7 @@ import ./make-test-python.nix ({ testlib, ... }:
     };
     psicgroup = {
       name = "psicgroup";
-      machine = { lib, ... }:
+      nodes.machine = { lib, ... }:
       {
         imports = [ (testlib.fcConfig { net.fe = false; }) ];
         flyingcircus.services.telegraf.psiCgroupRegex = [ ".*\\.service" ];

--- a/tests/rust-tools.nix
+++ b/tests/rust-tools.nix
@@ -3,7 +3,7 @@ import ./make-test-python.nix ({ pkgs, lib, ... }:
 {
   name = "rust-tools";
 
-  machine = {
+  nodes.machine = {
     imports = [ ../nixos ../nixos/roles ];
 
     environment.systemPackages = with pkgs; [

--- a/tests/servicecheck.nix
+++ b/tests/servicecheck.nix
@@ -2,7 +2,7 @@ import ./make-test-python.nix ({ pkgs, lib, ... }:
 {
   name = "servicecheck";
 
-  machine = {
+  nodes.machine = {
     imports = [ ../nixos ../nixos/roles ];
 
     flyingcircus.roles.servicecheck.enable = true;

--- a/tests/statshost/statshost-master.nix
+++ b/tests/statshost/statshost-master.nix
@@ -1,7 +1,7 @@
 import ../make-test-python.nix ({ pkgs, ... }:
 {
   name = "statshost-master";
-  machine =
+  nodes.machine =
     { config, ... }:
     {
       imports = [ ../../nixos ../../nixos/roles ];

--- a/tests/sudo.nix
+++ b/tests/sudo.nix
@@ -41,7 +41,7 @@ in
 {
   name = "sudo";
   enableOCR = true;
-  machine =
+  nodes.machine =
     { pkgs, lib, config, ... }:
     {
       imports = [

--- a/tests/systemd-service-cycles.nix
+++ b/tests/systemd-service-cycles.nix
@@ -3,7 +3,7 @@ import ./make-test-python.nix ({ ... }:
 # Checks that systemd does not detect any circular service dependencies on boot.
 {
   name = "systemd-service-cycles";
-  machine =
+  nodes.machine =
     { ... }:
     {
       imports = [ ../nixos ../nixos/roles ];

--- a/tests/users.nix
+++ b/tests/users.nix
@@ -2,7 +2,7 @@ import ./make-test-python.nix ({ lib, testlib, ... }:
 
 {
   name = "users";
-  machine =
+  nodes.machine =
     { pkgs, lib, config, ... }:
     let
       userData =


### PR DESCRIPTION
PL-132732


@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

(internal)

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - This PR should make sure we follow upstream renames/changes, in order to be compatible with new nixpkgs versions
  - It should also make test output more readable (by removing warnings that don't have anything to do with the actual test results), making it easier to focus on the _relevant_ parts.
- [x] Security requirements tested? (EVIDENCE)
  - Ran the corresponding tests locally and confirmed the warnings are gone.
