### PR TITLE
Update channel to use downgraded kernel version.

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1722555600,
-        "narHash": "sha256-XOQkdLafnb/p9ij77byFQjDf5m5QYl9b2REiVClC+x4=",
+        "lastModified": 1725234343,
+        "narHash": "sha256-+ebgonl3NbiKD2UD0x4BszCZQ6sTfL4xioaM49o5B3Y=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "8471fe90ad337a8074e957b69ca4d0089218391d",
+        "rev": "567b938d64d4b4112ee253b9274472dc3a346eb6",
         "type": "github"
       },
       "original": {
@@ -350,14 +350,14 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1722555339,
-        "narHash": "sha256-uFf2QeW7eAHlYXuDktm9c25OxOyCoUOQmh5SZ9amE5Q=",
+        "lastModified": 1725233747,
+        "narHash": "sha256-Ss8QWLXdr2JCBPcYChJhz4xJm+h/xjl4G0c0XlP6a74=",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/a5d394176e64ab29c852d03346c1fc9b0b7d33eb.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/356624c12086a18f2ea2825fed34523d60ccc4e3.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/a5d394176e64ab29c852d03346c1fc9b0b7d33eb.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/356624c12086a18f2ea2825fed34523d60ccc4e3.tar.gz"
       }
     },
     "nixpkgs-regression": {
@@ -410,16 +410,16 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1724858933,
-        "narHash": "sha256-F/S6sVz00ljxgPAu9C6r7BbkmfkLy0KihEdvRCobFTY=",
+        "lastModified": 1725351330,
+        "narHash": "sha256-/TWnMQLv73+pcuNiL2DI1m9bgZuItPGDrDANJ4EzY2A=",
         "owner": "flyingcircusio",
         "repo": "nixpkgs",
-        "rev": "ac9a8c52e1e69847cef1d41c9661034dc3909149",
+        "rev": "8dbeac8e250a79d33ae1eb9ec3d9bba294b7a3a4",
         "type": "github"
       },
       "original": {
         "owner": "flyingcircusio",
-        "ref": "nixos-24.05",
+        "ref": "PL-132971-downgrade-kernel-5.15",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -23,7 +23,7 @@
   description = "Flying Circus NixOS platform (dev/release tooling)";
 
   inputs = {
-    nixpkgs.url = "github:flyingcircusio/nixpkgs/nixos-24.05";
+    nixpkgs.url = "github:flyingcircusio/nixpkgs/PL-132971-downgrade-kernel-5.15";
     nixos-mailserver = {
       url = "gitlab:flyingcircus/nixos-mailserver/nixos-24.05?host=gitlab.flyingcircus.io";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/release/versions.json
+++ b/release/versions.json
@@ -8,9 +8,9 @@
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/"
   },
   "nixpkgs": {
-    "hash": "sha256-F/S6sVz00ljxgPAu9C6r7BbkmfkLy0KihEdvRCobFTY=",
+    "hash": "sha256-/TWnMQLv73+pcuNiL2DI1m9bgZuItPGDrDANJ4EzY2A=",
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "ac9a8c52e1e69847cef1d41c9661034dc3909149"
+    "rev": "8dbeac8e250a79d33ae1eb9ec3d9bba294b7a3a4"
   }
 }


### PR DESCRIPTION
In the most recent nixpkgs update #1039 we released kernel version 5.15.165, however this has a bug in the virtio_net driver which causes network performance problems in VMs.

I've created a feature branch on our nixpkgs fork with the update commit reverted; this change switches our nixpkgs channel to use that feature branch, so we can continue to use 5.15.164, which does not have this regression.

PL-132971

@flyingcircusio/release-managers

## Release process

Impact:

- [NixOS 24.05] Machines will reboot to activate the downgraded kernel.

Changelog:

- linux_5_15: 5.15.165 -> 5.15.164

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - The most recently released new kernel version has a regression which may degrade service availability.
- [x] Security requirements tested? (EVIDENCE)
  - Checked on a DEV VM with the reproduction test against RadosGW.