### PR TITLE
Activate fail2ban sshd ddos jail for non production machines

### DIFF
--- a/changelog.d/20241031_142143_PL-132477-dheat-ssh_scriv.md
+++ b/changelog.d/20241031_142143_PL-132477-dheat-ssh_scriv.md
@@ -1,0 +1,22 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+- Activate DDoS SSH rules in fail2ban for non-production machines
+
+### NixOS XX.XX platform
+
+- Activate DDoS SSH rules in fail2ban for non-production machines. (PL-132477)
+  This may have impact if you have multiple unauthenticated SSH connections in a short time.
+  We will roll out this change to production VMs too if no problems occur.

--- a/doc/src/firewall.md
+++ b/doc/src/firewall.md
@@ -114,3 +114,10 @@ ip6tables -L -nv   # show IPv6 firewall rules w/o DNS resolution
 
 If the intended rules do not show up, check the system journal for possible
 syntax errors in {file}`/etc/local/firewall` and re-run {command}`fc-manage -b`.
+
+## Fail2ban
+
+We use fail2ban to protect against brute-force attacks and DoS vectors via unauthenticated connections.
+
+Currently we only have the SSH jail enabled in the `ddos` mode. If you have 5 authentication failures
+or trigger the DDoS rules within 10 minutes, your IP will be blocked for 10 minutes.

--- a/nixos/platform/default.nix
+++ b/nixos/platform/default.nix
@@ -377,22 +377,28 @@ in {
       # overrides it
       cron.enable = fclib.mkPlatform true;
 
-      fail2ban.enable = fclib.mkPlatform true;
-      fail2ban.ignoreIP =
-        [
-          # loopback
-          "127.0.0.1/8"
-          "::1"
+      fail2ban = let
+        production = lib.attrByPath [ "parameters" "production" ] false config.flyingcircus.enc;
+      in {
+        enable = fclib.mkPlatform true;
+        maxretry = fclib.mkPlatform 5;
+        jails.sshd.settings.mode = lib.mkIf production (fclib.mkPlatform "ddos");
+        ignoreIP =
+          [
+            # loopback
+            "127.0.0.1/8"
+            "::1"
 
-          # rfc1918 addresses
-          "10.0.0.0/8"
-          "172.16.0.0/12"
-          "192.168.0.0/16"
-        ] ++
-        cfg.static.firewall.trusted ++
-        (flatten
-          (builtins.map (v: builtins.attrNames v.networks)
-            (builtins.attrValues (attrByPath [ "parameters" "interfaces" ] {} cfg.enc))));
+            # rfc1918 addresses
+            "10.0.0.0/8"
+            "172.16.0.0/12"
+            "192.168.0.0/16"
+          ] ++
+          cfg.static.firewall.trusted ++
+          (flatten
+            (builtins.map (v: builtins.attrNames v.networks)
+              (builtins.attrValues (attrByPath [ "parameters" "interfaces" ] {} cfg.enc))));
+      };
 
       nscd.enable = true;
       openssh.enable = fclib.mkPlatform true;


### PR DESCRIPTION
PL-132477

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
  - indirectly done by first enabling on staging
  - can be disabled with the one-liner `services.fail2ban.jails.sshd.settings.mode = "normal";`
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  1. Shouldn't infer with any workflows/usages of SSH
  2. Should mitigate SSH DHeat attacks
  3. `maxretry` change shouldn't have high security impact
- [x] Security requirements tested? (EVIDENCE)
  1. Tested with batou, monitoring on test47, roll out to staging only for one release cycle potentially catch issues in staging before they happen in production, increased `maxretry` limit to allow for more failures before blocking
  2. Tested using `ssh-audit` on test47
  3. Small change, and the most important brute force vector is with password auth which we don't allow.