### PR TITLE
ceph/radosgw: improve health monitoring

### DIFF
--- a/nixos/roles/ceph/rgw.nix
+++ b/nixos/roles/ceph/rgw.nix
@@ -182,6 +182,14 @@ in
         script = "${pkgs.fc.agent}/bin/fc-s3accounting --enc ${config.flyingcircus.encPath}";
       };
 
+      flyingcircus.services.sensu-client.checks = {
+        radosgw_probe_object = {
+          notification = "Probe object (/rgw-monitoring/probe) not OK.";
+          command =
+            "check_http -u /rgw-monitoring/probe -H localhost -m 1000000:1500000 -w 5 -c 10";
+        };
+      };
+
       services.logrotate.extraConfig = ''
         /var/log/ceph/client.radosgw.log {
             create 0644 root adm

--- a/nixos/roles/kvm.nix
+++ b/nixos/roles/kvm.nix
@@ -345,6 +345,9 @@ in
              in
                 "s3-${name} ${address}:7480 check inter 10s rise 2 fall 1 maxconn 40")
             (fclib.findServices "ceph_rgw-internal-server");
+          extraConfig = ''
+              option httpchk GET /rgw-monitoring/probe
+          '';
         };
       };
     };


### PR DESCRIPTION
We've seen instances where the / endpoint was responding but the radosgw was completely stuck.

We hope to notice those better now with checks that actually hit a real object.

Re PL-132070

@flyingcircusio/release-managers

## Release process

Impact:

n/a

Changelog:

* Improve our Ceph RadosGW checks to include hitting a real object instead of just /. We've seen instances of stuck RadosGWs that did respond to / but didn't respond to an actual object request. (PL-132070)

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

proper monitoring to ensure availability

- [x] Security requirements tested? (EVIDENCE)

manually tested with kyle06 and cartman06