### PR TITLE
webproxy/varnish: we decided to not deprecated the default.vcl mechanism

### DIFF
--- a/nixos/roles/webproxy.nix
+++ b/nixos/roles/webproxy.nix
@@ -38,8 +38,6 @@ in
 
   config = lib.mkMerge [
     (lib.mkIf fccfg.enable {
-      warnings = lib.optional (varnishCfg != null) "Configuring varnish via /etc/local/varnish/default.vcl is deprecated, please migrate your Configuration to Nix";
-
       assertions = [{
         assertion = builtins.length (builtins.attrNames config.flyingcircus.services.varnish.virtualHosts) <= 1 || builtins.isNull varnishCfg;
         message  = ''


### PR DESCRIPTION

Re PL-132174

@flyingcircusio/release-managers

## Release process

Impact:

none

Changelog:

- The `default.vcl` configuration mechanism for varnish is here to stay. We decided to un-deprecate this as it is useful and we will be integrating it with the newer mechanism in the near future. (PL-132174)

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider 
whether the default should be `on` or `off`. Example: rate limiting.

no toggle required, actually, this makes the toggle less scary ;)

- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

Docs will follow when the ticket is solved for good.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

n/a, simplifies multi-generational config rollovers

- [x] Security requirements tested? (EVIDENCE)

relying on automatic tests
