### PR TITLE
[21.05] Sensu monitoring for EVPN control plane

### DIFF
--- a/nixos/services/frr.nix
+++ b/nixos/services/frr.nix
@@ -173,7 +173,7 @@ in
       };
 
     systemd.tmpfiles.rules = [
-      "d /run/frr 0750 frr frr -"
+      "d /run/frr 0755 frr frr -"
     ];
 
     systemd.services =

--- a/pkgs/fc/check-rib-integrity/check_rib_integrity.py
+++ b/pkgs/fc/check-rib-integrity/check_rib_integrity.py
@@ -1,0 +1,471 @@
+#!/usr/bin/env python3
+"""Check that the state of the FRR routing information base matches
+the kernel network state.
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+from ipaddress import IPv4Address, IPv4Interface, IPv4Network, IPv6Address
+
+
+def ok(msg):
+    print("OK - {}".format(msg))
+    sys.exit(0)
+
+
+def critical(msg, *context):
+    print("CRITICAL - {}".format(msg))
+    for line in context:
+        print(line)
+    sys.exit(2)
+
+
+def fmtaddrs(addrs):
+    return map(lambda x: str(x), sorted(addrs))
+
+
+def json_cmd(*args, **kwargs):
+    data = subprocess.check_output(*args, **kwargs)
+    return json.loads(data.decode("utf-8"))
+
+
+def vtysh_json(cmd):
+    return json_cmd(["vtysh", "-c", cmd])
+
+
+def ip_route_json(net):
+    return json_cmd(["ip", "-j", "route", "show", "root", str(net)])
+
+
+def bridge_macs(bridge, vxlan):
+    # XXX: newer versions of iproute2 support bridge -j for json
+    # output
+    data = subprocess.check_output(["bridge", "fdb", "show", "br", bridge])
+    data = [item.split() for item in data.decode("utf-8").splitlines()]
+    data = [
+        item
+        for item in data
+        # drop forwarding entries for vlan-aware bridges
+        if "vlan" not in item
+    ]
+
+    local_macs = {
+        item[0]: (item[2] if item[2] != vxlan else bridge)
+        for item in data
+        # extern_learn records managed by zebra, self records handled
+        # internally by device drivers
+        if "extern_learn" not in item and "self" not in item
+        # ignore the mac addresses assigned to the host side of tap
+        # interfaces, but include the mac address assigned to the
+        # bridge interface
+        and ("permanent" not in item or item[2] == vxlan)
+    }
+
+    remote_macs = {
+        mac[0]: IPv4Address(dest[4])
+        for mac in data
+        if mac[2] == vxlan and mac[4] == "master" and mac[5] == bridge
+        for dest in data
+        if dest[0] == mac[0] and dest[2] == vxlan and dest[3] == "dst"
+    }
+
+    return local_macs, remote_macs
+
+
+def zebra_macs(vni):
+    data = vtysh_json(f"show evpn mac vni {vni} json")
+    data = data["macs"]
+
+    local_macs = {
+        key: value["intf"]
+        for key, value in data.items()
+        if value["type"] == "local"
+    }
+
+    remote_macs = {
+        key: IPv4Address(value["remoteVtep"])
+        for key, value in data.items()
+        if value["type"] == "remote"
+    }
+
+    return local_macs, remote_macs
+
+
+def vtysh_load_evpn_rib():
+    data = vtysh_json("show bgp l2vpn evpn route detail type 2 json")
+
+    macs = [
+        (
+            path["vni"],
+            route["mac"],
+            (
+                {
+                    IPv4Address(hop["ip"])
+                    for hop in path["nexthops"]
+                    if "used" in hop and hop["used"]
+                }
+                if path["aspath"]["segments"]
+                else {}
+            ),
+        )
+        for rd in data.values()
+        if isinstance(rd, dict)  # note: type heterogeneity in vtysh json!
+        for route in rd.values()
+        if isinstance(route, dict)
+        for paths in route["paths"]
+        for path in paths
+        if path["valid"]
+        and "bestpath" in path
+        and "overall" in path["bestpath"]
+        and path["bestpath"]["overall"]
+    ]
+
+    return {
+        int(outer_vni): {
+            mac: hops for inner_vni, mac, hops in macs if inner_vni == outer_vni
+        }
+        for outer_vni in {mac[0] for mac in macs}
+    }
+
+
+def bgpd_macs(rib, vni):
+    if vni not in rib:
+        return {}, {}
+
+    macs = rib[vni]
+
+    local_macs = {mac for mac, nexthops in macs.items() if not nexthops}
+    remote_macs = {mac: nexthops for mac, nexthops in macs.items() if nexthops}
+
+    return local_macs, remote_macs
+
+
+def check_unicast_rib(args):
+    fib = {}
+
+    for prefix in args.prefixes:
+        data = ip_route_json(prefix)
+        data = list(
+            filter(lambda x: "protocol" in x and x["protocol"] == "bgp", data)
+        )
+
+        dests = list(map(lambda entry: entry["dst"], data))
+        if len(set(dests)) != len(dests):
+            critical(
+                "duplicate addresses in kernel routing table",
+                "duplicate-kernel-address {}".format(" ".join(fmtaddrs(dests))),
+            )
+
+        for entry in data:
+            dest = IPv4Address(entry["dst"])
+            if dest not in prefix:
+                raise RuntimeError(
+                    f"ip route returned route for {dest} outside of queried prefix {prefix}"
+                )
+            nexthops = list()
+            if "via" in entry:
+                nexthops.append(IPv6Address(entry["via"]["host"]))
+            elif "nexthops" in entry:
+                for hop in entry["nexthops"]:
+                    nexthops.append(IPv6Address(hop["via"]["host"]))
+
+            if len(set(nexthops)) != len(nexthops):
+                raise RuntimeError(
+                    "ip route return duplicate nexthop for {}: {}".format(
+                        dest, ", ".join(fmtaddrs(nexthops))
+                    )
+                )
+
+            fib[dest] = set(nexthops)
+
+    data = vtysh_json("show bgp ipv4 unicast json")
+
+    rib = {}
+
+    for prefix, paths in data["routes"].items():
+        dest = IPv4Network(prefix, strict=True)
+        if dest.prefixlen != 32 or not any(
+            map(lambda arg: arg.supernet_of(dest), args.prefixes)
+        ):
+            continue
+
+        paths = [
+            p
+            for p in paths
+            if p["valid"]
+            and (
+                ("bestpath" in p and p["bestpath"])
+                or ("multipath" in p and p["multipath"])
+            )
+            # ignore locally announced routes
+            and p["path"] != ""
+        ]
+
+        if not paths:
+            continue
+
+        nexthops = [
+            IPv6Address(n["ip"])
+            for p in paths
+            for n in p["nexthops"]
+            if "used" in n and n["used"]
+        ]
+
+        if len(set(nexthops)) != len(nexthops):
+            raise RuntimeError(
+                "vtysh returned duplicate nexthop for {}: {}".format(
+                    dest, ", ".join(fmtaddrs(nexthops))
+                )
+            )
+
+        rib[dest.network_address] = set(nexthops)
+
+    mismatches = set()
+    context = list()
+
+    rib_only = set(rib.keys()) - set(fib.keys())
+    fib_only = set(fib.keys()) - set(rib.keys())
+    if rib_only or fib_only:
+        mismatches.add("addresses")
+    if rib_only:
+        context.append(
+            "extra-frr-addresses {}".format(" ".join(fmtaddrs(rib_only)))
+        )
+    if fib_only:
+        context.append(
+            "extra-kernel-addresses {}".format(" ".join(fmtaddrs(fib_only)))
+        )
+
+    neighdiff = dict()
+    for addr in set(rib.keys()).intersection(set(fib.keys())):
+        ribhops = rib[addr]
+        fibhops = fib[addr]
+
+        rib_only = ribhops - fibhops
+        fib_only = fibhops - ribhops
+
+        if rib_only or fib_only:
+            mismatches.add("nexthops")
+        if rib_only:
+            context.append(
+                "extra-frr-nexthops {} {}".format(
+                    addr, ",".join(fmtaddrs(rib_only))
+                )
+            )
+        if fib_only:
+            context.append(
+                "extra-kernel-nexthops {} {}".format(
+                    addr, ",".join(fmtaddrs(fib_only))
+                )
+            )
+
+    if mismatches:
+        critical(
+            "mismatching {} between frr and kernel".format(
+                " and ".join(mismatches)
+            ),
+            *sorted(context),
+        )
+    else:
+        ok("addresses and nexthop in frr and kernel match")
+
+
+def check_evpn_rib(args):
+    mismatches = set()
+    context = list()
+
+    evpn_rib = vtysh_load_evpn_rib()
+
+    for vni in args.vnis:
+        # discover bridge and vxlan interface for the vni
+        data = vtysh_json(f"show evpn vni {vni} json")
+        bridge = data["sviInterface"]
+        vxlan = data["vxlanInterface"]
+
+        bridge_local, bridge_remote = bridge_macs(bridge, vxlan)
+        zebra_local, zebra_remote = zebra_macs(vni)
+        bgpd_local, bgpd_remote = bgpd_macs(evpn_rib, vni)
+
+        # compare local mac state in kernel and zebra
+        bridge_only = set(bridge_local.keys()) - set(zebra_local.keys())
+        zebra_only = set(zebra_local.keys()) - set(bridge_local.keys())
+        if bridge_only or zebra_only:
+            mismatches.add("zebra and kernel (local macs)")
+        if bridge_only:
+            context.append(
+                "zebra-missing-kernel-macs {} {}".format(
+                    bridge, " ".join(sorted(bridge_only))
+                )
+            )
+        if zebra_only:
+            context.append(
+                "zebra-macs-not-in-kernel {} {}".format(
+                    bridge, " ".join(sorted(zebra_only))
+                )
+            )
+
+        for mac in set(bridge_local.keys()).intersection(
+            set(zebra_local.keys())
+        ):
+            if bridge_local[mac] != zebra_local[mac]:
+                mismatches.add("zebra and kernel (bridge port)")
+                context.append(
+                    "zebra-incorrect-bridge-port {} {} kernel {} zebra {}".format(
+                        bridge, mac, bridge_local[mac], zebra_local[mac]
+                    )
+                )
+
+        # compare remote mac state in kernel and zebra
+        bridge_only = set(bridge_remote.keys()) - set(zebra_remote.keys())
+        zebra_only = set(zebra_remote.keys()) - set(bridge_remote.keys())
+        if bridge_only or zebra_only:
+            mismatches.add("zebra and kernel (remote macs)")
+        if bridge_only:
+            context.append(
+                "kernel-macs-not-in-zebra {} {}".format(
+                    bridge, " ".join(sorted(bridge_only))
+                )
+            )
+        if zebra_only:
+            context.append(
+                "kernel-missing-zebra-macs {} {}".format(
+                    bridge, " ".join(sorted(zebra_only))
+                )
+            )
+
+        for mac in set(bridge_remote.keys()).intersection(
+            set(zebra_remote.keys())
+        ):
+            if bridge_remote[mac] != zebra_remote[mac]:
+                mismatches.add("zebra and kernel (remote vteps)")
+                context.append(
+                    "kernel-incorrect-vtep-address {} {} kernel {} zebra {}".format(
+                        bridge,
+                        mac,
+                        str(bridge_remote[mac]),
+                        str(zebra_remote[mac]),
+                    )
+                )
+
+        # compare local mac state in kernel and bgpd
+        bridge_only = set(bridge_local.keys()) - bgpd_local
+        bgpd_only = bgpd_local - set(bridge_local.keys())
+        if bridge_only or bgpd_only:
+            mismatches.add("bgpd and kernel (local macs)")
+        if bridge_only:
+            context.append(
+                "bgpd-missing-kernel-macs {} {}".format(
+                    bridge, " ".join(sorted(bridge_only))
+                )
+            )
+        if bgpd_only:
+            context.append(
+                "bgpd-macs-not-in-kernel {} {}".format(
+                    bridge, " ".join(sorted(bgpd_only))
+                )
+            )
+
+        # sanity check bgpd remote mac state
+        bgpd_multi_remote_macs = {
+            mac: addrs for mac, addrs in bgpd_remote.items() if len(addrs) > 1
+        }
+        if bgpd_multi_remote_macs:
+            mismatches.add("bgpd duplicate remote nexthops")
+            for mac, addrs in bgpd_multi_remote_macs:
+                context.append(
+                    "bgpd-duplicate-remote-nexthop {} {} {}".format(
+                        bridge, mac, " ".join(fmtaddrs(addrs))
+                    )
+                )
+        bgpd_remote = {mac: addrs.pop() for mac, addrs in bgpd_remote.items()}
+
+        # compare remote mac state in kernel and bgpd
+        bridge_only = set(bridge_remote.keys()) - set(bgpd_remote.keys())
+        bgpd_only = set(bgpd_remote.keys()) - set(bridge_remote.keys())
+        if bridge_only or bgpd_only:
+            mismatches.add("bgpd and kernel (remote macs)")
+        if bridge_only:
+            context.append(
+                "kernel-macs-not-in-bgpd {} {}".format(
+                    bridge, " ".join(sorted(bridge_only))
+                )
+            )
+        if bgpd_only:
+            context.append(
+                "kernel-missing-bgpd-macs {} {}".format(
+                    bridge, " ".join(sorted(bgpd_only))
+                )
+            )
+
+        for mac in set(bridge_remote.keys()).intersection(
+            set(bgpd_remote.keys())
+        ):
+            if bridge_remote[mac] != bgpd_remote[mac]:
+                mismatches.add("bgpd and kernel (remote vteps)")
+                context.append(
+                    "kernel-incorrect-vtep-address {} {} kernel {} bgpd {}".format(
+                        bridge,
+                        mac,
+                        str(bridge_remote[mac]),
+                        str(bgpd_remote[mac]),
+                    )
+                )
+
+    if mismatches:
+        critical(
+            "mismatches between EVPN RIB and FIB: {}".format(
+                ", ".join(mismatches)
+            ),
+            *sorted(context),
+        )
+    else:
+        ok("EVPN RIB and FIB state match")
+
+    print(mismatches)
+    for line in context:
+        print(line)
+
+
+def main():
+    parser = argparse.ArgumentParser(prog="check_rib_integrity")
+    subparsers = parser.add_subparsers(required=True, dest="command")
+
+    unicast_parser = subparsers.add_parser(
+        "check-unicast-rib", help="Check the status of the IPv4 unicast RIB"
+    )
+    unicast_parser.set_defaults(func=check_unicast_rib)
+    unicast_parser.add_argument(
+        "-p",
+        "--prefix",
+        metavar="PREFIX",
+        action="append",
+        dest="prefixes",
+        required=True,
+        type=lambda s: IPv4Network(s, True),
+        help="Underlay IPv4 prefix",
+    )
+
+    evpn_parser = subparsers.add_parser(
+        "check-evpn-rib", help="Check the status of the L2VPN EVPN RIB"
+    )
+    evpn_parser.set_defaults(func=check_evpn_rib)
+    evpn_parser.add_argument(
+        "-n",
+        "--vni",
+        metavar="IFACE",
+        action="append",
+        dest="vnis",
+        type=int,
+        required=True,
+        help="EVPN VNI number",
+    )
+
+    args = parser.parse_args()
+
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/pkgs/fc/check-rib-integrity/default.nix
+++ b/pkgs/fc/check-rib-integrity/default.nix
@@ -1,0 +1,26 @@
+{ lib, stdenv, makeWrapper, python3, iproute2, frr }:
+
+stdenv.mkDerivation rec {
+  version = "1";
+  pname = "check-rib-integrity";
+
+  src = ./.;
+  unpackPhase = ":";
+  dontBuild = true;
+  dontConfigure = true;
+  nativeBuildInputs = [ makeWrapper ];
+  propagatedBuildInputs = [ python3 iproute2 frr ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cd $src
+    install check_rib_integrity.py $out/bin/check_rib_integrity
+    wrapProgram $out/bin/check_rib_integrity --prefix PATH : \
+      ${lib.makeBinPath propagatedBuildInputs}
+  '';
+
+  meta = with lib; {
+    description = "Sensu check for monitoring FRR correctly maintaining the routing information base";
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/fc/default.nix
+++ b/pkgs/fc/default.nix
@@ -34,6 +34,7 @@ rec {
   logcheckhelper = callPackage ./logcheckhelper { };
   megacli = callPackage ./megacli { };
   multiping = callPackage ./multiping.nix {};
+  ping-on-tap = callPackage ./ping-on-tap {};
   qemu-nautilus = callPackage ./qemu rec {
     version = "1.4.3";
     src = pkgs.fetchFromGitHub {

--- a/pkgs/fc/default.nix
+++ b/pkgs/fc/default.nix
@@ -21,6 +21,7 @@ rec {
   check-link-redundancy = callPackage ./check-link-redundancy {};
   check-mongodb = callPackage ./check-mongodb {};
   check-postfix = callPackage ./check-postfix {};
+  check-rib-integrity = callPackage ./check-rib-integrity {};
 
   check-xfs-broken = callPackage ./check-xfs-broken {};
   collectdproxy = callPackage ./collectdproxy {};

--- a/pkgs/fc/ping-on-tap/default.nix
+++ b/pkgs/fc/ping-on-tap/default.nix
@@ -1,0 +1,29 @@
+{ lib, stdenv, makeWrapper, python3 }:
+
+let
+  pythonWithPackages = python3.withPackages (ps: [ ps.scapy ]);
+in
+stdenv.mkDerivation rec {
+  version = "1";
+  pname = "ping-on-tap";
+
+  src = ./.;
+  unpackPhase = ":";
+  dontBuild = true;
+  dontConfigure = true;
+  nativeBuildInputs = [ makeWrapper ];
+  propagatedBuildInputs = [ pythonWithPackages ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cd $src
+    install ping-on-tap.py $out/bin/ping-on-tap
+    wrapProgram $out/bin/ping-on-tap --prefix PATH : \
+      ${lib.makeBinPath propagatedBuildInputs}
+  '';
+
+  meta = with lib; {
+    description = "Helper script to respond to arp and ping on a tap interface";
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/fc/ping-on-tap/ping-on-tap.py
+++ b/pkgs/fc/ping-on-tap/ping-on-tap.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+
+# English Wiktionary:
+#
+#   "on tap": (of beer, etc) Available directly from the barrel, by
+#   way of a tap.
+
+import argparse
+
+import scapy.all as scapy
+
+
+class ArpIcmpMux_am(scapy.AnsweringMachine):
+    """Auto-responder which handles both ARP and ethernet frames with
+    ICMP echo-request packets.
+
+    """
+
+    def parse_options(self, **kwargs):
+        self.arp_am = scapy.ARP_am(**kwargs)
+
+    def is_request(self, req):
+        if self.arp_am.is_request(req):
+            return True
+        elif req.haslayer(scapy.ICMP):
+            icmp_req = req.getlayer(scapy.ICMP)
+            if icmp_req.type == 8:  # echo-request
+                return True
+
+        return False
+
+    def print_reply(self, req, reply):
+        if self.arp_am.is_request(req):
+            self.arp_am.print_reply(req, reply)
+        else:
+            print("Replying %s to %s" % (reply.getlayer(scapy.IP).dst, req.dst))
+
+    def make_reply(self, req):
+        if self.arp_am.is_request(req):
+            return self.arp_am.make_reply(req)
+
+        reply = (
+            scapy.Ether(src=req[scapy.Ether].dst, dst=req[scapy.Ether].src)
+            / scapy.IP(src=req[scapy.IP].dst, dst=req[scapy.IP].src)
+            / scapy.ICMP()
+            / scapy.Raw(load=req[scapy.Raw].load)
+        )
+        reply[scapy.ICMP].type = 0  # echo-reply
+        reply[scapy.ICMP].seq = req[scapy.ICMP].seq
+        reply[scapy.ICMP].id = req[scapy.ICMP].id
+        reply[scapy.ICMP].unused = req[scapy.ICMP].unused
+        # Force re-generation of the checksum
+        reply[scapy.ICMP].chksum = None
+        return reply
+
+
+def gratuitous_arp(args):
+    return scapy.Ether(src=args.mac, dst="ff:ff:ff:ff:ff:ff") / scapy.ARP(
+        op="who-has", psrc=args.ip, pdst=args.ip
+    )
+    pass
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Respond to arp and ping on a tap interface"
+    )
+
+    parser.add_argument(
+        "interface",
+        metavar="INTERFACE",
+        help="Tap interface to listen on (must already exist and be configured)",
+    )
+    parser.add_argument(
+        "mac",
+        metavar="MAC",
+        help="MAC address to respond to on the tap interface",
+    )
+    parser.add_argument(
+        "ip",
+        metavar="IP",
+        help="IPv4 address to respond to ICMP echo requests on the tap interface",
+    )
+
+    args = parser.parse_args()
+
+    tap = scapy.TunTapInterface(args.interface, mode_tun=False)
+
+    # send gratutous arp, so the host system's bridge interface learns
+    # which bridge port we're on.
+    pkt = gratuitous_arp(args)
+    for i in range(5):
+        tap.send(pkt)
+
+    responder = tap.am(ArpIcmpMux_am, IP_addr=args.ip, ARP_addr=args.mac)
+
+    # run infinitely until killed by signal
+    responder(store=False)

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -45,6 +45,7 @@ in {
   # elasticsearch7 = callTest ./elasticsearch.nix { version = "7"; };
   fcagent = callSubTests ./fcagent.nix {};
   ffmpeg = callTest ./ffmpeg.nix {};
+  frr = callSubTests ./frr.nix {};
   filebeat = callTest ./filebeat.nix {};
   garbagecollect = callTest ./garbagecollect.nix {};
   # Not supported on 21.05 anymore.

--- a/tests/frr.nix
+++ b/tests/frr.nix
@@ -4,6 +4,12 @@ let
   makeSubnetAddress = net: idx: "192.168.${toString net}.${toString idx}";
 
   makeUnderlayAddress = makeSubnetAddress 42;
+  makeOverlayHostAddress = makeSubnetAddress 23;
+  makeOverlayTapAddress = idx: makeSubnetAddress 23 (idx + 100);
+
+  makePrivateMac = scope: idx: "06:00:00:00:${scope}:0${toString idx}";
+  makeHostMac = makePrivateMac "42";
+  makeTapMac = makePrivateMac "23";
 
   baseConfig = { lib, ... }: {
     imports = [ ../nixos ../nixos/roles ];
@@ -19,8 +25,8 @@ let
     boot.initrd.availableKernelModules = [ "dummy" ];
   };
 
-  underlayLink = name: { ... }: {
-    networking.interfaces."${name}" = {};
+  underlayLink = name: { lib, ... }: {
+    networking.interfaces."${name}".ipv4.addresses = lib.mkForce [];
     networking.firewall.trustedInterfaces = [ name ];
     systemd.services."${name}-netdev" = {
       wantedBy = [ "network-setup.service" "multi-user.target" ];
@@ -44,6 +50,49 @@ let
       path = [ pkgs.iproute2 ];
       script = "ip link add underlay type dummy";
       preStop = "ip link delete underlay";
+      serviceConfig.Type = "oneshot";
+      serviceConfig.RemainAfterExit = true;
+    };
+  };
+
+  tapLink = name: { ... }: {
+    networking.interfaces."${name}" = {
+      virtual = true;
+      virtualType = "tap";
+    };
+  };
+
+  bridgeLink = mac: address: children: { ... }: {
+    networking.bridges.br0.interfaces = children;
+    networking.interfaces.br0 = {
+      macAddress = mac;
+      ipv4.addresses = [
+        { address = address; prefixLength = 24; }
+      ];
+    };
+  };
+
+  vxlanLink = mac: vtepAddr: { pkgs, ... }: {
+    networking.interfaces.vxlan0 = {};
+    systemd.services.vxlan0-netdev = rec {
+      description = "Set up overlay VXLAN device";
+      wantedBy = [ "network-setup.service" "multi-user.target" ];
+      before = wantedBy;
+      after = [ "network-pre.service" ];
+      requires = [ "network-setup.service" ];
+      path = [ pkgs.iproute2 ];
+      script = ''
+        ip link add vxlan0 type vxlan \
+          id 23 local ${vtepAddr} \
+          dstport 4789 nolearning
+
+        ip link set vxlan0 address ${mac}
+        ip link set vxlan0 mtu 1280
+        ip link set vxlan0 addrgenmode none
+      '';
+      preStop = ''
+        ip link delete vxlan0
+      '';
       serviceConfig.Type = "oneshot";
       serviceConfig.RemainAfterExit = true;
     };
@@ -127,6 +176,40 @@ let
       };
     };
 
+  makeEvpnHost = { idx, taps }: { pkgs, lib, ... }:
+    let
+      underlayAddr = makeUnderlayAddress idx;
+      bridgeMac = makeHostMac idx;
+      tapByName = builtins.listToAttrs
+        ((lib.imap0 (i: v: lib.nameValuePair "tap${toString i}" v)) taps);
+
+      makePingService = iface: tapidx: let
+        ipaddr = makeOverlayTapAddress tapidx;
+        macaddr = makeTapMac tapidx;
+      in lib.nameValuePair "ping-${iface}" (rec {
+        description = "Respond to ping and arp on ${iface}";
+        wantedBy = [ "multi-user.target" ];
+        requires = [ "network-addresses-${iface}.service" ];
+        after = requires;
+        serviceConfig.ExecStart = "${pkgs.fc.ping-on-tap}/bin/ping-on-tap ${iface} ${macaddr} ${ipaddr}";
+      });
+
+    in {
+      imports = [
+        (makeFrrHost { inherit idx; evpn = true; })
+        (vxlanLink bridgeMac underlayAddr)
+        (bridgeLink bridgeMac
+          (makeOverlayHostAddress idx)
+          ([ "vxlan0" ] ++ (builtins.attrNames tapByName))
+        )
+      ] ++
+      (builtins.map (n: tapLink n) (builtins.attrNames tapByName));
+
+      environment.systemPackages = [ pkgs.fc.check-rib-integrity ];
+
+      systemd.services = lib.mapAttrs' makePingService tapByName;
+    };
+
 in {
   name = "frr";
   testCases = {
@@ -187,6 +270,131 @@ in {
             host1.succeed("ip route show 192.168.42.3 | grep -F fe80::5054:ff:fe12:203")
             host1.succeed("ip route show 192.168.42.3 | grep -F fe80::5054:ff:fe12:104")
 
+      '';
+    };
+    evpn = {
+      name = "evpn";
+      nodes = {
+        host1 = makeEvpnHost { idx = 1; taps = [ 1 2 ]; };
+        switch1 = makeFrrHost { idx = 2; redistribute = true; evpn = true; };
+        host2 = makeEvpnHost { idx = 3; taps = [ 3 4 ]; };
+        switch2 = makeFrrHost { idx = 4; redistribute = true; evpn = true; };
+      };
+
+      testScript = ''
+        start_all()
+        all_vms = [host1, host2, switch1, switch2]
+        for vm in all_vms:
+            vm.wait_for_unit("network-online.target")
+
+        for vm in all_vms:
+            x = vm.succeed("vtysh -c 'show version'")
+
+        with subtest("wait for local tap MAC addresses to appear"):
+            for host, addrs in [
+                (host1, ["06:00:00:00:23:01", "06:00:00:00:23:02"]),
+                (host2, ["06:00:00:00:23:03", "06:00:00:00:23:04"]),
+            ]:
+                for addr in addrs:
+                    host.wait_until_succeeds(
+                        f"bridge fdb show br br0 | grep -F {addr}"
+                    )
+
+        with subtest("wait for remote tap MAC addresses to appear"):
+            for host, addrs in [
+                (host1, ["06:00:00:00:42:03", "06:00:00:00:23:03", "06:00:00:00:23:04"]),
+                (host2, ["06:00:00:00:42:01", "06:00:00:00:23:01", "06:00:00:00:23:02"]),
+            ]:
+                for addr in addrs:
+                    host.wait_until_succeeds(
+                        f"bridge fdb show br br0 | grep -F {addr}"
+                    )
+
+        with subtest("check evpn network reachability"):
+            with subtest("checking SVI addresses are reachable"):
+                host1.succeed("ping -c1 192.168.23.3")
+                host2.succeed("ping -c1 192.168.23.1")
+            with subtest("checking remote tap device responders are reachable"):
+                for host, addrs in [
+                    (host1, ["192.168.23.103", "192.168.23.104"]),
+                    (host2, ["192.168.23.101", "192.168.23.102"]),
+                ]:
+                    for addr in addrs:
+                        # send multiple pings in case ping-on-tap gets stuck
+                        host.succeed(f"ping -A -c5 {addr}")
+
+        with subtest("rib and fib should not have mismatches"):
+            for host in [host1, host2]:
+                host.succeed("check_rib_integrity check-unicast-rib -p 192.168.42.0/24")
+                host.succeed("check_rib_integrity check-evpn-rib -n 23")
+
+        with subtest("check script should detect ipv4 rib mismatches"):
+            # monitoring script should detect extra addresses in the kernel
+            # not in the rib
+            host1.succeed(
+                "ip route add 192.168.42.100/32 dev eth1 "
+                "via inet6 fe80::1 proto bgp"
+            )
+
+            code, output = host1.execute("check_rib_integrity check-unicast-rib -p 192.168.42.0/24")
+            assert code == 2, "Check script does not have CRITICAL status"
+            print(output)
+
+            host1.succeed("ip route del 192.168.42.100/32")
+            host1.wait_until_succeeds("check_rib_integrity check-unicast-rib -p 192.168.42.0/24")
+
+            # purposefully corrupt the rib in ways which frr doesn't
+            # automatically detect.
+            host1.succeed("ip route replace unreachable 192.168.42.3")
+            host1.succeed(
+                "ip route replace 192.168.42.3/32 proto bgp "
+                "nexthop via inet6 fe80::5054:ff:fe12:203 dev eth2 "
+                "nexthop via inet6 fe80::5054:ff:fe12:104 dev eth1 "
+                "nexthop via inet6 fe80::1 dev eth1"
+            )
+
+            code, output = host1.execute("check_rib_integrity check-unicast-rib -p 192.168.42.0/24")
+            assert code == 2, "Check script does not have CRITICAL status"
+            print(output)
+
+            # allow frr to reset the fib automatically
+            host1.succeed("ip route del 192.168.42.3/32")
+            host1.wait_until_succeeds("check_rib_integrity check-unicast-rib -p 192.168.42.0/24")
+
+        with subtest("check script should detect evpn rib mismatches"):
+            # monitoring script should detect extra entries in the macfdb
+            # not in the rib
+            host1.succeed(
+                "bridge fdb add 06:00:00:00:23:ff dev vxlan0 "
+                "dst 192.168.42.100 extern_learn dynamic"
+            )
+            host1.succeed(
+                "bridge fdb add 06:00:00:00:23:ff dev vxlan0 "
+                "extern_learn master"
+            )
+
+            code, output = host1.execute("check_rib_integrity check-evpn-rib -n 23")
+            assert code == 2, "Check script does not have CRITICAL status"
+            print(output)
+
+            host1.succeed("bridge fdb del 06:00:00:00:23:ff dev vxlan0")
+            host1.wait_until_succeeds("check_rib_integrity check-evpn-rib -n 23")
+
+
+            # purposefully corrupt the rib in ways which frr doesn't
+            # automatically detect
+            host1.succeed(
+                "bridge fdb replace 06:00:00:00:23:03 dev vxlan0 "
+                "dst 192.168.42.100 extern_learn dynamic"
+            )
+
+            code, output = host1.execute("check_rib_integrity check-evpn-rib -n 23")
+            assert code == 2, "Check script does not have CRITICAL status"
+            print(output)
+
+            # allow frr to reset the fib automatically
+            host1.succeed("bridge fdb del 06:00:00:00:23:03 dev vxlan0")
+            host1.wait_until_succeeds("check_rib_integrity check-evpn-rib -n 23")
       '';
     };
   };

--- a/tests/frr.nix
+++ b/tests/frr.nix
@@ -1,79 +1,92 @@
 import ./make-test-python.nix ({ pkgs, ... }:
 let
 
-  makeAddress = idx: "192.168.42.${toString idx}";
+  makeSubnetAddress = net: idx: "192.168.${toString net}.${toString idx}";
 
-  makeHost = idx: isRouter: { lib, pkgs, ... }: let
-    vlans = [ idx (if idx == 4 then 1 else idx + 1)];
-  in {
+  makeUnderlayAddress = makeSubnetAddress 42;
+
+  baseConfig = { lib, ... }: {
     imports = [ ../nixos ../nixos/roles ];
     services.telegraf.enable = false;
-    virtualisation.vlans = vlans;
-    networking = lib.mkForce {
-      useDHCP = false;
-        firewall.allowPing = true;
-        firewall.checkReversePath = false;
-        interfaces.eth1 = {};
-        interfaces.eth2 = {};
-        interfaces.underlay.ipv4.addresses = [
-          { address = makeAddress idx; prefixLength = 32; }
-        ];
-        firewall.trustedInterfaces = [ "eth1" "eth2" ];
+    networking = {
+      useDHCP = lib.mkForce false;
+      firewall.allowPing = lib.mkForce true;
+      firewall.checkReversePath = lib.mkForce false;
     };
 
     boot.kernel.sysctl."net.ipv4.conf.all.ip_forward" = 1;
     boot.extraModprobeConfig = "options dummy numdummies=0";
     boot.initrd.availableKernelModules = [ "dummy" ];
+  };
 
-    systemd.services = {
-      eth1-netdev = {
-        wantedBy = [ "network-setup.service" "multi-user.target" ];
-        requires = [ "network-setup.service" ];
-        script = ":";
-        serviceConfig.Type = "oneshot";
-        serviceConfig.RemainAfterExit = true;
-      };
-      eth2-netdev = {
-        wantedBy = [ "network-setup.service" "multi-user.target" ];
-        requires = [ "network-setup.service" ];
-        script = ":";
-        serviceConfig.Type = "oneshot";
-        serviceConfig.RemainAfterExit = true;
-      };
-      underlay-netdev = rec {
-        description = "Set up underlay loopback device";
-        wantedBy = [ "network-setup.service" "multi-user.target" ];
-        before = wantedBy;
-        after = [ "network-pre.service" ];
-        requires = [ "network-setup.service" ];
-        path = [ pkgs.iproute2 ];
-        script = "ip link add underlay type dummy";
-        preStop = "ip link delete underlay";
-        serviceConfig.Type = "oneshot";
-        serviceConfig.RemainAfterExit = true;
-      };
+  underlayLink = name: { ... }: {
+    networking.interfaces."${name}" = {};
+    networking.firewall.trustedInterfaces = [ name ];
+    systemd.services."${name}-netdev" = {
+      wantedBy = [ "network-setup.service" "multi-user.target" ];
+      requires = [ "network-setup.service" ];
+      script = ":";
+      serviceConfig.Type = "oneshot";
+      serviceConfig.RemainAfterExit = true;
     };
+  };
 
-    services.frr = {
-      zebra.enable = true;
-      zebra.config = ''
-          frr version 8.5.1
-          frr defaults datacentre
-          !
-          route-map set-source-address permit 1
-           set src ${makeAddress idx}
-          exit
-          !
-          ip protocol bgp route-map set-source-address
-      '';
-      bfd.enable = true;
-      bgp.enable = true;
-      bgp.config = ''
+  loopbackLink = address: { pkgs, ... }: {
+    networking.interfaces.underlay.ipv4.addresses = [
+      { address = address; prefixLength = 32; }
+    ];
+    systemd.services.underlay-netdev = rec {
+      description = "Set up underlay loopback device";
+      wantedBy = [ "network-setup.service" "multi-user.target" ];
+      before = wantedBy;
+      after = [ "network-pre.service" ];
+      requires = [ "network-setup.service" ];
+      path = [ pkgs.iproute2 ];
+      script = "ip link add underlay type dummy";
+      preStop = "ip link delete underlay";
+      serviceConfig.Type = "oneshot";
+      serviceConfig.RemainAfterExit = true;
+    };
+  };
+
+  makeFrrHost = { idx, redistribute ? false, evpn ? false }: { lib, ... }:
+    assert (idx > 0) && (idx <= 4);
+    let
+      vlans = [ idx (if idx == 4 then 1 else idx + 1) ];
+      address = makeUnderlayAddress idx;
+      export-filter = if redistribute
+                      then "accept-all-routes"
+                      else "accept-local-routes";
+    in {
+      imports = [
+        baseConfig
+        (underlayLink "eth1")
+        (underlayLink "eth2")
+        (loopbackLink address)
+      ];
+
+      virtualisation.vlans = vlans;
+
+      services.frr = {
+        zebra.enable = true;
+        zebra.config = ''
           frr version 8.5.1
           frr defaults datacenter
           !
-          router bgp 6500${toString idx}
-           bgp router-id ${makeAddress idx}
+          route-map set-source-address permit 1
+           set src ${address}
+          exit
+          !
+          ip protocol bgp route-map set-source-address
+        '';
+        bfd.enable = true;
+        bgp.enable = true;
+        bgp.config = ''
+          frr version 8.5.1
+          frr defaults datacenter
+          !
+          router bgp ${toString (65000 + idx)}
+           bgp router-id ${address}
            bgp bestpath as-path multipath-relax
            no bgp ebgp-requires-policy
            neighbor remotes peer-group
@@ -85,75 +98,96 @@ let
            !
            address-family ipv4 unicast
             redistribute connected
-            neighbor remotes prefix-list accept-all in
-            neighbor remotes prefix-list ${if isRouter then "accept-all" else "accept-self"} out
+            neighbor remotes route-map accept-all-routes in
+            neighbor remotes route-map ${export-filter} out
            exit-address-family
+           !
+           ${lib.optionalString evpn ''
+           address-family l2vpn evpn
+            neighbor remotes activate
+            neighbor remotes route-map accept-all-routes in
+            neighbor remotes route-map ${export-filter} out
+            advertise-all-vni
+            advertise-svi-ip
+           exit-address-family
+           ''}
           !
           exit
           !
-          ip prefix-list accept-self seq 1 permit ${makeAddress idx}/32
+          bgp as-path access-list local-origin seq 1 permit ^$
           !
-          ip prefix-list accept-all seq 1 permit ${makeAddress 0}/24 le 32
-      '';
+          route-map accept-local-routes permit 1
+           match as-path local-origin
+          exit
+          !
+          route-map accept-all-routes permit 1
+          exit
+          !
+        '';
+      };
     };
-  };
 
 in {
   name = "frr";
-  nodes = {
-    host1 = makeHost 1 false;
-    switch1 = makeHost 2 true;
-    host2 = makeHost 3 false;
-    switch2 = makeHost 4 true;
+  testCases = {
+    regression-test = {
+      name = "regression-test";
+      nodes = {
+        host1 = makeFrrHost { idx = 1; };
+        switch1 = makeFrrHost { idx = 2; redistribute = true; };
+        host2 = makeFrrHost { idx = 3; };
+        switch2 = makeFrrHost { idx = 4; redistribute = true; };
+      };
+
+      testScript = ''
+        start_all()
+        all_vms = [host1, host2, switch1, switch2]
+        for vm in all_vms:
+            vm.wait_for_unit("network-online.target")
+
+        for vm in all_vms:
+            x = vm.succeed("vtysh -c 'show version'")
+            print(x)
+
+        with subtest("wait for multi-path BGP routes to appear"):
+            for host, remote, peer_addr in [
+                (host1, 3, ["203", "104"]),
+                (host2, 1, ["303", "404"]),
+            ]:
+                for addr in peer_addr:
+                    host.wait_until_succeeds(
+                        f"ip route show 192.168.42.{remote} | grep -F fe80::5054:ff:fe12:{addr}"
+                    )
+
+        with subtest("check basic network reachability"):
+            host1.succeed("ping -c1 192.168.42.3")
+            host2.succeed("ping -c1 192.168.42.1")
+
+        with subtest("check nexthop group sync for indirect routes after link loss"):
+            # bug in (at least) 8.5.4: when a link goes down, nexthops pointing
+            # to the faulty link are deleted and removed from nexthop groups
+            # (for ecmp routes) by the kernel. when the link comes back up, frr
+            # recreates the nexthops pointing to the link, but does not
+            # correctly reinstall them into nexthop groups for indirect ecmp routes.
+
+            # simulate link loss (e.g. hardware fluke) by simply setting the
+            # link down.
+            host1.succeed("ip link set eth1 down")
+            host1.wait_until_succeeds("journalctl -u bgpd | grep -E 'eth1.*in vrf default Down'")
+            host1.sleep(2)
+
+            # recover from link loss event
+            host1.succeed("ip link set eth1 up")
+            host1.wait_until_succeeds("journalctl -u bgpd -n1 | grep -F 'End-of-RIB for IPv4 Unicast from eth1'")
+            host1.sleep(5)
+
+            out = host1.succeed("ip route show 192.168.42.3")
+            print(out)
+
+            host1.succeed("ip route show 192.168.42.3 | grep -F fe80::5054:ff:fe12:203")
+            host1.succeed("ip route show 192.168.42.3 | grep -F fe80::5054:ff:fe12:104")
+
+      '';
+    };
   };
-
-  testScript = ''
-    start_all()
-    all_vms = [host1, host2, switch1, switch2]
-    for vm in all_vms:
-        vm.wait_for_unit("network-online.target")
-
-    for vm in all_vms:
-        x = vm.succeed("vtysh -c 'show version'")
-        print(x)
-
-    with subtest("wait for multi-path BGP routes to appear"):
-        for host, remote, peer_addr in [
-            (host1, 3, ["203", "104"]),
-            (host2, 1, ["303", "404"]),
-        ]:
-            for addr in peer_addr:
-                host.wait_until_succeeds(
-                    f"ip route show 192.168.42.{remote} | grep -F fe80::5054:ff:fe12:{addr}"
-                )
-
-    with subtest("check basic network reachability"):
-        host1.succeed("ping -c1 192.168.42.3")
-        host2.succeed("ping -c1 192.168.42.1")
-
-    with subtest("check nexthop group sync for indirect routes after link loss"):
-        # bug in (at least) 8.5.4: when a link goes down, nexthops pointing
-        # to the faulty link are deleted and removed from nexthop groups
-        # (for ecmp routes) by the kernel. when the link comes back up, frr
-        # recreates the nexthops pointing to the link, but does not
-        # correctly reinstall them into nexthop groups for indirect ecmp routes.
-
-        # simulate link loss (e.g. hardware fluke) by simply setting the
-        # link down.
-        host1.succeed("ip link set eth1 down")
-        host1.wait_until_succeeds("journalctl -u bgpd | grep -E 'eth1.*in vrf default Down'")
-        host1.sleep(2)
-
-        # recover from link loss event
-        host1.succeed("ip link set eth1 up")
-        host1.wait_until_succeeds("journalctl -u bgpd -n1 | grep -F 'End-of-RIB for IPv4 Unicast from eth1'")
-        host1.sleep(5)
-
-        out = host1.succeed("ip route show 192.168.42.3")
-        print(out)
-
-        host1.succeed("ip route show 192.168.42.3 | grep -F fe80::5054:ff:fe12:203")
-        host1.succeed("ip route show 192.168.42.3 | grep -F fe80::5054:ff:fe12:104")
-
-  '';
 })


### PR DESCRIPTION
This change adds a sensu check script for detecting sync issues between the EVPN control plane (i.e. the FRR daemons) and the kernel, along with supporting infrastructure.

The check script itself is `check_rib_integrity.py` which loads and compares either the IPv4 unicast RIB (for monitoring of the underlay network routing) or the EVPN RIB (for monitoring of the overlay network configuration, i.e. mostly MAC addresses). If there are mismatches between the state in either the kernel or FRR, then the script will return a critical result. In case of the check being critical, the script will output a list of problems detected (e.g. which IP addresses or MAC addresses are in the kernel but not FRR and vice versa, or which destinations for which the kernel is missing nexthops) in a space-separated format which should be straightforwardly machine-readable.

Given that this script has to deal with relatively complex system network state, I've additionally expanded our FRR test suite to check that the sensu script detects the relevant faults correctly. In order to properly simulate an EVPN environment, I've written a `ping-on-tap.py` script, which opens a tap interface and then respond to ARP and ICMP echo on that interface. The test VMs then run one or more instances of this script so the kernel can dynamically learn MAC addresses from the python script on the tap interfaces, which are then exported to its peers by FRR.

I also realised that we never actually added the FRR tests to the default Hydra tests (as far as I can tell), so I've fixed that as well.

PL-132595

@flyingcircusio/release-managers

## Release process

Impact: internal.

Changelog: none.

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - This change adds monitoring for the VXLAN overlay network in order to improve observability when the control plane and data plane get out of sync.
- [x] Security requirements tested? (EVIDENCE)
  - Tested manually on a dev host.
  - Additional Hydra tests to automatically verify check script functionality.