### PR TITLE
[21.05] fc-qemu: fix freeze thaw

### DIFF
--- a/pkgs/fc/default.nix
+++ b/pkgs/fc/default.nix
@@ -37,12 +37,12 @@ rec {
   neighbour-cache-monitor = callPackage ./neighbour-cache-monitor {};
   ping-on-tap = callPackage ./ping-on-tap {};
   qemu-nautilus = callPackage ./qemu rec {
-    version = "1.4.6";
+    version = "1.5.0";
     src = pkgs.fetchFromGitHub {
       owner = "flyingcircusio";
       repo = "fc.qemu";
       rev = version;
-      hash = "sha256-lf0ByXo6cMg089DPnvYJpJHX6/445k8IKNawOA5Pf08=";
+      hash = "sha256-AbL8Xta+rZSJ/RmfBIYNSnDqH/G/l4rjg89RJrJ6xeY=";
     };
     qemu_ceph = pkgs.qemu-ceph-nautilus;
     ceph_client = pkgs.ceph-nautilus.ceph-client;


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

- Improve our Qemu guest agent interactions to avoid and recover from timeouts when freezing VMs that have large buffers and regular IOPS concurrency. (PL-132809)

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.

n/a

- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

n/a

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

no new requirements

- [x] Security requirements tested? (EVIDENCE)

automated tests