### PR TITLE
postgresql: fix database name quoting in verify collation script

### DIFF
--- a/nixos/services/postgresql/verify-collations.py
+++ b/nixos/services/postgresql/verify-collations.py
@@ -30,9 +30,9 @@ WHERE datname != 'template0'
 def psql(*args):
     env = os.environ.copy()
     env["PGCLIENTENCODING"] = "utf-8"
-    output = subprocess.check_output(
-        ("psql", "--csv") + args, env=env, encoding="utf-8"
-    )
+    command = ("psql", "--csv") + args
+    print(" ".join(command))
+    output = subprocess.check_output(command, env=env, encoding="utf-8")
     output = io.StringIO(output)
     rows = csv.DictReader(output, delimiter=",", quotechar='"')
     return rows
@@ -53,6 +53,7 @@ for database in databases:
     print(db_name)
     print(f"\tdb collation version: {db_collation_version}")
     print(f"\tos collation version: {os_collation_version}")
+
     if db_collation_version == os_collation_version:
         print("\tOK")
         continue
@@ -62,7 +63,7 @@ for database in databases:
         print("\tUpdating collation")
         psql(
             "-c",
-            f"ALTER DATABASE {db_name} REFRESH COLLATION VERSION",
+            f'ALTER DATABASE "{db_name}" REFRESH COLLATION VERSION',
             db_name,
         )
     else:


### PR DESCRIPTION
PostgreSQL allows database names that have to be quoted in SQL statements, like ALTER DATABASE "quote-me".

PL-133030

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

- postgresql: the script for verifying/updating collation versions on service start now works correctly with special database names that need "quoting" in SQL statements (PL-133030).

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - fixes a bug with "special" database names, the verify collation script should work for all allowed PostgreSQL DB names 
- [ ] Security requirements tested? (EVIDENCE)
  - checked on a test VM that a database name like `test-db` is processed correctly by the script 
