### PR TITLE
[23.11] Raise ClamAV warning threshold to 26 hours

### DIFF
--- a/pkgs/fc/sensuplugins/fc/sensuplugins/clamav_database.py
+++ b/pkgs/fc/sensuplugins/fc/sensuplugins/clamav_database.py
@@ -25,7 +25,7 @@ def main():
     check_age_cmd = [
         "check_file_age",
         "-w",
-        "86400",
+        "93600",
         "-c",
         "172800",
     ]


### PR DESCRIPTION
Backport of #1076.

PL-132905

@flyingcircusio/release-managers

## Release process

Impact: none.

Changelog:

- The antivirus role now only warns about stale ClamAV data files after 26 hours, to prevent spurious warnings from machines which have a delayed update job for load spreading purposes (PL-132905).

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - See parent PR.
- [x] Security requirements tested? (EVIDENCE)
  - Automated tests.
