### PR TITLE
fc.qemu: update to avoid accidental downsizes

### DIFF
--- a/changelog.d/20241112_120624_PL-133166-qemu-downsize-fix_scriv.md
+++ b/changelog.d/20241112_120624_PL-133166-qemu-downsize-fix_scriv.md
@@ -1,0 +1,19 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+
+
+### NixOS XX.XX platform
+
+- fc.qemu: fix bug that may cause accidental root disk shrinks after a
+  cold reboot. (PL-133166)

--- a/pkgs/fc/default.nix
+++ b/pkgs/fc/default.nix
@@ -45,8 +45,8 @@ rec {
       repo = "fc.qemu";
       # The release tooling didn't upgrade properly so we had to pick a specific
       # commit instead.
-      rev = "a0223a339c09deda39ce368bb5089f880aabd544";
-      hash = "sha256-rmNTGz1qrdKeB6Qk+Ty1Ly+x29OFg5uyY9CowNMpBkA=";
+      rev = "ffd5fb70a40e57ff56fdf6c038741d3bc82d489a";
+      hash = "sha256-0h6GdXFxo0TrmmE2JDW+Plt2kKDGxAxih58lb9uVe6M=";
     };
     qemu_ceph = pkgs.qemu-ceph-nautilus;
     ceph_client = pkgs.ceph-nautilus.ceph-client;


### PR DESCRIPTION
Re PL-133166

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`


## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

data consistency

- [x] Security requirements tested? (EVIDENCE)

add test coverage for the bug