### PR TITLE
Sync Flake to lock file, update nixos-mailserver

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -67,6 +67,7 @@
       "original": {
         "owner": "cachix",
         "repo": "devenv",
+        "rev": "f810f8d8cb4e674d7e635107510bcbbabaa755a3",
         "type": "github"
       }
     },
@@ -316,16 +317,17 @@
       },
       "locked": {
         "host": "gitlab.flyingcircus.io",
-        "lastModified": 1717507921,
-        "narHash": "sha256-T3BiZRyD/jsEYKYO8iBA0kBlAiyC2wnJehWO0Ky5tLU=",
+        "lastModified": 1720096716,
+        "narHash": "sha256-5wpN5zFhdY/L1WgZX8B/MKFnNws5rqNFU3NPVgTQQXk=",
         "owner": "flyingcircus",
         "repo": "nixos-mailserver",
-        "rev": "a03b2ae33db2f20961ef29b41e4696db58e0483a",
+        "rev": "d772ec77e8cc8133b00018a1e548d5a4b984e6e3",
         "type": "gitlab"
       },
       "original": {
         "host": "gitlab.flyingcircus.io",
         "owner": "flyingcircus",
+        "ref": "nixos-24.05",
         "repo": "nixos-mailserver",
         "type": "gitlab"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -25,12 +25,12 @@
   inputs = {
     nixpkgs.url = "github:flyingcircusio/nixpkgs/nixos-24.05";
     nixos-mailserver = {
-      url = "gitlab:flyingcircus/nixos-mailserver/23.11?host=gitlab.flyingcircus.io";
+      url = "gitlab:flyingcircus/nixos-mailserver/nixos-24.05?host=gitlab.flyingcircus.io";
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.nixpkgs-24_05.follows = "nixpkgs";
     };
     devenv = {
-      url = "github:cachix/devenv/a1290a186b9420e2c0b21700f300b486ad90dcc9";
+      url = "github:cachix/devenv/f810f8d8cb4e674d7e635107510bcbbabaa755a3";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     flake-parts.url = "github:hercules-ci/flake-parts";


### PR DESCRIPTION
The lock file was correct but rebasing on the last 23.11 release introduced overrides that are wrong for 24.05. This pins devenv to the version expected in the lock file and uses the versioned nixos-mailserver branch instead of master.

Moreover, nixos-mailserver got rebased on the current upstream state for 24.05.

PL-132776

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

(internal)

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - make sure correct Flake inputs are used for dev purposes (devenv) and for generating versions.json (nixos-mailserver) by using versioned branches and pinning.
- [x] Security requirements tested? (EVIDENCE)
  - `nix flake lock` produces the expected output, mail test still works