### PR TITLE
k3s: use 1.30 for new systems (state version 24.05)

### DIFF
--- a/doc/src/kubernetes.md
+++ b/doc/src/kubernetes.md
@@ -3,7 +3,7 @@
 # Kubernetes Cluster (k3s)
 
 :::{note}
-Kubernetes support is in beta. Feel free to use it but we suggest contacting
+Kubernetes/k3s is complex. Feel free to use it but we suggest contacting
 our support before putting anything into production.
 :::
 
@@ -30,7 +30,8 @@ run in a process called the `k3s agent`. We will prefer to use the words
 `server` and `agent` through the remainder of this document.
 :::
 
-We provide version 1.27.x of k3s.
+Machines created on NixOS 24.05 use k3s version 1.30.x. Machines upgraded
+from earlier platform versions use 1.27.x of k3s by default which was also the default for NixOS 23.11. Contact support if you want to use newer versions of k3s on these machines.
 
 ## Reference architecture and minimal resource requirements
 

--- a/nixos/roles/k3s/default.nix
+++ b/nixos/roles/k3s/default.nix
@@ -63,8 +63,11 @@
           }
         ];
 
-      services.k3s.package = pkgs.k3s_1_27;
     }
+
+    (lib.mkIf (lib.versionOlder config.system.stateVersion "24.05") {
+        services.k3s.package = pkgs.k3s_1_27;
+    })
 
     (lib.mkIf (server || agent) {
       flyingcircus.passwordlessSudoPackages = [


### PR DESCRIPTION
Current systems have a state version older than 24.05. They get the same k3s as for NixOS 23.11. New systems (or systems with an manually updated state version) get the current default version, that is 1.30

PL-132671

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - use current versions for k3s for new machines
  - allow smooth upgrades from older platform versions by pinning the k3s version to the same as for 23.11 
- [x] Security requirements tested? (EVIDENCE)
  - automated k3s test still runs, upgraded test cluster and checked that the version of k3s has not changed