### PR TITLE
[hotfix] [23.11] OpenSSH fix CVE-2024-6387

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1717285511,
-        "narHash": "sha256-iKzJcpdXih14qYVcZ9QC9XuZYnPc6T8YImb6dX166kw=",
+        "lastModified": 1719745305,
+        "narHash": "sha256-xwgjVUpqSviudEkpQnioeez1Uo2wzrsMaJKJClh+Bls=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "2a55567fcf15b1b1c7ed712a2c6fadaec7412ea8",
+        "rev": "c3c5ecc05edc7dafba779c6c1a61cd08ac6583e9",
         "type": "github"
       },
       "original": {
@@ -413,11 +413,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1719424578,
-        "narHash": "sha256-AWp2Fq+h+EXJcrjjWRB6AwttAtqptY+Hw6oC4VcYka8=",
+        "lastModified": 1719837770,
+        "narHash": "sha256-/wSTAlkXdhQoqLAdpAIqdkT3PxAuzv4rnxo8HSNz4cI=",
         "owner": "flyingcircusio",
         "repo": "nixpkgs",
-        "rev": "6219d53a07ea47253b08967d3b449e7b28000b2a",
+        "rev": "450420281855a0a946b47e0396dbef45c7f51a0a",
         "type": "github"
       },
       "original": {

--- a/release/versions.json
+++ b/release/versions.json
@@ -8,9 +8,9 @@
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/"
   },
   "nixpkgs": {
-    "hash": "sha256-AWp2Fq+h+EXJcrjjWRB6AwttAtqptY+Hw6oC4VcYka8=",
+    "hash": "sha256-/wSTAlkXdhQoqLAdpAIqdkT3PxAuzv4rnxo8HSNz4cI=",
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "6219d53a07ea47253b08967d3b449e7b28000b2a"
+    "rev": "450420281855a0a946b47e0396dbef45c7f51a0a"
   }
 }


### PR DESCRIPTION
Pull upstream NixOS changes, security fixes and package updates:

- openssh: add backported security fix patches

PL-132768-2311

@flyingcircusio/release-managers

## Release process

This is the ahead-of-schedule hotfix version of #1041.

Impact:
- sshd will be restarted

Changelog:
- patch a critical remote code execution vulnerability in openssh

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - patch a remote code execution vulnerability in openSSH https://www.qualys.com/2024/07/01/cve-2024-6387/regresshion.txt
  - must not introduce any know regressions 
- [x] Security requirements tested? (EVIDENCE)
  - [x] automated tests still pass
  - [x] successfully tested restarting openssh and connecting on releasetestprod VM for 23.11