### PR TITLE
docs/webgateway: link to official HAProxy upstream docs

### DIFF
--- a/doc/src/webgateway.md
+++ b/doc/src/webgateway.md
@@ -86,7 +86,7 @@ looks like this:
 
 Put your HAProxy configuration in {file}`/etc/local/haproxy/haproxy.cfg`.
 You can find an example config at {file}`/etc/local/haproxy/haproxy.cfg.example`.
-Please refer to the [official documentation](http://cbonte.github.io/haproxy-dconv/2.3/configuration.html)
+Please refer to the [official documentation](https://docs.haproxy.org/2.9/configuration.html)
 for more details.
 
 If you need more than just one centralized configuration file,


### PR DESCRIPTION
We used to link to some github pages instance. Also updates the version number to match the release we ship.
PL-132341

@flyingcircusio/release-managers

## Release process

Impact: -

Changelog: -

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - none, except not breaking the build or docs rendering
- [ ] Security requirements tested? (EVIDENCE)
  - looked at rendered docs
  - hydra tests still pass 
