### PR TITLE
 [24.05] OpenSSH fix CVE-2024-6387

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -408,11 +408,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1719409575,
-        "narHash": "sha256-R8riASa326cLXAEzld5SCU6YogLlyec10IkZ28BObcc=",
+        "lastModified": 1719856949,
+        "narHash": "sha256-Uajr8Rm4pTsCXXDsttmUwoKfMX/xw8jLCBhkbZQnwCI=",
         "owner": "flyingcircusio",
         "repo": "nixpkgs",
-        "rev": "339581035460157b80ef13a3e95590f7b6890800",
+        "rev": "11e806085509a1517f33fe94019d969b13b323a6",
         "type": "github"
       },
       "original": {

--- a/release/versions.json
+++ b/release/versions.json
@@ -8,9 +8,9 @@
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/"
   },
   "nixpkgs": {
-    "hash": "sha256-R8riASa326cLXAEzld5SCU6YogLlyec10IkZ28BObcc=",
+    "hash": "sha256-Uajr8Rm4pTsCXXDsttmUwoKfMX/xw8jLCBhkbZQnwCI=",
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "339581035460157b80ef13a3e95590f7b6890800"
+    "rev": "11e806085509a1517f33fe94019d969b13b323a6"
   }
 }


### PR DESCRIPTION
Pull upstream NixOS changes, security fixes and package updates:

- openssh: add backported security fix patches

PL-132768-2311

@flyingcircusio/release-managers

## Release process

Impact:
- sshd will be restarted

Changelog:
- patch a critical remote code execution vulnerability in openssh

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - patch a remote code execution vulnerability in openSSH https://www.qualys.com/2024/07/01/cve-2024-6387/regresshion.txt
  - must not introduce any know regressions 
- [x] Security requirements tested? (EVIDENCE)
  - [x] automated tests still pass
  - [x] successfully tested restarting openssh and connecting on a test vm