### PR TITLE
[21.05] devhost: improvements after deletion feature (PL-133005)

### DIFF
--- a/nixos/platform/agent.nix
+++ b/nixos/platform/agent.nix
@@ -8,9 +8,6 @@ with lib;
 let
   cfg = config.flyingcircus;
 
-  # WARNING: path and environment are duplicated in
-  # devhost. Unfortunately using references causes conflicts
-  # that can not be easily resolved.
   # Path elements needed by both agent units.
   commonEnvPath = with pkgs; [
     bzip2
@@ -45,6 +42,8 @@ let
   '';
 
 
+  # WARNING: environment is duplicated in devhost. Unfortunately using references
+  # causes conflicts that can not be easily resolved.
   environment = config.nix.envVars // {
     HOME = "/root";
     LANG = "en_US.utf8";

--- a/nixos/roles/devhost/vm.nix
+++ b/nixos/roles/devhost/vm.nix
@@ -191,6 +191,13 @@ in {
       "fc-devhost-vm@" = defaultService;
     } // lib.mapAttrs' mkService cfg.virtualMachines // {
       "fc-devhost-vm-cleanup" = {
+        inherit (config.systemd.services.fc-agent) path;
+        # duplicated from fc-agent.service
+        environment = config.nix.envVars // {
+          HOME = "/root";
+          LANG = "en_US.utf8";
+          NIX_PATH = lib.concatStringsSep ":" config.nix.nixPath;
+        };
         serviceConfig = {
           Type = "oneshot";
           ExecStart = "${manage_script}/bin/fc-devhost cleanup";


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact: None

Changelog: devhost: fix deletion of VMs in cleanup and more useful `fc-devhost ls -l` output

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - should work
  - should be compatible with old vm configs
- [x] Security requirements tested? (EVIDENCE)
  - tested deletion manually on largo00
     - Deletion time schedule works: current VMs are not touched, >14 days stopped, >31 days deleted
  - Code is designed to handle old configs (`.get`) and tested on largo00