### PR TITLE
PL-133099 scriv backport 23.11

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -2,11 +2,10 @@
 
 ## Release process
 
-Impact:
+- [ ] Created changelog entry using `./changelog.sh`
 
-Changelog:
 
-### PR release workflow (internal)
+## PR release workflow (internal)
 
 - [ ] PR has internal ticket
 - [ ] internal issue ID (PL-…) part of branch name

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-exclude: ^secrets/|^appenv$|pkgs/fc/sensusyntax/fixtures/(syntaxerror|empty).json|(nixos/infrastructure/container.nix|tests/testlib.nix|nixos/roles/devhost/vm.nix)
+exclude: ^secrets/|^appenv$|pkgs/fc/sensusyntax/fixtures/(syntaxerror|empty).json|(nixos/infrastructure/container.nix|tests/testlib.nix|nixos/roles/devhost/vm.nix)|^changelog.d/new_fragment.md.j2$
 repos:
 - hooks:
   - exclude: "(?x)^(\n  secrets/|environments/.*/secret.*|\n  .*\\.patch\n)$\n"

--- a/changelog.d/new_fragment.md.j2
+++ b/changelog.d/new_fragment.md.j2
@@ -1,0 +1,21 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+- A bullet item for the Impact category.
+
+
+### NixOS XX.XX platform
+
+- A bullet item for the NixOS XX.XX platform category.

--- a/changelog.d/scriv.ini
+++ b/changelog.d/scriv.ini
@@ -1,0 +1,6 @@
+[scriv]
+format = md
+entry_title_template =
+categories = Impact, NixOS platform
+output_file = changelog.d/CHANGELOG.md.tmp
+skip_fragments = CHANGELOG.*

--- a/changelog.sh
+++ b/changelog.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e
+
+base="./changelog.d"
+
+new_item="${base}/$(date '+%Y%m%d_%H%M%S')_$(git rev-parse --abbrev-ref HEAD)_scriv.md"
+cp "${base}/new_fragment.md.j2" ${new_item}
+$EDITOR $new_item

--- a/flake.nix
+++ b/flake.nix
@@ -140,6 +140,7 @@
 
             packages = with pkgs; [
               jq
+              scriv
             ] ++ (with self'.packages; [
               fcBranchDiffRelease
               fcGetCurrentChannelUrl

--- a/release/fc-release.sh
+++ b/release/fc-release.sh
@@ -18,6 +18,15 @@ if ! git remote -v | grep -Eq "^origin\s.*github.com.flyingcircusio/fc-nixos"; t
     exit 64
 fi
 
+if [[ ! -d ../doc/changelog.d ]] || ! git -C ../doc remote -v | grep -Eq "^origin\s.*github.com.flyingcircusio/doc"; then
+    echo "$0: please ensure that you have a checkout of flyingcircusio/doc next to this repo"
+    exit 64
+fi
+if [[ -e ../doc/changelog.d/"$nixos_version".md ]]; then
+    echo "$0: the changelog fragment '../doc/changelog.d/$nixos_version.md' already exists"
+    exit 64
+fi
+
 git fetch origin --tags --prune
 git checkout "$dev"
 git merge --ff-only  # expected to fail on unclean/unpushed workdirs
@@ -25,8 +34,22 @@ git merge --ff-only  # expected to fail on unclean/unpushed workdirs
 git checkout "$stag"
 git merge --ff-only
 
+TEMP_CHANGELOG=changelog.d/CHANGELOG.md.tmp
+CHANGELOG=changelog.d/CHANGELOG.md
+truncate -s 0 $TEMP_CHANGELOG
+scriv collect --add
+sed -e "s/^## Impact/## Impact\n### $nixos_version/" \
+    -e "s/^## NixOS XX.XX platform/## NixOS $nixos_version platform/" $TEMP_CHANGELOG > ../doc/changelog.d/"$nixos_version".md
+echo -e "\n" >> $TEMP_CHANGELOG
+cat $CHANGELOG >> $TEMP_CHANGELOG
+(echo "# Release $releaseid"; cat $TEMP_CHANGELOG) > $CHANGELOG
+rm $TEMP_CHANGELOG
+git add $TEMP_CHANGELOG $CHANGELOG
+git commit -m "Collect changelog fragments"
+
 git checkout "$prod"
 git merge --ff-only
+
 msg="Merge branch '$stag' into $prod for release $releaseid"
 git merge -m "$msg" "$stag"
 


### PR DESCRIPTION
@flyingcircusio/release-managers

PL-133099

## Release process

- [x] Created changelog entry using `./changelog.sh`

meta: n/a

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.

n/a

- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or 
update relevant documentation such that hosted and guided customers can understand it as well.

n/a

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

n/a

- [x] Security requirements tested? (EVIDENCE)

n/a
