### PR TITLE
Fix NFS remounts causing updates to hang

### DIFF
--- a/nixos/roles/nfs.nix
+++ b/nixos/roles/nfs.nix
@@ -82,7 +82,7 @@ in
           #############################################################
           options = [
             "rw"
-            "noauto"
+            "auto"
             # Retry infinitely
             "hard"
             # Start over the retry process after 10 tries
@@ -96,31 +96,6 @@ in
           ];
           noCheck = true;
         };
-      };
-
-      # SystemD strictly doesn't want to implement any kind of retry-logic
-      # around mount units. So lets not use them.
-      systemd.services.mount-nfs-shared = {
-          path = [ pkgs.util-linux ];
-          wantedBy = [ "remote-fs.target" ];
-          before = [ "remote-fs.target" ];
-          reloadIfChanged=true;
-          serviceConfig = {
-            Type = "oneshot";
-            RemainAfterExit = true;
-          };
-          reload = ''
-            set -x
-            while ! mount -o remount ${mountpoint}; do
-              sleep 5;
-            done
-          '';
-          script = ''
-            set -x
-            while ! mountpoint ${mountpoint}; do
-              mount ${mountpoint} || sleep 5
-            done
-          '';
       };
 
       systemd.tmpfiles.rules = [

--- a/nixos/roles/nfs.nix
+++ b/nixos/roles/nfs.nix
@@ -18,12 +18,22 @@ let
   export = "/srv/nfs/shared";
   mountpoint = "/mnt/nfs/shared";
 
+  # Workaround for DIR-155/ PL-133063: We need to use the same hostname as
+  # written into /etc/hosts for resilience against resolver failures. This
+  # currently deviates from the raw string provided by the directory.
+  normaliseHostname = hostname:
+    let hostPart = builtins.head (lib.splitString "." hostname);
+    in
+    if (config.networking.domain != null && hostPart != "")
+      then "${hostPart}.${config.networking.domain}"
+      else hostname;
+
   # This is a bit different than on Gentoo. We allow export to all nodes in the
   # RG, regardles of the node actually being a client.
   exportToClients =
     let
       flags = lib.concatStringsSep "," cfg.roles.nfs_rg_share.clientFlags;
-      clientWithFlags = c: "${c.node}(${flags})";
+      clientWithFlags = c: "${normaliseHostname c.node}(${flags})";
     in
       lib.concatMapStringsSep " " clientWithFlags serviceClients;
 
@@ -74,7 +84,7 @@ in
     (lib.mkIf (cfg.roles.nfs_rg_client.enable && service != null) {
       fileSystems = {
         "${mountpoint}" = {
-          device = "${service.address}:${export}";
+          device = "${normaliseHostname service.address}:${export}";
           fsType = "nfs4";
           #############################################################
           # WARNING: those settings are DUPLICATED in tests/nfs.nix to

--- a/tests/nfs.nix
+++ b/tests/nfs.nix
@@ -8,14 +8,20 @@ let
   };
 
   encServices = [{
-    address = "server";
+    address = "server.gocept.net";  # gocept.net due to PL-133063
     service = "nfs_rg_share-server";
   }];
 
-  encServiceClients = [{
-    node = "client";
-    service = "nfs_rg_share-server";
-  }];
+  encServiceClients = [
+    {
+      node = "client1.gocept.net";  # gocept.net due to PL-133063
+      service = "nfs_rg_share-server";
+    }
+    {
+      node = "client2";
+      service = "nfs_rg_share-server";
+    }
+  ];
 
   sdir = "/srv/nfs/shared";
   cdir = "/mnt/nfs/shared";
@@ -30,61 +36,66 @@ let
           sleep(600000);
         ?>
   ''; };
+  clientConfig = extraConfig: { lib, ... }:
+    {
+      imports = [ ../nixos ../nixos/roles ];
+      config = lib.recursiveUpdate {
+        flyingcircus.roles.nfs_rg_client.enable = true;
+        flyingcircus.roles.lamp.enable = true;
+        flyingcircus.roles.webgateway.enable = true;
+
+        flyingcircus.roles.lamp.vhosts = [
+          { port = 8000;
+            docroot = cdir;
+          }
+        ];
+
+        # XXX: same as upstream test, let's see how they fix this
+        networking.firewall.enable = false;
+        flyingcircus.encServices = encServices;
+
+        # The test framework overrides the fileSystems setting from the role,
+        # we must add it here with a higher priority
+        fileSystems = lib.mkVMOverride {
+          "${cdir}" = {
+            # TODO: Due to having to override this here, the normalisation of
+            # the server name in the filesystem entry is not tested.
+            device = "server.fcio.net:${sdir}";
+            fsType = "nfs4";
+            ################################################################
+            # WARNING: those settings are DUPLICATED in nixos/roles/nfs.nix
+            # to work around a deficiency of the test harness.
+            ################################################################
+            options = [
+              "rw"
+              "auto"
+              # Retry infinitely
+              "hard"
+              # Start over the retry process after 10 tries
+              "retrans=10"
+              # Start with a 3s (30 deciseconds) interval and add 3s as linear
+              # backoff
+              "timeo=30"
+              "rsize=8192"
+              "wsize=8192"
+              "nfsvers=4"
+            ];
+          noCheck = true;
+        };
+      };
+
+        users.users.u = user;
+      }
+      extraConfig;
+    };
 
 in {
   name = "nfs";
   nodes = {
-    client =
-      { lib, ... }:
-      {
-        imports = [ ../nixos ../nixos/roles ];
-        config = {
-          flyingcircus.roles.nfs_rg_client.enable = true;
-          flyingcircus.roles.lamp.enable = true;
-          flyingcircus.roles.webgateway.enable = true;
-
-          flyingcircus.roles.lamp.vhosts = [
-            { port = 8000;
-              docroot = cdir;
-            }
-          ];
-
-          # XXX: same as upstream test, let's see how they fix this
-          networking.firewall.enable = false;
-          flyingcircus.encServices = encServices;
-
-          # The test framework overrides the fileSystems setting from the role,
-          # we must add it here with a higher priority
-          fileSystems = lib.mkVMOverride {
-            "${cdir}" = {
-              device = "server:${sdir}";
-              fsType = "nfs4";
-              ################################################################
-              # WARNING: those settings are DUPLICATED in nixos/roles/nfs.nix
-              # to work around a deficiency of the test harness.
-              ################################################################
-              options = [
-                "rw"
-                "auto"
-                # Retry infinitely
-                "hard"
-                # Start over the retry process after 10 tries
-                "retrans=10"
-                # Start with a 3s (30 deciseconds) interval and add 3s as linear
-                # backoff
-                "timeo=30"
-                "rsize=8192"
-                "wsize=8192"
-                "nfsvers=4"
-              ];
-            noCheck = true;
-          };
-        };
-
-          users.users.u = user;
-        };
-
-      };
+    client1 = clientConfig {
+        networking.domain = "fcio.net"; # PL-133063
+    };
+    client2 = clientConfig {};
 
     server =
       { ... }:
@@ -96,6 +107,7 @@ in {
           # XXX: same as upstream test, let's see how they fix this
           networking.firewall.enable = false;
           users.users.u = user;
+          networking.domain = "fcio.net"; # PL-133063
 
           specialisation.withCustomFlags.configuration.flyingcircus.roles.nfs_rg_share.clientFlags = [ "rw" "sync" "no_root_squash" "no_subtree_check" ];
         };
@@ -112,7 +124,8 @@ in {
     server.wait_for_unit("nfs-server")
     server.wait_for_unit("nfs-idmapd")
     server.wait_for_unit("nfs-mountd")
-    client.start()
+    client1.start()
+    client2.start()
 
     server.succeed("chown test ${sdir}")
 
@@ -120,29 +133,67 @@ in {
     server.succeed("sudo -u test sh -c 'echo test_on_server > ${sdir}/test'")
 
     # share will be mounted after boot
-    client.wait_for_unit("multi-user.target")
+    client1.wait_for_unit("multi-user.target")
+    client2.wait_for_unit("multi-user.target")
 
-    client.succeed("grep test_on_server ${cdir}/test")
+    client1.succeed("grep test_on_server ${cdir}/test")
 
-    client.succeed("sudo -u test sh -c 'echo test_on_client > ${cdir}/test'")
+    client1.succeed("sudo -u test sh -c 'echo test_on_client > ${cdir}/test'")
     server.succeed("grep test_on_client ${sdir}/test")
 
-    client.fail("echo from_root_user > ${cdir}/test")
+    client1.fail("echo from_root_user > ${cdir}/test")
     server.succeed("grep test_on_client ${sdir}/test")
 
     # Verify proper shutdown while NFS is being used.
     # See PL-129954
-    client.wait_for_unit("httpd.service")
-    client.succeed("cd ${cdir}")
+    client1.wait_for_unit("httpd.service")
+    client1.succeed("cd ${cdir}")
 
     server.copy_from_host("${php_blocking_script}", "${sdir}/index.php")
 
-    client.execute('curl -v http://localhost:8000/index.php >&2 &')
+    client1.execute('curl -v http://localhost:8000/index.php >&2 &')
     time.sleep(2)
-    print(client.execute('lsof -n ${cdir}/test2')[1])
-    print(client.execute('journalctl -u httpd')[1])
-    content = client.execute('cat ${cdir}/test2')[1]
+    print(client1.execute('lsof -n ${cdir}/test2')[1])
+    print(client1.execute('journalctl -u httpd')[1])
+    content = client1.execute('cat ${cdir}/test2')[1]
     assert content == "asdf", repr(content)
+
+    # PL-133063
+    with subtest("NFS client and server can be resolved via /etc/hosts"):
+      server_hosts = server.succeed('cat /etc/hosts')
+      print("server_hosts", server_hosts, sep="\n")
+      client1_hosts = client1.succeed('cat /etc/hosts')
+      print("client1_hosts", client1_hosts, sep="\n")
+      client2_hosts = client2.succeed('cat /etc/hosts')
+      print("client2_hosts", client2_hosts, sep="\n")
+      exportinfo = server.succeed('cat /etc/exports')
+      print("exportinfo", exportinfo, sep="\n")
+      mountinfo_client1 = client1.succeed('cat /etc/fstab | grep ${cdir}')
+      print("mountinfo_client1", mountinfo_client1, sep="\n")
+      mountinfo_client2 = client2.succeed('cat /etc/fstab | grep ${cdir}')
+      print("mountinfo_client2", mountinfo_client2, sep="\n")
+
+      assert "client1.fcio.net client1" in server_hosts, "client1.fcio.net missing from server hosts file"
+      assert "server.fcio.net" in client1_hosts, "server missing from client1 host file"
+      assert "server.fcio.net" in mountinfo_client1, "NFS server domain missing from fstab"
+      assert "client1.fcio.net(" in exportinfo, "client1 domain missing from exports file"
+
+      # TODO: For machines without a domain, the mechanism does not fully work as intended:
+      # `client2` only announces itself without a domain in `flyingcircus.encAddresses`
+      # and thus is present only as `client2` in /etc/hosts. But for NFS mounts, its hostname is
+      # appended to the local domain of each other machine locally.
+      # Hence, resolving the NFS domain name is not possible via the hosts file in
+      # this particular edge case, it cannot be exported to successfully, and the NFS mounting fails.
+
+      # As a workaround this is acceptable, as all real machines share the same domain.
+      # The asserts below reflect the *is* state, not the *desired* state:
+      assert "client2" in server_hosts, "client2 missing from server hosts file"
+      assert "client2.fcio.net(" in exportinfo, "client2 missing from exports file"
+      assert "server.fcio.net" in mountinfo_client2, "NFS server domain missing from fstab"
+
+      print(client1.execute("findmnt")[1])
+      print(client2.execute("findmnt")[1])
+      print(client2.execute("systemctl status mnt-nfs-shared.mount")[1])
 
     deadline = time.time() + 10
     def wait_for_console_text(self, regex: str) -> str:
@@ -163,13 +214,13 @@ in {
 
         assert False, "Did not shut down cleanly (timeout)"
 
-    client.execute("poweroff", check_return=False)
+    client1.execute("poweroff", check_return=False)
 
-    console = wait_for_console_text(client, "reboot: Power down")
+    console = wait_for_console_text(client1, "reboot: Power down")
 
     assert "Failed unmounting" not in console, "Unmounting NFS cleanly failed, check console output"
 
-    client.wait_for_shutdown()
+    client1.wait_for_shutdown()
 
     config = server.execute('cat /etc/exports')[1]
     assert "rw,sync,root_squash,no_subtree_check" in config, "default flags not found"

--- a/tests/nfs.nix
+++ b/tests/nfs.nix
@@ -65,7 +65,7 @@ in {
               ################################################################
               options = [
                 "rw"
-                "noauto"
+                "auto"
                 # Retry infinitely
                 "hard"
                 # Start over the retry process after 10 tries


### PR DESCRIPTION
@flyingcircusio/release-managers

This fixes several issues with NFS update behaviour after the changes in #1115. See individual commit messages for details.

PL-133062

## Release process

Impact: NFS mountpoints are unmounted and mounted again.

Changelog:
- rely on system logic (systemd, fstab) for automatically mounting NFS filesystems again (PL-133962)
  - returning to the `hard` mount mode
  - resolves the potential for system upgrades getting stuck into an NFS remount loop
- ensure that NFS servers within the same RG can be resolved via /etc/hosts (PL-133962)

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - [x] must not introduce any known regressions
  - [x] fix potential infinite loops of mount-nfs-shared-service during system switch
  - [x] mounting and IO still needs to work when NFS server is unavailable (retry and failure after timeout)
  - [x] automatic mount/ export and recovery when client and server reboot
  - [x] extend test coverage to cover normalised names
- [x] Security requirements tested? (EVIDENCE)
  - [x] automated tests still pass
  - [x] manual test on test RG in dev:
    - [x] gracefully rebooting client and server sequentially
    - [x] recovery of blocking I/O and client mountpoint at server reboot
    - [x] observe retry and timeout on client side when server is unavailable (shutdown) and becomes available again
    - [x] checked hostname consistency between /etc/hosts and /etc/fstab 