### PR TITLE
switch to kernel 6.11 in preparation for getting debugging patches

### DIFF
--- a/nixos/platform/kernel.nix
+++ b/nixos/platform/kernel.nix
@@ -1,12 +1,24 @@
 { lib, pkgs, config, ...}:
 
-{
-
+let
+	defaultUseVerificationKernel =
+		if
+			(config.flyingcircus.enc.parameters.location == "dev") ||
+			(config.flyingcircus.enc.parameters.location == "whq") ||
+			(config.flyingcircus.enc.parameters.production  == false)
+		then true
+		else false;
+in {
 	options = {
 		flyingcircus.kernelOptions = lib.mkOption {
 		  default = null;
 		  type = lib.types.nullOr lib.types.str;
 		  description = "Additional options for the kernel configuration";
+		};
+		flyingcircus.useVerificationKernel = lib.mkOption {
+			default = defaultUseVerificationKernel;
+			type = lib.types.bool;
+			description = "Participate in using an evaluation kernel.";
 		};
 	};
 
@@ -15,31 +27,34 @@
 
 	config = {
 
-      boot.kernelPackages = pkgs.linuxKernel.packages.linux_5_15;
+      boot.kernelPackages = if config.flyingcircus.useVerificationKernel
+      	then pkgs.linuxPackagesFor pkgs.linuxKernelVerify
+      	else pkgs.linuxKernel.packages.linux_5_15;
 
       # Use this spelling if you need to try out custom kernels, try out patches
       # or otherwise deviate from our nixpkgs upstream.
       #
-			# boot.kernelPackages = let kernelPackage = pkgs.linux_5_15; in
-			# 	lib.mkForce (pkgs.linuxPackagesFor (kernelPackage.override {
-			# 	  argsOverride = {
-			# 	    src = pkgs.fetchurl {
-			# 	      url = "https://cdn.kernel.org/pub/linux/kernel/v5.x/linux-5.15.166.tar.xz";
-			# 	      hash = "sha256-LFbawrcIWcFrTvZRvvsNKMInSYvT7uCOikWjV/Itddc=";
-			# 	    };
-			# 	    version = "5.5";
-			# 	    modDirVersion = "5.15.166";
-			# 	    kernelPatches = kernelPackage.kernelPatches ++ [
-			# 	      {
-			# 	        name = "some-patch-name";
-			# 	        patch = (pkgs.fetchpatch {
-			# 	          url = "https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/patch/?id=d5618eaea8868e2534c375b8a512693658068cf8";
-			# 	          hash = "sha256-w5ntJNyOdpLbojJWCGxGYs7ikbrd2W4zby3xv3VJqjY=";
-			# 	        });
-			# 	      }
-			# 	    ];
-			# 	  };
-			# 	}));
+      # boot.kernelPackages = let kernelPackage = pkgs.linux_6_10; in
+      #   lib.mkForce (pkgs.linuxPackagesFor (kernelPackage.override {
+      #     argsOverride = {
+      #       src = pkgs.fetchurl {
+      #         url = "https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-6.11.tar.xz";
+      #         hash = "sha256-VdLGwCXrwngQx0jWYyXdW8YB6NMvhYHZ53ZzUpvayy4=";
+      #       };
+      #       version = "6.11";
+      #       modDirVersion = "6.11.0";
+      #       # kernelPatches = kernelPackage.kernelPatches ++ [
+      #       #   {
+      #       #     name = "some-patch-name";
+      #       #     patch = (pkgs.fetchpatch {
+      #       #       url = "https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/patch/?id=d5618eaea8868e2534c375b8a512693658068cf8";
+      #       #       hash = "sha256-w5ntJNyOdpLbojJWCGxGYs7ikbrd2W4zby3xv3VJqjY=";
+      #       #     });
+      #       #   }
+      #       # ];
+      #     };
+      #   }));
+
 
 		flyingcircus.kernelOptions =
 			''
@@ -56,9 +71,11 @@
 			VLAN_8021Q_GVRP y
 			XFS_POSIX_ACL y
 			XFS_QUOTA y
-			RANDOM_TRUST_CPU y
 			WARN_ALL_UNSEEDED_RANDOM y
-			'';
+			'' + (if !config.flyingcircus.useVerificationKernel
+				then ''
+				RANDOM_TRUST_CPU y
+				'' else "");
 
 		boot.kernelPatches = lib.mkIf ( config.flyingcircus.kernelOptions != null ) [ {
 			name = "fcio-kernel-options";

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -107,6 +107,19 @@ builtins.mapAttrs (_: patchPhps phpLogPermissionPatch) {
     '';
   });
 
+  # PL-131574
+  linuxKernelVerify = let kernelPackage = super.linux_6_10;  in
+    kernelPackage.override {
+          argsOverride = {
+            src = super.fetchurl {
+              url = "https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-6.11.tar.xz";
+              hash = "sha256-VdLGwCXrwngQx0jWYyXdW8YB6NMvhYHZ53ZzUpvayy4=";
+            };
+            version = "6.11";
+            modDirVersion = "6.11.0";
+          };
+        };
+
   matomo-beta = super.matomo-beta.overrideAttrs (oldAttrs: {
     installPhase = ''
       runHook preInstall

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -50,6 +50,8 @@ in {
   journal = callTest ./journal.nix {};
   journalbeat = callTest ./journalbeat.nix {};
   kernelconfig = callTest ./kernelconfig.nix {};
+  kernelversions = callTest ./kernelversions.nix {};
+
   k3s = callTest ./k3s {};
   k3s_monitoring = callTest ./k3s/monitoring.nix {};
   lampVm = callTest ./lamp/vm-test.nix { };

--- a/tests/kernelconfig.nix
+++ b/tests/kernelconfig.nix
@@ -158,6 +158,7 @@ in
     { config, ... }:
     {
       imports = [ ../nixos ../nixos/roles ];
+      flyingcircus.useVerificationKernel = false;
     };
 
   testScript = let

--- a/tests/kernelversions.nix
+++ b/tests/kernelversions.nix
@@ -1,0 +1,206 @@
+# Start VMs with the different kernels we expect to be pre-built
+import ./make-test-python.nix ({ ... }:
+{
+  name = "kernelversions";
+  nodes.rzobProdKernel =
+      { pkgs, lib, ... }:
+      {
+        imports = [ ../nixos ../nixos/roles ];
+
+        flyingcircus.roles.memcached.enable = true;
+
+        flyingcircus.enc.parameters = {
+          location = "rzob";
+          production = true;
+          resource_group = "test";
+          interfaces.srv = {
+            mac = "52:54:00:12:34:56";
+            bridged = false;
+            networks = {
+              "192.168.101.0/24" = [ "192.168.101.1" ];
+              "2001:db8:f030:1c3::/64" = [ "2001:db8:f030:1c3::1" ];
+            };
+            gateways = {};
+          };
+        };
+      };
+  nodes.devProdKernel =
+        { pkgs, lib, ... }:
+        {
+          imports = [ ../nixos ../nixos/roles ];
+
+          flyingcircus.roles.memcached.enable = true;
+
+          flyingcircus.enc.parameters = {
+            location = "dev";
+            production = true;
+            resource_group = "test";
+            interfaces.srv = {
+              mac = "52:54:00:12:34:56";
+              bridged = false;
+              networks = {
+                "192.168.101.0/24" = [ "192.168.101.2" ];
+                "2001:db8:f030:1c3::/64" = [ "2001:db8:f030:1c3::2" ];
+              };
+              gateways = {};
+            };
+          };
+        };
+  nodes.whqProdKernel =
+        { pkgs, lib, ... }:
+        {
+          imports = [ ../nixos ../nixos/roles ];
+
+          flyingcircus.roles.memcached.enable = true;
+
+          flyingcircus.enc.parameters = {
+            location = "whq";
+            production = true;
+            resource_group = "test";
+            interfaces.srv = {
+              mac = "52:54:00:12:34:56";
+              bridged = false;
+              networks = {
+                "192.168.101.0/24" = [ "192.168.101.3" ];
+                "2001:db8:f030:1c3::/64" = [ "2001:db8:f030:1c3::3" ];
+              };
+              gateways = {};
+            };
+          };
+        };
+    nodes.rzobNonProdKernel =
+          { pkgs, lib, ... }:
+          {
+            imports = [ ../nixos ../nixos/roles ];
+
+            flyingcircus.roles.memcached.enable = true;
+
+            flyingcircus.enc.parameters = {
+              location = "rzob";
+              production = false;
+              resource_group = "test";
+              interfaces.srv = {
+                mac = "52:54:00:12:34:56";
+                bridged = false;
+                networks = {
+                  "192.168.101.0/24" = [ "192.168.101.4" ];
+                  "2001:db8:f030:1c3::/64" = [ "2001:db8:f030:1c3::4" ];
+                };
+                gateways = {};
+              };
+            };
+          };
+  nodes.prodKernel =
+    { pkgs, lib, ... }:
+    {
+      imports = [ ../nixos ../nixos/roles ];
+
+      flyingcircus.useVerificationKernel = false;
+
+      flyingcircus.roles.memcached.enable = true;
+
+      flyingcircus.enc.parameters = {
+        resource_group = "test";
+        interfaces.srv = {
+          mac = "52:54:00:12:34:56";
+          bridged = false;
+          networks = {
+            "192.168.101.0/24" = [ "192.168.101.5" ];
+            "2001:db8:f030:1c3::/64" = [ "2001:db8:f030:1c3::5" ];
+          };
+          gateways = {};
+        };
+      };
+    };
+  nodes.verifyKernel =
+    { pkgs, lib, ... }:
+    {
+      imports = [ ../nixos ../nixos/roles ];
+
+      flyingcircus.useVerificationKernel = true;
+
+      flyingcircus.roles.memcached.enable = true;
+
+      flyingcircus.enc.parameters = {
+        resource_group = "test";
+        interfaces.srv = {
+          mac = "52:54:00:12:34:56";
+          bridged = false;
+          networks = {
+            "192.168.101.0/24" = [  "192.168.101.6" ];
+            "2001:db8:f030:1c3::/64" = [ "2001:db8:f030:1c3::6" ];
+          };
+          gateways = {};
+        };
+      };
+    };
+    nodes.devNonProdKernel =
+          { pkgs, lib, ... }:
+          {
+            imports = [ ../nixos ../nixos/roles ];
+
+            flyingcircus.roles.memcached.enable = true;
+
+            flyingcircus.enc.parameters = {
+              location = "dev";
+              production = false;
+              resource_group = "test";
+              interfaces.srv = {
+                mac = "52:54:00:12:34:56";
+                bridged = false;
+                networks = {
+                  "192.168.101.0/24" = [ "192.168.101.7" ];
+                  "2001:db8:f030:1c3::/64" = [ "2001:db8:f030:1c3::7" ];
+                };
+                gateways = {};
+              };
+            };
+          };
+    nodes.whqNonProdKernel =
+          { pkgs, lib, ... }:
+          {
+            imports = [ ../nixos ../nixos/roles ];
+
+            flyingcircus.roles.memcached.enable = true;
+
+            flyingcircus.enc.parameters = {
+              location = "whq";
+              production = false;
+              resource_group = "test";
+              interfaces.srv = {
+                mac = "52:54:00:12:34:56";
+                bridged = false;
+                networks = {
+                  "192.168.101.0/24" = [ "192.168.101.8" ];
+                  "2001:db8:f030:1c3::/64" = [ "2001:db8:f030:1c3::8" ];
+                };
+                gateways = {};
+              };
+            };
+          };
+  testScript = ''
+    start_all()
+
+    def assertKernelVersion(vm, expected):
+        vm.wait_for_unit('memcached.service')
+        vm.wait_for_open_port(11211)
+
+        foundKernel = vm.execute("uname -r")[1].strip()
+        if foundKernel != expected:
+            print(f"Expected kernel {expected!r}")
+            print(f"Found kernel {foundKernel!r}")
+            full = vm.execute("uname -a")[1]
+            print(f"Machine: {full}")
+            raise AssertionError("Unexpected kernel version")
+
+    assertKernelVersion(verifyKernel, "6.11.0")
+    assertKernelVersion(prodKernel, "5.15.164")
+    assertKernelVersion(rzobProdKernel, "5.15.164")
+    assertKernelVersion(rzobNonProdKernel, "6.11.0")
+    assertKernelVersion(whqProdKernel, "6.11.0")
+    assertKernelVersion(devProdKernel, "6.11.0")
+    assertKernelVersion(whqNonProdKernel, "6.11.0")
+    assertKernelVersion(devNonProdKernel, "6.11.0")
+
+  '';
+})


### PR DESCRIPTION
RE PL-132972

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

* This platform release includes a very new Linux kernel release (6.11) that gets activated in our DEV and WHQ locations as well as on all non-production VMs. Selected production VMs will be updated as well . However, customers affected by this on a production VM will be notified individually with an in-depth briefing. This Linux release includes a fix for a bug that has been stopping us from updating past the 5.15 LTS branch since last year – but 5.15 is considered ancient by now. The upstream developers are confident that this release fixes the bug and will provide a backport to an LTS release at a later point. However, due to the shy nature of the bug our part in fixing it is to help gather evidence that this bug does not reappear. We expect to be running this for at least 4-8 weeks for valid evidence. (PL-132972)

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

we need a stable kernel. unfortunately 5.15 is getting unstable due to missed patches in official kernel backports and 6.x has specific issues. we're running a bleeding edge kernel for now to help the maintainers verify that their fix is also effective in our scenario. so, running an unstable kernel close to production (and even in selected cases in production) is a specifically chosen risk.

- [x] Security requirements tested? (EVIDENCE)

automated tests to ensure we're targetting the right combinations of attributes which machines should be selected.
