### PR TITLE
Update nixpkgs (2024-08-12)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1719994518,
-        "narHash": "sha256-pQMhCCHyQGRzdfAkdJ4cIWiw+JNuWsTX7f0ZYSyz0VY=",
+        "lastModified": 1722555600,
+        "narHash": "sha256-XOQkdLafnb/p9ij77byFQjDf5m5QYl9b2REiVClC+x4=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "9227223f6d922fee3c7b190b2cc238a99527bbb7",
+        "rev": "8471fe90ad337a8074e957b69ca4d0089218391d",
         "type": "github"
       },
       "original": {
@@ -350,14 +350,14 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1719876945,
-        "narHash": "sha256-Fm2rDDs86sHy0/1jxTOKB1118Q0O3Uc7EC0iXvXKpbI=",
+        "lastModified": 1722555339,
+        "narHash": "sha256-uFf2QeW7eAHlYXuDktm9c25OxOyCoUOQmh5SZ9amE5Q=",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/5daf0514482af3f97abaefc78a6606365c9108e2.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/a5d394176e64ab29c852d03346c1fc9b0b7d33eb.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/5daf0514482af3f97abaefc78a6606365c9108e2.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/a5d394176e64ab29c852d03346c1fc9b0b7d33eb.tar.gz"
       }
     },
     "nixpkgs-regression": {
@@ -410,11 +410,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1722513903,
-        "narHash": "sha256-D1/3SQdD9v1s9FpZ+2unu7U8SsZlInlPRjkXtVq8QLc=",
+        "lastModified": 1723534182,
+        "narHash": "sha256-tE+xUiePq4vT/XUVYyIHD/GLabdj6uSTZ8jwkgbCGUM=",
         "owner": "flyingcircusio",
         "repo": "nixpkgs",
-        "rev": "d589a8e686ecdb4080b78578348d2ddb95c9b344",
+        "rev": "67385d65beeb877876792d396dc979f132fb2fe1",
         "type": "github"
       },
       "original": {

--- a/nixpkgs-config.nix
+++ b/nixpkgs-config.nix
@@ -13,5 +13,6 @@
     "openssl-1.1.1w" # EOL 2023-09-11, needed for Percona and older PHP versions.
     "python-2.7.18.8" # Needed for some legacy customer applications.
     "ruby-2.7.8" # EOL 2023-03-31, needed for Sensu checks
+    "docker-24.0.9" # Old installs still use storage driver removed in 25.x.
   ];
 }

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -84,6 +84,13 @@ builtins.mapAttrs (_: patchPhps phpLogPermissionPatch) {
 
   docsplit = super.callPackage ./docsplit { };
 
+  # Don't make docker 25.x the default yet, we still have old docker
+  # installs which use the devicemapper storage driver.
+  docker = super.docker_24.overrideAttrs (old: {
+    # Workaround for Hydra not reading nixpkgs-config.nix
+    meta = builtins.removeAttrs old.meta [ "knownVulnerabilites" ];
+  });
+
   innotop = super.callPackage ./percona/innotop.nix { };
 
   libmodsecurity = super.callPackage ./libmodsecurity { };

--- a/release/package-versions.json
+++ b/release/package-versions.json
@@ -140,9 +140,9 @@
     "version": "2.90"
   },
   "docker": {
-    "name": "docker-25.0.6",
+    "name": "docker-24.0.9",
     "pname": "docker",
-    "version": "25.0.6"
+    "version": "24.0.9"
   },
   "docker-compose": {
     "name": "docker-compose-2.27.0",

--- a/release/package-versions.json
+++ b/release/package-versions.json
@@ -10,9 +10,9 @@
     "version": "2.4.62"
   },
   "asterisk": {
-    "name": "asterisk-20.8.1",
+    "name": "asterisk-20.9.1",
     "pname": "asterisk",
-    "version": "20.8.1"
+    "version": "20.9.1"
   },
   "auditbeat7-oss": {
     "name": "auditbeat-oss-7.17.16",
@@ -70,14 +70,14 @@
     "version": "18.2.1"
   },
   "chromedriver": {
-    "name": "chromedriver-126.0.6478.182",
+    "name": "chromedriver-127.0.6533.99",
     "pname": "chromedriver",
-    "version": "126.0.6478.182"
+    "version": "127.0.6533.99"
   },
   "chromium": {
-    "name": "chromium-126.0.6478.182",
+    "name": "chromium-127.0.6533.99",
     "pname": "chromium",
-    "version": "126.0.6478.182"
+    "version": "127.0.6533.99"
   },
   "cifs-utils": {
     "name": "cifs-utils-7.0",
@@ -130,9 +130,9 @@
     "version": "5.3.28"
   },
   "discourse": {
-    "name": "discourse-3.2.4",
+    "name": "discourse-3.2.5",
     "pname": "discourse",
-    "version": "3.2.4"
+    "version": "3.2.5"
   },
   "dnsmasq": {
     "name": "dnsmasq-2.90",
@@ -140,9 +140,9 @@
     "version": "2.90"
   },
   "docker": {
-    "name": "docker-24.0.9",
+    "name": "docker-25.0.6",
     "pname": "docker",
-    "version": "24.0.9"
+    "version": "25.0.6"
   },
   "docker-compose": {
     "name": "docker-compose-2.27.0",
@@ -155,9 +155,9 @@
     "version": "2.3.21"
   },
   "element-web": {
-    "name": "element-web-1.11.71",
+    "name": "element-web-1.11.73",
     "pname": "element-web",
-    "version": "1.11.71"
+    "version": "1.11.73"
   },
   "erlang": {
     "name": "erlang-25.3.2.12",
@@ -190,9 +190,9 @@
     "version": "7.17.16"
   },
   "firefox": {
-    "name": "firefox-128.0.3",
+    "name": "firefox-129.0",
     "pname": "firefox",
-    "version": "128.0.3"
+    "version": "129.0"
   },
   "gcc": {
     "name": "gcc-wrapper-13.2.0",
@@ -225,9 +225,9 @@
     "version": "17.1.3"
   },
   "github-runner": {
-    "name": "github-runner-2.317.0",
+    "name": "github-runner-2.319.0",
     "pname": "github-runner",
-    "version": "2.317.0"
+    "version": "2.319.0"
   },
   "gitlab": {
     "name": "gitlab-17.1.3",
@@ -297,9 +297,9 @@
     "version": "2.9.7"
   },
   "imagemagick": {
-    "name": "imagemagick-7.1.1-35",
+    "name": "imagemagick-7.1.1-36",
     "pname": "imagemagick",
-    "version": "7.1.1-35"
+    "version": "7.1.1-36"
   },
   "imagemagick6": {
     "name": "imagemagick-6.9.13-10",
@@ -307,9 +307,9 @@
     "version": "6.9.13-10"
   },
   "imagemagick7": {
-    "name": "imagemagick-7.1.1-35",
+    "name": "imagemagick-7.1.1-36",
     "pname": "imagemagick",
-    "version": "7.1.1-35"
+    "version": "7.1.1-36"
   },
   "inetutils": {
     "name": "inetutils-2.5",
@@ -437,9 +437,9 @@
     "version": "0.2.5"
   },
   "linux_5_15": {
-    "name": "linux-5.15.163",
+    "name": "linux-5.15.164",
     "pname": "linux",
-    "version": "5.15.163"
+    "version": "5.15.164"
   },
   "logrotate": {
     "name": "logrotate-3.21.0",
@@ -482,9 +482,9 @@
     "version": "5.0.2"
   },
   "matrix-synapse": {
-    "name": "matrix-synapse-wrapped-1.111.0",
+    "name": "matrix-synapse-wrapped-1.112.0",
     "pname": "matrix-synapse-wrapped",
-    "version": "1.111.0"
+    "version": "1.112.0"
   },
   "mcpp": {
     "name": "mcpp-2.7.2.1",
@@ -933,9 +933,9 @@
     "version": "7.2.4"
   },
   "roundcube": {
-    "name": "roundcube-1.6.7",
+    "name": "roundcube-1.6.8",
     "pname": "roundcube",
-    "version": "1.6.7"
+    "version": "1.6.8"
   },
   "rsync": {
     "name": "rsync-3.3.0",
@@ -964,9 +964,9 @@
     "version": "4.9.1"
   },
   "slurm": {
-    "name": "slurm-23.11.7.1",
+    "name": "slurm-23.11.9.1",
     "pname": "slurm",
-    "version": "23.11.7.1"
+    "version": "23.11.9.1"
   },
   "solr": {
     "name": "solr-8.11.2",
@@ -999,9 +999,9 @@
     "version": "12.7.4"
   },
   "systemd": {
-    "name": "systemd-255.6",
+    "name": "systemd-255.9",
     "pname": "systemd",
-    "version": "255.6"
+    "version": "255.9"
   },
   "tcpdump": {
     "name": "tcpdump-4.99.4",

--- a/release/versions.json
+++ b/release/versions.json
@@ -8,9 +8,9 @@
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/"
   },
   "nixpkgs": {
-    "hash": "sha256-D1/3SQdD9v1s9FpZ+2unu7U8SsZlInlPRjkXtVq8QLc=",
+    "hash": "sha256-tE+xUiePq4vT/XUVYyIHD/GLabdj6uSTZ8jwkgbCGUM=",
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "d589a8e686ecdb4080b78578348d2ddb95c9b344"
+    "rev": "67385d65beeb877876792d396dc979f132fb2fe1"
   }
 }


### PR DESCRIPTION
Update nixpkgs (2024-08-12)

Pull upstream NixOS changes, security fixes and package updates:

- asterisk: 20.8.1 -> 20.9.0
- chromedriver: 126.0.6478.182 -> 127.0.6533.72
- chromium: 126.0.6478.182 -> 127.0.6533.72
- curl: fix CVE-2024-6197
- discourse: 3.2.4 -> 3.2.5 (CVE-2024-37165, CVE-2024-39320, CVE-2024-37299)
- element-web: 1.11.71 -> 1.11.73
- github-runner: 2.317.0 -> 2.319.0
- imagemagick: 7.1.1-35 -> 7.1.1-36
- linux_5_15: 5.15.163 -> 5.15.164
- matrix-synapse: 1.111.0 -> 1.112.0
- nss: 3.90.2 -> 3.101.2
- roundcube: 1.6.7 -> 1.6.8 (CVE-2024-42009, CVE-2024-42008, CVE-2024-42010)
- slurm: 23.11.7.1 -> 23.11.9.1
- systemd: 255.6 -> 255.9

PL-132908

@flyingcircusio/release-managers

## Release process

Impact:

- Reboot.

Changelog:

- See description.

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Regularly sync with upstream to pull in security fixes.
- [x] Security requirements tested? (EVIDENCE)
  - Checked commit log for CVE fixes and possible update problems, checked [synapse/upgrade.md](https://github.com/element-hq/synapse/blob/develop/docs/upgrade.md).
  - Hydra tests pass, manually tested on a handful of dev VMs.