### PR TITLE
fc.qemu: update to pull in last minute fixes

### DIFF
--- a/pkgs/fc/ceph/src/fc/ceph/keys/nautilus.py
+++ b/pkgs/fc/ceph/src/fc/ceph/keys/nautilus.py
@@ -219,7 +219,11 @@ class ClientKey(KeyConfig):
     filename = "/etc/ceph/ceph.client.{id}.keyring"
     entity = "client.{id}"
     # assumption: all clients are allowed to use RBD
-    capabilities = {"mon": "allow r, allow profile rbd", "osd": "allow rwx"}
+    capabilities = {
+        "mon": "allow r, allow profile rbd",
+        "mgr": "allow profile rbd",
+        "osd": "allow rwx",
+    }
 
 
 class RGWKey(KeyConfig):

--- a/pkgs/fc/default.nix
+++ b/pkgs/fc/default.nix
@@ -38,11 +38,13 @@ rec {
   neighbour-cache-monitor = callPackage ./neighbour-cache-monitor {};
   ping-on-tap = callPackage ./ping-on-tap {};
   qemu-nautilus = callPackage ./qemu rec {
-    version = "1.6";
+    version = "1.7dev";
     src = pkgs.fetchFromGitHub {
       owner = "flyingcircusio";
       repo = "fc.qemu";
-      rev = version;
+      # The release tooling didn't upgrade properly so we had to pick a specific
+      # commit instead.
+      rev = "b3344e47c5b12fdc51c0e2745f7dd052a904041c";
       hash = "sha256-oxV29okkTqkNm5HvwrwWS+hABcH7cd70mL83f72SLsQ=";
     };
     qemu_ceph = pkgs.qemu-ceph-nautilus;


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

- [x] ~~Created changelog entry using `./changelog.sh`~~ not needed, those are fixups for changes that are already communicated


## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

fixup only, no specific requirements

- [x] Security requirements tested? (EVIDENCE)

functionality was tested manually and through automated tests