### PR TITLE
nfs: switch to hard recovery to avoid potential data consistency issues

### DIFF
--- a/nixos/roles/nfs.nix
+++ b/nixos/roles/nfs.nix
@@ -73,15 +73,23 @@ in
 
     (lib.mkIf (cfg.roles.nfs_rg_client.enable && service != null) {
       fileSystems = {
-        # WARNING: those settings are duplicated in the tests to
-        # fix a deficiency of the test harness.
         "${mountpoint}" = {
           device = "${service.address}:${export}";
           fsType = "nfs4";
+          #############################################################
+          # WARNING: those settings are DUPLICATED in tests/nfs.nix to
+          # work around a deficiency of the test harness.
+          #############################################################
           options = [
             "rw"
             "noauto"
-            "soft"
+            # Retry infinitely
+            "hard"
+            # Start over the retry process after 10 tries
+            "retrans=10"
+            # Start with a 3s (30 deciseconds) interval and add 3s as linear
+            # backoff
+            "timeo=30"
             "rsize=8192"
             "wsize=8192"
             "nfsvers=4"

--- a/tests/nfs.nix
+++ b/tests/nfs.nix
@@ -59,9 +59,20 @@ in {
             "${cdir}" = {
               device = "server:${sdir}";
               fsType = "nfs4";
+              ################################################################
+              # WARNING: those settings are DUPLICATED in nixos/roles/nfs.nix
+              # to work around a deficiency of the test harness.
+              ################################################################
               options = [
                 "rw"
-                "soft"
+                "noauto"
+                # Retry infinitely
+                "hard"
+                # Start over the retry process after 10 tries
+                "retrans=10"
+                # Start with a 3s (30 deciseconds) interval and add 3s as linear
+                # backoff
+                "timeo=30"
                 "rsize=8192"
                 "wsize=8192"
                 "nfsvers=4"


### PR DESCRIPTION
We discovered that soft ist a sub-optimal setting but was initially set due to recovery issues. Having investigated the current issue we decided to switch back to hard.

Re PL-133015

@flyingcircusio/release-managers

## Release process

Impact:

* NFS clients will update their mount options. In some situations this may be delayed until their next natural reboot. (PL-133015)

Changelog:

* Switch NFS mounts to `hard` mode to prefer consistency over responsiveness. (PL-133015)

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.

clients can already override those settings

- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

prefer data consistency over responsiveness

- [x] Security requirements tested? (EVIDENCE)

manually tested
