### PR TITLE
[21.05] Adapt netboot installer for nvme-only hosts

### DIFF
--- a/nixos/infrastructure/flyingcircus-physical.nix
+++ b/nixos/infrastructure/flyingcircus-physical.nix
@@ -26,6 +26,8 @@ mkIf (cfg.infrastructureModule == "flyingcircus-physical") {
         "mlx5_core"
         "mlxfw"
         "tg3"
+        # storage drivers, for hardware discovery
+        "nvme"
       ];
 
       kernelParams = [

--- a/nixos/infrastructure/flyingcircus-physical.nix
+++ b/nixos/infrastructure/flyingcircus-physical.nix
@@ -16,16 +16,16 @@ mkIf (cfg.infrastructureModule == "flyingcircus-physical") {
       initrd.availableKernelModules = [
         # assorted network drivers, for hardware discovery during
         # stage 1.
+        "3w-9xxx"
+        "bnx2"
+        "bnxt_en"
         "e1000e"
         "i40e"
-        "mlxfw"
-        "tg3"
-        "mlx5_core"
-        "bnxt_en"
         "igb"
         "ixgbe"
-        "bnx2"
-        "3w-9xxx"
+        "mlx5_core"
+        "mlxfw"
+        "tg3"
       ];
 
       kernelParams = [

--- a/release/netboot-installer.nix
+++ b/release/netboot-installer.nix
@@ -74,6 +74,10 @@ fi
 # also for keeping state (specifically old backup servers)
 # we need to ensure that grub and boot are placed early
 # on the disk.
+#
+# We keep creating a swap partition just out of an abundance of caution and
+# to stay in line with the long term partition numbers - even though we've
+# been using symbolic names for a long time now everywhere.
 sgdisk $root_disk -a 2048 \
   -n 1:1M:+1M -c 1:grub   -t 1:ef02 \
   -n 2:2M:+1G -c 2:boot   -t 2:ea00 \
@@ -82,13 +86,6 @@ sgdisk $root_disk -a 2048 \
 
 udevadm settle
 
-# We disabled swap in hardware, because it's basically detrimental to
-# continuous operation.
-# We keep the partition (see above) to be able to respond if we want it again,
-# but creating a swap signature here will cause systemd to automatically
-# activate it. I'm keeping this commented out here for future assistance of
-# whoever may need to tackle this again.
-# mkswap -L swap ''${root_disk}3
 mkfs -t ext4 -q -E stride=16 -m 1 -F -L boot /dev/disk/by-partlabel/boot
 
 pvcreate -ffy -Z y /dev/disk/by-partlabel/vgsys1

--- a/release/netboot-installer.nix
+++ b/release/netboot-installer.nix
@@ -86,7 +86,7 @@ sgdisk $root_disk -a 2048 \
 
 udevadm settle
 
-mkfs -t ext4 -q -E stride=16 -m 1 -F -L boot /dev/disk/by-partlabel/boot
+mkfs -t ext4 -q -F -L boot /dev/disk/by-partlabel/boot
 
 pvcreate -ffy -Z y /dev/disk/by-partlabel/vgsys1
 vgcreate -fy vgsys /dev/disk/by-partlabel/vgsys1


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

none

Changelog:

- Adapt our platform to support physical machines with nvme-only configuration. (PL-132817)

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.

no toggles needed afaict

- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

not customer facing

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

no changed requirements afaict

- [x] Security requirements tested? (EVIDENCE)

being tested on new hardware right now
