### PR TITLE
[21.05] restore-single-files: reduce chance of UUID collision

### DIFF
--- a/nixos/roles/kvm.nix
+++ b/nixos/roles/kvm.nix
@@ -17,8 +17,9 @@ in
       supportsContainers = fclib.mkDisableDevhostSupport;
       mkfsXfsFlags = lib.mkOption {
         type = with lib.types; nullOr str;
-        # XXX: reflink=0 can be removed when 15.09 is out. See #PL-130977
+        # XXX: reflink=0 can be removed when 15.09 is gone. See PL-130977
         # XXX: set reflink=0 to make file systems compatible with NixOS 15.09
+        # XXX: set bigtime=1 once 15.09 and 20.09 are gone. See PL-130365.
         default = "-q -f -K -m crc=1,finobt=1,reflink=0 -d su=4m,sw=1";
       };
       migrationBandwidth = lib.mkOption {

--- a/pkgs/fc/default.nix
+++ b/pkgs/fc/default.nix
@@ -34,12 +34,12 @@ rec {
   megacli = callPackage ./megacli { };
   multiping = callPackage ./multiping.nix {};
   qemu-nautilus = callPackage ./qemu rec {
-    version = "1.4.3";
+    version = "1.4.4";
     src = pkgs.fetchFromGitHub {
       owner = "flyingcircusio";
       repo = "fc.qemu";
       rev = version;
-      hash = "sha256-1kMdHXjsxxIW0bEV6PfDeagdLVxZP87kPKm0Z4ZtXJA=";
+      hash = "sha256-JyKToKWrkA1GT8GtayDyXHZvp2/UzrFFNednAavax2w=";
     };
     qemu_ceph = pkgs.qemu-ceph-nautilus;
     ceph_client = pkgs.ceph-nautilus.ceph-client;

--- a/pkgs/restore-single-files/restore-single-files.sh
+++ b/pkgs/restore-single-files/restore-single-files.sh
@@ -56,6 +56,13 @@ while [ ! -e $LOOPPART ]; do
 	sleep 0.2
 done
 
+info "Pre-mounting image to flush log"
+mount -oloop ${LOOPPART} $LOOPMNT
+umount $LOOPMNT
+
+info "Regenerating UUID to avoid collisions"
+xfs_admin -U generate ${LOOPPART}
+
 info "Mounting image"
 mount -oloop ${LOOPPART} $LOOPMNT
 

--- a/tests/kvm_host_ceph-nautilus.nix
+++ b/tests/kvm_host_ceph-nautilus.nix
@@ -421,6 +421,8 @@ in
 
     with subtest("Initialize first mon"):
       host1.succeed('fc-ceph osd prepare-journal /dev/vdb')
+      host1.execute('systemctl stop fc-ceph-mon')
+      host1.execute('systemctl reset-failed fc-ceph-mon')
       host1.execute('fc-ceph mon create --no-encrypt --size 500m --bootstrap-cluster > /dev/kmsg 2>&1')
       host1.sleep(5)
       host1.succeed('ceph -s > /dev/kmsg 2>&1')
@@ -452,6 +454,11 @@ in
       host1.succeed("rbd pool init rbd.hdd")
 
       host1.succeed("rbd create --size 100 rbd.hdd/fc-21.05-dev")
+      host1.succeed("rbd map rbd.hdd/fc-21.05-dev")
+      host1.succeed("sgdisk /dev/rbd0 -o -a 2048 -n 1:8192:0 -c 1:ROOT -t 1:8300")
+      host1.succeed("partprobe")
+      host1.succeed("mkfs.xfs /dev/rbd0p1")
+      host1.succeed("rbd unmap /dev/rbd0")
       host1.succeed("rbd snap create rbd.hdd/fc-21.05-dev@v1")
       host1.succeed("rbd snap protect rbd.hdd/fc-21.05-dev@v1")
 


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

none

Changelog:

- Our restore-single-file utility now handles situations better where multiple disks happen to have the same filesystem UUID, which can happen in image or cloning cases. (PL-132849)

- To avoid the issue of duplicate filesystem UUIDs (as is happening when VMs are or have been bootstrapped from the same base image) we now regenerate the XFS UUID upon every cold boot. (PL-132849)

- Full KVM host migrations use shorter lock retry intervals to reduce long tail finishing times. The maximum delay has been reduced from 80 seconds to 20 seconds. The average delay is expected to be around 10 seconds.

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

This affects restore reliability and improves our capacity of restoring backups without encountering roadblocks.

- [x] Security requirements tested? (EVIDENCE)

restore script: manually tested
fc.qemu integration: covered with automated tests and manually tested
