### PR TITLE
Trigger cold reboots upon changes in KVM environment parameters

### DIFF
--- a/pkgs/fc/agent/fc/maintenance/cli.py
+++ b/pkgs/fc/agent/fc/maintenance/cli.py
@@ -11,8 +11,8 @@ from fc.maintenance.lib.shellscript import ShellScriptActivity
 from fc.maintenance.maintenance import (
     request_reboot_for_cpu,
     request_reboot_for_kernel,
+    request_reboot_for_kvm_environment,
     request_reboot_for_memory,
-    request_reboot_for_qemu,
     request_update,
 )
 from fc.maintenance.reqmanager import DEFAULT_SPOOLDIR, ReqManager
@@ -299,7 +299,7 @@ def system_properties():
         if enc["parameters"]["machine"] == "virtual":
             rm.add(request_reboot_for_memory(log, enc))
             rm.add(request_reboot_for_cpu(log, enc))
-            rm.add(request_reboot_for_qemu(log))
+            rm.add(request_reboot_for_kvm_environment(log))
 
         rm.add(request_reboot_for_kernel(log, current_requests))
         log.info("fc-maintenance-system-properties-finished")

--- a/pkgs/fc/agent/fc/maintenance/tests/test_cli.py
+++ b/pkgs/fc/agent/fc/maintenance/tests/test_cli.py
@@ -155,7 +155,7 @@ def test_invoke_request_cold_reboot(activity, invoke_app_as_root):
 
 
 @unittest.mock.patch("fc.maintenance.cli.request_reboot_for_kernel")
-@unittest.mock.patch("fc.maintenance.cli.request_reboot_for_qemu")
+@unittest.mock.patch("fc.maintenance.cli.request_reboot_for_kvm_environment")
 @unittest.mock.patch("fc.maintenance.cli.request_reboot_for_cpu")
 @unittest.mock.patch("fc.maintenance.cli.request_reboot_for_memory")
 def test_invoke_request_system_properties_virtual(
@@ -169,10 +169,10 @@ def test_invoke_request_system_properties_virtual(
 
 
 @unittest.mock.patch("fc.maintenance.cli.request_reboot_for_kernel")
-@unittest.mock.patch("fc.maintenance.cli.request_reboot_for_qemu")
+@unittest.mock.patch("fc.maintenance.cli.request_reboot_for_kvm_environment")
 @unittest.mock.patch("fc.maintenance.cli.request_reboot_for_cpu")
 @unittest.mock.patch("fc.maintenance.cli.request_reboot_for_memory")
-def test_invoke_request_system_properties_virtual(
+def test_invoke_request_system_properties_physical(
     memory, cpu, qemu, kernel, tmpdir, invoke_app_as_root
 ):
     enc_file = tmpdir / "enc.json"


### PR DESCRIPTION
This change adds support to fc-agent for a new mechanism in fc.qemu which signals selected boot-time parameters from the KVM environment, similar to the existing qemu binary generation handling. The corresponding side in fc.qemu will seed the parameters once at boot and then periodically write them into /run at runtime through the qemu guest agent. If fc-agent detects changes, then it will schedule a cold reboot in a maintenance window so the KVM host can carry out changes which require a restart of the qemu process.

PL-131857

@flyingcircusio/release-managers

## Release process

Impact:

Changelog:
- VMs will now automatically schedule reboots during maintenance when changes in KVM parameters such as CPU flags or VM backing storage (i.e. SSD or HDD) are detected (PL-131857).

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - This is an extension of the existing qemu binary generation upgrade mechanism, where the hypervisor signals the state of the guest-external KVM environment through the qemu guest agent.
- [x] Security requirements tested? (EVIDENCE)
  - Additional unit tests, in particular to test compatibility with the previous qemu binary generation handling mechanism, and the upgrade path from the existing code to the new code in fc.qemu.
  - Verified manually in DEV.