### PR TITLE
[22.05] backport ntp server fix

### DIFF
--- a/nixos/platform/static.nix
+++ b/nixos/platform/static.nix
@@ -67,17 +67,14 @@ with lib;
       };
 
       nameservers = {
-        # ns.$location.gocept.net, ns2.$location.gocept.net
+        # The virtual router SRV IP which acts as the location-wide resolver.
+        #
         # We are currently not using IPv6 resolvers as we have seen obscure bugs
         # when enabling them, like weird search path confusion that results in
         # arbitrary negative responses, combined with the rotate flag.
-        #
-        # This seems to be https://sourceware.org/bugzilla/show_bug.cgi?id=13028
-        # which is fixed in glibc 2.22 which is included in NixOS 16.03.
-        dev = [ "172.20.2.1" "172.20.3.7" "172.20.3.57" ];
-        whq = [ "212.122.41.129" "212.122.41.173" "212.122.41.169" ];
-        rzob = [ "195.62.125.1" "195.62.126.130" "195.62.126.131" ];
-        rzrl1 = [ "84.46.82.1" "172.24.48.2" "172.24.48.10" ];
+        dev = [ "172.20.3.1" ];
+        whq = [ "172.16.48.1" ];
+        rzob = [ "172.22.48.1" ];
         standalone = [ "9.9.9.9" "8.8.8.8" ];
       };
 
@@ -116,10 +113,9 @@ with lib;
         # Those are the routers and backup servers. This needs to move to the
         # directory service discovery or just make them part of the router and
         # backup server role.
-        dev = [ "eddie" "kenny00" ];
-        whq = [ "lou" "kenny01" ];
-        rzob = [ "kenny06" "kenny07" ];
-        rzrl1 = [ "kenny02" "kenny03" ];
+        dev = [ "dev-router" ];
+        whq = [ "whq-router" ];
+        rzob = [ "rzob-router" ];
       };
 
       adminKeys = {


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

none

Changelog:

* Backport adapted NTP and resolver configs to help selected VMs that can't be updated at the moment. (PL-132604)

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

backport of known issue

- [x] Security requirements tested? (EVIDENCE)

backport, proven to work on current branch