### PR TITLE
Add basic role and integration for Grafana Loki

### DIFF
--- a/nixos/platform/default.nix
+++ b/nixos/platform/default.nix
@@ -34,6 +34,7 @@ in {
     ./monitoring.nix
     ./network.nix
     ./packages.nix
+    ./promtail.nix
     ./shell.nix
     ./static.nix
     ./syslog.nix

--- a/nixos/platform/promtail.nix
+++ b/nixos/platform/promtail.nix
@@ -1,0 +1,51 @@
+{ lib, config, ... }:
+
+let
+  enc = config.flyingcircus.enc;
+  fclib = config.fclib;
+
+  # XXX support multiple loki servers. the upstream docs note: "It is
+  # generally recommended to run multiple Promtail clients in parallel
+  # if you want to send to multiple remote Loki instances."
+  lokiServer = fclib.findOneService "loki-collector";
+in
+{
+  config = lib.mkIf (!builtins.isNull lokiServer) {
+    services.promtail = {
+      enable = true;
+      configuration = {
+        # don't expose the http and grpc api
+        server.disable = true;
+
+        clients = [{
+          url = "http://${lokiServer.address}:3100/loki/api/v1/push";
+        }];
+
+        scrape_configs = [{
+          job_name = "systemd-journal";
+          journal = {
+            json = true;
+            # there are server side limits to how many labels loki
+            # will accept on log lines. consider them a scarce
+            # resource and use them sparingly.
+            labels = {
+              resource_group = enc.parameters.resource_group;
+              location = enc.parameters.location;
+              hostname = config.networking.hostName;
+            };
+          };
+          relabel_configs = [
+            {
+              source_labels = [ "__journal__systemd_unit" ];
+              target_label = "systemd_unit";
+            }
+            {
+              source_labels = [ "__journal_syslog_identifier" ];
+              target_label = "syslog_identifier";
+            }
+          ];
+        }];
+      };
+    };
+  };
+}

--- a/nixos/roles/default.nix
+++ b/nixos/roles/default.nix
@@ -20,6 +20,7 @@ in {
     ./jitsi
     ./k3s
     ./lamp.nix
+    ./loki.nix
     ./mailout.nix
     ./mailserver.nix
     ./matomo.nix

--- a/nixos/roles/loki.nix
+++ b/nixos/roles/loki.nix
@@ -3,21 +3,93 @@
 let
   cfg = config.flyingcircus.roles.loki;
   fclib = config.fclib;
+
+  storageScheduleSubmodule = with lib; with types; submodule {
+    options = {
+      startDate = mkOption {
+        type = strMatching "[[:digit:]]{4}-[[:digit:]]{2}-[[:digit:]]{2}";
+      };
+      backend = mkOption { type = enum [ "filesystem" "s3" ]; };
+      schemaVersion = mkOption { type = ints.positive; default = 13; };
+    };
+  };
+
+  renderStorageSchema = opts: {
+    from = opts.startDate;
+    # always tsdb for index tables
+    store = "tsdb";
+    schema = "v${toString opts.schemaVersion}";
+    # default values in loki 3.1.1, here specified explicitly
+    index.prefix = "";
+    index.path_prefix = "index/";
+    index.period = "24h";
+
+    object_store = opts.backend;
+  };
 in
 {
   options = with lib; {
     flyingcircus.roles.loki = {
       enable = mkEnableOption "Flying Circus Grafana Loki server";
       supportsContainers = fclib.mkEnableContainerSupport;
+
       logRetentionPeriod = mkOption {
         type = types.ints.unsigned;
         default = 30;
         description = "Global retention period for log data in days. Setting to zero disables automatic log expiry";
       };
+
+      s3 = mkOption {
+        description = "Configure log storage in S3-compatible object store";
+        default = {};
+        type = types.submodule {
+          options = {
+            enable = mkEnableOption "store log data in S3";
+            endpoint = mkOption {
+              description = "HTTP(S) endpoint of S3 storage server";
+              type = types.str;
+              default = "http://rgw.local:7840";
+            };
+            bucketName = mkOption {
+              description = "S3 bucket name";
+              type = types.str;
+            };
+            credentialFile = mkOption {
+              description = "Path to file containing credentials used for authenticating to the S3 server (must be readable by the loki user)";
+              type = types.path;
+              default = "/etc/local/loki/s3.cfg";
+            };
+          };
+        };
+      };
+
+      storageSchedule = mkOption {
+        description = "Log storage schedule configuration";
+        default = {};
+        type = with types; submodule {
+          options = {
+            default = mkOption {
+              visible = false;
+              type = listOf storageScheduleSubmodule;
+              default = [{ startDate = "2024-09-10"; backend = "filesystem"; }];
+            };
+            extra = mkOption {
+              description = "Additional entries to add to the log storage schedule";
+              type = listOf storageScheduleSubmodule;
+              default = [];
+              defaultText = "[]";
+            };
+          };
+        };
+      };
     };
   };
 
   config = lib.mkIf cfg.enable {
+    environment.etc."local/loki/README.txt".text = ''
+      This is a stub README for the Loki role.
+    '';
+
     services.loki = {
       enable = true;
       configuration = {
@@ -25,16 +97,8 @@ in
 
         auth_enabled = false;
 
-        schema_config.configs = [{
-          from = "2024-09-10";
-          store = "tsdb";
-          object_store = "filesystem";
-          schema = "v13";
-          # default values in loki 3.1.1, here specified explicitly
-          index.prefix = "";
-          index.path_prefix = "index/";
-          index.period = "24h";
-        }];
+        schema_config.configs = map renderStorageSchema
+          (cfg.storageSchedule.default ++ cfg.storageSchedule.extra);
 
         storage_config = {
           # index file management
@@ -44,6 +108,13 @@ in
           };
           # log data configuration
           filesystem.directory = "/var/lib/loki/chunk-store";
+        } // lib.optionalAttrs (cfg.s3.enable) {
+          s3 = {
+            # authentication configured separately
+            endpoint = cfg.s3.endpoint;
+            bucketNames = cfg.s3.bucketNames;
+            s3forcepathstyle = true;
+          };
         };
 
         compactor = {
@@ -53,7 +124,7 @@ in
         };
 
         limits_config = {
-          retention_period = (builtins.toString cfg.logRetentionPeriod) + "d";
+          retention_period = (toString cfg.logRetentionPeriod) + "d";
         };
 
         # configuration stubs for multi-process management plane
@@ -62,6 +133,10 @@ in
           ring.kvstore.store = "inmemory";
         };
       };
+    };
+
+    systemd.services.loki.serviceConfig = lib.mkIf (cfg.s3.enable) {
+      Environment = "AWS_SHARED_CREDENTIALS_FILE=${cfg.s3.credentialFile}";
     };
 
     flyingcircus.services.nginx = {

--- a/nixos/roles/loki.nix
+++ b/nixos/roles/loki.nix
@@ -1,0 +1,68 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.flyingcircus.roles.loki;
+  fclib = config.fclib;
+in
+{
+  options = with lib; {
+    flyingcircus.roles.loki = {
+      enable = mkEnableOption "Flying Circus Grafana Loki server";
+      supportsContainers = fclib.mkEnableContainerSupport;
+      logRetentionPeriod = mkOption {
+        type = types.ints.unsigned;
+        default = 30;
+        description = "Global retention period for log data in days. Setting to zero disables automatic log expiry";
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    services.loki = {
+      enable = true;
+      configuration = {
+        # XXX loki only uses a single listen address.
+        server.http_listen_address = builtins.head fclib.network.srv.v4.addresses;
+
+        auth_enabled = false;
+
+        schema_config.configs = [{
+          from = "2024-09-10";
+          store = "tsdb";
+          object_store = "filesystem";
+          schema = "v13";
+          # default values in loki 3.1.1, here specified explicitly
+          index.prefix = "";
+          index.path_prefix = "index/";
+          index.period = "24h";
+        }];
+
+        storage_config = {
+          # index file management
+          tsdb_shipper = {
+            active_index_directory = "/var/lib/loki/tsdb-shipper-index";
+            cache_location = "/var/lib/loki/tsdb-shipper-cache";
+          };
+          # log data configuration
+          filesystem.directory = "/var/lib/loki/chunk-store";
+        };
+
+        compactor = {
+          working_directory = "/var/lib/loki/compactor-workdir";
+          retention_enabled = true;
+          delete_request_store = "filesystem";
+        };
+
+        limits_config = {
+          retention_period = (builtins.toString cfg.logRetentionPeriod) + "d";
+        };
+
+        # configuration stubs for multi-process management plane
+        common = {
+          replication_factor = 1;
+          ring.kvstore.store = "inmemory";
+        };
+      };
+    };
+  };
+}

--- a/nixos/roles/statshost/default.nix
+++ b/nixos/roles/statshost/default.nix
@@ -18,6 +18,8 @@ let
   cfgProxyLocation = config.flyingcircus.roles.statshost-location-proxy;
   cfgProxyRG = config.flyingcircus.roles.statshost-relay;
 
+  cfgLokiRG = config.flyingcircus.roles.loki;
+
   promFlags = [
     "--storage.tsdb.retention.time ${toString cfgStats.prometheusRetention}d"
   ];
@@ -517,12 +519,30 @@ in
               isDefault: true
           '';
         };
+
+        # support loki running on the same host as grafana in
+        # single-RG mode.
+        lokiDatasource = pkgs.writeTextFile {
+          name = "loki.yaml";
+          text = ''
+            apiVersion: 1
+            datasources:
+            - name: Loki
+              type: loki
+              access: proxy
+              orgId: 1
+              url: http://${config.networking.hostName}:3100
+              editable: false
+              isDefault: false
+          '';
+        };
       in ''
         rm -rf ${grafanaProvisioningPath}
         mkdir -p ${grafanaProvisioningPath}/dashboards ${grafanaProvisioningPath}/datasources
         ln -fs ${fcioDashboards} ${grafanaProvisioningPath}/dashboards/fcio.yaml
         ln -fs ${prometheusDatasource} ${grafanaProvisioningPath}/datasources/prometheus.yaml
-
+      '' + optionalString (cfgStatsRG.enable && cfgLokiRG.enable) ''
+        ln -fs ${lokiDatasource} ${grafanaProvisioningPath}/datasources/loki.yaml
       '';
 
       # Provide FC dashboards, and update them automatically.

--- a/nixos/roles/statshost/default.nix
+++ b/nixos/roles/statshost/default.nix
@@ -531,7 +531,7 @@ in
               type: loki
               access: proxy
               orgId: 1
-              url: http://${config.networking.hostName}:3100
+              url: http://localhost:3100
               editable: false
               isDefault: false
           '';


### PR DESCRIPTION
This change introduces minimal, bare-bones platform integration for Grafana Loki, intended to serve as a basis for further development.

This includes:
- A role which can be assigned to VMs, which installs and provisions an instance of Loki. Currently this is statically configured to use filesystem-backed storage.
- Automatic configuration of promtail, a log-shipping client for Loki, when a Loki server is discovered in the same resource group. Currently only a single Loki server is supported. promtail is configured to read the system journal in JSON format, as this reads annotations and metadata which would otherwise be lost if reading only the plain journal messages. The Loki query language LogQL supports decoding JSON log messages with the `json` filter.
- Initial integration with Grafana in the existing statshost role. Hosts with the statshost-master role for a per-RG Grafana instance which also have the loki role enabled will have a data source added to allow Grafana to read and query data from the local Loki instance.

@flyingcircusio/release-managers

## Release process

Impact: internal. 

Changelog: none. This role is still under development, and is not yet intended for public use.

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
  - The log retention time is intentionally configurable, as this may differ between use cases and applications.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
  - No documentation yet, this is a development preview which is subject to change.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

This is a basic first implementation, we're reviewing and considering overall security measures in PL-133025.

At this point we're limiting retention to 30 days by default (overridable per loki instance). We are relying on the SRV firewall as usual and find unauthed/cleartext submission acceptable for now.

To reduce impact if attackers have access on a non-loki machine, we're limiting access to the loki API to selected endpoints.

- [x] Security requirements tested? (EVIDENCE)
  - Integrations tested incrementally in a development environment to ensure correct functioning.
  - [x] data separation is handled with regular dev/whq/rzob and also RG separation for customer involvement
  - [x] attack surface area minimisation: no auth used, but covered by RG firewalling, service only on SRV
  - [x] loki runs as separate user