### PR TITLE
[24.11] security.acme.defaults.server: customise only for stateVersion <= 24.05

### DIFF
--- a/nixos/platform/acme.nix
+++ b/nixos/platform/acme.nix
@@ -2,7 +2,7 @@
 let
   inherit (config) fclib;
 in
-{
+lib.mkMerge [{
   # Generate a sensu check for each acme cert to check its validity and warn
   # when it expires.
   flyingcircus.services.sensu-client.checks =
@@ -42,7 +42,12 @@ in
     # fallback ACME settings
     security.acme.acceptTerms = true;
     security.acme.defaults.email = "admin@flyingcircus.io";
-    # get back ACME account hash generation of <= NixOS 23.11 to avoid forced
-    # re-registration, see https://github.com/NixOS/nixpkgs/issues/316608
-    security.acme.defaults.server = null;
-}
+  }
+
+  # Machines set up with 24.05 or earlier need to use the ACME account hash
+  # generation of <= NixOS 23.11 to avoid forced
+  # re-registration, see https://github.com/NixOS/nixpkgs/issues/316608
+  (lib.mkIf (lib.versionOlder config.system.stateVersion "24.11") {
+    security.acme.defaults.server = fclib.mkPlatform null;
+  })
+  ]

--- a/release/default.nix
+++ b/release/default.nix
@@ -446,4 +446,3 @@ jobs // {
   releaseUntested = mkRelease { releaseName = "releaseUntested"; };
   releaseSmall = mkRelease { releaseName = "releaseSmall"; constituents = [ testedSmall ]; };
 }
-


### PR DESCRIPTION
In PL-132659, we've decided to override security.acme.defaults.server from the upstream value to avoid triggering mass letsencrypt account re-registrations.

**Re-**registrations are only an issue for existing machines. Freshly bootstrapped systems won't cause any problems. As we cannot be certain that our workaround is going to work for all future NixOS releases, I propose to make this conditional on the VM state version <= 24.05. If ever necessary, this reduces the number of VMs in need of a state migration for the account in the future.

PL-133038

@flyingcircusio/release-managers

## Release process

Impact: none, only new VMs affected

Changelog:
- acme: newly bootstrapped VMs now use the new default configuration for acme registries
  - upgraded VMs maintain the existing configuration to avoid forced re-registration at the letsencrypt registry 

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - must not introduce any regressions
  - verify upgrade behaviour
- [ ] Security requirements tested? (EVIDENCE)
  - [ ] automated tests still pass
  - [x] verified state version difference on a testvm