### PR TITLE
roles.mysql: introduce percona84 role

### DIFF
--- a/doc/src/mysql.md
+++ b/doc/src/mysql.md
@@ -15,7 +15,8 @@ There's a role for each supported major version, currently:
 
 - mysql57: Percona 5.7.x (End-of-life)
 - percona80: Percona 8.0.x (*LTS* release)
-- percona83: Percona 8.3.x (*Innovation* release)
+- percona83: Percona 8.3.x (*Innovation* release, End-of-life)
+- percona84: Percona 8.4.x (*LTS* release)
 
 Percona and MySQL currently follow a [two-fold release model](https://www.percona.com/blog/lts-and-innovation-releases-for-percona-server-for-mysql/)
 and provide support for 2 releases in parallel:

--- a/nixos/roles/mysql.nix
+++ b/nixos/roles/mysql.nix
@@ -8,7 +8,7 @@ with builtins;
 
 let
   fclib = config.fclib;
-  supportedPerconaVersions = ["8.0" "8.3"];
+  supportedPerconaVersions = ["8.0" "8.3" "8.4"];
   removeDot = builtins.replaceStrings ["."] [""];
 in
 {

--- a/nixos/roles/mysql.nix
+++ b/nixos/roles/mysql.nix
@@ -249,9 +249,17 @@ in
           # connect otherwise.
           lib.optionalString
           (lib.versionAtLeast package.version "8.0") ''
-            default_authentication_plugin = mysql_native_password
             log_error_suppression_list = MY-013360
           ''}
+        ${# In 8.4, the deprecated plugin is disabled by default and needs to be manually enabled
+          lib.optionalString (lib.versionAtLeast package.version "8.4")
+            "mysql_native_password = ON"
+        }
+        ${# while in earlier versions, it can just be set as default
+          lib.optionalString (lib.versionAtLeast package.version "8.0" && lib.versionOlder package.version "8.4")
+            "default_authentication_plugin = mysql_native_password"
+        }
+
 
         ${# Query cache is gone in 8.0
           # https://mysqlserverteam.com/mysql-8-0-retiring-support-for-the-query-cache/

--- a/nixpkgs-config.nix
+++ b/nixpkgs-config.nix
@@ -15,5 +15,6 @@
     "ruby-2.7.8" # EOL 2023-03-31, needed for Sensu checks
     "docker-24.0.9" # Old installs still use storage driver removed in 25.x.
     "jitsi-meet-1.0.7952" # insecure libolm but this only affects optional e2ee which we don't really support.
+    "discourse-3.2.5"  # currently not regularly updated in nixpkgs as upstream keeps changing build system in minor versions
   ];
 }

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -91,6 +91,7 @@ in {
   openvpn = callTest ./openvpn.nix {};
   percona80 = callTest ./mysql.nix { rolename = "percona80"; };
   percona83 = callTest ./mysql.nix { rolename = "percona83"; };
+  percona84 = callTest ./mysql.nix { rolename = "percona84"; };
   physical-installer = callTest ./physical-installer.nix { inherit nixpkgs; };
   postgresql12 = callTest ./postgresql { version = "12"; };
   postgresql13 = callTest ./postgresql { version = "13"; };


### PR DESCRIPTION
@flyingcircusio/release-managers

Provides the new percona84 role, which is now the latest LTS and Innovation package. We continue to default to percona80, which is still maintained as another LTS release.
percona83 is end of life, we're shipping it as a vendored package to allow customers to transition.

rebased on and includes #1129, which needs to be merged first!

## Release process

Impact: none

Changelog:
- percona84: new role providing percona-8.4.0.1 and the corresponding percona-xtrabackup
- percona83: The version is end-of-life and won't receive any updates anymore, we recommend upgrading to the percona84 role
  - role and package continue to be provided by the Flyingcircus Platform throughout the release

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - provide updated packages for provided roles
  - customers need to be informed about software not being maintained anymore
  - provide a transition path by keeping the old package around
  - must not introduce known regressions 
- [x] Security requirements tested? (EVIDENCE)
  - [x] automated tests still pass
