### PR TITLE
[21.05] Update router configs after hardware changes in RZHAL

### DIFF
--- a/nixos/platform/static.nix
+++ b/nixos/platform/static.nix
@@ -191,6 +191,11 @@ with lib;
         rzob = [ "mgm" "srv" "fe" "tr-kamp-dhp" ];
       };
 
+      # Additional networks for which the routers provide DHCP service
+      additionalDhcpNetworks = {
+        whq = [ "video" "access" ];
+      };
+
       adminKeys = {
         directory = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDSejGFORJ7hlFraV3caVir3rWlo/QcsWptWrukk2C7eaGu/8tXMKgPtBHYdk4DYRi7EcPROllnFVzyVTLS/2buzfIy7XDjn7bwHzlHoBHZ4TbC9auqW3j5oxTDA4s2byP6b46Dh93aEP9griFideU/J00jWeHb27yIWv+3VdstkWTiJwxubspNdDlbcPNHBGOE+HNiAnRWzwyj8D0X5y73MISC3pSSYnXJWz+fI8IRh5LSLYX6oybwGX3Wu+tlrQjyN1i0ONPLxo5/YDrS6IQygR21j+TgLXaX8q8msi04QYdvnOqk1ntbY4fU8411iqoSJgCIG18tOgWTTOcBGcZX directory@directory.fcio.net";
         ctheune = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIA/lhMiMJBednrahZUJvb+dZVhLysbcuGf4p2J4D6MU/ ctheune@fourteen-3.local";

--- a/nixos/roles/router/bird2/dev.conf
+++ b/nixos/roles/router/bird2/dev.conf
@@ -92,7 +92,7 @@ template bgp peer_whq_6 from peer_whq {
   };
 }
 
-protocol bgp peer_whq_kenny05_4 from peer_whq_4 {
+protocol bgp peer_whq_kenny11_4 from peer_whq_4 {
   neighbor 172.20.6.8 as 64513;
 }
 
@@ -100,7 +100,7 @@ protocol bgp peer_whq_kenny01_4 from peer_whq_4 {
   neighbor 172.20.6.7 as 64513;
 }
 
-protocol bgp peer_whq_kenny05_6 from peer_whq_6 {
+protocol bgp peer_whq_kenny11_6 from peer_whq_6 {
   neighbor 2a02:238:f030:1c6::8 as 64513;
 }
 

--- a/nixos/roles/router/bird2/whq.conf
+++ b/nixos/roles/router/bird2/whq.conf
@@ -20,7 +20,7 @@ protocol device {
 
 protocol bfd {
   strict bind on;
-  interface "brtr";
+  interface "ethtr";
 }
 
 filter net_dev_4 {
@@ -91,7 +91,7 @@ template bgp peer_dev_6 from peer_dev {
   };
 }
 
-protocol bgp peer_dev_kenny00_4 from peer_dev_4 {
+protocol bgp peer_dev_kenny10_4 from peer_dev_4 {
   neighbor 172.20.6.9 as 64512;
 }
 
@@ -99,7 +99,7 @@ protocol bgp peer_dev_kenny04_4 from peer_dev_4 {
   neighbor 172.20.6.10 as 64512;
 }
 
-protocol bgp peer_dev_kenny00_6 from peer_dev_6 {
+protocol bgp peer_dev_kenny10_6 from peer_dev_6 {
   neighbor 2a02:238:f030:1c6::9 as 64512;
 }
 

--- a/nixos/roles/router/dhcpd.nix
+++ b/nixos/roles/router/dhcpd.nix
@@ -48,6 +48,12 @@ let
     # DHCPv6 specific general options
     option dhcp6.name-servers ${lib.concatStringsSep ", " resolvers6};
   '';
+
+  dhcpInterfaces = let
+    names = [ "mgm" "srv" "fe" ] ++
+            (config.flyingcircus.static.additionalDhcpNetworks."${location}" or []);
+  in
+    map (net: fclib.network."${net}".interface) names;
 in
 {
   options = with lib; {
@@ -64,11 +70,7 @@ in
   config = lib.mkIf (role.enable) {
     services.dhcpd4 = {
       enable = role.isPrimary;
-      interfaces = [
-        fclib.network.fe.interface
-        fclib.network.srv.interface
-        fclib.network.mgm.interface
-      ];
+      interfaces = dhcpInterfaces;
       configFile = pkgs.writeText "dhcpd4.conf" ''
         ${baseConf}
         ${dhcpd4Conf}
@@ -78,11 +80,7 @@ in
 
     services.dhcpd6 = {
       enable = role.isPrimary;
-      interfaces = [
-        fclib.network.fe.interface
-        fclib.network.srv.interface
-        fclib.network.mgm.interface
-      ];
+      interfaces = dhcpInterfaces;
       configFile = pkgs.writeText "dhcpd6.conf" ''
         ${baseConf}
         ${dhcpd6Conf}

--- a/nixos/roles/router/keepalived/whq.conf
+++ b/nixos/roles/router/keepalived/whq.conf
@@ -114,7 +114,7 @@ vrrp_instance video {
 }
 
 vrrp_instance tr {
-    interface brtr-whq-sl
+    interface ethtr-whq-sl
     state BACKUP
     virtual_router_id 51
     priority 100
@@ -130,12 +130,12 @@ vrrp_instance tr {
     virtual_routes {
         # We don't have a sufficiently large transfer net so we
         # need to use the default route only when we're the primary.
-        default via 213.187.81.6 dev brtr-whq-sl
+        default via 213.187.81.6 dev ethtr-whq-sl
     }
 }
 
 vrrp_instance access {
-    interface braccess
+    interface ethaccess
     state BACKUP
     virtual_router_id 51
     priority 100


### PR DESCRIPTION
This change updates the keepalived and Bird configs after we replaced some routers in RZHAL. In WHQ the transfer and access networks are now no longer bridged through VXLAN, and are instead normal tagged VLANs. The peer names in the Bird configs have also been updated correspondingly.

Additionally, I've added a new static data flag to indicate extra networks on which dhcpd should listen. Previously, we've been using machine-specific configs in order to ensure that dhcpd on the WHQ routers binds to the video and access interfaces, however as we've managed to forget to copy the machine-specific config when replacing a router once already, I've added this into the platform.

@flyingcircusio/release-managers

## Release process

Impact: internal.

Changelog: none.

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - No specific requirements, updating names in config files to appropriately reflect the currently deployed router hardware.
- [x] Security requirements tested? (EVIDENCE)
  - Tested manually in DEV.
  - System configuration built on WHQ router and inspected with `nix-diff` against the running system configuration, to ensure that the dhcpd command line is unchanged.