### PR TITLE
[21.05] Fix guest TAP interface MTU setup on KVM hosts

### DIFF
--- a/nixos/roles/kvm.nix
+++ b/nixos/roles/kvm.nix
@@ -135,7 +135,7 @@ in
         BRIDGE="br''${VLAN}"
 
         ${pkgs.iproute}/bin/ip link set $INTERFACE up
-        ${pkgs.iproute}/bin/ip link set mtu $(< /sys/class/net/eth''${VLAN}/mtu) dev $INTERFACE
+        ${pkgs.iproute}/bin/ip link set mtu $(< /sys/class/net/br''${VLAN}/mtu) dev $INTERFACE
         ${pkgs.bridge-utils}/bin/brctl addif $BRIDGE $INTERFACE
         '';
       mode = "0744";


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

Changelog:

- Fix MTU detection for VM tap devices (PL-133040)

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.

not needed

- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

not needed

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

no special requirements

- [x] Security requirements tested? (EVIDENCE)

manually tested
