### PR TITLE
[21.05] Monitoring and alerting for kernel neighbour cache state

### DIFF
--- a/pkgs/fc/default.nix
+++ b/pkgs/fc/default.nix
@@ -34,6 +34,7 @@ rec {
   logcheckhelper = callPackage ./logcheckhelper { };
   megacli = callPackage ./megacli { };
   multiping = callPackage ./multiping.nix {};
+  neighbour-cache-monitor = callPackage ./neighbour-cache-monitor {};
   ping-on-tap = callPackage ./ping-on-tap {};
   qemu-nautilus = callPackage ./qemu rec {
     version = "1.4.4";

--- a/pkgs/fc/neighbour-cache-monitor/default.nix
+++ b/pkgs/fc/neighbour-cache-monitor/default.nix
@@ -1,0 +1,26 @@
+{ lib, stdenv, makeWrapper, python3, iproute2, procps }:
+
+stdenv.mkDerivation rec {
+  version = "1";
+  pname = "neighbour-cache-monitor";
+
+  src = ./.;
+  unpackPhase = ":";
+  dontBuild = true;
+  dontConfigure = true;
+  nativeBuildInputs = [ makeWrapper ];
+  propagatedBuildInputs = [ python3 iproute2 procps ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cd $src
+    install neighbour-cache-monitor.py $out/bin/neighbour-cache-monitor
+    wrapProgram $out/bin/neighbour-cache-monitor --prefix PATH : \
+      ${lib.makeBinPath propagatedBuildInputs}
+  '';
+
+  meta = with lib; {
+    description = "Script for monitoring and metrics of kernel neighbour table";
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/fc/neighbour-cache-monitor/neighbour-cache-monitor.py
+++ b/pkgs/fc/neighbour-cache-monitor/neighbour-cache-monitor.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import subprocess
+import sys
+
+CACHE_TYPES = {
+    "ipv4": "arp_cache",
+    "ipv6": "ndisc_cache",
+}
+
+
+def warning(msg):
+    print(f"WARN - {msg}")
+    sys.exit(1)
+
+
+def critical(msg):
+    print(f"CRITICAL - {msg}")
+    sys.exit(2)
+
+
+def ok(msg):
+    print(f"OK - {msg}")
+    sys.exit(0)
+
+
+def read_cache_stats(cache_type):
+    # XXX: lnstat unconditionally returns exit code 1, even on
+    # success.
+    proc = subprocess.run(
+        [
+            "lnstat",
+            "-f",
+            cache_type,
+            "-j",
+            "-c1",
+        ],
+        capture_output=True,
+    )
+    return json.loads(proc.stdout.decode("utf-8"))
+
+
+def read_table_threshold(family):
+    data = subprocess.check_output(
+        ["sysctl", "-n", f"net.{family}.neigh.default.gc_thresh3"]
+    )
+    data = data.strip()
+    return int(data)
+
+
+def telegraf(args):
+    # pass through lnstat output to telegraf verbatim, annotated with
+    # address family
+    metrics = []
+    for family, cache_type in CACHE_TYPES.items():
+        data = read_cache_stats(cache_type)
+        data["family"] = family
+        metrics.append(data)
+    print(json.dumps(metrics))
+
+
+def sensu(args):
+    entries = {}
+    overflows = {}
+    thresholds = {}
+    for family, cache_type in CACHE_TYPES.items():
+        data = read_cache_stats(cache_type)
+        overflows[family] = data["table_fulls"]
+        entries[family] = data["entries"]
+
+        thresholds[family] = read_table_threshold(family)
+
+    with open(args.state_file, "a+b") as fh:
+        fh.seek(0)
+        data = fh.read()
+
+        # only attempt to decode json if the file is non-empty. file
+        # is empty on first creation.
+        state = None
+        if len(data) > 0:
+            try:
+                state = json.loads(data.decode("utf-8"))
+            except json.JSONDecodeError:
+                pass
+
+        fh.seek(0)
+        fh.truncate()
+        fh.write(json.dumps(overflows).encode("utf-8"))
+
+    # perform checks family-wise in descending order of urgency
+
+    if state is not None:
+        for family in CACHE_TYPES.keys():
+            if overflows[family] > state[family]:
+                critical(f"{family} neighbour table overflows detected!")
+
+    for family in CACHE_TYPES.keys():
+        if (
+            entries[family]
+            > (thresholds[family] * args.critical_threshold) // 100
+        ):
+            critical(
+                f"{family} neighbour table exceeded {args.critical_threshold}% capacity"
+            )
+
+    for family in CACHE_TYPES.keys():
+        if entries[family] > (thresholds[family] * args.warn_threshold) // 100:
+            warning(
+                f"{family} neighbour table exceeded {args.warn_threshold}% capacity"
+            )
+
+    ok("neighbour tables within capacity limits")
+
+
+def main():
+    parser = argparse.ArgumentParser(prog="neighbour-cache-monitor")
+    subparsers = parser.add_subparsers(required=True, dest="command")
+
+    telegraf_parser = subparsers.add_parser(
+        "telegraf-metrics", help="Generate Telegraf-compatible metrics"
+    )
+    telegraf_parser.set_defaults(func=telegraf)
+
+    sensu_parser = subparsers.add_parser(
+        "sensu-check",
+        help="Sensu-compatible check which monitors neighbour table size and overflow state",
+    )
+    sensu_parser.set_defaults(func=sensu)
+
+    sensu_parser.add_argument(
+        "-s",
+        "--state-file",
+        metavar="FILE",
+        required=True,
+        help="Table overflow statistics state file",
+    )
+    sensu_parser.add_argument(
+        "-w",
+        "--warn-threshold",
+        metavar="WARN",
+        type=int,
+        default=30,
+        help="Issue warning when table entry count greater than WARN % of gc_thresh3",
+    )
+    sensu_parser.add_argument(
+        "-c",
+        "--critical-threshold",
+        metavar="CRIT",
+        type=int,
+        default=50,
+        help="Issue critical when table entry count greater than CRIT % of gc_thresh3",
+    )
+
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This change introduces a new script, which uses `lnstat(1)` from iproute2 to monitor the state of the kernel neighbour cache tables for both IPv4 and IPv6. The script provides metrics to Telegraf in order to monitor the neighbour table state over time, and also provides a Sensu check for detecting when the number of entries in the cache has exceeded a threshold, and for when the table has overflowed.

The monitoring and alerting is currently only enabled on routers. The Sensu check is intentionally configured to run every minute, instead of the usual every ten minutes, as problems with the neighbour cache filling up can cause significant problems very suddenly.

PL-132950

@flyingcircusio/release-managers

## Release process

Impact: internal.

Changelog: none.

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Overflowing neighbour caches can cause outages and denial of service, so we should proactively monitor for kernel states which may cause problems.
- [x] Security requirements tested? (EVIDENCE)
  - Telegraf metrics verified with curl on a test host.
  - Sensu monitoring verified on a test host with an active load test to simulate an overflowing neighbour cache.