### PR TITLE
[23.11] make updates happen only in maintenance

### DIFF
--- a/nixos/platform/agent.nix
+++ b/nixos/platform/agent.nix
@@ -111,8 +111,12 @@ in
       };
 
       updateInMaintenance = mkOption {
-        default = attrByPath [ "parameters" "production" ] false cfg.enc;
-        description = "Perform channel updates in scheduled maintenance. Default: all production VMs";
+        default = true;
+        description = ''
+          Perform channel updates in scheduled maintenance. If set to false,
+          machines switch to new channels immediately, without running
+          maintenance enter and exit commands.
+          '';
         type = types.bool;
       };
 

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -39,7 +39,7 @@ in {
   coturn = callTest ./coturn.nix {};
   devhost = callTest ./devhost.nix {};
   docker = callTest ./docker.nix {};
-  fcagent = callSubTests ./fcagent.nix {};
+  fcagent = callTest ./fcagent.nix {};
   ferretdb = callTest ./ferretdb.nix {};
   ffmpeg = callTest ./ffmpeg.nix {};
   filebeat = callTest ./filebeat.nix {};

--- a/tests/fcagent.nix
+++ b/tests/fcagent.nix
@@ -1,34 +1,15 @@
 import ./make-test-python.nix ({ pkgs, testlib, ... }:
 {
   name = "fc-agent";
-  testCases = {
-    prod = {
-      name = "prod";
-      machine =
-        { config, lib, ... }:
-        {
-          imports = [
-            (testlib.fcConfig { extraEncParameters = { production = true; }; })
-          ];
-        };
-      testScript = ''
-        machine.wait_for_unit('multi-user.target')
-        machine.succeed("systemctl show fc-update-channel.service --property ExecStart | grep 'request update'")
-      '';
+  nodes.machine =
+    { config, lib, ... }:
+    {
+      imports = [
+        (testlib.fcConfig { extraEncParameters = { production = true; }; })
+      ];
     };
-    nonprod = {
-      name = "nonprod";
-      machine =
-        { config, lib, ... }:
-        {
-          imports = [
-            (testlib.fcConfig { extraEncParameters = { production = false; }; })
-          ];
-        };
-      testScript = ''
-        machine.wait_for_unit('multi-user.target')
-        machine.succeed("systemctl show fc-update-channel.service --property ExecStart | grep 'switch --update-channel'")
-      '';
-    };
-  };
+  testScript = ''
+    machine.wait_for_unit('multi-user.target')
+    machine.succeed("systemctl show fc-update-channel.service --property ExecStart | grep 'request update'")
+  '';
 })


### PR DESCRIPTION
@flyingcircusio/release-managers

PL-132792 

This is a Backport of #1067

## Release process

Impact:

Changelog:

(see 24.05 changelog)

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - see #1067 
- [x] Security requirements tested? (EVIDENCE)
  - This has been successfully running on 24.05 for over a month now
