### PR TITLE
gitlab: 17.2.5 -> 17.2.7

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -410,11 +410,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1726214531,
-        "narHash": "sha256-6sXBTZ0R5t1oRK57vFSs5TyClHmID9Ih8tlQvrVf/0M=",
+        "lastModified": 1726668836,
+        "narHash": "sha256-k/m92YGpRzjB48X2po7jtNycdY40JhweOfeGysmwhjM=",
         "owner": "flyingcircusio",
         "repo": "nixpkgs",
-        "rev": "4c934f9fa9a0c9239a1bc2817d01231807f5d2ba",
+        "rev": "ecb04ae94077cca3595752f8c3adce8a5e445b34",
         "type": "github"
       },
       "original": {

--- a/release/package-versions.json
+++ b/release/package-versions.json
@@ -220,9 +220,9 @@
     "version": "2.44.1"
   },
   "gitaly": {
-    "name": "gitaly-17.2.5",
+    "name": "gitaly-17.2.7",
     "pname": "gitaly",
-    "version": "17.2.5"
+    "version": "17.2.7"
   },
   "github-runner": {
     "name": "github-runner-2.319.1",
@@ -230,9 +230,9 @@
     "version": "2.319.1"
   },
   "gitlab": {
-    "name": "gitlab-17.2.5",
+    "name": "gitlab-17.2.7",
     "pname": "gitlab",
-    "version": "17.2.5"
+    "version": "17.2.7"
   },
   "gitlab-container-registry": {
     "name": "gitlab-container-registry-4.9.0",
@@ -240,14 +240,14 @@
     "version": "4.9.0"
   },
   "gitlab-ee": {
-    "name": "gitlab-ee-17.2.5",
+    "name": "gitlab-ee-17.2.7",
     "pname": "gitlab-ee",
-    "version": "17.2.5"
+    "version": "17.2.7"
   },
   "gitlab-pages": {
-    "name": "gitlab-pages-17.2.5",
+    "name": "gitlab-pages-17.2.7",
     "pname": "gitlab-pages",
-    "version": "17.2.5"
+    "version": "17.2.7"
   },
   "gitlab-runner": {
     "name": "gitlab-runner-17.1.0",
@@ -255,9 +255,9 @@
     "version": "17.1.0"
   },
   "gitlab-workhorse": {
-    "name": "gitlab-workhorse-17.2.5",
+    "name": "gitlab-workhorse-17.2.7",
     "pname": "gitlab-workhorse",
-    "version": "17.2.5"
+    "version": "17.2.7"
   },
   "glibc": {
     "name": "glibc-2.39-52",

--- a/release/versions.json
+++ b/release/versions.json
@@ -8,9 +8,9 @@
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/"
   },
   "nixpkgs": {
-    "hash": "sha256-6sXBTZ0R5t1oRK57vFSs5TyClHmID9Ih8tlQvrVf/0M=",
+    "hash": "sha256-k/m92YGpRzjB48X2po7jtNycdY40JhweOfeGysmwhjM=",
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "4c934f9fa9a0c9239a1bc2817d01231807f5d2ba"
+    "rev": "ecb04ae94077cca3595752f8c3adce8a5e445b34"
   }
 }


### PR DESCRIPTION
Pull in the gitlab update we did on our nixpkgs fork:
- gitlab: 17.2.5 -> 17.2.7

PL-133033

@flyingcircusio/release-managers

## Release process

Impact: gitlab will be restarted

Changelog:
- gitlab: 17.2.5 -> 17.2.7

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - [x] review fixed CVEs and their impact
  - [x] must not introduce known regressions
  - [x] has to work in our staging gitlab
- [x] Security requirements tested? (EVIDENCE)
  - [x] automated NixOS tests still pass
  - [x] updated our staging gitlab and worked through manual test checklist