### PR TITLE
[21.05] OpenSSH fix CVE-2024-6387

### DIFF
--- a/pkgs/openssh/openssh-9.6_p1-CVE-2024-6387.patch
+++ b/pkgs/openssh/openssh-9.6_p1-CVE-2024-6387.patch
@@ -1,0 +1,19 @@
+https://bugs.gentoo.org/935271
+Backport proposed by upstream at https://marc.info/?l=oss-security&m=171982317624594&w=2.
+--- a/log.c
++++ b/log.c
+@@ -451,12 +451,14 @@ void
+ sshsigdie(const char *file, const char *func, int line, int showfunc,
+     LogLevel level, const char *suffix, const char *fmt, ...)
+ {
++#ifdef SYSLOG_R_SAFE_IN_SIGHAND
+ 	va_list args;
+ 
+ 	va_start(args, fmt);
+ 	sshlogv(file, func, line, showfunc, SYSLOG_LEVEL_FATAL,
+ 	    suffix, fmt, args);
+ 	va_end(args);
++#endif
+ 	_exit(1);
+ }
+ 

--- a/pkgs/openssh/openssh-9.6_p1-chaff-logic.patch
+++ b/pkgs/openssh/openssh-9.6_p1-chaff-logic.patch
@@ -1,0 +1,16 @@
+"Minor logic error in ObscureKeystrokeTiming"
+https://marc.info/?l=oss-security&m=171982317624594&w=2
+--- a/clientloop.c
++++ b/clientloop.c
+@@ -608,8 +608,9 @@ obfuscate_keystroke_timing(struct ssh *ssh, struct timespec *timeout,
+ 		if (timespeccmp(&now, &chaff_until, >=)) {
+ 			/* Stop if there have been no keystrokes for a while */
+ 			stop_reason = "chaff time expired";
+-		} else if (timespeccmp(&now, &next_interval, >=)) {
+-			/* Otherwise if we were due to send, then send chaff */
++		} else if (timespeccmp(&now, &next_interval, >=) &&
++		    !ssh_packet_have_data_to_write(ssh)) {
++			/* If due to send but have no data, then send chaff */
+ 			if (send_chaff(ssh))
+ 				nchaff++;
+ 		}

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -462,7 +462,11 @@ in {
     patches = with builtins;
       filter (p: ! (elem (builtins.baseNameOf p)
                  ["CVE-2021-41617-1.patch" "CVE-2021-41617-2.patch"]))
-      old_ssh.patches;
+      old_ssh.patches
+      ++ [
+        ./openssh/openssh-9.6_p1-CVE-2024-6387.patch
+        ./openssh/openssh-9.6_p1-chaff-logic.patch
+      ];
 
   });
 


### PR DESCRIPTION
@flyingcircusio/release-managers

Apply patches to fix the critical CVE-2024-6387 in openssh.
Package taken from NixOS 23.05, we've been using openssh-9.6p1 anyways already.

Just building the nix expression for 9.6 on 21.05 did not work.

PL-132768

## Release process

This is supposed to go through the normal dev -> staging -> production process, but just faster. Making a separate hotfix for this otherwise unmaintained release does not make sense.

Impact:
- sshd will be restarted

Changelog:
- openssh: apply patches for CVE-2024-6387
  - fixes a remote code execution vulnerability https://www.qualys.com/2024/07/01/cve-2024-6387/regresshion.txt
  - additionally also backport a fix for a minor logic error in ObscureKeystrokeTiming
  - note that this only updates the `openssh_9_6` package, which is used by the in-path `ssh` command and the `sshd.service` of the platform

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - patch a remote code execution vulnerability in openSSH https://www.qualys.com/2024/07/01/cve-2024-6387/regresshion.txt
  - must not introduce any know regressions 
- [x] Security requirements tested? (EVIDENCE)
  - [x] automated tests still pass
  - [x] successfully tested restarting openssh and connecting on a host in dev