### PR TITLE
[FC-41403] fail during unit reload with syntax errors in the varnish config

### DIFF
--- a/changelog.d/20241102_183935_phil\-FC-41403_varnish-service-reload-breakage_scriv.md
+++ b/changelog.d/20241102_183935_phil\-FC-41403_varnish-service-reload-breakage_scriv.md
@@ -1,0 +1,20 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+
+### NixOS XX.XX platform
+
+- varnish: Fix syntax error handling during hot reloads. We silently did
+  not fail on errors which masked issues until the next reboot causing
+  varnish to then fail e.g. during scheduled maintenance. We now fail
+  more visibly but keep running the old config, still. (FC-41403)


### PR DESCRIPTION
FC-41403

@flyingcircusio/release-managers

## Release process

Impact:

Reloading the varnish unit during runtime did previously not fail if there were any syntax errors in the VCLs that Varnish attempted to load and label for use in the main config (similarly for the main config). The error would only appear in the unit's journal and surface on the next unit restart.

The cause of that was varnishadm command not returning an appropriate exit code when all of the reload commands are passed via stdin. 
Passing the commands individually as explicit commands does fix this issue, however loading a valid varnish module into an already used name will also fail, leading to unexpected errors when reloading the unit even though there were no changes.

Rewriting the load/label logic in bash and only loading VCL files that are not currently loaded solves this issue. The filtering can only be added here since the VCL files and their corresponding names are uniquely identified by the hash derived from the file's nix store path, which changes with every change to the VCL file.

I have also added a test that checks that a unit reload with a syntax error in the corresponding VCL file fails successfully.   

Changelog:

### PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [ ] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [ ] Security requirements tested? (EVIDENCE)
