### PR TITLE
Update nixpkgs (2024-11-04)

### DIFF
--- a/changelog.d/20241105_161901_PL-133141-update-nixpkgs-2405-update-nixpkgs-2024-11-04_scriv.md
+++ b/changelog.d/20241105_161901_PL-133141-update-nixpkgs-2405-update-nixpkgs-2024-11-04_scriv.md
@@ -1,0 +1,32 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+- Machines will schedule a maintenance reboot to activate the new kernel.
+
+
+### NixOS XX.XX platform
+
+- Pull upstream NixOS changes, security fixes and package updates:
+    - chromium: 129.0.6668.100 -> 130.0.6723.69 (CVE-2024-10229, CVE-2024-10230, CVE-2024-10231)
+    - discourse: 3.2.5 -> 3.3.2
+    - docker: 27.3.0 -> 27.3.1
+    - element-web: 1.11.81 -> 1.11.82
+    - firefox: 131.0.3 -> 132.0
+    - github-runner: 2.319.1 -> 2.320.0
+    - gitlab: 17.2.8 -> 17.3.6
+    - grafana: 10.4.10 -> 10.4.11
+    - linux: 5.15.164 -> 5.15.169
+    - nss_latest: 3.105 -> 3.106
+    - unifi8: 8.4.62 -> 8.5.6

--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1727826117,
-        "narHash": "sha256-K5ZLCyfO/Zj9mPFldf3iwS6oZStJcU4tSpiXTMYaaL0=",
+        "lastModified": 1730504689,
+        "narHash": "sha256-hgmguH29K2fvs9szpq2r3pz2/8cJd2LPS+b4tfNFCwE=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "3d04084d54bedc3d6b8b736c70ef449225c361b1",
+        "rev": "506278e768c2a08bec68eb62932193e341f55c90",
         "type": "github"
       },
       "original": {
@@ -350,14 +350,14 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1727825735,
-        "narHash": "sha256-0xHYkMkeLVQAMa7gvkddbPqpxph+hDzdu1XdGPJR+Os=",
+        "lastModified": 1730504152,
+        "narHash": "sha256-lXvH/vOfb4aGYyvFmZK/HlsNsr/0CVWlwYvo2rxJk3s=",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/fb192fec7cc7a4c26d51779e9bab07ce6fa5597a.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/cc2f28000298e1269cea6612cd06ec9979dd5d7f.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/fb192fec7cc7a4c26d51779e9bab07ce6fa5597a.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/cc2f28000298e1269cea6612cd06ec9979dd5d7f.tar.gz"
       }
     },
     "nixpkgs-regression": {
@@ -410,11 +410,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1729510358,
-        "narHash": "sha256-LRQk0y4OqyXZ8t3S9343ga0r59PHZXfwWG+XZTjsqQI=",
+        "lastModified": 1730736583,
+        "narHash": "sha256-VfMf/lTp57jquEKlpm1rnUGZIoQuIFyu4Sg2y6FKHKo=",
         "owner": "flyingcircusio",
         "repo": "nixpkgs",
-        "rev": "f4f7b96b213014c55cc2a54c4cdb771c244a7308",
+        "rev": "e418e84f113fe9ee0fad1604af830036d1432862",
         "type": "github"
       },
       "original": {

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -120,22 +120,7 @@ builtins.mapAttrs (_: patchPhps phpLogPermissionPatch) {
           };
         };
 
-  linuxKernelStable =
-    let
-      kernelPackage = super.linux_5_15;
-      version = "5.15.164";
-  in
-    kernelPackage.override {
-      argsOverride = {
-        src = super.fetchurl {
-          url = "https://cdn.kernel.org/pub/linux/kernel/v5.x/linux-${version}.tar.xz";
-          hash = "sha256-7GCY+u1kuKR7oXcugSputEQ4X3qjxg0+RzmrL9OykYY=";
-        };
-        modDirVersion = version;
-        inherit version;
-      };
-    };
-
+  linuxKernelStable = self.linux_5_15;
 
 
   matomo-beta = super.matomo-beta.overrideAttrs (oldAttrs: {

--- a/release/package-versions.json
+++ b/release/package-versions.json
@@ -70,14 +70,14 @@
     "version": "18.2.4"
   },
   "chromedriver": {
-    "name": "chromedriver-129.0.6668.91",
+    "name": "chromedriver-130.0.6723.69",
     "pname": "chromedriver",
-    "version": "129.0.6668.91"
+    "version": "130.0.6723.69"
   },
   "chromium": {
-    "name": "chromium-129.0.6668.100",
+    "name": "chromium-130.0.6723.69",
     "pname": "chromium",
-    "version": "129.0.6668.100"
+    "version": "130.0.6723.69"
   },
   "cifs-utils": {
     "name": "cifs-utils-7.0",
@@ -130,9 +130,9 @@
     "version": "5.3.28"
   },
   "discourse": {
-    "name": "discourse-3.2.5",
+    "name": "discourse-3.3.2",
     "pname": "discourse",
-    "version": "3.2.5"
+    "version": "3.3.2"
   },
   "dnsmasq": {
     "name": "dnsmasq-2.90",
@@ -155,9 +155,9 @@
     "version": "2.3.21.1"
   },
   "element-web": {
-    "name": "element-web-1.11.81",
+    "name": "element-web-1.11.82",
     "pname": "element-web",
-    "version": "1.11.81"
+    "version": "1.11.82"
   },
   "erlang": {
     "name": "erlang-25.3.2.12",
@@ -190,9 +190,9 @@
     "version": "7.17.16"
   },
   "firefox": {
-    "name": "firefox-131.0.3",
+    "name": "firefox-132.0",
     "pname": "firefox",
-    "version": "131.0.3"
+    "version": "132.0"
   },
   "gcc": {
     "name": "gcc-wrapper-13.2.0",
@@ -220,34 +220,34 @@
     "version": "2.44.1"
   },
   "gitaly": {
-    "name": "gitaly-17.2.9",
+    "name": "gitaly-17.3.6",
     "pname": "gitaly",
-    "version": "17.2.9"
+    "version": "17.3.6"
   },
   "github-runner": {
-    "name": "github-runner-2.319.1",
+    "name": "github-runner-2.320.0",
     "pname": "github-runner",
-    "version": "2.319.1"
+    "version": "2.320.0"
   },
   "gitlab": {
-    "name": "gitlab-17.2.9",
+    "name": "gitlab-17.3.6",
     "pname": "gitlab",
-    "version": "17.2.9"
+    "version": "17.3.6"
   },
   "gitlab-container-registry": {
-    "name": "gitlab-container-registry-4.10.0",
+    "name": "gitlab-container-registry-4.11.0",
     "pname": "gitlab-container-registry",
-    "version": "4.10.0"
+    "version": "4.11.0"
   },
   "gitlab-ee": {
-    "name": "gitlab-ee-17.2.9",
+    "name": "gitlab-ee-17.3.6",
     "pname": "gitlab-ee",
-    "version": "17.2.9"
+    "version": "17.3.6"
   },
   "gitlab-pages": {
-    "name": "gitlab-pages-17.2.9",
+    "name": "gitlab-pages-17.3.6",
     "pname": "gitlab-pages",
-    "version": "17.2.9"
+    "version": "17.3.6"
   },
   "gitlab-runner": {
     "name": "gitlab-runner-17.1.0",
@@ -255,9 +255,9 @@
     "version": "17.1.0"
   },
   "gitlab-workhorse": {
-    "name": "gitlab-workhorse-17.2.9",
+    "name": "gitlab-workhorse-17.3.6",
     "pname": "gitlab-workhorse",
-    "version": "17.2.9"
+    "version": "17.3.6"
   },
   "glibc": {
     "name": "glibc-2.39-52",
@@ -290,9 +290,9 @@
     "version": "1.22.6"
   },
   "grafana": {
-    "name": "grafana-10.4.10",
+    "name": "grafana-10.4.11",
     "pname": "grafana",
-    "version": "10.4.10"
+    "version": "10.4.11"
   },
   "grub2": {
     "name": "grub-2.12",
@@ -460,9 +460,9 @@
     "version": "0.2.5"
   },
   "linuxKernelStable": {
-    "name": "linux-5.15.164",
+    "name": "linux-5.15.169",
     "pname": "linux",
-    "version": "5.15.164"
+    "version": "5.15.169"
   },
   "linuxKernelVerify": {
     "name": "linux-6.11",
@@ -605,9 +605,9 @@
     "version": "4.35"
   },
   "nss_latest": {
-    "name": "nss-3.105",
+    "name": "nss-3.106",
     "pname": "nss",
-    "version": "3.105"
+    "version": "3.106"
   },
   "openjdk": {
     "name": "openjdk-21.0.3+9",
@@ -1072,9 +1072,9 @@
     "version": "9.0.88"
   },
   "unifi8": {
-    "name": "unifi-controller-8.4.62",
+    "name": "unifi-controller-8.5.6",
     "pname": "unifi-controller",
-    "version": "8.4.62"
+    "version": "8.5.6"
   },
   "unzip": {
     "name": "unzip-6.0",
@@ -1135,6 +1135,11 @@
     "name": "zlib-1.3.1",
     "pname": "zlib",
     "version": "1.3.1"
+  },
+  "zoneminder": {
+    "name": "zoneminder-1.36.34",
+    "pname": "zoneminder",
+    "version": "1.36.34"
   },
   "zsh": {
     "name": "zsh-5.9",

--- a/release/versions.json
+++ b/release/versions.json
@@ -8,9 +8,9 @@
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/"
   },
   "nixpkgs": {
-    "hash": "sha256-LRQk0y4OqyXZ8t3S9343ga0r59PHZXfwWG+XZTjsqQI=",
+    "hash": "sha256-VfMf/lTp57jquEKlpm1rnUGZIoQuIFyu4Sg2y6FKHKo=",
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "f4f7b96b213014c55cc2a54c4cdb771c244a7308"
+    "rev": "e418e84f113fe9ee0fad1604af830036d1432862"
   }
 }

--- a/tests/kernelversions.nix
+++ b/tests/kernelversions.nix
@@ -1,6 +1,7 @@
 # Start VMs with the different kernels we expect to be pre-built
-import ./make-test-python.nix ({ ... }:
-{
+import ./make-test-python.nix ({ pkgs, ... }: let
+  stableVersion = pkgs.linuxKernelStable.version;
+in {
   name = "kernelversions";
   nodes.rzobProdKernel =
       { pkgs, lib, ... }:
@@ -192,9 +193,10 @@ import ./make-test-python.nix ({ ... }:
               f"Expected: {expected}, found: {found}. uname -a: {uname_a}"
             )
 
+    assert "${stableVersion}".startswith("5.15."), "Expecting a 5.15.x kernel as stable kernel"
     assertKernelVersion(verifyKernel, "6.11.0")
-    assertKernelVersion(prodKernel, "5.15.164")
-    assertKernelVersion(rzobProdKernel, "5.15.164")
+    assertKernelVersion(prodKernel, "${stableVersion}")
+    assertKernelVersion(rzobProdKernel, "${stableVersion}")
     assertKernelVersion(rzobNonProdKernel, "6.11.0")
     assertKernelVersion(whqProdKernel, "6.11.0")
     assertKernelVersion(devProdKernel, "6.11.0")


### PR DESCRIPTION
Pull upstream NixOS changes, security fixes and package updates:

- chromium: 129.0.6668.100 -> 130.0.6723.69 (https://github.com/advisories/GHSA-3hjp-j522-245f, https://github.com/advisories/GHSA-g4gj-m346-585c, https://github.com/advisories/GHSA-3wfx-mj93-vf8v)
- discourse: 3.2.5 -> 3.3.2
- docker: 27.3.0 -> 27.3.1
- element-web: 1.11.81 -> 1.11.82
- firefox: 131.0.3 -> 132.0
- github-runner: 2.319.1 -> 2.320.0
- gitlab: 17.2.8 -> 17.3.6
- grafana: 10.4.10 -> 10.4.11
- linux: 5.15.164 -> 5.15.169
- nss_latest: 3.105 -> 3.106
- unifi8: 8.4.62 -> 8.5.6

PL-133141

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`


## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - regularly pull in software updates to improve security and stability
- [x] Security requirements tested? (EVIDENCE)
  - [x] automated tests still pass
  - [x] updated and checked staging gitlab
  - [x] checked release notes of gitlab
  - [x] checked git log for fixed CVEs