### PR TITLE
Raise ClamAV warning threshold to 26 hours

### DIFF
--- a/pkgs/fc/sensuplugins/fc/sensuplugins/clamav_database.py
+++ b/pkgs/fc/sensuplugins/fc/sensuplugins/clamav_database.py
@@ -25,7 +25,7 @@ def main():
     check_age_cmd = [
         "check_file_age",
         "-w",
-        "86400",
+        "93600",
         "-c",
         "172800",
     ]


### PR DESCRIPTION
The antivirus role in the platform includes a check which ensures that the ClamAV data definitions have been updated in the last 24 hours. However, the ClamAV update timer is configured with some jitter, to prevent a thundering herd where many machines with the role enabled attempt to download the new definitions from ClamAV's servers simultaneously. This means that under normal operation the ClamAV definitions may temporarily be more than 24 hours old due to load spreading.

This change raises the warning threshold from 24 to 26 hours. It is expected that the data files may briefly be more than 24 hours old, and raising a warning at 24 hours can cause a lot of noise in the monitoring review which will resolve on its own.

PL-132844

@flyingcircusio/release-managers

## Release process

Impact: none.

Changelog: The antivirus role now only warns about stale ClamAV data files after 26 hours, to prevent spurious warnings from machines which have a delayed update job for load spreading purposes. (PL-132844)

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Raising warning threshold to avoid spurious warning.
- [x] Security requirements tested? (EVIDENCE)
  - This is a small change, so I've chosen not to test it explicitly. I expect code review and Hydra tests to be sufficent.
