### PR TITLE
release tarball building: fix missing files due to gitignore

### DIFF
--- a/release/default.nix
+++ b/release/default.nix
@@ -379,7 +379,6 @@ jobs // {
     tarOpts = ''
       --owner=0 --group=0 \
       --mtime="1970-01-01 00:00:00 UTC" \
-      --exclude-vcs-ignores \
     '';
 
     installPhase = ''


### PR DESCRIPTION
The path `nixos/nixpkgs/pkgs/development/python-modules/result` was missing from our generated release channel tarballs. This was due to the `release.release` job using the tar `--exclude-vcs-ignores` flag, thus parsing the .gitignore files in the subdirectories. This parsing is incomplete and incorrec though, ignoring the explizit entry in the upstream nixpkgs gitignore that includes said path again.

We've verified that we can just drop the option again. Channel tarballs are generated on hydra based on fresh git repo checkouts with no unexpected garbage files. By comparing tarball file listings with and without the flag, we've also verified that the original reason for this flag in commit b636b6c8b09bc0c1b972284d9472863a4c89254a – excluding `fc/channels` – is not necessary anymore.

PL-132753

@flyingcircusio/release-managers

## Release process

Impact: -

Changelog:
- `pkgs.python3Packages.result` was accidentally missing from our shipped version of nixpkgs. It is available again.

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - must not introduce any regressions
  - fix accidentally missing files
  - verify that no unnecessary files are included due to this change 
- [ ] Security requirements tested? (EVIDENCE)
  - [ ] automated tests still pass
  - [x] compared content path listing of generated tarballs, the only diff is the missing python *result* package which is no included again
