### PR TITLE
rabbitmq: fix telegraf warnings due to unused federation plugin

### DIFF
--- a/nixos/services/rabbitmq/default.nix
+++ b/nixos/services/rabbitmq/default.nix
@@ -311,6 +311,8 @@ in {
           # Drop string fields. They are converted to labels in Prometheus
           # which blows up the number of metrics.
           fielddrop = [ "idle_since" ];
+          # The federation plugin is optional and causing spurious logging.
+          metric_exclude = [ "federation" ];
         }
       ];
 


### PR DESCRIPTION
Fixes PL-131423

@flyingcircusio/release-managers

## Release process

Impact:

none

Changelog:

- Fix spurious warnings in telegraf about missing rabbitmq URLs. The `federation` plugin is not enabled by default and thus the URLs are inaccessible. (PL-131423)

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

Improve signal to noise ratio.

- [x] Security requirements tested? (EVIDENCE)

Relying on automated tests.