### PR TITLE
docs/matomo: postpone promised Matomo 5

### DIFF
--- a/doc/src/matomo.md
+++ b/doc/src/matomo.md
@@ -4,7 +4,8 @@
 
 Managed instance of [Matomo](https://matomo.org), a real-time Web analytics application in the latest LTS version provided by NixOS which is 4.x.x.
 
-The next platform version 24.05 will use Matomo 5 as default version. Matomo 4 is supported until the end of 2024 and will still be available on 24.05.
+The next platform version 24.11 will use Matomo 5 as default version. Matomo 4 is supported until the end of 2024 only, so while we are still going
+to provide it in 24.11 be prepared to upgrade by then.
 
 ## Setup
 

--- a/doc/src/matomo.md
+++ b/doc/src/matomo.md
@@ -4,8 +4,8 @@
 
 Managed instance of [Matomo](https://matomo.org), a real-time Web analytics application in the latest LTS version provided by NixOS which is 4.x.x.
 
-The next platform version 24.11 will use Matomo 5 as default version. Matomo 4 is supported until the end of 2024 only, so while we are still going
-to provide it in 24.11 be prepared to upgrade by then.
+The next platform version 24.11 will use Matomo 5 as default version.
+Matomo 4 is supported only until the end of 2024.
 
 ## Setup
 


### PR DESCRIPTION
We won't provide Matomo 5 from the start of NixOS 24.05, especially not as a default. Correcting the docs.
PL-132236

@flyingcircusio/release-managers

## Release process

Impact: -

Changelog: -

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
  - n/a 
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - provide correct information in docs, set correct expectation
  - docs need to render correctly 
- [x] Security requirements tested? (EVIDENCE)
  - checked rendering result of changed doc page