### PR TITLE
[21.05] Check the number of LLDP peers matches the number of interfaces

### DIFF
--- a/pkgs/fc/check-link-redundancy/check_link_redundancy.py
+++ b/pkgs/fc/check-link-redundancy/check_link_redundancy.py
@@ -36,7 +36,10 @@ def main():
             switches_all.append(data.keys())
             switches_unique.update(data.keys())
 
-    if len(switches_all) != len(switches_unique):
+    if len(switches_all) != len(args.interfaces):
+        print("CRITICAL - interfaces are missing visible peer devices in LLDP ")
+        sys.exit(2)
+    elif len(switches_all) != len(switches_unique):
         print("CRITICAL - multiple interfaces are connected to the same switch")
         sys.exit(2)
     else:

--- a/pkgs/fc/check-link-redundancy/default.nix
+++ b/pkgs/fc/check-link-redundancy/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, makeWrapper, python3, lldpd }:
 
 stdenv.mkDerivation rec {
-  version = "1";
+  version = "2";
   pname = "check-link-redundancy";
 
   src = ./.;


### PR DESCRIPTION
We have a sensu check script which monitors whether links for the VXLAN underlay are connected to different switches, to avoid situations where both links are accidentally connected to the same switch. However, in circumstances where one link is connected as normal but the other is disconnected entirely, then the check script will not trigger, as it only checks that all reported LLDP peers are unique, and not whether the number of LLDP peers matches the number of links.

This change extends the script to check that the number of detected LLDP peers matches the number of links given as arguments as a proxy for detecting links with missing carrier.

PL-132748

@flyingcircusio/release-managers

## Release process

Impact: internal.

Changelog: none.

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - No direct security implications. Refinement of monitoring to better handle unwanted hardware states.
- [x] Security requirements tested? (EVIDENCE)
  - Tested manually in DEV.
