### PR TITLE
[22.05] [hotfix] openssh: use 9.6p1 by default, patched against CVE-2024-6387

### DIFF
--- a/nixos/platform/default.nix
+++ b/nixos/platform/default.nix
@@ -325,6 +325,8 @@ in {
         attrByPath [ "static" "ntpServers" loc ] [ "pool.ntp.org" ] cfg;
     };
 
+    programs.ssh.package = pkgs.openssh_9_6;
+
     system.activationScripts = let
       cfgDirs = cfg.localConfigDirs;
 

--- a/pkgs/openssh/openssh-9.6_p1-CVE-2024-6387.patch
+++ b/pkgs/openssh/openssh-9.6_p1-CVE-2024-6387.patch
@@ -1,0 +1,19 @@
+https://bugs.gentoo.org/935271
+Backport proposed by upstream at https://marc.info/?l=oss-security&m=171982317624594&w=2.
+--- a/log.c
++++ b/log.c
+@@ -451,12 +451,14 @@ void
+ sshsigdie(const char *file, const char *func, int line, int showfunc,
+     LogLevel level, const char *suffix, const char *fmt, ...)
+ {
++#ifdef SYSLOG_R_SAFE_IN_SIGHAND
+ 	va_list args;
+ 
+ 	va_start(args, fmt);
+ 	sshlogv(file, func, line, showfunc, SYSLOG_LEVEL_FATAL,
+ 	    suffix, fmt, args);
+ 	va_end(args);
++#endif
+ 	_exit(1);
+ }
+ 

--- a/pkgs/openssh/openssh-9.6_p1-chaff-logic.patch
+++ b/pkgs/openssh/openssh-9.6_p1-chaff-logic.patch
@@ -1,0 +1,16 @@
+"Minor logic error in ObscureKeystrokeTiming"
+https://marc.info/?l=oss-security&m=171982317624594&w=2
+--- a/clientloop.c
++++ b/clientloop.c
+@@ -608,8 +608,9 @@ obfuscate_keystroke_timing(struct ssh *ssh, struct timespec *timeout,
+ 		if (timespeccmp(&now, &chaff_until, >=)) {
+ 			/* Stop if there have been no keystrokes for a while */
+ 			stop_reason = "chaff time expired";
+-		} else if (timespeccmp(&now, &next_interval, >=)) {
+-			/* Otherwise if we were due to send, then send chaff */
++		} else if (timespeccmp(&now, &next_interval, >=) &&
++		    !ssh_packet_have_data_to_write(ssh)) {
++			/* If due to send but have no data, then send chaff */
+ 			if (send_chaff(ssh))
+ 				nchaff++;
+ 		}

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -305,6 +305,27 @@ in {
 
   openldap_2_4 = super.callPackage ./openldap_2_4.nix { };
 
+  # fixes critical CVEs, especially CVE-2024-6387
+  openssh_9_6 = super.openssh.overrideAttrs(old_ssh: rec {
+    version = "9.6p1";
+    name = "openssh-${version}";
+
+    src = super.fetchurl {
+      url = "mirror://openbsd/OpenSSH/portable/openssh-${version}.tar.gz";
+      hash = "sha256-kQIRwHJVqMWtZUORtA7lmABxDdgRndU2LeCThap6d3w=";
+    };
+
+    patches = with builtins;
+      filter (p: ! (elem (builtins.baseNameOf p)
+                 ["CVE-2021-41617-1.patch" "CVE-2021-41617-2.patch"]))
+      old_ssh.patches
+      ++ [
+        ./openssh/openssh-9.6_p1-CVE-2024-6387.patch
+        ./openssh/openssh-9.6_p1-chaff-logic.patch
+      ];
+
+  });
+
   # fixes several CVEs https://www.openssl.org/news/secadv/20230207.txt
   inherit (super.callPackages ./openssl { })
       openssl_1_1


### PR DESCRIPTION
@flyingcircusio/release-managers

Hotfix version of #1053.

Package openssh-9.6p1 with patches against CVE-2024-6387 and use it as new platform default.

PL-132768

## Release process

Impact: sshd.service will be restarted

Changelog:
- openssh: apply patches for https://github.com/advisories/GHSA-2x8c-95vh-gfv4, default package used changes 9.0p1 -> 9.6p1
  - fixes a remote code execution vulnerability https://www.qualys.com/2024/07/01/cve-2024-6387/regresshion.txt
  - additionally also backport a fix for a minor logic error in ObscureKeystrokeTiming
  - note that this only updates the `openssh_9_6` package, which is used by the in-path `ssh` command and the `sshd.service` of the platform
  - This might affect the defaults for cryptographic algorithms, see the [openssh release notes](https://www.openssh.com/releasenotes.html) for details

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - patch a remote code execution vulnerability in openSSH https://www.qualys.com/2024/07/01/cve-2024-6387/regresshion.txt
  - same as for #1053, the branches are identical