### PR TITLE
network: monitor for subtle network bandwith issues

### DIFF
--- a/nixos/platform/default.nix
+++ b/nixos/platform/default.nix
@@ -252,8 +252,6 @@ in {
         "bfq"
       ];
 
-      kernelPackages = pkgs.linuxKernel.packages.linux_5_15;
-
       kernelParams = [
         # Crash management
         "panic=1"

--- a/nixos/platform/kernel.nix
+++ b/nixos/platform/kernel.nix
@@ -1,4 +1,4 @@
-{ lib, config, ...}:
+{ lib, pkgs, config, ...}:
 
 {
 
@@ -14,6 +14,33 @@
 	# structured when needed.
 
 	config = {
+
+      boot.kernelPackages = pkgs.linuxKernel.packages.linux_5_15;
+
+      # Use this spelling if you need to try out custom kernels, try out patches
+      # or otherwise deviate from our nixpkgs upstream.
+      #
+			# boot.kernelPackages = let kernelPackage = pkgs.linux_5_15; in
+			# 	lib.mkForce (pkgs.linuxPackagesFor (kernelPackage.override {
+			# 	  argsOverride = {
+			# 	    src = pkgs.fetchurl {
+			# 	      url = "https://cdn.kernel.org/pub/linux/kernel/v5.x/linux-5.15.166.tar.xz";
+			# 	      hash = "sha256-LFbawrcIWcFrTvZRvvsNKMInSYvT7uCOikWjV/Itddc=";
+			# 	    };
+			# 	    version = "5.5";
+			# 	    modDirVersion = "5.15.166";
+			# 	    kernelPatches = kernelPackage.kernelPatches ++ [
+			# 	      {
+			# 	        name = "some-patch-name";
+			# 	        patch = (pkgs.fetchpatch {
+			# 	          url = "https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/patch/?id=d5618eaea8868e2534c375b8a512693658068cf8";
+			# 	          hash = "sha256-w5ntJNyOdpLbojJWCGxGYs7ikbrd2W4zby3xv3VJqjY=";
+			# 	        });
+			# 	      }
+			# 	    ];
+			# 	  };
+			# 	}));
+
 		flyingcircus.kernelOptions =
 			''
 			ASYNC_TX_DMA y

--- a/nixos/platform/network.nix
+++ b/nixos/platform/network.nix
@@ -299,5 +299,15 @@ in
       # as a reasonable size and I'd suggest generalizing this number to all machines.
       "net.netfilter.nf_conntrack_max" = 262144;
     };
+
+    # This check is here to identify abysmal but otherwise subtle network speed
+    # issues as we have seen in PL-132971. If downloading a 1MiB test file
+    # takes longer than 5-10 seconds, something is very much off.
+    flyingcircus.services.sensu-client.checks.network_speed = {
+      notification = "General network speed";
+      command = "check_http -u /rgw-monitoring/probe -H rgw.local -p 7480 -m 1000000:1500000 -w 5 -c 10";
+      interval = 7200;
+    };
+
   };
 }


### PR DESCRIPTION
Due to a recent kernel bug this introduces a general worst case monitoring (a VM not being able to download a 1MiB file from a very close S3 host) that runs every 2 hours.

This should catch future similar issues in our release process but runs on every VM because it might also catch other network issues.

Also: add an example how to conveniently test kernel patches.

Re PL-132971

@flyingcircusio/release-managers

## Release process

Impact:

none

Changelog:

- Add a monitoring probe that checks for potentially subtle bandwidth issues that might otherwise be missed. (PL-132971)

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

no special requirements, is a helper to assist in preventing availability problems 

- [x] Security requirements tested? (EVIDENCE)

manually verified on test38
