### PR TITLE
[FC-41616] overlay: add patchelf-venv

### DIFF
--- a/changelog.d/20241113_135856_FC-41616-patched-patchelf_scriv.md
+++ b/changelog.d/20241113_135856_FC-41616-patched-patchelf_scriv.md
@@ -1,0 +1,22 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+- None.
+
+
+### NixOS XX.XX platform
+
+- Adds a package `patchelf-venv` to the platform overlay which contains an implementation
+  for the option `--add-rpath-and-shrink`.

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -347,6 +347,18 @@ builtins.mapAttrs (_: patchPhps phpLogPermissionPatch) {
 
   opensearch-dashboards = super.callPackage ./opensearch-dashboards { };
 
+  patchelf-venv = super.patchelf.overrideAttrs ({ patches ? [], ... }: {
+    patches = patches ++ [
+      # Adds `--add-rpath-and-shrink` option, required for convergent deployment
+      # tooling invoking `patchelf` multiple times on a virtualenv (see
+      # `batou_ext.python.FixELFRunPath`)
+      (fetchpatch {
+        url = "https://github.com/flyingcircusio/patchelf/commit/6ffde887d77275323c81c2e091891251b021abb3.patch";
+        hash = "sha256-4Qct2Ez3v6DyUG26JTWt6/tkaqB9h1gYaoaObqhvFS8=";
+      })
+    ];
+  });
+
   percona = self.percona80;
   percona-toolkit = super.perlPackages.PerconaToolkit.overrideAttrs(oldAttrs: {
     # The script uses usr/bin/env perl and the Perl builder adds PERL5LIB to it.

--- a/release/important_packages.json
+++ b/release/important_packages.json
@@ -133,6 +133,7 @@
   "openssl_1_1",
   "openssl_3",
   "openvpn",
+  "patchelf-venv",
   "pcre",
   "pcre2",
   "percona",


### PR DESCRIPTION


This patch adds a `--add-rpath-and-shrink` option which performs `--add-rpath` and `--shrink-rpath` in a single write to not leak space (`--add-rpath` increases the ELF header size, `--shrink-rpath` doesn't reduce it when necessary).

See also https://github.com/flyingcircusio/batou_ext/pull/199 & FC-41616.

@flyingcircusio/release-managers

__Note:__ this is a draft until I know whether this has a chance of getting upstreamed. Would still be interested in your opinion on the change itself and the patch in https://github.com/flyingcircusio/patchelf/commit/6ffde887d77275323c81c2e091891251b021abb3.patch

## Release process

- [x] Created changelog entry using `./changelog.sh`


## PR release workflow (internal)

- [ ] PR has internal ticket
- [ ] internal issue ID (PL-…) part of branch name
- [ ] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [ ] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [ ] Security requirements tested? (EVIDENCE)
