### PR TITLE
slurm: fixes and upgrade docs for 24.05, update docs

### DIFF
--- a/doc/src/slurm.md
+++ b/doc/src/slurm.md
@@ -122,7 +122,7 @@ The usual Slurm commands are installed globally on every Slurm machine.
 
 In general, all users can run slurm commands on all machines with a `slurm-*`
 role. Some commands require the use of `sudo -u slurm` to run as slurm user.
-This is allowed for(human) user accounts with the `sudo-srv` permission
+This is allowed for (human) user accounts with the `sudo-srv` permission
 without password.
 
 Use `slurm-readme` to show dynamically-generated documentation specific for
@@ -273,7 +273,18 @@ sudo -u slurm scancel -n jobname
 - `slurm-dbdserver` and `slurm-controller` roles must be on the same machine.
 - we support only one `slurm-controller` per cluster at the moment.
 
+(nixos-slurm-upgrade)=
 
+## Upgrading the Slurm clsuter
+
+When upgrading nodes between different *major versions* of Slurm, this need to happen in a [recommended order](https://slurm.schedmd.com/upgrades.html#procedure):
+1. Upgrade the `slurm-controller` node (possibly also running the `slurm-dbdserver`).
+1. Upgrade the `slurm-node` machines. This can happen in a rolling manner by updating only a subset of the worker nodes at a time to reduce total cluster downtime.
+
+Machines only running the `slurm-external-dependency` role can be updated independently.
+
+*Major versions* of slurm are denoted by the first two numbers of a version string, making 23.04.2 and 23.11.1 different major releases. \
+When running the default Slurm versions provided by our platform, such major upgrades only happen between major platform releases and are listed in the [upgrade notes](#nixos-upgrade).
 
 (nixos-slurm-config-reference)=
 

--- a/doc/src/upgrade.md
+++ b/doc/src/upgrade.md
@@ -125,6 +125,10 @@ Machines created on NixOS 24.05 use k3s version 1.30.x. Machines upgraded
 from earlier platform versions use 1.27.x of k3s by default which was also the
 default for NixOS 23.11. Contact support if you want to use newer versions of k3s on these machines.
 
+### Slurm
+
+This release contains a major version upgrade of Slurm from 23.04.x.x (NixOS 23.11) to 23.11.x.x. Nodes of a cluster need to be upgraded in a prticular order, the the [upgrade instructions of the role](#nixos-slurm-upgrade) for details.
+
 ## Other notable changes
 
 - `lamp` roles: Platform integration for the <https://tideways.com> application profiler has been dropped, the respective NixOS options are not available anymore.

--- a/doc/src/upgrade.md
+++ b/doc/src/upgrade.md
@@ -129,6 +129,8 @@ default for NixOS 23.11. Contact support if you want to use newer versions of k3
 
 This release contains a major version upgrade of Slurm from 23.04.x.x (NixOS 23.11) to 23.11.x.x. Nodes of a cluster need to be upgraded in a prticular order, the the [upgrade instructions of the role](#nixos-slurm-upgrade) for details.
 
+The default scheduler `SelectType` has been changed from `select/cons_res` to the default. As of now, this is `cons/tres`.
+
 ## Other notable changes
 
 - `lamp` roles: Platform integration for the <https://tideways.com> application profiler has been dropped, the respective NixOS options are not available anymore.

--- a/nixos/roles/slurm/default.nix
+++ b/nixos/roles/slurm/default.nix
@@ -394,7 +394,7 @@ in
           ExecStartPre = lib.mkForce [
             "${pkgs.coreutils}/bin/stat ${cfg.mungeKeyFile}"
           ];
-          Restart = "always";
+          Restart = lib.mkOverride 90 "always";
           RestartSec = "5s";
         };
       };

--- a/nixos/roles/slurm/default.nix
+++ b/nixos/roles/slurm/default.nix
@@ -294,7 +294,7 @@ in
         (pkgs.writeShellScriptBin "slurm-config-dir" "echo ${slurmCfg.etcSlurm}")
         (pkgs.writeShellScriptBin
           "slurm-readme"
-          "${pkgs.rich-cli}/bin/rich --pager /etc/local/slurm/README.md"
+          "${pkgs.rich-cli}/bin/rich /etc/local/slurm/README.md"
         )
         (pkgs.writeShellScriptBin "slurm-show-config" ''
           for x in ${slurmCfg.etcSlurm}/*; do

--- a/nixos/roles/slurm/default.nix
+++ b/nixos/roles/slurm/default.nix
@@ -331,13 +331,14 @@ in
           # FCIO extra config
           # XXX: Some settings probably be separate options later.
 
+          MailProg = ${pkgs.mailutils}/bin/mail
+
           # JOB PRIORITY
           PriorityType = priority/multifactor
           PriorityWeightQOS = 2000
 
           # SCHEDULING
           # Allocate individual processors and memory
-          SelectType = select/cons_res
           SelectTypeParameters = CR_CPU_Memory
 
           # Upon registration with a valid configuration only if it was set


### PR DESCRIPTION
Same behaviour as before but upstream introduced `Restart = on-failure` in 24.05. We want `always`.

Also use the default `cons_tres` scheduler instead of `cons_res`, since cons_res doesn't exist anymore.

Additionally, set `MailProg` to the corresponding nix store path, instead of the default `/bin/mail`. Note that this wasn't tested. 

PL-132833

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

- slurm: is usable now and works as before on 23.11, with the only difference that `SelectType` is now `cons_tres`. This is the slurm default and can be overridden as needed in custom config (PL-132833). 

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - critical slurm units should always be restarted.
  - special upgrade instructions need to be documented
  - docs need to render properly
- [x] Security requirements tested? (EVIDENCE)
  - builds in our slurm test cluster, checked that the munged.service unit file has the expected setting `Restart=always`
  - added upgrade instructions to docs, checked rendered result