### PR TITLE
[21.05] Ensure sensu has permission to read LLDP state

### DIFF
--- a/nixos/platform/network.nix
+++ b/nixos/platform/network.nix
@@ -776,9 +776,14 @@ in
         command = let
           links = lib.concatStringsSep " " (map (i: i.link) fclib.underlay.links);
         in
-          "${pkgs.fc.check-link-redundancy}/bin/check_link_redundancy ${links}";
+          "/run/wrappers/bin/sudo ${pkgs.fc.check-link-redundancy}/bin/check_link_redundancy ${links}";
       };
     };
+
+    flyingcircus.passwordlessSudoRules = lib.optionals (!isNull fclib.underlay) [{
+      commands = [ "${pkgs.fc.check-link-redundancy}/bin/check_link_redundancy" ];
+      groups = [ "sensuclient" ];
+    }];
 
     systemd.timers.fc-lldp-to-altnames = lib.mkIf (!isNull fclib.underlay) {
       description = "Timer for updating interface altnames based on peer hostname advertised in LLDP";


### PR DESCRIPTION
The uplink redundancy sensu check uses data provided by lldpd, however the sensu process did not have the permissions to connect to the lldpd socket in order to read this data, which led to this check failing where it should have otherwise been succeeding.

This change adds a sudo rule to allow sensu to elevate privileges in order to communicate with lldpd.

PL-132852

@flyingcircusio/release-managers

## Release process

Impact: internal.

Changelog: none.

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - sensu-client has limited abilities to elevate privileges in order to check machine and application state which is not world-readable.
- [x] Security requirements tested? (EVIDENCE)
  - Verified on a test host in DEV.