### PR TITLE
[FC-41933] update the mailserver docs to show an example nix configuration

### DIFF
--- a/changelog.d/20241119_093402_phil-FC-41933_update-mailserver-docs_scriv.md
+++ b/changelog.d/20241119_093402_phil-FC-41933_update-mailserver-docs_scriv.md
@@ -1,0 +1,19 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+
+### NixOS XX.XX platform
+
+- Update the mailserver role documentation with an example nix configuration

--- a/nixos/services/mail/default.nix
+++ b/nixos/services/mail/default.nix
@@ -45,7 +45,7 @@ in {
 
   options = {
     flyingcircus.services.mail.enable = lib.mkEnableOption ''
-      Mail server (SNM) with Postfix, Dovecot, rspamd, DKIM & SPF
+      Mail server (SNM) with Postfix, Dovecot, Rspamd, DKIM & SPF
     '';
   };
 


### PR DESCRIPTION
@flyingcircusio/release-managers

Internal ticket: FC-41933

Update the documentation for the mailserver role as well as fixing capitalization for Rspamd.

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [ ] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [ ] Security requirements tested? (EVIDENCE)
