### PR TITLE
Update nixpkgs (2024-06-24)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -137,11 +137,11 @@
     "flake-compat_3": {
       "flake": false,
       "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "lastModified": 1668681692,
+        "narHash": "sha256-Ht91NGdewz8IQLtWZ9LCeNXMSXHUss+9COoqu6JLmXU=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "rev": "009399224d5e398d03b22badca40a37ac85412a1",
         "type": "github"
       },
       "original": {
@@ -413,11 +413,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1718705262,
-        "narHash": "sha256-S2xodELdL3UB/tJ/1Ihijx+PIRBCqPqh0nazvj6JYbA=",
+        "lastModified": 1719424578,
+        "narHash": "sha256-AWp2Fq+h+EXJcrjjWRB6AwttAtqptY+Hw6oC4VcYka8=",
         "owner": "flyingcircusio",
         "repo": "nixpkgs",
-        "rev": "c7db71f5e6bbec6d50187b752095c29f749a6a7b",
+        "rev": "6219d53a07ea47253b08967d3b449e7b28000b2a",
         "type": "github"
       },
       "original": {
@@ -518,31 +518,13 @@
         "type": "github"
       }
     },
-    "systems_3": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
     "utils": {
-      "inputs": {
-        "systems": "systems_3"
-      },
       "locked": {
-        "lastModified": 1709126324,
-        "narHash": "sha256-q6EQdSeUZOG26WelxqkmR7kArjgWCdw5sfJVHPH/7j8=",
+        "lastModified": 1605370193,
+        "narHash": "sha256-YyMTf3URDL/otKdKgtoMChu4vfVL3vCMkRqpGifhUn0=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "d465f4819400de7c8d874d50b982301f28a84605",
+        "rev": "5021eac20303a61fafe17224c087f5519baed54d",
         "type": "github"
       },
       "original": {

--- a/release/package-versions.json
+++ b/release/package-versions.json
@@ -70,14 +70,14 @@
     "version": "18.2.0"
   },
   "chromedriver": {
-    "name": "chromedriver-125.0.6422.141",
+    "name": "chromedriver-126.0.6478.61",
     "pname": "chromedriver",
-    "version": "125.0.6422.141"
+    "version": "126.0.6478.61"
   },
   "chromium": {
-    "name": "chromium-125.0.6422.141",
+    "name": "chromium-126.0.6478.61",
     "pname": "chromium",
-    "version": "125.0.6422.141"
+    "version": "126.0.6478.61"
   },
   "cifs-utils": {
     "name": "cifs-utils-7.0",
@@ -190,9 +190,9 @@
     "version": "7.17.16"
   },
   "firefox": {
-    "name": "firefox-127.0",
+    "name": "firefox-127.0.1",
     "pname": "firefox",
-    "version": "127.0"
+    "version": "127.0.1"
   },
   "gcc": {
     "name": "gcc-wrapper-12.3.0",
@@ -220,9 +220,9 @@
     "version": "2.42.2"
   },
   "gitaly": {
-    "name": "gitaly-16.10.7",
+    "name": "gitaly-16.11.5",
     "pname": "gitaly",
-    "version": "16.10.7"
+    "version": "16.11.5"
   },
   "github-runner": {
     "name": "github-runner-2.317.0",
@@ -230,9 +230,9 @@
     "version": "2.317.0"
   },
   "gitlab": {
-    "name": "gitlab-16.10.7",
+    "name": "gitlab-16.11.5",
     "pname": "gitlab",
-    "version": "16.10.7"
+    "version": "16.11.5"
   },
   "gitlab-container-registry": {
     "name": "gitlab-container-registry-4.5.0",
@@ -240,14 +240,14 @@
     "version": "4.5.0"
   },
   "gitlab-ee": {
-    "name": "gitlab-ee-16.10.7",
+    "name": "gitlab-ee-16.11.5",
     "pname": "gitlab-ee",
-    "version": "16.10.7"
+    "version": "16.11.5"
   },
   "gitlab-pages": {
-    "name": "gitlab-pages-16.10.7",
+    "name": "gitlab-pages-16.11.5",
     "pname": "gitlab-pages",
-    "version": "16.10.7"
+    "version": "16.11.5"
   },
   "gitlab-runner": {
     "name": "gitlab-runner-16.10.0",
@@ -255,9 +255,9 @@
     "version": "16.10.0"
   },
   "gitlab-workhorse": {
-    "name": "gitlab-workhorse-16.10.7",
+    "name": "gitlab-workhorse-16.11.5",
     "pname": "gitlab-workhorse",
-    "version": "16.10.7"
+    "version": "16.11.5"
   },
   "glibc": {
     "name": "glibc-2.38-77",
@@ -435,9 +435,9 @@
     "version": "0.2.5"
   },
   "linux_5_15": {
-    "name": "linux-5.15.160",
+    "name": "linux-5.15.161",
     "pname": "linux",
-    "version": "5.15.160"
+    "version": "5.15.161"
   },
   "logrotate": {
     "name": "logrotate-3.21.0",
@@ -475,9 +475,9 @@
     "version": "4.16.1"
   },
   "matrix-synapse": {
-    "name": "matrix-synapse-wrapped-1.108.0",
+    "name": "matrix-synapse-wrapped-1.109.0",
     "pname": "matrix-synapse-wrapped",
-    "version": "1.108.0"
+    "version": "1.109.0"
   },
   "mcpp": {
     "name": "mcpp-2.7.2.1",

--- a/release/versions.json
+++ b/release/versions.json
@@ -8,9 +8,9 @@
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/"
   },
   "nixpkgs": {
-    "hash": "sha256-S2xodELdL3UB/tJ/1Ihijx+PIRBCqPqh0nazvj6JYbA=",
+    "hash": "sha256-AWp2Fq+h+EXJcrjjWRB6AwttAtqptY+Hw6oC4VcYka8=",
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "c7db71f5e6bbec6d50187b752095c29f749a6a7b"
+    "rev": "6219d53a07ea47253b08967d3b449e7b28000b2a"
   }
 }


### PR DESCRIPTION
Update nixpkgs (2024-06-24)

Pull upstream NixOS changes, security fixes and package updates:

- chromedriver: 125.0.6422.141 -> 126.0.6478.61
- chromium: 125.0.6422.141 -> 126.0.6478.61
- firefox: 127.0 -> 127.0.1
- gitlab: 16.10.7 -> 16.11.5
- linux_5_15: 5.15.160 -> 5.15.161
- matrix-synapse: 1.108.0 -> 1.109.0

PL-132741


@flyingcircusio/release-managers

## Release process

Impact:

- reboot

Changelog:

- include commit msg

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - pull in upstream security fixes regularly
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still run, works on various test VM, including a Gitlab test system
  - checked commit log for fixed CVEs and possible problems with updates, looked at [synapse/upgrade.md](https://github.com/element-hq/synapse/blob/develop/docs/upgrade.md) and [GitLab 16 changes | GitLab](https://docs.gitlab.com/ee/update/versions/gitlab_16_changes.html)