### PR TITLE
varnish: revert recent state dir related changes

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1726151147,
-        "narHash": "sha256-MgSpXGOFeMQOjB1qMlTm6CV9XG8eJ5tUOHs9E9eTk5c=",
+        "lastModified": 1726153070,
+        "narHash": "sha256-HO4zgY0ekfwO5bX0QH/3kJ/h4KvUDFZg8YpkNwIbg1U=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "dc3b467eac0fe1436e897d01c35dabe63b4749ea",
+        "rev": "bcef6817a8b2aa20a5a6dbb19b43e63c5bf8619a",
         "type": "github"
       },
       "original": {
@@ -410,11 +410,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1726151616,
-        "narHash": "sha256-Pu+odXzikSAkl/39zdvB86hasDrEImixpU3RXi45I74=",
+        "lastModified": 1726214531,
+        "narHash": "sha256-6sXBTZ0R5t1oRK57vFSs5TyClHmID9Ih8tlQvrVf/0M=",
         "owner": "flyingcircusio",
         "repo": "nixpkgs",
-        "rev": "6ce38e4d52cbb7313f5170903deb4b8b3d3ff022",
+        "rev": "4c934f9fa9a0c9239a1bc2817d01231807f5d2ba",
         "type": "github"
       },
       "original": {

--- a/nixos/services/varnish/default.nix
+++ b/nixos/services/varnish/default.nix
@@ -126,12 +126,7 @@ in {
       reloadIfChanged = true;
       restartTriggers = [ cfg.extraCommandLine vcfg.package cfg.http_address ];
       reload = ''
-        if [ -d "${vcfg.stateDir}" ]; then
-          statedir="${vcfg.stateDir}"
-        else
-          statedir="/var/spool/varnish/${config.networking.hostName}" #temporary migration
-        fi
-        vadm="${vcfg.package}/bin/varnishadm -n $statedir"
+        vadm="${vcfg.package}/bin/varnishadm -n ${vcfg.stateDir}"
         cat ${commandsfile} | $vadm
 
         coldvcls=$($vadm vcl.list | grep " cold " | ${pkgs.gawk}/bin/awk {'print $5'})

--- a/release/versions.json
+++ b/release/versions.json
@@ -8,9 +8,9 @@
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/"
   },
   "nixpkgs": {
-    "hash": "sha256-Pu+odXzikSAkl/39zdvB86hasDrEImixpU3RXi45I74=",
+    "hash": "sha256-6sXBTZ0R5t1oRK57vFSs5TyClHmID9Ih8tlQvrVf/0M=",
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "6ce38e4d52cbb7313f5170903deb4b8b3d3ff022"
+    "rev": "4c934f9fa9a0c9239a1bc2817d01231807f5d2ba"
   }
 }


### PR DESCRIPTION
Going back to the varnish state as running in production (release 2024_026_1).

This reverts the upstream change of the state dir and our (faulty) commit to support old and new state dir locations until the proper fix in #1104 is ready and tested.

PL-132901

@flyingcircusio/release-managers

## Release process

Impact:

Changelog: (no changes)

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - varnish has to work properly with the same configuration as the last released version
- [x]  Security requirements tested? (EVIDENCE)
  - checked on a test VM that there are no changes in the varnish unit file and no varnish restarts/reloads going from fc/2024_026_1 to this version and that varnish + varnishncsa are running as expected
