### PR TITLE
[21.05] nixpkgs: fix revision to latest one from nixos-21.05 branch again

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "ac16a2cf6697c7acec2deac4e1a0dda7b446ebb9",
-    "sha256": "sha256:0qggp84mi73b229k8da75pla7nxp26ghwlqf299hpd75dldy8z0x"
+    "rev": "ef04308d458246202859145f7e583fe3a220cc34",
+    "sha256": "sha256-HXzkG23ltAtTEg5TDp8Rt9uj6C1HNTSTEGucWAm672E="
   },
   "nixpkgs-23.05": {
     "owner": "flyingcircusio",


### PR DESCRIPTION
We accidentally locked an intermediate result while rebasing. The content of the old and new revision is semantically identical.

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - availability of code: pick a revision that is part of a git branch to prevent accidental garbage collection
  - investigate weirdly looking git histories
  - must not introduce any known regressions 
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still pass