### PR TITLE
provide uids for the provisioned statshost datasources

### DIFF
--- a/changelog.d/20241111_172150_phil-statshost-provide-uid_scriv.md
+++ b/changelog.d/20241111_172150_phil-statshost-provide-uid_scriv.md
@@ -1,0 +1,16 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### NixOS XX.XX platform
+
+- Provision Datasources with fixed UIDs for the provisioned dashboards

--- a/nixos/roles/statshost/default.nix
+++ b/nixos/roles/statshost/default.nix
@@ -517,6 +517,7 @@ in
               url: http://${config.networking.hostName}:9090
               editable: false
               isDefault: true
+              uid: PBFA97CFB590B2093
           '';
         };
 
@@ -534,6 +535,7 @@ in
               url: http://localhost:3100
               editable: false
               isDefault: false
+              uid: P8E80F9AEF21F6940
           '';
         };
       in ''


### PR DESCRIPTION
All statshosts can share the same uid for their datasources explicitly so that dashboards can be provisioned easier.

The uid for the prometheus datasource was taken from the dashboards in the grafana respistory, the uid for the loki datasource is newly generated for use in a new dashboard.

It appears that the prometheus data source uids were identical across statshost probably due to how they are generated in grafana, however being more explicit helps streamline creating new dashboard provisions.

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`


## PR release workflow (internal)

- [ ] PR has internal ticket
- [ ] internal issue ID (PL-…) part of branch name
- [ ] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [ ] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [ ] Security requirements tested? (EVIDENCE)
