### PR TITLE
Fix varnish monitoring 2.0

### DIFF
--- a/nixos/services/varnish/default.nix
+++ b/nixos/services/varnish/default.nix
@@ -120,6 +120,12 @@ in {
     http_address = mkOption {
       type = types.str;
       default = "*:8008";
+      description = ''
+        The http address for the varnish service to listen on.
+        Unix sockets can technically be used for varnish, but are not currently supported on the FCIO platform due to monitoring constraints.
+        Multiple addressess can be specified in a comma-separated fashion in the form of `address[:port][,address[:port][...]`.
+        See `varnishd(1)` for details.
+      '';
     };
     virtualHosts = mkOption {
       type = types.attrsOf (types.submodule ({ name, config, ... }: {


### PR DESCRIPTION
the default monitoring check relied on varnish to run on a specific address.
since this address can be changed, the sensu check needs to be adjusted to correctly infer the host and port that varnish is running on

This pr is based on https://github.com/flyingcircusio/fc-nixos/pull/996 but fixes an issue where an incorrect address was inferred when multiple addresses were passed to varnish.

FC-36891

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - [x] the varnish monitors the correct address when not using the default
- [x] Security requirements tested? (EVIDENCE)

```
phil@test01 ~ $ sensu-client-show-config | jq '.checks.varnish_http'
{
  "command": "/nix/store/4c1bx0qnfylqxqr4gi72ws0snvgg3y0q-check-varnish-http",
  "interval": 60,
  "notification": "varnish port 8008 HTTP response",
  "standalone": true,
  "timeout": null,
  "ttl": null,
  "warnIsCritical": false
}

phil@test01 ~ $ cat /nix/store/4c1bx0qnfylqxqr4gi72ws0snvgg3y0q-check-varnish-http
#!/nix/store/516kai7nl5dxr792c0nzq0jp8m4zvxpi-bash-5.2p32/bin/bash
ADDRS=$(/nix/store/m7agwiiz62q5nq7fhsj6vgd4b86i6rqi-varnish-7.4.3/bin/varnishadm debug.listen_address | awk '/([0-9.]+\.)+/ { print $2":"$3; }')
for ADDR in $ADDRS; do
  host=$(echo $ADDR | cut -d ":" -f 1)
  port=$(echo $ADDR | cut -d ":" -f 2)

  echo "checking host '$host' on port '$port'"
  /nix/store/j6r4xyhlr11wk7pad33y1f18c0wmj8zj-monitoring-plugins-2.3.5/bin/check_http -H $host -p $port -c 10 -w 3 -t 20 -e HTTP
done


phil@test01 ~ $ sudo -u sensuclient /nix/store/4c1bx0qnfylqxqr4gi72ws0snvgg3y0q-check-varnish-http
checking host '172.22.57.135' on port '8008'
HTTP OK: Status line output matched "HTTP" - 520 bytes in 0.001 second response time |time=0.000553s;3.000000;10.000000;0.000000;20.000000 size=520B;;;0;
checking host '127.0.0.1' on port '8008'
HTTP OK: Status line output matched "HTTP" - 526 bytes in 0.000 second response time |time=0.000360s;3.000000;10.000000;0.000000;20.000000 size=526B;;;0;

phil@test01 ~ $
```