### PR TITLE
[21.05] increase tcp connection limits for ceph servers

### DIFF
--- a/nixos/services/ceph/server.nix
+++ b/nixos/services/ceph/server.nix
@@ -69,8 +69,8 @@ in
     ];
 
     flyingcircus.services.sensu-client.expectedConnections = {
-      warning = 20000;
-      critical = 25000;
+      warning = 30000;
+      critical = 50000;
     };
 
     services.logrotate.extraConfig = ''


### PR DESCRIPTION
Fixes PL-132746

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* Increase TCP connection monitoring limit for Ceph hosts. (PL-132746)

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

monitoring must be tuned as needed

- [x] Security requirements tested? (EVIDENCE)

relying on hydra