### PR TITLE
fc-luks: specify rekey parameters

### DIFF
--- a/changelog.d/20241113_202234_PL-133174-rekey-pbkdf_scriv.md
+++ b/changelog.d/20241113_202234_PL-133174-rekey-pbkdf_scriv.md
@@ -1,0 +1,17 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+
+### NixOS XX.XX platform
+
+- fc-luks: fix rekeying to use the specified encryption parameters. We accidentally fell back to defaults before. (PL-133174)

--- a/pkgs/fc/ceph/src/fc/ceph/luks/__init__.py
+++ b/pkgs/fc/ceph/src/fc/ceph/luks/__init__.py
@@ -138,6 +138,7 @@ class Cryptsetup:
     def luksAddKey(cls, *args: str, **kwargs):
         return cls.cryptsetup(
             *cls._tunables_luks_header,
+            *cls._tunables_cipher,
             "luksAddKey",
             *args, **kwargs,
         )  # fmt: skip

--- a/pkgs/fc/ceph/src/fc/ceph/luks/manage.py
+++ b/pkgs/fc/ceph/src/fc/ceph/luks/manage.py
@@ -174,9 +174,11 @@ class LUKSKeyStoreManager(object):
 
         header_arg = ["--header", header] if header else []
 
-        dump = run.cryptsetup("luksDump", *header_arg, device, encoding="ascii")
+        dump = Cryptsetup.cryptsetup(
+            "luksDump", *header_arg, device, encoding="ascii"
+        )
         if f"  {slot_id}: luks2" in dump:
-            run.cryptsetup(
+            Cryptsetup.cryptsetup(
                 "luksKillSlot",
                 f"--key-file={key_file_verification}",
                 *header_arg,
@@ -184,11 +186,13 @@ class LUKSKeyStoreManager(object):
                 slot_id,
                 input=kill_input,
             )
-        run.cryptsetup(
+        Cryptsetup.cryptsetup(
             "luksAddKey",
             f"--key-file={key_file_verification}",
             f"--key-slot={slot_id}",
             *header_arg,
+            *Cryptsetup._tunables_luks_header,
+            *Cryptsetup._tunables_cipher,
             device,
             new_key_file,
             input=add_input,


### PR DESCRIPTION
When rekeying LUKS volumes, accidentally the default cipher and PBKDF parameters had been used. Instead, explicitly specify our tunables that we've decided on using.

PL-133174

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`


## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - disk encryption shall use the desired pinned encryption parameters 
  - fixes a regression discovered via an existing monitoring check (hence decided not to extend test coverage

- [x] Security requirements tested? (EVIDENCE)
  - [x] automated tests still pass
  - [x] successfully fixed wrong encryption parameters on a development hosts via rekeying
