### PR TITLE
[21.05] physical: add dm_mirror as default kernel module

### DIFF
--- a/changelog.d/20241115_114908_dm-mirror-physical_scriv.md
+++ b/changelog.d/20241115_114908_dm-mirror-physical_scriv.md
@@ -1,0 +1,17 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+
+### NixOS XX.XX platform
+
+- physical machines: load `dm_mirror` kernel module by default, to support several LVM disk migration scenarios

--- a/nixos/infrastructure/flyingcircus-physical.nix
+++ b/nixos/infrastructure/flyingcircus-physical.nix
@@ -31,6 +31,11 @@ mkIf (cfg.infrastructureModule == "flyingcircus-physical") (lib.mkMerge [
         "nvme"
       ];
 
+      # not relevant for boot stage1
+      kernelModules = [
+        "dm_mirror"   # LVM disk migration scenarios
+      ];
+
       kernelParams = [
         # Drivers
         "dolvm"


### PR DESCRIPTION
necessary for allowing several LVM disk migration scenarios

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`


## PR release workflow (internal)

- [ ] PR has internal ticket
- [ ] internal issue ID (PL-…) part of branch name
- [ ] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
  - module only added for physical machines 

- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - improve operability for disk migration scenarios
  - the kernel module is a mainline kernel module that was present on disk anyways, just not loaded by default before 
- [x] Security requirements tested? (EVIDENCE)
  - [x] manually `modprobe`d `dm_mirror` on a physical machine
  - [x] automated tests still pass 
