### PR TITLE
[hotfix] [21.05-frozen] openssh: pull in 9.6 from 23.05 with CVE-2024-6387 patches

### DIFF
--- a/nixos/platform/default.nix
+++ b/nixos/platform/default.nix
@@ -254,7 +254,7 @@ in {
       agent.collect-garbage = true;
     };
 
-    programs.ssh.package = pkgs.openssh_8_7;
+    programs.ssh.package = pkgs.openssh_9_6;
 
     # implementation for flyingcircus.passwordlessSudoRules
     security.sudo.extraRules = let

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -402,15 +402,13 @@ in {
     ];
   });
 
-  openssh_8_7 = super.openssh.overrideAttrs(_: rec {
-    version = "8.7p1";
-    name = "openssh-${version}";
+  openssh_9_6 = nixpkgs-23_05.openssh;
 
-    src = super.fetchurl {
-      url = "mirror://openbsd/OpenSSH/portable/openssh-${version}.tar.gz";
-      sha256 = "090yxpi03pxxzb4ppx8g8hdpw7c4nf8p0avr6c7ybsaana5lp8vw";
-    };
-
+  libpcap-vxlan = super.libpcap.overrideAttrs (old: {
+    pname = "libpcap-vxlan";
+    patches = old.patches or [] ++ [
+      ./libpcap-replace-geneve-with-vxlan.patch
+    ];
   });
 
   percona = self.percona80;

--- a/versions.json
+++ b/versions.json
@@ -14,8 +14,8 @@
   "nixpkgs-23.05": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "9a23ab5c399dc8b4cd9f2580fad6edec2b03d151",
-    "sha256": "M++P0depmUF4gwGWxgAqvVGLLhdp6B/z4LXTbpvkQnU="
+    "rev": "c7168a363305a7191c620622ed4600b5c4a974f4",
+    "sha256": "sha256-0kj+RZCLkBMlPAp5ubSd9fcqDM8NUngFV+rXOHeo5nY="
   },
   "nixos-mailserver": {
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/",


### PR DESCRIPTION
We've been using openssh_9_6 anyways for a while as the default ssh package in 21.05.
To fix the vulnerability CVE-2024-6387, we can simply pull in the fixed package from 23.05 as we are pulling that nixpkgs channel anyways.

This obviously also updates all other packages we're pulling in from there, e.g. python.

(cherry picked from commit 2dcf2612f1758524bfc2514b6d4e7663f00a6cfa)

PL-132768

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

### PR release workflow (internal)

- [ ] PR has internal ticket
- [ ] internal issue ID (PL-…) part of branch name
- [ ] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [ ] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [ ] Security requirements tested? (EVIDENCE)
