### PR TITLE
images.fc: fix opening with kernel 5.15

### DIFF
--- a/release/make-disk-image.nix
+++ b/release/make-disk-image.nix
@@ -113,12 +113,13 @@ let format' = format; in let
       # mkfs.xfs does not support --offset, so we must place a separately
       # generated XFS image into the main disk image.
       truncate -s ''${sizeMB}M rootfs.img
-      mkfs.xfs -L ${rootLabel} rootfs.img
+      # TODO: nrext64 can be enabled again once we are at kernel >= 6.5 in the VMs
+      mkfs.xfs -i nrext64=0 -L ${rootLabel} rootfs.img
       dd if=rootfs.img of=$diskImage bs=1M seek=$startMB count=$sizeMB \
         conv=sparse,notrunc iflag=direct
       rm rootfs.img
     '' else ''
-      mkfs.xfs -L ${rootLabel} $diskImage
+      mkfs.xfs -i nrext64=0 -L ${rootLabel} $diskImage
     ''}
 
     root="$PWD/root"


### PR DESCRIPTION
We're still using kernel 5.15 in our VMs for now. Opening the XFS from the VM image had failed due to incompatible XFS features.

`nrext64` is only availabe from 5.19 on and non-experimental since 6.5, so we need to explicitly disable that feature for now when writing images.

PL-132780

@flyingcircusio/release-managers

## Release process

Impact: -

Changelog: -

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [ ] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - image file system needs to be mountable by the VM kernel at bootstrap
  - must not introduce known regressions
- [ ] Security requirements tested? (EVIDENCE)
  - [ ] automated tests still pass
  - [x] successfully mounted the image from a running 24.05 VM
    - as bootstrapping was broken all the time so far, I refrain from explicitly testing a bootstrap from this PR built product image and will do that once it has reached dev. I'm certain to have identified, tested and corrected the underlying issue.  