### PR TITLE
PL-133125 acme: increase certificate check timeouts

### DIFF
--- a/changelog.d/20241106_115939_PL-133125-ssl-cert-check-timeout_scriv.md
+++ b/changelog.d/20241106_115939_PL-133125-ssl-cert-check-timeout_scriv.md
@@ -1,0 +1,18 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+
+### NixOS XX.XX platform
+
+- Increase SSL validation check timeout to better distinguish DNS resolution
+  errors and other causes of timeouts. (PL-133125)

--- a/nixos/platform/acme.nix
+++ b/nixos/platform/acme.nix
@@ -9,7 +9,11 @@ in
     lib.listToAttrs
       (map (n: lib.nameValuePair "ssl_cert_acme_${n}" {
         notification = "ACME (Letsencrypt) certificate for ${n} is invalid or will expire soon";
-        command = "check_http -p 443 -S --sni -C 25,14 -H ${n}";
+        # We're using a timeout of 15 seconds because 10 seconds is the timeout
+        # that will trigger if DNS issues occur and giving the check a higher
+        # timeout allows us to see those. Otherwise they get hidden behind
+        # a generic timeout message.
+        command = "check_http -p 443 -S --sni -C 25,14 -H ${n} -t 15";
         interval = 600;
       })
       (lib.attrNames config.security.acme.certs));


### PR DESCRIPTION
This helps to better distinguish between DNS issues and other timeouts.

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`


## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

improve error messages / operability

- [x] Security requirements tested? (EVIDENCE)

simple change, relying on hydra and dev