### PR TITLE
Update nixpkgs (2024-10-04)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1726153070,
-        "narHash": "sha256-HO4zgY0ekfwO5bX0QH/3kJ/h4KvUDFZg8YpkNwIbg1U=",
+        "lastModified": 1727826117,
+        "narHash": "sha256-K5ZLCyfO/Zj9mPFldf3iwS6oZStJcU4tSpiXTMYaaL0=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "bcef6817a8b2aa20a5a6dbb19b43e63c5bf8619a",
+        "rev": "3d04084d54bedc3d6b8b736c70ef449225c361b1",
         "type": "github"
       },
       "original": {
@@ -350,14 +350,14 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1725233747,
-        "narHash": "sha256-Ss8QWLXdr2JCBPcYChJhz4xJm+h/xjl4G0c0XlP6a74=",
+        "lastModified": 1727825735,
+        "narHash": "sha256-0xHYkMkeLVQAMa7gvkddbPqpxph+hDzdu1XdGPJR+Os=",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/356624c12086a18f2ea2825fed34523d60ccc4e3.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/fb192fec7cc7a4c26d51779e9bab07ce6fa5597a.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/356624c12086a18f2ea2825fed34523d60ccc4e3.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/fb192fec7cc7a4c26d51779e9bab07ce6fa5597a.tar.gz"
       }
     },
     "nixpkgs-regression": {
@@ -410,11 +410,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1727335565,
-        "narHash": "sha256-D7sIMls9rUl9xkT/U/R0hBE9R+sbbz1bwy7YX7jBHJg=",
+        "lastModified": 1728026046,
+        "narHash": "sha256-MhQxvqWpKzf0mhCZI0z72z2vbWD14NAnAlwvMV74bvY=",
         "owner": "flyingcircusio",
         "repo": "nixpkgs",
-        "rev": "8d3f4935a5ba572241685c6814258df8a93d6731",
+        "rev": "1a4ac073de5f6c533f3929c97994125a60d68a29",
         "type": "github"
       },
       "original": {

--- a/release/package-versions.json
+++ b/release/package-versions.json
@@ -70,14 +70,14 @@
     "version": "18.2.4"
   },
   "chromedriver": {
-    "name": "chromedriver-129.0.6668.58",
+    "name": "chromedriver-129.0.6668.70",
     "pname": "chromedriver",
-    "version": "129.0.6668.58"
+    "version": "129.0.6668.70"
   },
   "chromium": {
-    "name": "chromium-129.0.6668.58",
+    "name": "chromium-129.0.6668.70",
     "pname": "chromium",
-    "version": "129.0.6668.58"
+    "version": "129.0.6668.70"
   },
   "cifs-utils": {
     "name": "cifs-utils-7.0",
@@ -155,9 +155,9 @@
     "version": "2.3.21.1"
   },
   "element-web": {
-    "name": "element-web-1.11.77",
+    "name": "element-web-1.11.79",
     "pname": "element-web",
-    "version": "1.11.77"
+    "version": "1.11.79"
   },
   "erlang": {
     "name": "erlang-25.3.2.12",
@@ -290,9 +290,9 @@
     "version": "1.22.6"
   },
   "grafana": {
-    "name": "grafana-10.4.8",
+    "name": "grafana-10.4.9",
     "pname": "grafana",
-    "version": "10.4.8"
+    "version": "10.4.9"
   },
   "grub2": {
     "name": "grub-2.12",
@@ -495,9 +495,9 @@
     "version": "3.3.5"
   },
   "mastodon": {
-    "name": "mastodon-4.2.12",
+    "name": "mastodon-4.2.13",
     "pname": "mastodon",
-    "version": "4.2.12"
+    "version": "4.2.13"
   },
   "matomo": {
     "name": "matomo-4.16.1",
@@ -510,9 +510,9 @@
     "version": "5.1.1"
   },
   "matrix-synapse": {
-    "name": "matrix-synapse-wrapped-1.114.0",
+    "name": "matrix-synapse-wrapped-1.116.0",
     "pname": "matrix-synapse-wrapped",
-    "version": "1.114.0"
+    "version": "1.116.0"
   },
   "mcpp": {
     "name": "mcpp-2.7.2.1",
@@ -575,9 +575,9 @@
     "version": "1.26.2"
   },
   "nix": {
-    "name": "nix-2.18.5",
+    "name": "nix-2.18.8",
     "pname": "nix",
-    "version": "2.18.5"
+    "version": "2.18.8"
   },
   "nodejs": {
     "name": "nodejs-20.15.1",
@@ -605,9 +605,9 @@
     "version": "4.35"
   },
   "nss_latest": {
-    "name": "nss-3.104",
+    "name": "nss-3.105",
     "pname": "nss",
-    "version": "3.104"
+    "version": "3.105"
   },
   "openjdk": {
     "name": "openjdk-21.0.3+9",
@@ -750,19 +750,19 @@
     "version": "8.0.30"
   },
   "php81": {
-    "name": "php-with-extensions-8.1.29",
+    "name": "php-with-extensions-8.1.30",
     "pname": "php-with-extensions",
-    "version": "8.1.29"
+    "version": "8.1.30"
   },
   "php82": {
-    "name": "php-with-extensions-8.2.23",
+    "name": "php-with-extensions-8.2.24",
     "pname": "php-with-extensions",
-    "version": "8.2.23"
+    "version": "8.2.24"
   },
   "php83": {
-    "name": "php-with-extensions-8.3.11",
+    "name": "php-with-extensions-8.3.12",
     "pname": "php-with-extensions",
-    "version": "8.3.11"
+    "version": "8.3.12"
   },
   "phpPackages.composer": {
     "name": "composer-2.7.7",
@@ -845,9 +845,9 @@
     "version": "3.11.9"
   },
   "python310": {
-    "name": "python3-3.10.14",
+    "name": "python3-3.10.15",
     "pname": "python3",
-    "version": "3.10.14"
+    "version": "3.10.15"
   },
   "python311": {
     "name": "python3-3.11.9",
@@ -861,9 +861,9 @@
   },
   "python38": {},
   "python39": {
-    "name": "python3-3.9.19",
+    "name": "python3-3.9.20",
     "pname": "python3",
-    "version": "3.9.19"
+    "version": "3.9.20"
   },
   "python3Packages.boto3": {
     "name": "python3.11-boto3-1.34.58",

--- a/release/versions.json
+++ b/release/versions.json
@@ -8,9 +8,9 @@
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/"
   },
   "nixpkgs": {
-    "hash": "sha256-D7sIMls9rUl9xkT/U/R0hBE9R+sbbz1bwy7YX7jBHJg=",
+    "hash": "sha256-MhQxvqWpKzf0mhCZI0z72z2vbWD14NAnAlwvMV74bvY=",
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "8d3f4935a5ba572241685c6814258df8a93d6731"
+    "rev": "1a4ac073de5f6c533f3929c97994125a60d68a29"
   }
 }


### PR DESCRIPTION
Pull upstream NixOS changes, security fixes and package updates:

- chromedriver: 129.0.6668.58 -> 129.0.6668.70
- grafana: 10.4.8 -> 10.4.9 (CVE-2024-8118)
- mastodon: 4.2.12 -> 4.2.13
- nss_latest: 3.104 -> 3.105
- php81: 8.1.29 -> 8.1.30 (CVE-2024-8927, CVE-2024-9026, CVE-2024-8925)
- php82: 8.2.23 -> 8.2.24 (CVE-2024-8927, CVE-2024-9026, CVE-2024-8925)
- php83: 8.3.11 -> 8.3.12 (CVE-2024-8927, CVE-2024-9026, CVE-2024-8925)
- python310: 3.10.14 -> 3.10.15
- python39: 3.9.19 -> 3.9.20

PL-133072

@flyingcircusio/release-managers

## Release process

Impact: several services will be restarted; but this will merge into the system reboot caused by the previous nixpkgs update PR #1113.

Changelog:
*manually merged changelog of both nixpkgs update PRs* #1113

- asterisk: 20.9.2 -> 20.9.3
- cacert: 3.101 -> 3.104
- calibre: add patches for CVE-2024-6781, CVE-2024-6782, CVE-2024-7008, CVE-2024-7009
- chromedriver: 129.0.6668.58 -> 129.0.6668.70
- clamav: 1.3.1 -> 1.3.2
- curl: apply patch for CVE-2024-8096
- element-web: 1.11.77 -> 1.11.79
- grafana: 10.4.8 -> 10.4.9 (CVE-2024-8118)
- k3s_1_28: 1.28.12+k3s1 -> 1.28.13+k3s1
- k3s_1_29: 1.29.7+k3s2 -> 1.29.8+k3s1
- k3s_1_30: 1.30.3+k3s1 -> 1.30.4+k3s1
- k3s_1_31: init 1.31.0+k3s1
- mastodon: 4.2.12 -> 4.2.13
- matrix-synapse: 1.114.0 -> 1.116.0
- nss_latest: 3.104 -> 3.105
- php81: 8.1.29 -> 8.1.30 (CVE-2024-8927, CVE-2024-9026, CVE-2024-8925)
- php82: 8.2.23 -> 8.2.24 (CVE-2024-8927, CVE-2024-9026, CVE-2024-8925)
- php83: 8.3.11 -> 8.3.12 (CVE-2024-8927, CVE-2024-9026, CVE-2024-8925)
- python39: 3.9.19 -> 3.9.20
- python310: 3.10.14 -> 3.10.15
- python312: 3.12.4 -> 3.12.5
- python3Packages.urllib3: 2.2.1 -> 2.2.2
- ruby: 3.3.4 -> 3.3.5
- runc: 1.1.12 -> 1.1.14
- slurm: 23.11.9.1 -> 23.11.10.1
- strace: 6.10 -> 6.11
- tcpdump: 4.99.4 -> 4.99.5
- unifi7: mark insecure due to CVE-2024-42025
- unifi8: 8.1.127 -> 8.4.62
- vim: 9.1.0377 -> 9.1.0707

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - regularly pull in security updates from upstream 
- [x] Security requirements tested? (EVIDENCE)
  - [x] automated tests still pass
  - [x] checked fixed CVEs in the commit logs; looked at [Grafana changelog](https://github.com/grafana/grafana/blob/main/CHANGELOG.md) and [synapse/upgrade.md](https://github.com/element-hq/synapse/blob/develop/docs/upgrade.md).
