### PR TITLE
[21.05] rclone: add as default platform package

### DIFF
--- a/nixos/platform/packages.nix
+++ b/nixos/platform/packages.nix
@@ -64,6 +64,7 @@
         python2Full
         python3
         python3Packages.virtualenv
+        rclone
         ripgrep
         screen
         strace


### PR DESCRIPTION
rclone is a useful tool that is part of many of our workflows nowadays. Add it to the platform default packages.

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:
- rclone: add as a default platform package

### PR release workflow (internal)

- [ ] PR has internal ticket
- [ ] internal issue ID (PL-…) part of branch name
- [ ] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - none, just another default package that does not expose s running service nor is setuid 
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still need to pass though
