### PR TITLE
[21.05] router: use more generic netboot url and adapt menu item

### DIFF
--- a/nixos/roles/router/flyingcircus.ipxe
+++ b/nixos/roles/router/flyingcircus.ipxe
@@ -16,7 +16,7 @@ item --gap --				MAC: ${mac}
 item --gap --				Location: ${location}
 item --gap --				--- Boot ---
 item local					Boot machine from local disk
-item netboot				Launch netboot iPXE menu
+item netboot				Launch netboot.xyz (various live images and tools)
 item --gap --           	--- Install ---
 item install_nixos_20_09	Boot NixOS 20.09 install image
 item install_nixos_21_05	Boot NixOS 21.05 install image
@@ -47,7 +47,7 @@ imgargs installer root=/dev/ram0 init=/linuxrc loop=/image.squashfs looptype=squ
 boot || goto error
 
 :netboot
-chain --autofree https://boot.netboot.xyz/ipxe/netboot.xyz.lkrn
+chain --autofree https://boot.netboot.xyz
 goto start
 
 :local


### PR DESCRIPTION
Re PL-132254

@flyingcircusio/release-managers

## Release process

Impact:

none

Changelog:

* Repair and better label our default iPXE boot menu with options to boot netboot.xyz menus for firmware updates and diagnostics. (PL-132254)
* 
### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

Using netboot.xyz needs to be done carefully and we have internal documentation about that.

- [x] Security requirements tested? (EVIDENCE)

Nothing to test. We documented the aspects and had it security reviewed.