### PR TITLE
[21.05] Ensure DNSSEC trust anchors are cached in persistent storage on routers

### DIFF
--- a/nixos/roles/router/bind/default.nix
+++ b/nixos/roles/router/bind/default.nix
@@ -119,6 +119,11 @@ lib.mkIf role.enable {
     ];
   };
 
+  flyingcircus.services.sensu-client.checks.bind_resolver = {
+    notification = "Bind can resolve hostnames";
+    command = "check_dig -H localhost -l flyingcircus.io";
+  };
+
   networking.firewall.extraCommands = ''
     ip46tables -A nixos-fw -p tcp --dport 53 -j nixos-fw-accept
     ip46tables -A nixos-fw -p udp --dport 53 -j nixos-fw-accept

--- a/nixos/roles/router/bind/default.nix
+++ b/nixos/roles/router/bind/default.nix
@@ -102,6 +102,7 @@ lib.mkIf role.enable {
 
   services.bind = {
     enable = true;
+    directory = "/var/cache/named";
     configFile = ./named.conf;
   };
 

--- a/nixos/roles/router/bind/named.conf
+++ b/nixos/roles/router/bind/named.conf
@@ -1,7 +1,7 @@
 include "/etc/bind/acl.conf";
 
 options {
-	directory "/run/named";
+	directory "/var/cache/named";
 	pid-file "/run/named/named.pid";
 
 	listen-on-v6 { any; };

--- a/versions.json
+++ b/versions.json
@@ -2,8 +2,8 @@
   "nixpkgs": {
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "ef04308d458246202859145f7e583fe3a220cc34",
-    "sha256": "sha256-HXzkG23ltAtTEg5TDp8Rt9uj6C1HNTSTEGucWAm672E="
+    "rev": "a467063b4abb8bd7636d9bb2475edbd2f0e6c6b6",
+    "sha256": "sha256-5ufC/t0sUFS/LspiEwU8DW5+uVYM3diZ1IC7KjX9ek4="
   },
   "nixpkgs-23.05": {
     "owner": "flyingcircusio",


### PR DESCRIPTION
We have encountered problems where Bind on a router was started while the router did not have an internet connection, which led to Bind failing to resolve the DNSSEC trust anchor. Due to the missing trust anchor, Bind could not perform DNSSEC verification, which broke resolution completely. The missing trust anchor was negatively cached, and Bind was not able to recover from this state without manual intervention. The trust anchor files (which may or may not be populated with the anchor keys) are cached in Bind's data directory, which in NixOS 21.05 is hard-coded as `/run/named`, which is not persistent when the machine reboots.

This change fixes this issue by bumping the Nixpkgs pin to our 21.05 branch with a fix backported which allows the cache directory to be configured, and configures this directory to a persistent path under `/var/cache`. Additionally, there is a new Sensu check which checks that the Bind instance running on localhost on routers can resolve external hostnames.

PL-132779

@flyingcircusio/release-managers

## Release process

Impact: internal.

Changelog: none.

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - This change makes our DNSSEC-enabled resolvers more resilient against circumstances where internet connectivity is not immediately available when the Bind process is started.
- [x] Security requirements tested? (EVIDENCE)
  - Manually tested on the routers in DEV.