### PR TITLE
[PL-133007] implement the D(HE)at Attack mitigation

### DIFF
--- a/changelog.d/20241112_110807_phil-PL-133007_nginx-dheat-mitigation_scriv.md
+++ b/changelog.d/20241112_110807_phil-PL-133007_nginx-dheat-mitigation_scriv.md
@@ -1,0 +1,22 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+- There is a small but non-zero potential that some clients may experience connectivity issues with nginx.
+  Multiple connectivity testing tools showed no change for clients and/or libraries but cannot cover every single implementation out there.
+
+### NixOS XX.XX platform
+
+- Restrict a class of key agreement protocols, called Diffie-Hellman Elliptic Curves, enabled in Nginx to mitigate a DoS attack vector
+  described in CVE-2024-41996. The curves for ECDHE ciphers are then restricted to x25519, secp256r1, and x448.

--- a/nixos/services/nginx/default.nix
+++ b/nixos/services/nginx/default.nix
@@ -175,6 +175,14 @@ in
   options.flyingcircus.services.nginx = with lib; {
     enable = mkEnableOption "FC-customized nginx";
 
+    disableDHEATMitigation = lib.mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Disable the suggested mitigations against the D(HE)at Attack
+      '';
+    };
+
     defaultListenAddresses = lib.mkOption {
       type = lib.types.listOf lib.types.str;
       default = fclib.network.fe.dualstack.addressesQuoted;
@@ -454,6 +462,12 @@ in
 
           # === Config from flyingcircus.services.nginx ===
           ${cfg.httpConfig}
+
+          ${lib.optionalString (!cfg.disableDHEATMitigation) ''
+          # mitigate the D(HE)at Attack
+          # see https://dheatattack.gitlab.io/mitigations/
+          ssl_ecdh_curve x25519:secp256r1:x448;
+          ''}
         '';
 
         eventsConfig = ''


### PR DESCRIPTION
mitigate CVE-2024-41996

Since restricting encryption curves might impact compatibility with various clients, this was made an option for now with the default being on so that it can be turned off selectively.

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`


## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
    - [x] mitigates CVE-2024-41996
- [x] Security requirements tested? (EVIDENCE)

### without the patch

```
λ ❱ dheat --protocol [ ... ]
2024-11-12T11:01:34+0100 Server offers protocol version TLS 1.2
2024-11-12T11:01:34+0100 Server offers protocol version TLS 1.3 supported
### Software

    * Version: 0.4.3

### Arguments

    * Thread num: 1
    * Protocol: TLS 1.3
    * Address: [ ... ]

### Service

    * IP: [ ... ]
    * Port: 443
    * Key size: 8192
    * Algorithm: TLS_AES_128_GCM_SHA256
^C⏎

```

### with the patch

```
λ ❱ dheat --protocol tls [ ... ]
2024-11-12T10:59:37+0100 Server offers protocol version TLS 1.2
2024-11-12T10:59:37+0100 Server offers protocol version TLS 1.3 supported
Diffie-Hellman ephemeral (DHE) key exchange (with the given key size) not supported by the server; uri="[ ... ]", protocol="tls"
```

see also the internal ticket for a more detailed writeup