### PR TITLE
[21.05] stop updating uuids on cold boot

### DIFF
--- a/pkgs/fc/default.nix
+++ b/pkgs/fc/default.nix
@@ -54,7 +54,7 @@ rec {
   # qemu-dev-nautilus = callPackage ./qemu {
   #   version = "dev";
   #   # builtins.toPath (testPath + "/.")
-  #   src = ../../../fc.qemu/.;
+  #   src = ../../../../../fc.qemu/.;
   #   qemu_ceph = pkgs.qemu-ceph-nautilus;
   #   ceph_client = pkgs.ceph-nautilus.ceph-client;
   # };

--- a/pkgs/fc/default.nix
+++ b/pkgs/fc/default.nix
@@ -37,12 +37,12 @@ rec {
   neighbour-cache-monitor = callPackage ./neighbour-cache-monitor {};
   ping-on-tap = callPackage ./ping-on-tap {};
   qemu-nautilus = callPackage ./qemu rec {
-    version = "1.4.4";
+    version = "1.4.5";
     src = pkgs.fetchFromGitHub {
       owner = "flyingcircusio";
       repo = "fc.qemu";
       rev = version;
-      hash = "sha256-JyKToKWrkA1GT8GtayDyXHZvp2/UzrFFNednAavax2w=";
+      hash = "sha256-m6uEhDZ9oeYBrhi6txgnK/pvzIAKhqAXeuU2H6zAkUo=";
     };
     qemu_ceph = pkgs.qemu-ceph-nautilus;
     ceph_client = pkgs.ceph-nautilus.ceph-client;

--- a/tests/kvm_host_ceph-nautilus.nix
+++ b/tests/kvm_host_ceph-nautilus.nix
@@ -1,6 +1,6 @@
 import ./make-test-python.nix ({ testlib, useCheckout ? false, testOpts ? "", clientCephRelease ? "nautilus", ... }:
 #import ./make-test-python.nix ({ testlib, useCheckout ? true, testOpts ? "-k test_vm_migration_pattern", clientCephRelease ? "nautilus", ... }:
-#import ./make-test-python.nix ({ testlib, useCheckout ? true, testOpts ? "", clientCephRelease ? "nautilus", ... }:
+#import ./make-test-python.nix ({ testlib, useCheckout ? true, testOpts ? "-vv", clientCephRelease ? "nautilus", ... }:
 #import ./make-test-python.nix ({ testlib, useCheckout ? true, testOpts ? "--flake-finder --flake-runs=500 -x --no-cov", clientCephRelease ? "nautilus", ... }:
 with testlib;
 let


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

- none

Changelog:

- We're changing our policy on XFS root disk UUID updates: we introduced automatic UUID resets for the root filesystems earlier to avoid having all VMs that were cloned from the same base image to inherit the same UUID. To apply this change to all existing VMs we decided to always update the UUID on every cold boot. However, this caused issues with rebooting NFS servers where clients could not longer automatically reconnect and needed to be rebooted or remounted. (PL-133015)

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.

decided not to provide a toggle

- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

not customer facing

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

improve availability

- [x] Security requirements tested? (EVIDENCE)

updated automated tests