### PR TITLE
webproxy/varnish: fix runtime/state dir issues and restart on unit changes

### DIFF
--- a/nixos/roles/webproxy.nix
+++ b/nixos/roles/webproxy.nix
@@ -121,13 +121,6 @@ in
       systemd.tmpfiles.rules = [
         "d /etc/local/varnish 2775 varnish service"
         "f /var/log/varnish.log 644 varnish varnish"
-        # Link the default dir expected by varnish tools to
-        # the actual location of the state dir. This makes the commands
-        # usable without specifying the -n option every time.
-
-        ### XXX: where do we rely on this symlink? Can be problematic when changing the state dir.
-        ### XXX: I think that platform code should explicitly set the work dir to force service restarts after changes.
-        "L /run/varnishd - - - - ${cfg.stateDir}"
       ];
 
       users.groups.varnish.members = [

--- a/nixos/roles/webproxy.nix
+++ b/nixos/roles/webproxy.nix
@@ -108,11 +108,11 @@ in
           serviceConfig = {
             Type = "forking";
             Restart = "always";
-            RuntimeDirectory = "varnish";
-            PIDFile = "/run/varnish/varnishncsa.pid";
+            RuntimeDirectory = "varnishncsa";
+            PIDFile = "/run/varnishncsa/varnishncsa.pid";
             User = "varnish";
             Group = "varnish";
-            ExecStart = "${cfg.package}/bin/varnishncsa -n ${cfg.stateDir} -D -a -w /var/log/varnish.log -P /run/varnish/varnishncsa.pid";
+            ExecStart = "${cfg.package}/bin/varnishncsa -n ${cfg.stateDir} -D -a -w /var/log/varnish.log -P /run/varnishncsa/varnishncsa.pid";
             ExecReload = "${kill} -HUP $MAINPID";
           };
         };
@@ -124,6 +124,9 @@ in
         # Link the default dir expected by varnish tools to
         # the actual location of the state dir. This makes the commands
         # usable without specifying the -n option every time.
+
+        ### XXX: where do we rely on this symlink? Can be problematic when changing the state dir.
+        ### XXX: I think that platform code should explicitly set the work dir to force service restarts after changes.
         "L /run/varnishd - - - - ${cfg.stateDir}"
       ];
 

--- a/nixos/roles/webproxy.nix
+++ b/nixos/roles/webproxy.nix
@@ -112,7 +112,7 @@ in
             PIDFile = "/run/varnish/varnishncsa.pid";
             User = "varnish";
             Group = "varnish";
-            ExecStart = "${cfg.package}/bin/varnishncsa -D -a -w /var/log/varnish.log -P /run/varnish/varnishncsa.pid";
+            ExecStart = "${cfg.package}/bin/varnishncsa -n ${cfg.stateDir} -D -a -w /var/log/varnish.log -P /run/varnish/varnishncsa.pid";
             ExecReload = "${kill} -HUP $MAINPID";
           };
         };


### PR DESCRIPTION
The first change already would fix our issues with state dir changes but the two other commits are still useful to make things more explicit and less confusing.

1. webproxy/varnish: final version of the fix to manage the varnish state dir properly

a) use the real varnish upstream state directory
b) only reload if it's a pure VCL change, restart otherwise

For channel upgrades (e.g. when this statedir change is rolled out) this
happens in maintenance anyway. We'll provide better public docs about
the restart conditions in the near future.

2. webproxy: varnishncsa should have a runtime dir named after the service

Using /run/varnish for the varnishncsa was quite confusing and can lead
to weird errors when varnish uses the same run time dir and restarting
one of the services clears the runtime directory for both. We don't do
that at the moment, but the varnish work dir can be changed.

3. webproxy: explicitly set work dir for varnishncsa

Before, we relied on varnishncsa's behaviour, looking for the default
varnish work dir at /var/run/varnishd (where /var/run is linked to
/run). /run/varnishd is a symlink created by us, pointing to the real
location /var/spool/varnish/<hostname>.

Setting the work dir in the varnishncsa command line easier to
understand and less error-prone when the state dir changes.

@flyingcircusio/release-managers

## Release process

Impact:

- \[NixOS 24.05] varnish will be restarted.

Changelog:

- webproxy/varnish: use varnish default work dir and restart varnish on unit file changes. Before, we always reloaded the service which can cause various problems when changes are not picked up. We ran into this problem when the varnish work dir changed in NixOS.  To simplify things, we also override the work dir and use the varnish default of `/run/varnishd` instead of symlinking it to a different location. This path is checked by CLI tools like varnishadm, for example. (PL-132901).

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - make sure that varnish is reloaded properly when config changes and that other changes to the unit file are picked up by restarting the service 
- [x] Security requirements tested? (EVIDENCE)
  - checked on a test VM that varnish is reloaded/restarted as expected