### PR TITLE
Update nixpkgs (2024-11-25)

### DIFF
--- a/changelog.d/20241125_205222_PL-133203-2405-update-nixpkgs-2024-11-25_scriv.md
+++ b/changelog.d/20241125_205222_PL-133203-2405-update-nixpkgs-2024-11-25_scriv.md
@@ -1,0 +1,48 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+- services using an updated package will be restarted
+
+
+### NixOS XX.XX platform
+
+- Pull upstream NixOS changes, security fixes and package updates (PL-133203):
+    - chromium: 130.0.6723.69 -> 130.0.6723.116 (CVE-2024-10826, CVE-2024-10827, CVE-2024-10487, CVE-2024-10488)
+    - element-web: 1.11.82 -> 1.11.85
+    - firefox: 132.0 -> 132.0.2
+    - ghostscript: 10.03.1 -> 10.04.0
+    - git: 2.44.1 -> 2.44.2
+    - github-runner: 2.320.0 -> 2.321.0
+    - gitlab: 17.2.9 -> 17.3.7
+    - go_1_22: 1.22.6 -> 1.22.8
+    - go_1_22: 1.22.6 -> 1.22.8, (#345953)
+    - grafana: 10.4.11 -> 10.4.12
+    - imagemagick: 7.1.1-38 -> 7.1.1-39
+    - libtiff: patch for CVE-2023-52356 & CVE-2024-7006
+    - matrix-synapse: 1.118.0 -> 1.119.0
+    - nodejs_18: 18.20.4 -> 18.20.5
+    - nodejs_22: 22.8.0 -> 22.10.0, (#349157)
+    - nspr: 4.35 -> 4.36
+    - nss_latest: 3.105 -> 3.106
+    - postgresql_12: 12.20 -> 12.21
+    - postgresql_13: 13.16 -> 13.17
+    - postgresql_14: 14.13 -> 14.14
+    - postgresql_15: 15.8 -> 15.9
+    - postgresql_16: 16.4 -> 16.5
+    - python311: 3.11.9 -> 3.11.10
+    - python312: 3.12.5 -> 3.12.6
+    - redis: 7.2.4 -> 7.2.6 (CVE-2024-31449, CVE-2024-31227, CVE-2024-31228)
+    - unzip: apply patch for CVE-2021-4217
+    - vim: 9.1.0707 -> 9.1.0765 (CVE-2024-47814)

--- a/flake.lock
+++ b/flake.lock
@@ -410,11 +410,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1730736583,
-        "narHash": "sha256-VfMf/lTp57jquEKlpm1rnUGZIoQuIFyu4Sg2y6FKHKo=",
+        "lastModified": 1732552704,
+        "narHash": "sha256-tqRguWLOIq+t4FKRj9i6xm+SgE0AlR+HvrZJYmfkl4o=",
         "owner": "flyingcircusio",
         "repo": "nixpkgs",
-        "rev": "e418e84f113fe9ee0fad1604af830036d1432862",
+        "rev": "e8368806d2c792603b4c47afe0e3709a51d232a2",
         "type": "github"
       },
       "original": {

--- a/release/package-versions.json
+++ b/release/package-versions.json
@@ -70,14 +70,14 @@
     "version": "18.2.4"
   },
   "chromedriver": {
-    "name": "chromedriver-130.0.6723.69",
+    "name": "chromedriver-130.0.6723.116",
     "pname": "chromedriver",
-    "version": "130.0.6723.69"
+    "version": "130.0.6723.116"
   },
   "chromium": {
-    "name": "chromium-130.0.6723.69",
+    "name": "chromium-130.0.6723.116",
     "pname": "chromium",
-    "version": "130.0.6723.69"
+    "version": "130.0.6723.116"
   },
   "cifs-utils": {
     "name": "cifs-utils-7.0",
@@ -95,9 +95,9 @@
     "version": "3.29.2"
   },
   "consul": {
-    "name": "consul-1.18.4",
+    "name": "consul-1.18.5",
     "pname": "consul",
-    "version": "1.18.4"
+    "version": "1.18.5"
   },
   "containerd": {
     "name": "containerd-1.7.16",
@@ -155,9 +155,9 @@
     "version": "2.3.21.1"
   },
   "element-web": {
-    "name": "element-web-1.11.82",
+    "name": "element-web-1.11.85",
     "pname": "element-web",
-    "version": "1.11.82"
+    "version": "1.11.85"
   },
   "erlang": {
     "name": "erlang-25.3.2.12",
@@ -190,9 +190,9 @@
     "version": "7.17.16"
   },
   "firefox": {
-    "name": "firefox-132.0",
+    "name": "firefox-132.0.2",
     "pname": "firefox",
-    "version": "132.0"
+    "version": "132.0.2"
   },
   "gcc": {
     "name": "gcc-wrapper-13.2.0",
@@ -210,44 +210,44 @@
     "version": "2.3.3"
   },
   "ghostscript": {
-    "name": "ghostscript-with-X-10.03.1",
+    "name": "ghostscript-with-X-10.04.0",
     "pname": "ghostscript-with-X",
-    "version": "10.03.1"
+    "version": "10.04.0"
   },
   "git": {
-    "name": "git-2.44.1",
+    "name": "git-2.44.2",
     "pname": "git",
-    "version": "2.44.1"
+    "version": "2.44.2"
   },
   "gitaly": {
-    "name": "gitaly-17.3.6",
+    "name": "gitaly-17.3.7",
     "pname": "gitaly",
-    "version": "17.3.6"
+    "version": "17.3.7"
   },
   "github-runner": {
-    "name": "github-runner-2.320.0",
+    "name": "github-runner-2.321.0",
     "pname": "github-runner",
-    "version": "2.320.0"
+    "version": "2.321.0"
   },
   "gitlab": {
-    "name": "gitlab-17.3.6",
+    "name": "gitlab-17.3.7",
     "pname": "gitlab",
-    "version": "17.3.6"
+    "version": "17.3.7"
   },
   "gitlab-container-registry": {
-    "name": "gitlab-container-registry-4.11.0",
+    "name": "gitlab-container-registry-4.13.0",
     "pname": "gitlab-container-registry",
-    "version": "4.11.0"
+    "version": "4.13.0"
   },
   "gitlab-ee": {
-    "name": "gitlab-ee-17.3.6",
+    "name": "gitlab-ee-17.3.7",
     "pname": "gitlab-ee",
-    "version": "17.3.6"
+    "version": "17.3.7"
   },
   "gitlab-pages": {
-    "name": "gitlab-pages-17.3.6",
+    "name": "gitlab-pages-17.3.7",
     "pname": "gitlab-pages",
-    "version": "17.3.6"
+    "version": "17.3.7"
   },
   "gitlab-runner": {
     "name": "gitlab-runner-17.1.0",
@@ -255,9 +255,9 @@
     "version": "17.1.0"
   },
   "gitlab-workhorse": {
-    "name": "gitlab-workhorse-17.3.6",
+    "name": "gitlab-workhorse-17.3.7",
     "pname": "gitlab-workhorse",
-    "version": "17.3.6"
+    "version": "17.3.7"
   },
   "glibc": {
     "name": "glibc-2.39-52",
@@ -275,9 +275,9 @@
     "version": "2.4.5"
   },
   "go": {
-    "name": "go-1.22.6",
+    "name": "go-1.22.8",
     "pname": "go",
-    "version": "1.22.6"
+    "version": "1.22.8"
   },
   "go_1_21": {
     "name": "go-1.21.13",
@@ -285,14 +285,14 @@
     "version": "1.21.13"
   },
   "go_1_22": {
-    "name": "go-1.22.6",
+    "name": "go-1.22.8",
     "pname": "go",
-    "version": "1.22.6"
+    "version": "1.22.8"
   },
   "grafana": {
-    "name": "grafana-10.4.11",
+    "name": "grafana-10.4.12",
     "pname": "grafana",
-    "version": "10.4.11"
+    "version": "10.4.12"
   },
   "grub2": {
     "name": "grub-2.12",
@@ -305,9 +305,9 @@
     "version": "2.9.10"
   },
   "imagemagick": {
-    "name": "imagemagick-7.1.1-38",
+    "name": "imagemagick-7.1.1-39",
     "pname": "imagemagick",
-    "version": "7.1.1-38"
+    "version": "7.1.1-39"
   },
   "imagemagick6": {
     "name": "imagemagick-6.9.13-10",
@@ -315,9 +315,9 @@
     "version": "6.9.13-10"
   },
   "imagemagick7": {
-    "name": "imagemagick-7.1.1-38",
+    "name": "imagemagick-7.1.1-39",
     "pname": "imagemagick",
-    "version": "7.1.1-38"
+    "version": "7.1.1-39"
   },
   "inetutils": {
     "name": "inetutils-2.5",
@@ -460,9 +460,9 @@
     "version": "0.2.5"
   },
   "linuxKernelStable": {
-    "name": "linux-5.15.169",
+    "name": "linux-5.15.172",
     "pname": "linux",
-    "version": "5.15.169"
+    "version": "5.15.172"
   },
   "linuxKernelVerify": {
     "name": "linux-6.11",
@@ -510,9 +510,9 @@
     "version": "5.1.1"
   },
   "matrix-synapse": {
-    "name": "matrix-synapse-wrapped-1.117.0",
+    "name": "matrix-synapse-wrapped-1.119.0",
     "pname": "matrix-synapse-wrapped",
-    "version": "1.117.0"
+    "version": "1.119.0"
   },
   "mcpp": {
     "name": "mcpp-2.7.2.1",
@@ -580,29 +580,29 @@
     "version": "2.18.8"
   },
   "nodejs": {
-    "name": "nodejs-20.15.1",
+    "name": "nodejs-20.17.0",
     "pname": "nodejs",
-    "version": "20.15.1"
+    "version": "20.17.0"
   },
   "nodejs_18": {
-    "name": "nodejs-18.20.4",
+    "name": "nodejs-18.20.5",
     "pname": "nodejs",
-    "version": "18.20.4"
+    "version": "18.20.5"
   },
   "nodejs_20": {
-    "name": "nodejs-20.15.1",
+    "name": "nodejs-20.17.0",
     "pname": "nodejs",
-    "version": "20.15.1"
+    "version": "20.17.0"
   },
   "nodejs_22": {
-    "name": "nodejs-22.4.1",
+    "name": "nodejs-22.10.0",
     "pname": "nodejs",
-    "version": "22.4.1"
+    "version": "22.10.0"
   },
   "nspr": {
-    "name": "nspr-4.35",
+    "name": "nspr-4.36",
     "pname": "nspr",
-    "version": "4.35"
+    "version": "4.36"
   },
   "nss_latest": {
     "name": "nss-3.106",
@@ -760,9 +760,9 @@
     "version": "8.2.24"
   },
   "php83": {
-    "name": "php-with-extensions-8.3.12",
+    "name": "php-with-extensions-8.3.13",
     "pname": "php-with-extensions",
-    "version": "8.3.12"
+    "version": "8.3.13"
   },
   "phpPackages.composer": {
     "name": "composer-2.7.7",
@@ -800,19 +800,19 @@
     "version": "15.8"
   },
   "postgresql_12": {
-    "name": "postgresql-12.20",
+    "name": "postgresql-12.21",
     "pname": "postgresql",
-    "version": "12.20"
+    "version": "12.21"
   },
   "postgresql_13": {
-    "name": "postgresql-13.16",
+    "name": "postgresql-13.17",
     "pname": "postgresql",
-    "version": "13.16"
+    "version": "13.17"
   },
   "postgresql_14": {
-    "name": "postgresql-14.13",
+    "name": "postgresql-14.14",
     "pname": "postgresql",
-    "version": "14.13"
+    "version": "14.14"
   },
   "postgresql_15": {
     "name": "postgresql-15.8",
@@ -820,9 +820,9 @@
     "version": "15.8"
   },
   "postgresql_16": {
-    "name": "postgresql-16.4",
+    "name": "postgresql-16.5",
     "pname": "postgresql",
-    "version": "16.4"
+    "version": "16.5"
   },
   "powerdns": {
     "name": "pdns-4.9.1",
@@ -840,9 +840,9 @@
     "version": "0.12.4"
   },
   "python3": {
-    "name": "python3-3.11.9",
+    "name": "python3-3.11.10",
     "pname": "python3",
-    "version": "3.11.9"
+    "version": "3.11.10"
   },
   "python310": {
     "name": "python3-3.10.15",
@@ -850,14 +850,14 @@
     "version": "3.10.15"
   },
   "python311": {
-    "name": "python3-3.11.9",
+    "name": "python3-3.11.10",
     "pname": "python3",
-    "version": "3.11.9"
+    "version": "3.11.10"
   },
   "python312": {
-    "name": "python3-3.12.5",
+    "name": "python3-3.12.6",
     "pname": "python3",
-    "version": "3.12.5"
+    "version": "3.12.6"
   },
   "python38": {},
   "python39": {
@@ -941,9 +941,9 @@
     "version": "2.2.2"
   },
   "qemu": {
-    "name": "qemu-8.2.6",
+    "name": "qemu-8.2.7",
     "pname": "qemu",
-    "version": "8.2.6"
+    "version": "8.2.7"
   },
   "rabbitmq-server": {
     "name": "rabbitmq-server-3.12.13",
@@ -966,9 +966,9 @@
     "version": "3.1"
   },
   "redis": {
-    "name": "redis-7.2.4",
+    "name": "redis-7.2.6",
     "pname": "redis",
-    "version": "7.2.4"
+    "version": "7.2.6"
   },
   "rich-cli": {
     "name": "rich-cli-1.8.0",
@@ -1092,9 +1092,9 @@
     "version": "7.4.3"
   },
   "vim": {
-    "name": "vim-9.1.0707",
+    "name": "vim-9.1.0765",
     "pname": "vim",
-    "version": "9.1.0707"
+    "version": "9.1.0765"
   },
   "webkitgtk": {
     "name": "webkitgtk-2.44.3+abi=4.0",

--- a/release/versions.json
+++ b/release/versions.json
@@ -8,9 +8,9 @@
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/"
   },
   "nixpkgs": {
-    "hash": "sha256-VfMf/lTp57jquEKlpm1rnUGZIoQuIFyu4Sg2y6FKHKo=",
+    "hash": "sha256-tqRguWLOIq+t4FKRj9i6xm+SgE0AlR+HvrZJYmfkl4o=",
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "e418e84f113fe9ee0fad1604af830036d1432862"
+    "rev": "e8368806d2c792603b4c47afe0e3709a51d232a2"
   }
 }


### PR DESCRIPTION
Pull upstream NixOS changes, security fixes and package updates:

- ghostscript: 10.03.1 -> 10.04.0
- git: 2.44.1 -> 2.44.2
- gitaly: Embed git binaries
- gitlab: 17.2.9 -> 17.3.7
- go_1_22: 1.22.6 -> 1.22.8
- go_1_22: 1.22.6 -> 1.22.8, (#345953)
- grafana: 10.4.11 -> 10.4.12
- imagemagick: 7.1.1-38 -> 7.1.1-39
- libtiff: patch for CVE-2023-52356 & CVE-2024-7006
- matrix-synapse: 1.118.0 -> 1.119.0
- nodejs_18: 18.20.4 -> 18.20.5
- nodejs_22: 22.8.0 -> 22.10.0, (#349157)
- nspr: 4.35 -> 4.36
- nss_latest: 3.105 -> 3.106
- postgresql_12: 12.20 -> 12.21
- postgresql_13: 13.16 -> 13.17
- postgresql_14: 14.13 -> 14.14
- postgresql_15: 15.8 -> 15.9
- postgresql_16: 16.4 -> 16.5
- python311: 3.11.9 -> 3.11.10
- python312: 3.12.5 -> 3.12.6
- qemu: 8.2.6 -> 8.2.7
- redis: 7.2.4 -> 7.2.6
- unzip: apply patch for CVE-2021-4217
- vim: 9.1.0707 -> 9.1.0765

PL-133203

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`


## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - regularly pull in security updates for software
  - must not introduce known regressions
  - check for breaking changes 
- [x] Security requirements tested? (EVIDENCE)
  - [x] automated tests still pass
  - [x] test gitlab update in staging environment
  - [x] check git log for fixed CVEs
  - [x] checked changelog for breaking changes of: matrix-synapse, gitlab, element