### PR TITLE
Skip cluster green check for single-node opensearch clusters

### DIFF
--- a/doc/src/opensearch.md
+++ b/doc/src/opensearch.md
@@ -157,3 +157,12 @@ The following checks are provided by our opensearch service:
 - Heap too full
 - Node status
 - Shard allocation status
+
+## Automated maintenance
+
+When operating as a multi-node cluster, the automated maintenance
+system ensures that at most one member of the cluster performs
+maintenance at the same time. Additionally, before running maintenance
+activities on hosts which are members of a multi-node cluster, the
+cluster state must be green. The check will wait for up to 60 seconds
+for the cluster to become green.

--- a/nixos/roles/opensearch.nix
+++ b/nixos/roles/opensearch.nix
@@ -152,11 +152,14 @@ in
 
       ## Automated Maintenance
 
-      Our automated maintenance system makes sure that only one member of the cluster
-      (as specified by `nodes`) is in maintenance at the same time.
+      For multi-node clusters, our automated maintenance system makes sure that
+      only one member of the cluster (as specified by `nodes`) is in maintenance
+      at the same time. Also, before running maintenance activities, the cluster
+      state must be "green". The check waits for 60 seconds for the cluster to
+      become green.
 
-      Also, before running maintenance activities, the cluster state must be "green".
-      The check waits for 60 seconds for the cluster to become green.
+      Single-node clusters will not consider the cluster state before performing
+      automated maintenance.
     '';
 
     # Require other nodes to be in service before going into maintenance.

--- a/nixos/roles/opensearch.nix
+++ b/nixos/roles/opensearch.nix
@@ -161,9 +161,11 @@ in
 
     # Require other nodes to be in service before going into maintenance.
     flyingcircus.agent.maintenanceConstraints.machinesInService = cfg.nodes;
-    flyingcircus.agent.maintenance."opensearch-cluster-green".enter = ''
-      ${waitForGreenCluster}/bin/opensearch-wait-for-green-cluster
-    '';
+    flyingcircus.agent.maintenance = lib.mkIf (lib.length cfg.nodes > 1) {
+      "opensearch-cluster-green".enter = ''
+        ${waitForGreenCluster}/bin/opensearch-wait-for-green-cluster
+      '';
+    };
 
     flyingcircus.services.opensearch = {
       enable = true;


### PR DESCRIPTION
The opensearch role has a maintenance script to ensure that the cluster is green before allowing a host to enter maintenance and possibly reboot. This functionality is mostly intended for use with multi-node clusters, where multiple nodes may reboot in sequence, and the cluster should be allowed to recover in between hosts rebooting. However we have seen cases where a single-node opensearch cluster may have indices in the yellow state, and as these indices do not recover by themselves this means that the cluster health check prevents these nodes from running maintenances.

With this change, the cluster health check is only enabled for multi-node clusters, and single-node clusters will no longer check the cluster health state before entering maintenance.

@flyingcircusio/release-managers

## Release process

Impact: none.

Changelog: Single-node opensearch clusters will now enter maintenance without checking if the cluster health is in the green state. (PL-132797)

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Ensure that hosts running opensearch in single-node mode will still be able to run automated maintenances independent of the cluster health.
- [x] Security requirements tested? (EVIDENCE)
  - Maintenance configuration compared and verified on single-node and multi-node test clusters.