### PR TITLE
[21.05] monitoring/network: check explicit list of interfaces

### DIFF
--- a/nixos/infrastructure/flyingcircus-physical.nix
+++ b/nixos/infrastructure/flyingcircus-physical.nix
@@ -153,7 +153,11 @@ mkIf (cfg.infrastructureModule == "flyingcircus-physical") {
     flyingcircus.services.sensu-client.checks = with pkgs; {
       interfaces = {
         notification = "Network interfaces are healthy";
-        command = "sudo ${fc.sensuplugins}/bin/check_interfaces -a -s 1000:";
+        command = "sudo ${fc.sensuplugins}/bin/check_interfaces " + (
+           lib.concatMapStringsSep " "
+             (link: "-i ${link.link},1000:10000")
+             cfg.networking.monitorLinks
+           );
         interval = 60;
       };
       lvm_integrity = {

--- a/nixos/platform/network.nix
+++ b/nixos/platform/network.nix
@@ -50,7 +50,6 @@ let
     ) physicalLinkNames);
   in (attrValues physicalLinksByMtu) ++ underlayLinks;
 
-
   virtualLinks = let
     allLinks = lib.unique
       (lib.foldl (acc: iface: acc ++ iface.linkStack) [] managedInterfaces);
@@ -92,6 +91,11 @@ in
       type = lib.types.bool;
       description = "Enable default routes for all networks with known default gateways.";
       default = true;
+    };
+    flyingcircus.networking.monitorLinks = lib.mkOption {
+      type = lib.types.listOf lib.types.attrs;
+      description = "Names of ethernet devices to monitor.";
+      default = [];
     };
   };
 
@@ -278,6 +282,8 @@ in
         tag_keys = [ "family" "path" ];
       }];
     };
+
+    flyingcircus.networking.monitorLinks = ethernetLinks;
 
     services.frr = lib.mkIf (!isNull fclib.underlay) {
       zebra = {


### PR DESCRIPTION
We used to "autodetect" the interfaces to check. However, with recent changes there may be intermediate states where interfaces are stuck in a semi-configured state until reboots.

This change adapts the interface check to only verify the explicitly named interfaces that we expect to be up. We don't really care about others.

Re PL-132536

@flyingcircusio/release-managers

## Release process

Impact:

n/a

Changelog:

- Fix network interface check to only apply to explicitly configured interfaces. (PL-132536)

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

Avoid monitoring noise.

- [x] Security requirements tested? (EVIDENCE)

Manually tested.