### PR TITLE
direnv: add artifacts to gitignore, provide example config file

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -1,0 +1,2 @@
+use flake . --impure --allow-dirty --no-write-lock-file
+build_channels_dir

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ result-*
 share/
 target/
 tmp/
+# direnv
+.envrc
+.direnv/

--- a/README.md
+++ b/README.md
@@ -39,11 +39,15 @@ Automatically enter the dev shell with direnv
 
 Use `direnv` to automatically enter the dev shell when you change to the fc-nixos directory.
 
+A recommended direnv config is shipped in `.envrc.example` to use it in your repo checkout just
+`cp .envrc{.example,} && direnv allow`.
+
+We recommend the usage of the [nix-community/nix-direnv](https://github.com/nix-community/nix-direnv) hook
+instead of the one shipped by direnv itself.
 To set it up with `home-manager`, see:
 https://github.com/nix-community/nix-direnv?tab=readme-ov-file#via-home-manager
 
-Without home-manager
---------------------
+### Without home-manager
 
 On a NixOS machine, enabling `programs.direnv.enable` should be enough.
 
@@ -54,17 +58,13 @@ Add `/etc/local/nixos/dev_vm.nix`, for example:
       nix.extraOptions = ''
         keep-outputs = true
       '';
-      programs.direnv.enable = true;
+      programs.direnv = {
+        enable = true;
+        nix-direnv.enable = true;
+      };
     }
 
 Rebuild the system, close the shell/tmux session and log in again.
-
-In `fc-nixos`, add an `.envrc` file like:
-
-    use flake . --impure --allow-dirty
-    build_channels_dir
-
-Then, run `direnv allow` to build and enter the dev shell.
 
 Run `direnv allow` again if the dev shell disappears or doesn't reload automatically.
 


### PR DESCRIPTION
Adds direnv files and directories to gitignore. Also moves the recommended `.envrc` to an example file that can just be copied, and updates the Readme accordingly.

This was triggered by my editor (vscodium) search suddenly also displaying matches from flake inputs.
I never saw these files in the git status because I have a global gitignore matching direnv artifacts already, but the editor only parses the repo-local files.

As several team members utilise direnv with https://github.com/nix-community/nix-direnv, it makes sense to ship these paths in the gitignore.

@flyingcircusio/release-managers

## Release process

Impact: none

Changelog: internal only

### PR release workflow (internal)

just a minor quality-of-life improvement, has no ticket

- [ ] PR has internal ticket
- [ ] internal issue ID (PL-…) part of branch name
- [ ] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - ignored paths must not be security relevant or meaningful to the repository 
- [x] Security requirements tested? (EVIDENCE)
  - [x] ignored paths are just caches or config relevant to local workspace setup
