### PR TITLE
nfs: hard mount and fixed remount (v2)

### DIFF
--- a/changelog.d/20241030_191209_PL-133062-nfs-hard-remount-v2_scriv.md
+++ b/changelog.d/20241030_191209_PL-133062-nfs-hard-remount-v2_scriv.md
@@ -1,0 +1,23 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+- NFS clients will be rebooted to activate the new configuration. This happens
+  as a side effect of a kernel update. In the future changes to NFS client
+  settings will cause explicit reboot requests.
+
+### NixOS XX.XX platform
+
+- Make NFS clients more resilient against missing servers during bootstrap,
+  upgrades, and reboot scenarios. (PL-133062)

--- a/doc/src/nfs.md
+++ b/doc/src/nfs.md
@@ -22,6 +22,12 @@ server before the system call returns control to user space. This provides
 greater data cache coherence among clients, but at a significant performance
 cost.
 
+The NFS clients are connected in `hard` mode to ensure data consistency. In
+addition we use an automount unit, to avoid applications unexpectedly running
+without access to NFS due to mounting issues at boot time. If NFS is absent
+applications will experience infinite blocking or receive explicit errors
+when accessing NFS-backed paths.
+
 **flyingcircus.roles.nfs_rg_share.clientFlags**
 
 List of strings that are applied as options for every client.

--- a/pkgs/fc/agent/default.nix
+++ b/pkgs/fc/agent/default.nix
@@ -96,6 +96,13 @@ buildPythonPackage rec {
   ];
   dontStrip = true;
   doCheck = true;
+  checkPhase = ''
+    runHook preCheck
+
+    pytest -vv
+
+    runHook postCheck
+  '';
   passthru.pythonDevEnv = python.withPackages (_:
     checkInputs ++ [ py.pytest ] ++ propagatedBuildInputs
   );

--- a/pkgs/fc/agent/fc/maintenance/maintenance.py
+++ b/pkgs/fc/agent/fc/maintenance/maintenance.py
@@ -252,7 +252,7 @@ def request_update(
 
     There are several shortcuts. The first one skip preparing the update
     altogether if the new channel URL is the same as the current channel of the system.
-    This save preparing, thus building the system which is quite expensive to do.
+    This saves preparing (and thus building) the system which is quite expensive to do.
 
     Also, if the preparation yields a system which is the same as the current one,
     we just switch to the new channel to save time and avoid announcing an update which

--- a/tests/nfs.nix
+++ b/tests/nfs.nix
@@ -8,14 +8,20 @@ let
   };
 
   encServices = [{
-    address = "server";
+    address = "server.gocept.net";  # gocept.net due to PL-133063
     service = "nfs_rg_share-server";
   }];
 
-  encServiceClients = [{
-    node = "client";
-    service = "nfs_rg_share-server";
-  }];
+  encServiceClients = [
+    {
+      node = "client1.gocept.net";  # gocept.net due to PL-133063
+      service = "nfs_rg_share-server";
+    }
+    {
+      node = "client2";
+      service = "nfs_rg_share-server";
+    }
+  ];
 
   sdir = "/srv/nfs/shared";
   cdir = "/mnt/nfs/shared";
@@ -30,50 +36,70 @@ let
           sleep(600000);
         ?>
   ''; };
+  clientConfig = extraConfig: { lib, ... }:
+    {
+      imports = [ ../nixos ../nixos/roles ];
+      config = lib.recursiveUpdate {
+        flyingcircus.roles.nfs_rg_client.enable = true;
+        flyingcircus.roles.lamp.enable = true;
+        flyingcircus.roles.webgateway.enable = true;
+
+        flyingcircus.roles.lamp.vhosts = [
+          { port = 8000;
+            docroot = cdir;
+          }
+        ];
+
+        # XXX: same as upstream test, let's see how they fix this
+        networking.firewall.enable = false;
+        flyingcircus.encServices = encServices;
+
+        # The test framework overrides the fileSystems setting from the role,
+        # we must add it here with a higher priority
+        fileSystems = lib.mkVMOverride {
+          "${cdir}" = {
+            # TODO: Due to having to override this here, the normalisation of
+            # the server name in the filesystem entry is not tested.
+            device = "server.fcio.net:${sdir}";
+            fsType = "nfs4";
+            ################################################################
+            # WARNING: those settings are DUPLICATED in nixos/roles/nfs.nix
+            # to work around a deficiency of the test harness.
+            ################################################################
+            options = [
+              "rw"
+              "auto"
+              # Retry infinitely
+              "hard"
+              # perform mount unit activation in background to avoid
+              # blocking nixos-rebuild switches if the server isn't
+              # responsive at that point in time.
+              "x-systemd.automount"
+              # Start over the retry process after 10 tries
+              "retrans=10"
+              # Start with a 3s (30 deciseconds) interval and add 3s as linear
+              # backoff
+              "timeo=30"
+              "rsize=8192"
+              "wsize=8192"
+              "nfsvers=4"
+            ];
+          noCheck = true;
+        };
+      };
+
+        users.users.u = user;
+      }
+      extraConfig;
+    };
 
 in {
   name = "nfs";
   nodes = {
-    client =
-      { lib, ... }:
-      {
-        imports = [ ../nixos ../nixos/roles ];
-        config = {
-          flyingcircus.roles.nfs_rg_client.enable = true;
-          flyingcircus.roles.lamp.enable = true;
-          flyingcircus.roles.webgateway.enable = true;
-
-          flyingcircus.roles.lamp.vhosts = [
-            { port = 8000;
-              docroot = cdir;
-            }
-          ];
-
-          # XXX: same as upstream test, let's see how they fix this
-          networking.firewall.enable = false;
-          flyingcircus.encServices = encServices;
-
-          # The test framework overrides the fileSystems setting from the role,
-          # we must add it here with a higher priority
-          fileSystems = lib.mkVMOverride {
-            "${cdir}" = {
-              device = "server:${sdir}";
-              fsType = "nfs4";
-              options = [
-                "rw"
-                "soft"
-                "rsize=8192"
-                "wsize=8192"
-                "nfsvers=4"
-              ];
-            noCheck = true;
-          };
-        };
-
-          users.users.u = user;
-        };
-
-      };
+    client1 = clientConfig {
+        networking.domain = "fcio.net"; # PL-133063
+    };
+    client2 = clientConfig {};
 
     server =
       { ... }:
@@ -85,6 +111,7 @@ in {
           # XXX: same as upstream test, let's see how they fix this
           networking.firewall.enable = false;
           users.users.u = user;
+          networking.domain = "fcio.net"; # PL-133063
 
           specialisation.withCustomFlags.configuration.flyingcircus.roles.nfs_rg_share.clientFlags = [ "rw" "sync" "no_root_squash" "no_subtree_check" ];
         };
@@ -101,7 +128,8 @@ in {
     server.wait_for_unit("nfs-server")
     server.wait_for_unit("nfs-idmapd")
     server.wait_for_unit("nfs-mountd")
-    client.start()
+    client1.start()
+    client2.start()
 
     server.succeed("chown test ${sdir}")
 
@@ -109,29 +137,67 @@ in {
     server.succeed("sudo -u test sh -c 'echo test_on_server > ${sdir}/test'")
 
     # share will be mounted after boot
-    client.wait_for_unit("multi-user.target")
+    client1.wait_for_unit("multi-user.target")
+    client2.wait_for_unit("multi-user.target")
 
-    client.succeed("grep test_on_server ${cdir}/test")
+    client1.succeed("grep test_on_server ${cdir}/test")
 
-    client.succeed("sudo -u test sh -c 'echo test_on_client > ${cdir}/test'")
+    client1.succeed("sudo -u test sh -c 'echo test_on_client > ${cdir}/test'")
     server.succeed("grep test_on_client ${sdir}/test")
 
-    client.fail("echo from_root_user > ${cdir}/test")
+    client1.fail("echo from_root_user > ${cdir}/test")
     server.succeed("grep test_on_client ${sdir}/test")
 
     # Verify proper shutdown while NFS is being used.
     # See PL-129954
-    client.wait_for_unit("httpd.service")
-    client.succeed("cd ${cdir}")
+    client1.wait_for_unit("httpd.service")
+    client1.succeed("cd ${cdir}")
 
     server.copy_from_host("${php_blocking_script}", "${sdir}/index.php")
 
-    client.execute('curl -v http://localhost:8000/index.php >&2 &')
+    client1.execute('curl -v http://localhost:8000/index.php >&2 &')
     time.sleep(2)
-    print(client.execute('lsof -n ${cdir}/test2')[1])
-    print(client.execute('journalctl -u httpd')[1])
-    content = client.execute('cat ${cdir}/test2')[1]
+    print(client1.execute('lsof -n ${cdir}/test2')[1])
+    print(client1.execute('journalctl -u httpd')[1])
+    content = client1.execute('cat ${cdir}/test2')[1]
     assert content == "asdf", repr(content)
+
+    # PL-133063
+    with subtest("NFS client and server can be resolved via /etc/hosts"):
+      server_hosts = server.succeed('cat /etc/hosts')
+      print("server_hosts", server_hosts, sep="\n")
+      client1_hosts = client1.succeed('cat /etc/hosts')
+      print("client1_hosts", client1_hosts, sep="\n")
+      client2_hosts = client2.succeed('cat /etc/hosts')
+      print("client2_hosts", client2_hosts, sep="\n")
+      exportinfo = server.succeed('cat /etc/exports')
+      print("exportinfo", exportinfo, sep="\n")
+      mountinfo_client1 = client1.succeed('cat /etc/fstab | grep ${cdir}')
+      print("mountinfo_client1", mountinfo_client1, sep="\n")
+      mountinfo_client2 = client2.succeed('cat /etc/fstab | grep ${cdir}')
+      print("mountinfo_client2", mountinfo_client2, sep="\n")
+
+      assert "client1.fcio.net client1" in server_hosts, "client1.fcio.net missing from server hosts file"
+      assert "server.fcio.net" in client1_hosts, "server missing from client1 host file"
+      assert "server.fcio.net" in mountinfo_client1, "NFS server domain missing from fstab"
+      assert "client1.fcio.net(" in exportinfo, "client1 domain missing from exports file"
+
+      # TODO: For machines without a domain, the mechanism does not fully work as intended:
+      # `client2` only announces itself without a domain in `flyingcircus.encAddresses`
+      # and thus is present only as `client2` in /etc/hosts. But for NFS mounts, its hostname is
+      # appended to the local domain of each other machine locally.
+      # Hence, resolving the NFS domain name is not possible via the hosts file in
+      # this particular edge case, it cannot be exported to successfully, and the NFS mounting fails.
+
+      # As a workaround this is acceptable, as all real machines share the same domain.
+      # The asserts below reflect the *is* state, not the *desired* state:
+      assert "client2" in server_hosts, "client2 missing from server hosts file"
+      assert "client2.fcio.net(" in exportinfo, "client2 missing from exports file"
+      assert "server.fcio.net" in mountinfo_client2, "NFS server domain missing from fstab"
+
+      print(client1.execute("findmnt")[1])
+      print(client2.execute("findmnt")[1])
+      print(client2.execute("systemctl status mnt-nfs-shared.mount")[1])
 
     deadline = time.time() + 10
     def wait_for_console_text(self, regex: str) -> str:
@@ -152,13 +218,13 @@ in {
 
         assert False, "Did not shut down cleanly (timeout)"
 
-    client.execute("poweroff", check_return=False)
+    client1.execute("poweroff", check_return=False)
 
-    console = wait_for_console_text(client, "reboot: Power down")
+    console = wait_for_console_text(client1, "reboot: Power down")
 
     assert "Failed unmounting" not in console, "Unmounting NFS cleanly failed, check console output"
 
-    client.wait_for_shutdown()
+    client1.wait_for_shutdown()
 
     config = server.execute('cat /etc/exports')[1]
     assert "rw,sync,root_squash,no_subtree_check" in config, "default flags not found"


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

- NFS clients will be rebooted to activate the new configuration. This happens as a side effect of a kernel update. In the future changes to NFS client settings will cause explicit reboot requests.

Changelog:

- Make NFS clients more resilient against missing servers during bootstrap, upgrades, and reboot scenarios. (PL-133062)

## Release process

- [ ] Created changelog entry using `./changelog.sh`

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.

n/a

- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

done

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

Ensure availability, no further requirements.

- [x] Security requirements tested? (EVIDENCE)

Manual testing various scenarios against various solutions. Extended functional tests.