### PR TITLE
disable intersphinx hydra inputs

### DIFF
--- a/.hydra/config.json
+++ b/.hydra/config.json
@@ -7,16 +7,6 @@
             "value": "https://github.com/flyingcircusio/nixpkgs.git nixos-24.05",
             "emailresponsible": false
         },
-        "platformDoc": {
-            "type": "git",
-            "value": "https://github.com/flyingcircusio/doc.git old-restructuredtext",
-            "emailresponsible": false
-        },
-        "docObjectsInventory": {
-            "type": "path",
-            "value": "https://hydra.flyingcircus.io/job/flyingcircus/doc/platformDoc/latest/download-by-type/file/inventory",
-            "emailresponsible": false
-        },
         "branch": {
             "type": "string",
             "value": "fc-24.05-dev",


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

Impact:

none

Changelog:

not for changelog - Support pL-132115 by disabling hydra intersphinx 

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

no relevant security requirements

- [x] Security requirements tested? (EVIDENCE)

n/a