### PR TITLE
Remove broken rich-cli options in opensearch role

### DIFF
--- a/nixos/services/opensearch.nix
+++ b/nixos/services/opensearch.nix
@@ -97,10 +97,10 @@ in
 
     environment.systemPackages = [
       (pkgs.writeShellScriptBin "opensearch-show-config" ''
-        ${pkgs.rich-cli}/bin/rich --pager /etc/current-config/opensearch.yml
+        ${pkgs.rich-cli}/bin/rich /etc/current-config/opensearch.yml
       '')
       (pkgs.writeShellScriptBin "opensearch-readme" ''
-        ${pkgs.rich-cli}/bin/rich --pager ${localConfigDir}/README.md
+        ${pkgs.rich-cli}/bin/rich ${localConfigDir}/README.md
       '')
     ];
 


### PR DESCRIPTION
The opensearch role uses rich-cli in order to syntax highlight the README and config file when viewed in the terminal. In 24.05 the `--pager` option to rich-cli no longer works correctly due to some dependency problem.

As a workaround, this option is removed so the README and config are still viewable, though without terminal paging.

PL-132830

@flyingcircusio/release-managers

## Release process

Impact: The opensearch README and configuration files are not displayed with terminal paging.

Changelog: The `opensearch-readme` and `opensearch-show-config` scripts now function correctly without crashing on NixOS 24.05 (PL-132830).

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - No particular security considerations.
- [x] Security requirements tested? (EVIDENCE)
  - Tested manually on a development VM.
