### PR TITLE
gitlab: 17.1.1 -> 17.1.3

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -410,11 +410,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1721239998,
-        "narHash": "sha256-NTxsSGYdItizMebyg93QeV8yFpxwx8mjZ21qM8L74mE=",
+        "lastModified": 1721932847,
+        "narHash": "sha256-pMjEjqIN3ptAJRcEwAp9FWwWzubxW2TQ7XwIgyzJaqs=",
         "owner": "flyingcircusio",
         "repo": "nixpkgs",
-        "rev": "41a14fc52d08954ad18d3efb05dc283cba9ce346",
+        "rev": "934560deafee33c72d3622ac7942133f630e9d85",
         "type": "github"
       },
       "original": {

--- a/release/package-versions.json
+++ b/release/package-versions.json
@@ -220,9 +220,9 @@
     "version": "2.44.1"
   },
   "gitaly": {
-    "name": "gitaly-17.1.1",
+    "name": "gitaly-17.1.3",
     "pname": "gitaly",
-    "version": "17.1.1"
+    "version": "17.1.3"
   },
   "github-runner": {
     "name": "github-runner-2.317.0",
@@ -230,24 +230,24 @@
     "version": "2.317.0"
   },
   "gitlab": {
-    "name": "gitlab-17.1.1",
+    "name": "gitlab-17.1.3",
     "pname": "gitlab",
-    "version": "17.1.1"
+    "version": "17.1.3"
   },
   "gitlab-container-registry": {
-    "name": "gitlab-container-registry-4.5.0",
+    "name": "gitlab-container-registry-4.6.0",
     "pname": "gitlab-container-registry",
-    "version": "4.5.0"
+    "version": "4.6.0"
   },
   "gitlab-ee": {
-    "name": "gitlab-ee-17.1.1",
+    "name": "gitlab-ee-17.1.3",
     "pname": "gitlab-ee",
-    "version": "17.1.1"
+    "version": "17.1.3"
   },
   "gitlab-pages": {
-    "name": "gitlab-pages-17.1.1",
+    "name": "gitlab-pages-17.1.3",
     "pname": "gitlab-pages",
-    "version": "17.1.1"
+    "version": "17.1.3"
   },
   "gitlab-runner": {
     "name": "gitlab-runner-17.1.0",
@@ -255,9 +255,9 @@
     "version": "17.1.0"
   },
   "gitlab-workhorse": {
-    "name": "gitlab-workhorse-17.1.1",
+    "name": "gitlab-workhorse-17.1.3",
     "pname": "gitlab-workhorse",
-    "version": "17.1.1"
+    "version": "17.1.3"
   },
   "glibc": {
     "name": "glibc-2.39-52",

--- a/release/versions.json
+++ b/release/versions.json
@@ -8,9 +8,9 @@
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/"
   },
   "nixpkgs": {
-    "hash": "sha256-NTxsSGYdItizMebyg93QeV8yFpxwx8mjZ21qM8L74mE=",
+    "hash": "sha256-pMjEjqIN3ptAJRcEwAp9FWwWzubxW2TQ7XwIgyzJaqs=",
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "41a14fc52d08954ad18d3efb05dc283cba9ce346"
+    "rev": "934560deafee33c72d3622ac7942133f630e9d85"
   }
 }


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

(none, no Gitlab instances on 24.05, yet)

Changelog:

- gitlab: 17.1.1 -> 17.1.3 (PL-132857).

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - apply security updates asap 
  - major gitlab upgrades should not break customer instances
- [x] Security requirements tested? (EVIDENCE)
  - checked on our Gitlab staging system that upgrading from 23.11 (Gitlab 16.11) to 24.05 (first 17.1.1, then 17.1.2, and finally 17.1.3) works without manual intervention. We had to enable registration tokens on the target version to get gitlab-runner working with the new version. 
  - validated functionality using our standard staging Gitlab checklist
  - looked at [Gitlab 17 changes](https://docs.gitlab.com/ee/update/versions/gitlab_17_changes.html)
    - the mentioned migration problem should not affect us because we are directly upgrading to 17.1.3 and not to the buggy version 17.1.1
