### PR TITLE
Pl 131857 rbd pool migration

### DIFF
--- a/pkgs/fc/ceph/src/fc/ceph/keys/nautilus.py
+++ b/pkgs/fc/ceph/src/fc/ceph/keys/nautilus.py
@@ -177,15 +177,15 @@ class KeyConfig(object):
     ids, and interaction with Ceph and text keyring files.
     """
 
-    filename = None
+    filename: str
     is_stub = False
 
     # Ceph knows two concepts:
     # 1. 'usernames' and 'entities'. The include the type like 'client.admin'
     # 2. 'names' and 'ids'. They do not include the type like 'admin'
 
-    entity = None
-    capabilities = None
+    entity: str
+    capabilities: dict[str, str]
     additional_salt = b""
 
     def __init__(self, id):
@@ -218,21 +218,32 @@ key = {self.key.to_string()}
 class ClientKey(KeyConfig):
     filename = "/etc/ceph/ceph.client.{id}.keyring"
     entity = "client.{id}"
-    # assumption: all clients are allowed to use RBD
-    capabilities = {"mon": "allow r, allow profile rbd", "osd": "allow rwx"}
+    capabilities = {
+        # assumption: all clients are allowed to use RBD
+        "mon": "allow r, allow profile rbd",
+        "osd": "allow rwx",
+        # clients are also allowed to start rbd live migration tasks
+        "mgr": "allow profile rbd",
+    }
 
 
 class RGWKey(KeyConfig):
     filename = "/etc/ceph/ceph.client.radosgw.{id}.keyring"
     entity = "client.radosgw.{id}"
-    capabilities = {"mon": "allow rwx", "osd": "allow rwx"}
+    capabilities = {
+        "mon": "allow rwx",
+        "osd": "allow rwx",
+    }
     additional_salt = b"rgw"
 
 
 class ManagerKey(KeyConfig):
     filename = "/etc/ceph/ceph.mgr.{id}.keyring"
     entity = "mgr.{id}"
-    capabilities = {"mon": "allow profile mgr", "osd": "allow *"}
+    capabilities = {
+        "mon": "allow profile mgr",
+        "osd": "allow *",
+    }
     additional_salt = b"mgr"
 
 

--- a/pkgs/fc/qemu/default.nix
+++ b/pkgs/fc/qemu/default.nix
@@ -4,6 +4,7 @@
   pkgs,
   python3Packages,
   lib,
+  file,
   libceph,
   ceph_client,
   fetchFromGitHub,
@@ -85,7 +86,9 @@ in
       py.pytest
       py.pytest-cov
       py.pytest-timeout
+      py.pytest-xdist
       py.mock
+      file
 
       # Allow passing through to pytest in the NixOS test.
       (py.buildPythonPackage rec {
@@ -109,7 +112,8 @@ in
     doCheck = true;
     checkPhase = ''
       runHook preCheck
-      PATH="${lib.makeBinPath propagatedBuildInputs}:$PATH" pytest -vv -m "unit"
+      export PATH="${lib.makeBinPath propagatedBuildInputs}:$PATH"
+      pytest -vv -n auto --maxprocesses 10 -m "not live"
       runHook postCheck
     '';
 


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

none

Changelog:

- Introduce automation to allow automatic (cold) migration of VMs between RBD volumes (HDD/SSD) (PL-131857)

### PR release workflow (internal)

- [x] PR has internal ticket
- [x]  internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.

no toggle required

- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

still to do 

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

Data loss needs to be avoided. 

- [x] Security requirements tested? (EVIDENCE)

We've manually tested various workflows and have taken great care to provide good factoring for this feature. I'll be adding more unit tests and make sure the important branches are covered.
