### PR TITLE
Fix kernel selection option

### DIFF
--- a/nixos/platform/kernel.nix
+++ b/nixos/platform/kernel.nix
@@ -1,35 +1,35 @@
 { lib, pkgs, config, ...}:
 
 let
-	defaultUseVerificationKernel =
-		if
-			(config.flyingcircus.enc.parameters.location == "dev") ||
-			(config.flyingcircus.enc.parameters.location == "whq") ||
-			(config.flyingcircus.enc.parameters.production  == false)
-		then true
-		else false;
+  defaultUseVerificationKernel =
+    if
+      (config.flyingcircus.enc.parameters.location == "dev") ||
+      (config.flyingcircus.enc.parameters.location == "whq") ||
+      (config.flyingcircus.enc.parameters.production  == false)
+    then true
+    else false;
 in {
-	options = {
-		flyingcircus.kernelOptions = lib.mkOption {
-		  default = null;
-		  type = lib.types.nullOr lib.types.str;
-		  description = "Additional options for the kernel configuration";
-		};
-		flyingcircus.useVerificationKernel = lib.mkOption {
-			default = defaultUseVerificationKernel;
-			type = lib.types.bool;
-			description = "Participate in using an evaluation kernel.";
-		};
-	};
+  options = {
+    flyingcircus.kernelOptions = lib.mkOption {
+      default = null;
+      type = lib.types.nullOr lib.types.str;
+      description = "Additional options for the kernel configuration";
+    };
+    flyingcircus.useVerificationKernel = lib.mkOption {
+      default = defaultUseVerificationKernel;
+      type = lib.types.bool;
+      description = "Participate in using an evaluation kernel.";
+    };
+  };
 
-	# This is a lift-and-shift from Gentoo and can be modularized and
-	# structured when needed.
+  # This is a lift-and-shift from Gentoo and can be modularized and
+  # structured when needed.
 
-	config = {
+  config = {
 
       boot.kernelPackages = if config.flyingcircus.useVerificationKernel
-      	then pkgs.linuxPackagesFor pkgs.linuxKernelVerify
-      	else pkgs.linuxKernel.packages.linux_5_15;
+        then pkgs.linuxPackagesFor pkgs.linuxKernelVerify
+        else pkgs.linuxKernel.packages.linux_5_15;
 
       # Use this spelling if you need to try out custom kernels, try out patches
       # or otherwise deviate from our nixpkgs upstream.
@@ -56,31 +56,31 @@ in {
       #   }));
 
 
-		flyingcircus.kernelOptions =
-			''
-			ASYNC_TX_DMA y
-			CPU_FREQ_STAT y
-			BLK_DEV_MD y
-			MQ_IOSCHED_DEADLINE y
-			IPMI_PANIC_EVENT y
-			IPMI_PANIC_STRING y
-			LATENCYTOP y
-			NET_IPGRE_BROADCAST y
-			SCHEDSTATS y
-			SCSI_DH y
-			VLAN_8021Q_GVRP y
-			XFS_POSIX_ACL y
-			XFS_QUOTA y
-			WARN_ALL_UNSEEDED_RANDOM y
-			'' + (if !config.flyingcircus.useVerificationKernel
-				then ''
-				RANDOM_TRUST_CPU y
-				'' else "");
+    flyingcircus.kernelOptions =
+      ''
+      ASYNC_TX_DMA y
+      CPU_FREQ_STAT y
+      BLK_DEV_MD y
+      MQ_IOSCHED_DEADLINE y
+      IPMI_PANIC_EVENT y
+      IPMI_PANIC_STRING y
+      LATENCYTOP y
+      NET_IPGRE_BROADCAST y
+      SCHEDSTATS y
+      SCSI_DH y
+      VLAN_8021Q_GVRP y
+      XFS_POSIX_ACL y
+      XFS_QUOTA y
+      WARN_ALL_UNSEEDED_RANDOM y
+      '' + (if !config.flyingcircus.useVerificationKernel
+        then ''
+        RANDOM_TRUST_CPU y
+        '' else "");
 
-		boot.kernelPatches = lib.mkIf ( config.flyingcircus.kernelOptions != null ) [ {
-			name = "fcio-kernel-options";
-			patch = null;
-			extraConfig = config.flyingcircus.kernelOptions;
-		}];
-	};
+    boot.kernelPatches = lib.mkIf ( config.flyingcircus.kernelOptions != null ) [ {
+      name = "fcio-kernel-options";
+      patch = null;
+      extraConfig = config.flyingcircus.kernelOptions;
+    }];
+  };
 }

--- a/nixos/platform/kernel.nix
+++ b/nixos/platform/kernel.nix
@@ -1,13 +1,8 @@
 { lib, pkgs, config, ...}:
 
 let
-  defaultUseVerificationKernel =
-    if
-      (config.flyingcircus.enc.parameters.location == "dev") ||
-      (config.flyingcircus.enc.parameters.location == "whq") ||
-      (config.flyingcircus.enc.parameters.production  == false)
-    then true
-    else false;
+  location = lib.attrByPath [ "parameters" "location" ] "" config.flyingcircus.enc;
+  production = lib.attrByPath [ "parameters" "production" ] "" config.flyingcircus.enc;
 in {
   options = {
     flyingcircus.kernelOptions = lib.mkOption {
@@ -16,9 +11,14 @@ in {
       description = "Additional options for the kernel configuration";
     };
     flyingcircus.useVerificationKernel = lib.mkOption {
-      default = defaultUseVerificationKernel;
+      default = (location == "dev") || (location == "whq") || (production  == false);
       type = lib.types.bool;
-      description = "Participate in using an evaluation kernel.";
+      description = ''
+        Participate in using an evaluation kernel.
+        This currently selects a 6.11 kernel for testing purposes.
+        By default, all non-prod VMs in all locations and all VMs in our internal locations
+        DEV and WHQ use the evaluation kernel.
+      '';
     };
   };
 


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

Changelog: 

(internal)

### PR release workflow (internal)

- [ ] PR has internal ticket
- [ ] internal issue ID (PL-…) part of branch name
- [ ] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - no effect on regular operations, just to fix an error in NixOS tests  
- [x] Security requirements tested? (EVIDENCE)
  - NixOS tests green on Hydra 