### PR TITLE
[23.05] OpenSSH fix CVE-2024-6387

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "5a7db58a8a8528e558b5d4bf10433b43766249bf",
-    "hash": "sha256-0FjW2Ry6sZHq6lroqn7uyqPS+VrGKPONOPDveX4LRck="
+    "rev": "c7168a363305a7191c620622ed4600b5c4a974f4",
+    "hash": "sha256-0kj+RZCLkBMlPAp5ubSd9fcqDM8NUngFV+rXOHeo5nY="
   },
   "nixos-mailserver": {
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/",


### PR DESCRIPTION
@flyingcircusio/release-managers

Apply patches to fix the critical CVE-2024-6387 in openssh.
Patches taken from NixOS 23.11.

PL-132768

## Release process

This is supposed to go through the normal dev -> staging -> production process, but just faster. Making a separate hotfix for this otherwise unmaintained release does not make sense.

Impact:
- sshd will be restarted

Changelog:
- patch a critical remote code execution vulnerability in openssh

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - patch a remote code execution vulnerability in openSSH https://www.qualys.com/2024/07/01/cve-2024-6387/regresshion.txt
  - must not introduce any know regressions 
- [x] Security requirements tested? (EVIDENCE)
  - [x] automated tests still pass
  - [x] successfully tested restarting openssh and connecting on releasedev VM for 23.05