### PR TITLE
always restart gitlab-mailroom

### DIFF
--- a/nixos/roles/gitlab.nix
+++ b/nixos/roles/gitlab.nix
@@ -268,7 +268,7 @@ in
     # Needed for Git via SSH.
     users.users.gitlab.extraGroups = [ "login" ];
 
-    systemd.services.gitlab-mailroom.serviceConfig.Restart = lib.mkForce "always";
+    systemd.services.gitlab-mailroom.serviceConfig.Restart = lib.mkOverride 90 "always";
   })
 
   (lib.mkIf (cfg.enable && cfg.extraSecrets != []) {

--- a/nixos/roles/gitlab.nix
+++ b/nixos/roles/gitlab.nix
@@ -267,6 +267,8 @@ in
 
     # Needed for Git via SSH.
     users.users.gitlab.extraGroups = [ "login" ];
+
+    systemd.services.gitlab-mailroom.serviceConfig.Restart = lib.mkForce "always";
   })
 
   (lib.mkIf (cfg.enable && cfg.extraSecrets != []) {


### PR DESCRIPTION
PL-131890

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - This should make incoming mail on gitlab more reliable, so problems like the one in the ticket don't occur.
- [x] Security requirements tested? (EVIDENCE)
  - ran the gitlab test locally, with a slightly modified config to activate the gitlab-mailroom service
  - verified that it was restarted multiple times