### PR TITLE
devhost: cleanup unused VMs (PL-132737)

### DIFF
--- a/nixos/roles/devhost/vm.nix
+++ b/nixos/roles/devhost/vm.nix
@@ -7,6 +7,12 @@ let
 
   vmOptions = {
     options = with lib; {
+      enable = mkOption {
+        default = true;
+        example = true;
+        description = "Whether to enable VM";
+        type = types.bool;
+      };
       id = mkOption {
         description = "Internal ID of the VM";
         type = types.int;
@@ -54,7 +60,7 @@ let
     serviceConfig.ExecStart = "${pkgs.coreutils}/bin/true";
   };
   mkService = name: vmCfg: lib.nameValuePair "fc-devhost-vm@${name}" (lib.recursiveUpdate defaultService {
-    enable = true;
+    enable = vmCfg.enable;
     wantedBy = [ "machines.target" ];
 
     serviceConfig.ExecStart = (lib.escapeShellArgs
@@ -195,7 +201,7 @@ in {
       "fc-devhost-vm-cleanup" = {
         wantedBy = [ "timers.target" ];
         timerConfig = {
-          OnCalendar = "weekly";
+          OnCalendar = "daily";
           Persistent = true;
         };
       };


### PR DESCRIPTION
PL-132737

@flyingcircusio/release-managers

## Release process

Impact:

- devhost VMs will be shut down after 14 days and deleted after 31 days now if they don't get a deployment in the mean time

Changelog:

- devhost VMs will be shut down after 14 days and deleted after 31 days now if they don't get a deployment in the mean time (PL-132737)

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - This is according the process as discussed internally and with customers
  1. VMs created before this PR should not be stopped and deleted directly, but their countdown should then start.
  2. Data should not be lost 
 
- [x] Security requirements tested? (EVIDENCE)
  - Change tested on largo00
  1. VMs that were created before the `last_deploy_date` config attribute was introduced - i.e. before this PR arrived on machines - get this attribute with the first cleanup run and a value of `now`
  2. devhost VMs are intended to be short-lived, so by concept they should not have any valuable data. Also by shutting down the VM before it gets deleted, users of the VM get informed when they want to use it
 
