### PR TITLE
[23.11] Update nixpkgs (2024-07-09), Gitlab 16.11.6

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1719745305,
-        "narHash": "sha256-xwgjVUpqSviudEkpQnioeez1Uo2wzrsMaJKJClh+Bls=",
+        "lastModified": 1719994518,
+        "narHash": "sha256-pQMhCCHyQGRzdfAkdJ4cIWiw+JNuWsTX7f0ZYSyz0VY=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "c3c5ecc05edc7dafba779c6c1a61cd08ac6583e9",
+        "rev": "9227223f6d922fee3c7b190b2cc238a99527bbb7",
         "type": "github"
       },
       "original": {
@@ -353,14 +353,14 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1717284937,
-        "narHash": "sha256-lIbdfCsf8LMFloheeE6N31+BMIeixqyQWbSr2vk79EQ=",
+        "lastModified": 1719876945,
+        "narHash": "sha256-Fm2rDDs86sHy0/1jxTOKB1118Q0O3Uc7EC0iXvXKpbI=",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/eb9ceca17df2ea50a250b6b27f7bf6ab0186f198.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/5daf0514482af3f97abaefc78a6606365c9108e2.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/eb9ceca17df2ea50a250b6b27f7bf6ab0186f198.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/5daf0514482af3f97abaefc78a6606365c9108e2.tar.gz"
       }
     },
     "nixpkgs-regression": {
@@ -413,11 +413,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1719837770,
-        "narHash": "sha256-/wSTAlkXdhQoqLAdpAIqdkT3PxAuzv4rnxo8HSNz4cI=",
+        "lastModified": 1721221303,
+        "narHash": "sha256-GmCL4TD20jSVnf9yx7zJ3KmBO1dlY/k7aTS2yf049jA=",
         "owner": "flyingcircusio",
         "repo": "nixpkgs",
-        "rev": "450420281855a0a946b47e0396dbef45c7f51a0a",
+        "rev": "d9fbd7e2be156b9081161a2bbd34467ddbea1a1b",
         "type": "github"
       },
       "original": {

--- a/release/package-versions.json
+++ b/release/package-versions.json
@@ -70,14 +70,14 @@
     "version": "18.2.0"
   },
   "chromedriver": {
-    "name": "chromedriver-126.0.6478.61",
+    "name": "chromedriver-126.0.6478.126",
     "pname": "chromedriver",
-    "version": "126.0.6478.61"
+    "version": "126.0.6478.126"
   },
   "chromium": {
-    "name": "chromium-126.0.6478.61",
+    "name": "chromium-126.0.6478.126",
     "pname": "chromium",
-    "version": "126.0.6478.61"
+    "version": "126.0.6478.126"
   },
   "cifs-utils": {
     "name": "cifs-utils-7.0",
@@ -190,9 +190,9 @@
     "version": "7.17.16"
   },
   "firefox": {
-    "name": "firefox-127.0.1",
+    "name": "firefox-127.0.2",
     "pname": "firefox",
-    "version": "127.0.1"
+    "version": "127.0.2"
   },
   "gcc": {
     "name": "gcc-wrapper-12.3.0",
@@ -220,9 +220,9 @@
     "version": "2.42.2"
   },
   "gitaly": {
-    "name": "gitaly-16.11.5",
+    "name": "gitaly-16.11.6",
     "pname": "gitaly",
-    "version": "16.11.5"
+    "version": "16.11.6"
   },
   "github-runner": {
     "name": "github-runner-2.317.0",
@@ -230,9 +230,9 @@
     "version": "2.317.0"
   },
   "gitlab": {
-    "name": "gitlab-16.11.5",
+    "name": "gitlab-16.11.6",
     "pname": "gitlab",
-    "version": "16.11.5"
+    "version": "16.11.6"
   },
   "gitlab-container-registry": {
     "name": "gitlab-container-registry-4.5.0",
@@ -240,14 +240,14 @@
     "version": "4.5.0"
   },
   "gitlab-ee": {
-    "name": "gitlab-ee-16.11.5",
+    "name": "gitlab-ee-16.11.6",
     "pname": "gitlab-ee",
-    "version": "16.11.5"
+    "version": "16.11.6"
   },
   "gitlab-pages": {
-    "name": "gitlab-pages-16.11.5",
+    "name": "gitlab-pages-16.11.6",
     "pname": "gitlab-pages",
-    "version": "16.11.5"
+    "version": "16.11.6"
   },
   "gitlab-runner": {
     "name": "gitlab-runner-16.10.0",
@@ -255,9 +255,9 @@
     "version": "16.10.0"
   },
   "gitlab-workhorse": {
-    "name": "gitlab-workhorse-16.11.5",
+    "name": "gitlab-workhorse-16.11.6",
     "pname": "gitlab-workhorse",
-    "version": "16.11.5"
+    "version": "16.11.6"
   },
   "glibc": {
     "name": "glibc-2.38-77",
@@ -290,9 +290,9 @@
     "version": "1.20.12"
   },
   "grafana": {
-    "name": "grafana-10.2.7",
+    "name": "grafana-10.2.8",
     "pname": "grafana",
-    "version": "10.2.7"
+    "version": "10.2.8"
   },
   "grub2": {
     "name": "grub-2.12-rc1",
@@ -510,9 +510,9 @@
     "version": "10.11.6"
   },
   "mysql80": {
-    "name": "mysql-8.0.36",
+    "name": "mysql-8.0.37",
     "pname": "mysql",
-    "version": "8.0.36"
+    "version": "8.0.37"
   },
   "nfs-utils": {
     "name": "nfs-utils-2.6.2",
@@ -535,9 +535,9 @@
     "version": "1.24.0"
   },
   "nix": {
-    "name": "nix-2.18.1",
+    "name": "nix-2.18.4",
     "pname": "nix",
-    "version": "2.18.1"
+    "version": "2.18.4"
   },
   "nodejs": {
     "name": "nodejs-18.19.1",

--- a/release/versions.json
+++ b/release/versions.json
@@ -8,9 +8,9 @@
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/"
   },
   "nixpkgs": {
-    "hash": "sha256-/wSTAlkXdhQoqLAdpAIqdkT3PxAuzv4rnxo8HSNz4cI=",
+    "hash": "sha256-GmCL4TD20jSVnf9yx7zJ3KmBO1dlY/k7aTS2yf049jA=",
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "450420281855a0a946b47e0396dbef45c7f51a0a"
+    "rev": "d9fbd7e2be156b9081161a2bbd34467ddbea1a1b"
   }
 }


### PR DESCRIPTION
Update nixpkgs (2024-07-09), Gitlab 16.11.6

Pull upstream NixOS changes, security fixes and package updates:

- chromedriver: 126.0.6478.61 -> 126.0.6478.126
- chromium: 126.0.6478.61 -> 126.0.6478.126
- grafana: 10.2.7 -> 10.2.8
- mysql80: 8.0.36 -> 8.0.37
- nix: 2.18.1 -> 2.18.4

Additional packages updated by us (security fixes):

- gitlab: 16.11.5 -> 16.11.6

PL-132805

@flyingcircusio/release-managers

## Release process

Impact:

- \[NixOS 23.11] Gitlab will be restarted.

Changelog:

(see PR description)

### PR release workflow (internal)

- [x] Internal ticket handled correctly? internal issue ID (PL-…) must be part of branch name, and mentioned in PR description text (depending on workflow: agile board set?, PR ready?, ...)
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - pull in upstream security fixes from nixpkgs and for Gitlab regularly
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still run, works on various test VM, completed checklist for Gitlab test system
  - checked commit log for fixed CVEs and possible problems with updates looked at [GitLab 16 changes | GitLab](https://docs.gitlab.com/ee/update/versions/gitlab_16_changes.html) and  and [Grafana changelog](https://github.com/grafana/grafana/blob/main/CHANGELOG.md)
