### PR TITLE
Update URLs to web documentation for 24.05

### DIFF
--- a/nixos/platform/firewall.nix
+++ b/nixos/platform/firewall.nix
@@ -74,7 +74,7 @@ in
       - nixos-nat-pre: prerouting rules, e.g. port redirects (-t nat)
       - nixos-nat-post: postrouting rules, e.g. masquerading (-t nat)
 
-      See also https://doc.flyingcircus.io/roles/fc-23.11-production/firewall.html
+      See also ${fclib.roleDocUrl "firewall"}
     '';
 
     flyingcircus.services.sensu-client.checks = {

--- a/nixos/roles/mysql.nix
+++ b/nixos/roles/mysql.nix
@@ -323,7 +323,7 @@ in
       `sudo systemctl restart mysql`
 
       For more information, see our documentation at
-      https://doc.flyingcircus.io/roles/fc-23.11-production/mysql.html
+      ${fclib.roleDocUrl "mysql"}
     '';
 
     systemd.services.fc-mysql-post-init = {

--- a/nixos/services/mail/README
+++ b/nixos/services/mail/README
@@ -7,7 +7,7 @@ It uses Postfix for mail delivery, Dovecot as IMAP access server, and Roundcube 
 
 Refer to the platform documentation for detailed information on how to configure this:
 
-https://doc.flyingcircus.io/roles/fc-23.11-production/mailserver.html
+https://doc.flyingcircus.io/roles/fc-24.05-production/mailserver.html
 
 
 Role Settings

--- a/nixos/services/mail/stub.nix
+++ b/nixos/services/mail/stub.nix
@@ -39,7 +39,7 @@ let
 
     This role shares some configuration options which the 'mailserver' role:
     mailHost, rootAlias, smtpBind[46], explicitSmtpBind. Refer to
-    https://doc.flyingcircus.io/roles/fc-23.11-production/mailserver.html for
+    ${fclib.roleDocUrl "mailserver"} for
     explanation.
   '';
 

--- a/nixos/services/nginx/README.txt
+++ b/nixos/services/nginx/README.txt
@@ -3,7 +3,7 @@ Nginx is enabled on this machine.
 The recommended method is structured configuration via Nix code in `/etc/local/nixos`.
 You can also find an example at `/etc/local/nixos/nginx.nix.example`.
 Refer to the webgateway role documentation at
-https://doc.flyingcircus.io/roles/fc-23.11-production/webgateway.html for more info.
+https://doc.flyingcircus.io/roles/fc-24.05-production/webgateway.html for more info.
 
 
 Old configuration methods

--- a/nixos/services/postgresql/default.nix
+++ b/nixos/services/postgresql/default.nix
@@ -54,7 +54,7 @@ let
   legacyConfigWarning =
     ''Plain PostgreSQL configuration found in ${toString localConfigPath}.
     This does not work properly anymore and must be migrated to NixOS configuration.
-    See https://doc.flyingcircus.io/roles/fc-23.11-production/postgresql.html for details.'';
+    See ${fclib.roleDocUrl "postgresql"} for details.'';
 
   localConfig =
     if legacyConfigFiles != []
@@ -204,7 +204,7 @@ in {
 
         See the platform documentation for more details:
 
-        https://doc.flyingcircus.io/roles/fc-23.11-production/postgresql.html
+        ${fclib.roleDocUrl "postgresql"}
       '';
 
       flyingcircus.infrastructure.preferNoneSchedulerOnSsd = true;


### PR DESCRIPTION
There are a few URLs for the platform web documentation in role README files which pointed to the documentation for 23.11 instead of 24.05. This change updates these links to point to the 24.05 platform documentation, and for README files generated from Nix code uses the platform function which interpolates a link to the appropriate role documentation automatically.

PL-132885

@flyingcircusio/release-managers

## Release process

Impact: none.

Changelog:

- Updated documentation URLs in role README files to point to the correct platform version (PL-132885).

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - No particular security requirements, this is an update of document links.
- [x] Security requirements tested? (EVIDENCE)
  - Affected roles have been tested on dev VMs to ensure the URL interpolation works as expected.