### PR TITLE
Update nixpkgs (2024-09-09)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1725234343,
-        "narHash": "sha256-+ebgonl3NbiKD2UD0x4BszCZQ6sTfL4xioaM49o5B3Y=",
+        "lastModified": 1726151147,
+        "narHash": "sha256-MgSpXGOFeMQOjB1qMlTm6CV9XG8eJ5tUOHs9E9eTk5c=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "567b938d64d4b4112ee253b9274472dc3a346eb6",
+        "rev": "dc3b467eac0fe1436e897d01c35dabe63b4749ea",
         "type": "github"
       },
       "original": {
@@ -410,16 +410,16 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1725351330,
-        "narHash": "sha256-/TWnMQLv73+pcuNiL2DI1m9bgZuItPGDrDANJ4EzY2A=",
+        "lastModified": 1726151616,
+        "narHash": "sha256-Pu+odXzikSAkl/39zdvB86hasDrEImixpU3RXi45I74=",
         "owner": "flyingcircusio",
         "repo": "nixpkgs",
-        "rev": "8dbeac8e250a79d33ae1eb9ec3d9bba294b7a3a4",
+        "rev": "6ce38e4d52cbb7313f5170903deb4b8b3d3ff022",
         "type": "github"
       },
       "original": {
         "owner": "flyingcircusio",
-        "ref": "PL-132971-downgrade-kernel-5.15",
+        "ref": "nixos-24.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -23,7 +23,7 @@
   description = "Flying Circus NixOS platform (dev/release tooling)";
 
   inputs = {
-    nixpkgs.url = "github:flyingcircusio/nixpkgs/PL-132971-downgrade-kernel-5.15";
+    nixpkgs.url = "github:flyingcircusio/nixpkgs/nixos-24.05";
     nixos-mailserver = {
       url = "gitlab:flyingcircus/nixos-mailserver/nixos-24.05?host=gitlab.flyingcircus.io";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/nixpkgs-config.nix
+++ b/nixpkgs-config.nix
@@ -14,5 +14,6 @@
     "python-2.7.18.8" # Needed for some legacy customer applications.
     "ruby-2.7.8" # EOL 2023-03-31, needed for Sensu checks
     "docker-24.0.9" # Old installs still use storage driver removed in 25.x.
+    "jitsi-meet-1.0.7952" # insecure libolm but this only affects optional e2ee which we don't really support.
   ];
 }

--- a/release/package-versions.json
+++ b/release/package-versions.json
@@ -70,14 +70,14 @@
     "version": "18.2.4"
   },
   "chromedriver": {
-    "name": "chromedriver-128.0.6613.84",
+    "name": "chromedriver-128.0.6613.119",
     "pname": "chromedriver",
-    "version": "128.0.6613.84"
+    "version": "128.0.6613.119"
   },
   "chromium": {
-    "name": "chromium-128.0.6613.84",
+    "name": "chromium-128.0.6613.119",
     "pname": "chromium",
-    "version": "128.0.6613.84"
+    "version": "128.0.6613.119"
   },
   "cifs-utils": {
     "name": "cifs-utils-7.0",
@@ -95,9 +95,9 @@
     "version": "3.29.2"
   },
   "consul": {
-    "name": "consul-1.18.3",
+    "name": "consul-1.18.4",
     "pname": "consul",
-    "version": "1.18.3"
+    "version": "1.18.4"
   },
   "containerd": {
     "name": "containerd-1.7.16",
@@ -155,9 +155,9 @@
     "version": "2.3.21.1"
   },
   "element-web": {
-    "name": "element-web-1.11.75",
+    "name": "element-web-1.11.76",
     "pname": "element-web",
-    "version": "1.11.75"
+    "version": "1.11.76"
   },
   "erlang": {
     "name": "erlang-25.3.2.12",
@@ -190,9 +190,9 @@
     "version": "7.17.16"
   },
   "firefox": {
-    "name": "firefox-129.0.2",
+    "name": "firefox-130.0",
     "pname": "firefox",
-    "version": "129.0.2"
+    "version": "130.0"
   },
   "gcc": {
     "name": "gcc-wrapper-13.2.0",
@@ -220,9 +220,9 @@
     "version": "2.44.1"
   },
   "gitaly": {
-    "name": "gitaly-17.2.4",
+    "name": "gitaly-17.2.5",
     "pname": "gitaly",
-    "version": "17.2.4"
+    "version": "17.2.5"
   },
   "github-runner": {
     "name": "github-runner-2.319.1",
@@ -230,24 +230,24 @@
     "version": "2.319.1"
   },
   "gitlab": {
-    "name": "gitlab-17.2.4",
+    "name": "gitlab-17.2.5",
     "pname": "gitlab",
-    "version": "17.2.4"
+    "version": "17.2.5"
   },
   "gitlab-container-registry": {
-    "name": "gitlab-container-registry-4.7.0",
+    "name": "gitlab-container-registry-4.9.0",
     "pname": "gitlab-container-registry",
-    "version": "4.7.0"
+    "version": "4.9.0"
   },
   "gitlab-ee": {
-    "name": "gitlab-ee-17.2.4",
+    "name": "gitlab-ee-17.2.5",
     "pname": "gitlab-ee",
-    "version": "17.2.4"
+    "version": "17.2.5"
   },
   "gitlab-pages": {
-    "name": "gitlab-pages-17.2.4",
+    "name": "gitlab-pages-17.2.5",
     "pname": "gitlab-pages",
-    "version": "17.2.4"
+    "version": "17.2.5"
   },
   "gitlab-runner": {
     "name": "gitlab-runner-17.1.0",
@@ -255,9 +255,9 @@
     "version": "17.1.0"
   },
   "gitlab-workhorse": {
-    "name": "gitlab-workhorse-17.2.4",
+    "name": "gitlab-workhorse-17.2.5",
     "pname": "gitlab-workhorse",
-    "version": "17.2.4"
+    "version": "17.2.5"
   },
   "glibc": {
     "name": "glibc-2.39-52",
@@ -282,9 +282,9 @@
   "go_1_19": {},
   "go_1_20": {},
   "grafana": {
-    "name": "grafana-10.4.7",
+    "name": "grafana-10.4.8",
     "pname": "grafana",
-    "version": "10.4.7"
+    "version": "10.4.8"
   },
   "grub2": {
     "name": "grub-2.12",
@@ -292,14 +292,14 @@
     "version": "2.12"
   },
   "haproxy": {
-    "name": "haproxy-2.9.7",
+    "name": "haproxy-2.9.10",
     "pname": "haproxy",
-    "version": "2.9.7"
+    "version": "2.9.10"
   },
   "imagemagick": {
-    "name": "imagemagick-7.1.1-36",
+    "name": "imagemagick-7.1.1-38",
     "pname": "imagemagick",
-    "version": "7.1.1-36"
+    "version": "7.1.1-38"
   },
   "imagemagick6": {
     "name": "imagemagick-6.9.13-10",
@@ -307,9 +307,9 @@
     "version": "6.9.13-10"
   },
   "imagemagick7": {
-    "name": "imagemagick-7.1.1-36",
+    "name": "imagemagick-7.1.1-38",
     "pname": "imagemagick",
-    "version": "7.1.1-36"
+    "version": "7.1.1-38"
   },
   "inetutils": {
     "name": "inetutils-2.5",
@@ -437,9 +437,9 @@
     "version": "0.2.5"
   },
   "linux_5_15": {
-    "name": "linux-5.15.165",
+    "name": "linux-5.15.164",
     "pname": "linux",
-    "version": "5.15.165"
+    "version": "5.15.164"
   },
   "logrotate": {
     "name": "logrotate-3.21.0",
@@ -477,14 +477,14 @@
     "version": "4.16.1"
   },
   "matomo_5": {
-    "name": "matomo_5-5.0.2",
+    "name": "matomo_5-5.1.1",
     "pname": "matomo_5",
-    "version": "5.0.2"
+    "version": "5.1.1"
   },
   "matrix-synapse": {
-    "name": "matrix-synapse-wrapped-1.113.0",
+    "name": "matrix-synapse-wrapped-1.114.0",
     "pname": "matrix-synapse-wrapped",
-    "version": "1.113.0"
+    "version": "1.114.0"
   },
   "mcpp": {
     "name": "mcpp-2.7.2.1",
@@ -577,9 +577,9 @@
     "version": "4.35"
   },
   "nss_latest": {
-    "name": "nss-3.102",
+    "name": "nss-3.104",
     "pname": "nss",
-    "version": "3.102"
+    "version": "3.104"
   },
   "openjdk": {
     "name": "openjdk-21.0.3+9",
@@ -727,14 +727,14 @@
     "version": "8.1.29"
   },
   "php82": {
-    "name": "php-with-extensions-8.2.21",
+    "name": "php-with-extensions-8.2.23",
     "pname": "php-with-extensions",
-    "version": "8.2.21"
+    "version": "8.2.23"
   },
   "php83": {
-    "name": "php-with-extensions-8.3.9",
+    "name": "php-with-extensions-8.3.11",
     "pname": "php-with-extensions",
-    "version": "8.3.9"
+    "version": "8.3.11"
   },
   "phpPackages.composer": {
     "name": "composer-2.7.7",
@@ -802,9 +802,9 @@
     "version": "4.9.1"
   },
   "prometheus": {
-    "name": "prometheus-2.53.1",
+    "name": "prometheus-2.54.1",
     "pname": "prometheus",
-    "version": "2.53.1"
+    "version": "2.54.1"
   },
   "prosody": {
     "name": "prosody-0.12.4",
@@ -887,6 +887,11 @@
     "pname": "rich",
     "version": "13.7.1"
   },
+  "python3Packages.rich-rst": {
+    "name": "python3.11-rich-rst-1.3.1",
+    "pname": "rich-rst",
+    "version": "1.3.1"
+  },
   "python3Packages.structlog": {
     "name": "python3.11-structlog-24.1.0",
     "pname": "structlog",
@@ -932,10 +937,15 @@
     "pname": "redis",
     "version": "7.2.4"
   },
+  "rich-cli": {
+    "name": "rich-cli-1.8.0",
+    "pname": "rich-cli",
+    "version": "1.8.0"
+  },
   "roundcube": {
-    "name": "roundcube-1.6.8",
+    "name": "roundcube-1.6.9",
     "pname": "roundcube",
-    "version": "1.6.8"
+    "version": "1.6.9"
   },
   "rsync": {
     "name": "rsync-3.3.0",

--- a/release/versions.json
+++ b/release/versions.json
@@ -8,9 +8,9 @@
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/"
   },
   "nixpkgs": {
-    "hash": "sha256-/TWnMQLv73+pcuNiL2DI1m9bgZuItPGDrDANJ4EzY2A=",
+    "hash": "sha256-Pu+odXzikSAkl/39zdvB86hasDrEImixpU3RXi45I74=",
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "8dbeac8e250a79d33ae1eb9ec3d9bba294b7a3a4"
+    "rev": "6ce38e4d52cbb7313f5170903deb4b8b3d3ff022"
   }
 }


### PR DESCRIPTION
Update nixpkgs (2024-09-09)

Pull upstream NixOS changes, security fixes and package updates:

- chromedriver: 128.0.6613.84 -> 128.0.6613.119
- chromium: 128.0.6613.84 -> 128.0.6613.119
- consul: 1.18.3 -> 1.18.4
- element-web: 1.11.75 -> 1.11.76
- firefox: 129.0.2 -> 130.0
- grafana: 10.4.7 -> 10.4.8
- haproxy: 2.9.7 -> 2.9.10 (CVE-2024-45506)
- imagemagick: 7.1.1-36 -> 7.1.1-38
- matomo_5: 5.0.2 -> 5.1.1
- matrix-synapse: 1.113.0 -> 1.114.0
- nss_latest: 3.102 -> 3.104
- php82: 8.2.21 -> 8.2.23
- php83: 8.3.9 -> 8.3.11
- prometheus: 2.53.1 → 2.54.1
- roundcube: 1.6.8 -> 1.6.9

Skip kernel (linux_5_15) updates from upstream by reverting 2 update
commits. We want to stay at 5.15.164 for now and update to 5.15.167 or
later (see PL-132971).

Additional package update by us:

- gitlab: 17.2.4 -> 17.2.5


Allow jitsi-meet which is marked as insecure now

This is caused by libolm used for e2ee which is an optional feature.

There's no fix in sight (libolm deprecated, no signs in lib-jitsi-meet
to move away from it) and the attacks are AFAIK for on the theoretical
side. I don't think that this should stop us from using Jitsi.

PL-132999

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

(include pkg changes)

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - pull in upstream security fixes from nixpkgs and for Gitlab regularly
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still run, works on various test VMs, including a Gitlab test machine
  - checked commit log for fixed CVEs and possible problems with updates; looked at [Grafana changelog](https://github.com/grafana/grafana/blob/main/CHANGELOG.md),  [GitLab 17 changes | GitLab](https://docs.gitlab.com/ee/update/versions/gitlab_17_changes.html), [Releases · roundcube/roundcubemail](https://github.com/roundcube/roundcubemail/releases), [prometheus/CHANGELOG.md at main · prometheus/prometheus · GitHub](https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md) and [synapse/upgrade.md](https://github.com/element-hq/synapse/blob/develop/docs/upgrade.md).