### PR TITLE
varnish: handle change in default stateDir

### DIFF
--- a/nixos/services/varnish/default.nix
+++ b/nixos/services/varnish/default.nix
@@ -126,7 +126,12 @@ in {
       reloadIfChanged = true;
       restartTriggers = [ cfg.extraCommandLine vcfg.package cfg.http_address ];
       reload = ''
-        vadm="${vcfg.package}/bin/varnishadm -n ${vcfg.stateDir}"
+        if [ -d "${vcfg.stateDir}" ]; then
+          statedir="${vcfg.stateDir}"
+        else
+          statedir="/var/spool/varnish/${config.networking.hostName}" #temporary migration
+        fi
+        vadm="${vcfg.package}/bin/varnishadm -n $statedir"
         cat ${commandsfile} | $vadm
 
         coldvcls=$($vadm vcl.list | grep " cold " | ${pkgs.gawk}/bin/awk {'print $5'})


### PR DESCRIPTION
@flyingcircusio/release-managers
PL-132901
## Release process

Impact:

Changelog:
The default value for stateDir has changed upstream, this migration
falls back to the old default in the reload script. This can be reverted
as soon as all VMs have been rebooted.

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - varnish shouldn't crash due to performance issues, this is why the stateDir is moved in the first place
  - however, running instances of varnish should continue to use the old stateDir until the next reboot/service restart
- [x] Security requirements tested? (EVIDENCE)
  - tested changing the stateDir on pntest00, reloading went successfully