### PR TITLE
[21.05] Replace dhcpd from isc-dhcp with Kea

### DIFF
--- a/changelog.d/20241126_174743_PL-133205-dhcp-port-to-kea_scriv.md
+++ b/changelog.d/20241126_174743_PL-133205-dhcp-port-to-kea_scriv.md
@@ -1,0 +1,20 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+
+### NixOS XX.XX platform
+
+- router: the ISC DHCP server, which is end-of-life, has been replaced
+  with its successor implementation, Kea. (PL-133205)

--- a/nixos/roles/router/default.nix
+++ b/nixos/roles/router/default.nix
@@ -73,7 +73,7 @@ in
     ./bird2
     ./keepalived
     ./chrony.nix
-    ./dhcpd.nix
+    ./kea.nix
     ./pmacctd.nix
     ./radvd.nix
     ./trafficclient.nix
@@ -276,8 +276,6 @@ in
 
     flyingcircus.agent = {
       extraPreCommands = ''
-        fc-dhcpd -4 -o /etc/nixos/localconfig-dhcpd4.conf ${location}
-        fc-dhcpd -6 -o /etc/nixos/localconfig-dhcpd6.conf ${location}
         # Updates files in /etc/bind and /etc/bind/pri where also Nix-generated config exists.
         fc-zones
       '';

--- a/nixos/roles/router/kea.nix
+++ b/nixos/roles/router/kea.nix
@@ -98,11 +98,11 @@ in
   options = with lib; {
     flyingcircus.services.dhcpd4.localconfig = mkOption {
       type = types.attrs;
-      default = fclib.jsonFromFile "/etc/nixos/localconfig-dhcpd4.json" "";
+      default = fclib.jsonFromFile "/etc/nixos/localconfig-dhcpd4.json" "{}";
     };
     flyingcircus.services.dhcpd6.localconfig = mkOption {
       type = types.attrs;
-      default = fclib.jsonFromFile "/etc/nixos/localconfig-dhcpd6.json" "";
+      default = fclib.jsonFromFile "/etc/nixos/localconfig-dhcpd6.json" "{}";
     };
   };
 

--- a/nixos/roles/router/kea.nix
+++ b/nixos/roles/router/kea.nix
@@ -45,6 +45,8 @@ let
       name = "/var/lib/kea/dhcp4.leases";
     };
 
+    authoritative = true;  # match previous isc-dhcpd behaviour
+
     option-data = [
       { name = "domain-name"; data = suffix; }
       { name = "domain-search"; data = "${suffix}, ${location}.${suffix}"; }

--- a/nixos/roles/router/kea.nix
+++ b/nixos/roles/router/kea.nix
@@ -1,0 +1,149 @@
+{ config, pkgs, lib, ... }:
+
+with builtins;
+
+let
+  role = config.flyingcircus.roles.router;
+  inherit (config) fclib;
+  inherit (config.flyingcircus) location;
+  inherit (config.networking) hostName;
+  suffix = "gocept.net";
+
+  dhcpNetworks' =
+    [ "mgm" "srv" "fe" ] ++
+    (config.flyingcircus.static.additionalDhcpNetworks."${location}" or []);
+
+  dhcpNetworks = [ "ipmi" ] ++ dhcpNetworks';
+  dhcpInterfaces = map (net: fclib.network."${net}".interface) dhcpNetworks';
+
+  resolvers4 = if (hasAttr location config.flyingcircus.static.nameservers)
+        then config.flyingcircus.static.nameservers.${location}
+        else [];
+
+  resolvers6 =
+        if (hasAttr location config.flyingcircus.static.nameservers6)
+        then config.flyingcircus.static.nameservers6.${location}
+        else [];
+
+  baseConfig = {
+    dhcp-ddns = { enable-updates = false; };
+    valid-lifetime = 1800;
+    max-valid-lifetime = 7200;
+  };
+
+  kea4Config = {
+    interfaces-config = {
+      interfaces = dhcpInterfaces;
+      dhcp-socket-type = "raw";
+    };
+
+    lease-database = {
+      type = "memfile";
+      persist = true;
+      name = "/var/lib/kea/dhcp4.leases";
+    };
+
+    option-data = [
+      { name = "domain-name"; data = suffix; }
+      { name = "domain-search"; data = "${suffix}, ${location}.${suffix}"; }
+      { name = "domain-name-servers"; data = lib.concatStringsSep ", " resolvers4; }
+      # NTP options set on a per-subnet basis by fc-kea
+    ];
+
+    # default efi netboot configuration, overridden for bios clients
+    # and ipxe in client classes
+    next-server = "${location}-router.mgm.${location}.${suffix}";
+    boot-file-name = "ipxe.efi";
+
+    client-classes = [
+      {
+        name = "iPXE";
+        test = "option[user-class].exists and (option[user-class].hex == 'iPXE')";
+        boot-file-name = "flyingcircus.ipxe";
+      }
+      {
+        name = "BIOS PXE";
+        test = "substring(option[vendor-class-identifier].hex, 15, 5) == '00000'";
+        boot-file-name = "undionly.kpxe";
+      }
+    ];
+  };
+
+  kea6Config = {
+    interfaces-config = {
+      interfaces = dhcpInterfaces;
+    };
+
+    lease-database = {
+      type = "memfile";
+      persist = true;
+      name = "/var/lib/kea/dhcp6.leases";
+    };
+
+    option-data = [
+      { name = "dns-servers"; data = lib.concatStringsSep ", " resolvers6; }
+      { name = "domain-search"; data = "${suffix}, ${location}.${suffix}"; }
+      # no direct equivalent to dhcpv4 option 15 in dhcpv6, fqdn
+      # configured on a per-host basis.
+    ];
+  };
+
+in
+{
+  options = with lib; {
+    flyingcircus.services.dhcpd4.localconfig = mkOption {
+      type = types.attrs;
+      default = fclib.jsonFromFile "/etc/nixos/localconfig-dhcpd4.json" "";
+    };
+    flyingcircus.services.dhcpd6.localconfig = mkOption {
+      type = types.attrs;
+      default = fclib.jsonFromFile "/etc/nixos/localconfig-dhcpd6.json" "";
+    };
+  };
+
+  config = lib.mkIf role.enable {
+    flyingcircus.agent.extraPreCommands = ''
+      # Generate DHCP server configuration
+      fc-kea -4 -L ${location} -o /etc/nixos/localconfig-dhcpd4.json -e ipmi ${lib.concatMapStringsSep " " (net: "-n ${net}") dhcpNetworks}
+      fc-kea -6 -L ${location} -o /etc/nixos/localconfig-dhcpd6.json -e ipmi ${lib.concatMapStringsSep " " (net: "-n ${net}") dhcpNetworks} -d ${suffix}
+    '';
+
+    services.kea.dhcp4 = {
+      enable = role.isPrimary;
+      settings = (
+        baseConfig //
+        kea4Config //
+        config.flyingcircus.services.dhcpd4.localconfig
+      );
+    };
+    services.kea.dhcp6 = {
+      enable = role.isPrimary;
+      settings = (
+        baseConfig //
+        kea6Config //
+        config.flyingcircus.services.dhcpd6.localconfig
+      );
+    };
+
+    services.atftpd = {
+      enable = role.isPrimary;
+      extraOptions = [
+        "--verbose=5"
+      ];
+      root = pkgs.runCommand "tftpd-root-for-dhcpd4" {} ''
+        mkdir $out
+        # place a file called "flyingcircus.ipxe" in this path, take it from ./flyingcircus.ipxe
+        cp ${./flyingcircus.ipxe} $out/flyingcircus.ipxe
+        # place a file called "undionly.kpxe" in this path, take it from ${pkgs.ipxe}/undionly.kpxe
+        cp ${pkgs.ipxe}/undionly.kpxe $out/
+        cp ${pkgs.ipxe}/ipxe.efi $out/
+      '';
+    };
+
+    networking.firewall.extraCommands = ''
+      # TFTP
+      ip46tables -A nixos-fw -i ${fclib.network.mgm.interface} -p udp --dport 69 -j nixos-fw-accept
+    '';
+
+  };
+}

--- a/nixos/roles/router/kea.nix
+++ b/nixos/roles/router/kea.nix
@@ -16,6 +16,8 @@ let
   dhcpNetworks = [ "ipmi" ] ++ dhcpNetworks';
   dhcpInterfaces = map (net: fclib.network."${net}".interface) dhcpNetworks';
 
+  bootServer = head fclib.network.mgm.v4.defaultGateways;
+
   resolvers4 = if (hasAttr location config.flyingcircus.static.nameservers)
         then config.flyingcircus.static.nameservers.${location}
         else [];
@@ -50,11 +52,12 @@ let
       # NTP options set on a per-subnet basis by fc-kea
     ];
 
-    # default efi netboot configuration, overridden for bios clients
-    # and ipxe in client classes
-    next-server = "${location}-router.mgm.${location}.${suffix}";
-    boot-file-name = "ipxe.efi";
+    next-server = bootServer;
 
+    # default to efi netboot. bios clients and the ipxe loader are
+    # identified with client classes, with the options specified in
+    # the first match taking precedence.
+    boot-file-name = "ipxe.efi";
     client-classes = [
       {
         name = "iPXE";

--- a/nixos/services/default.nix
+++ b/nixos/services/default.nix
@@ -48,6 +48,9 @@ in {
     # Imported from NixOS 23.05
     ./frr.nix
 
+    # Imported from NixOS 24.05
+    ./kea.nix
+
     (mkRemovedOptionModule [ "flyingcircus" "services" "percona" "rootPassword" ] "Change the root password via MySQL and modify secret files")
   ];
 }

--- a/nixos/services/kea.nix
+++ b/nixos/services/kea.nix
@@ -1,0 +1,455 @@
+{ config
+, lib
+, pkgs
+, ...
+}:
+
+with lib;
+
+let
+  cfg = config.services.kea;
+
+  xor = x: y: (!x && y) || (x && !y);
+  format = pkgs.formats.json {};
+
+  chooseNotNull = x: y: if x != null then x else y;
+
+  ctrlAgentConfig = chooseNotNull cfg.ctrl-agent.configFile (format.generate "kea-ctrl-agent.conf" {
+    Control-agent = cfg.ctrl-agent.settings;
+  });
+
+  dhcp4Config = chooseNotNull cfg.dhcp4.configFile (format.generate "kea-dhcp4.conf" {
+    Dhcp4 = cfg.dhcp4.settings;
+  });
+
+  dhcp6Config = chooseNotNull cfg.dhcp6.configFile (format.generate "kea-dhcp6.conf" {
+    Dhcp6 = cfg.dhcp6.settings;
+  });
+
+  dhcpDdnsConfig = chooseNotNull cfg.dhcp-ddns.configFile (format.generate "kea-dhcp-ddns.conf" {
+    DhcpDdns = cfg.dhcp-ddns.settings;
+  });
+
+  package = pkgs.kea;
+in
+{
+  options.services.kea = with types; {
+    ctrl-agent = mkOption {
+      description = lib.mdDoc ''
+        Kea Control Agent configuration
+      '';
+      default = {};
+      type = submodule {
+        options = {
+          enable = mkEnableOption (lib.mdDoc "Kea Control Agent");
+
+          extraArgs = mkOption {
+            type = listOf str;
+            default = [];
+            description = lib.mdDoc ''
+              List of additional arguments to pass to the daemon.
+            '';
+          };
+
+          configFile = mkOption {
+            type = nullOr path;
+            default = null;
+            description = lib.mdDoc ''
+              Kea Control Agent configuration as a path, see <https://kea.readthedocs.io/en/kea-${package.version}/arm/agent.html>.
+
+              Takes preference over [settings](#opt-services.kea.ctrl-agent.settings).
+              Most users should prefer using [settings](#opt-services.kea.ctrl-agent.settings) instead.
+            '';
+          };
+
+          settings = mkOption {
+            type = format.type;
+            default = null;
+            description = lib.mdDoc ''
+              Kea Control Agent configuration as an attribute set, see <https://kea.readthedocs.io/en/kea-${package.version}/arm/agent.html>.
+            '';
+          };
+        };
+      };
+    };
+
+    dhcp4 = mkOption {
+      description = lib.mdDoc ''
+        DHCP4 Server configuration
+      '';
+      default = {};
+      type = submodule {
+        options = {
+          enable = mkEnableOption (lib.mdDoc "Kea DHCP4 server");
+
+          extraArgs = mkOption {
+            type = listOf str;
+            default = [];
+            description = lib.mdDoc ''
+              List of additional arguments to pass to the daemon.
+            '';
+          };
+
+          configFile = mkOption {
+            type = nullOr path;
+            default = null;
+            description = lib.mdDoc ''
+              Kea DHCP4 configuration as a path, see <https://kea.readthedocs.io/en/kea-${package.version}/arm/dhcp4-srv.html>.
+
+              Takes preference over [settings](#opt-services.kea.dhcp4.settings).
+              Most users should prefer using [settings](#opt-services.kea.dhcp4.settings) instead.
+            '';
+          };
+
+          settings = mkOption {
+            type = format.type;
+            default = null;
+            example = {
+              valid-lifetime = 4000;
+              renew-timer = 1000;
+              rebind-timer = 2000;
+              interfaces-config = {
+                interfaces = [
+                  "eth0"
+                ];
+              };
+              lease-database = {
+                type = "memfile";
+                persist = true;
+                name = "/var/lib/kea/dhcp4.leases";
+              };
+              subnet4 = [ {
+                subnet = "192.0.2.0/24";
+                pools = [ {
+                  pool = "192.0.2.100 - 192.0.2.240";
+                } ];
+              } ];
+            };
+            description = lib.mdDoc ''
+              Kea DHCP4 configuration as an attribute set, see <https://kea.readthedocs.io/en/kea-${package.version}/arm/dhcp4-srv.html>.
+            '';
+          };
+        };
+      };
+    };
+
+    dhcp6 = mkOption {
+      description = lib.mdDoc ''
+        DHCP6 Server configuration
+      '';
+      default = {};
+      type = submodule {
+        options = {
+          enable = mkEnableOption (lib.mdDoc "Kea DHCP6 server");
+
+          extraArgs = mkOption {
+            type = listOf str;
+            default = [];
+            description = lib.mdDoc ''
+              List of additional arguments to pass to the daemon.
+            '';
+          };
+
+          configFile = mkOption {
+            type = nullOr path;
+            default = null;
+            description = lib.mdDoc ''
+              Kea DHCP6 configuration as a path, see <https://kea.readthedocs.io/en/kea-${package.version}/arm/dhcp6-srv.html>.
+
+              Takes preference over [settings](#opt-services.kea.dhcp6.settings).
+              Most users should prefer using [settings](#opt-services.kea.dhcp6.settings) instead.
+            '';
+          };
+
+          settings = mkOption {
+            type = format.type;
+            default = null;
+            example = {
+              valid-lifetime = 4000;
+              renew-timer = 1000;
+              rebind-timer = 2000;
+              preferred-lifetime = 3000;
+              interfaces-config = {
+                interfaces = [
+                  "eth0"
+                ];
+              };
+              lease-database = {
+                type = "memfile";
+                persist = true;
+                name = "/var/lib/kea/dhcp6.leases";
+              };
+              subnet6 = [ {
+                subnet = "2001:db8:1::/64";
+                pools = [ {
+                  pool = "2001:db8:1::1-2001:db8:1::ffff";
+                } ];
+              } ];
+            };
+            description = lib.mdDoc ''
+              Kea DHCP6 configuration as an attribute set, see <https://kea.readthedocs.io/en/kea-${package.version}/arm/dhcp6-srv.html>.
+            '';
+          };
+        };
+      };
+    };
+
+    dhcp-ddns = mkOption {
+      description = lib.mdDoc ''
+        Kea DHCP-DDNS configuration
+      '';
+      default = {};
+      type = submodule {
+        options = {
+          enable = mkEnableOption (lib.mdDoc "Kea DDNS server");
+
+          extraArgs = mkOption {
+            type = listOf str;
+            default = [];
+            description = lib.mdDoc ''
+              List of additional arguments to pass to the daemon.
+            '';
+          };
+
+          configFile = mkOption {
+            type = nullOr path;
+            default = null;
+            description = lib.mdDoc ''
+              Kea DHCP-DDNS configuration as a path, see <https://kea.readthedocs.io/en/kea-${package.version}/arm/ddns.html>.
+
+              Takes preference over [settings](#opt-services.kea.dhcp-ddns.settings).
+              Most users should prefer using [settings](#opt-services.kea.dhcp-ddns.settings) instead.
+            '';
+          };
+
+          settings = mkOption {
+            type = format.type;
+            default = null;
+            example = {
+              ip-address = "127.0.0.1";
+              port = 53001;
+              dns-server-timeout = 100;
+              ncr-protocol = "UDP";
+              ncr-format = "JSON";
+              tsig-keys = [ ];
+              forward-ddns = {
+                ddns-domains = [ ];
+              };
+              reverse-ddns = {
+                ddns-domains = [ ];
+              };
+            };
+            description = lib.mdDoc ''
+              Kea DHCP-DDNS configuration as an attribute set, see <https://kea.readthedocs.io/en/kea-${package.version}/arm/ddns.html>.
+            '';
+          };
+        };
+      };
+    };
+  };
+
+  config = let
+    commonServiceConfig = {
+      ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
+      DynamicUser = true;
+      User = "kea";
+      ConfigurationDirectory = "kea";
+      RuntimeDirectory = "kea";
+      RuntimeDirectoryPreserve = true;
+      StateDirectory = "kea";
+      UMask = "0077";
+    };
+  in mkIf (cfg.ctrl-agent.enable || cfg.dhcp4.enable || cfg.dhcp6.enable || cfg.dhcp-ddns.enable) (mkMerge [
+  {
+    environment.systemPackages = [ package ];
+  }
+
+  (mkIf cfg.ctrl-agent.enable {
+    assertions = [{
+        assertion = xor (cfg.ctrl-agent.settings == null) (cfg.ctrl-agent.configFile == null);
+        message = "Either services.kea.ctrl-agent.settings or services.kea.ctrl-agent.configFile must be set to a non-null value.";
+    }];
+
+    environment.etc."kea/ctrl-agent.conf".source = ctrlAgentConfig;
+
+    systemd.services.kea-ctrl-agent = {
+      description = "Kea Control Agent";
+      documentation = [
+        "man:kea-ctrl-agent(8)"
+        "https://kea.readthedocs.io/en/kea-${package.version}/arm/agent.html"
+      ];
+
+      after = [
+        "network-online.target"
+        "time-sync.target"
+      ];
+      wantedBy = [
+        "kea-dhcp4-server.service"
+        "kea-dhcp6-server.service"
+        "kea-dhcp-ddns-server.service"
+      ];
+
+      environment = {
+        KEA_PIDFILE_DIR = "/run/kea";
+        KEA_LOCKFILE_DIR = "/run/kea";
+      };
+
+      restartTriggers = [
+        ctrlAgentConfig
+      ];
+
+      serviceConfig = {
+        ExecStart = "${package}/bin/kea-ctrl-agent -c /etc/kea/ctrl-agent.conf ${lib.escapeShellArgs cfg.ctrl-agent.extraArgs}";
+        KillMode = "process";
+        Restart = "on-failure";
+      } // commonServiceConfig;
+    };
+  })
+
+  (mkIf cfg.dhcp4.enable {
+    assertions = [{
+        assertion = xor (cfg.dhcp4.settings == null) (cfg.dhcp4.configFile == null);
+        message = "Either services.kea.dhcp4.settings or services.kea.dhcp4.configFile must be set to a non-null value.";
+    }];
+
+    environment.etc."kea/dhcp4-server.conf".source = dhcp4Config;
+
+    systemd.services.kea-dhcp4-server = {
+      description = "Kea DHCP4 Server";
+      documentation = [
+        "man:kea-dhcp4(8)"
+        "https://kea.readthedocs.io/en/kea-${package.version}/arm/dhcp4-srv.html"
+      ];
+
+      after = [
+        "network-online.target"
+        "time-sync.target"
+      ];
+      wants = [
+        "network-online.target"
+      ];
+      wantedBy = [
+        "multi-user.target"
+      ];
+
+      environment = {
+        KEA_PIDFILE_DIR = "/run/kea";
+        KEA_LOCKFILE_DIR = "/run/kea";
+      };
+
+      restartTriggers = [
+        dhcp4Config
+      ];
+
+      serviceConfig = {
+        ExecStart = "${package}/bin/kea-dhcp4 -c /etc/kea/dhcp4-server.conf ${lib.escapeShellArgs cfg.dhcp4.extraArgs}";
+        # Kea does not request capabilities by itself
+        AmbientCapabilities = [
+          "CAP_NET_BIND_SERVICE"
+          "CAP_NET_RAW"
+        ];
+        CapabilityBoundingSet = [
+          "CAP_NET_BIND_SERVICE"
+          "CAP_NET_RAW"
+        ];
+      } // commonServiceConfig;
+    };
+  })
+
+  (mkIf cfg.dhcp6.enable {
+    assertions = [{
+        assertion = xor (cfg.dhcp6.settings == null) (cfg.dhcp6.configFile == null);
+        message = "Either services.kea.dhcp6.settings or services.kea.dhcp6.configFile must be set to a non-null value.";
+    }];
+
+    environment.etc."kea/dhcp6-server.conf".source = dhcp6Config;
+
+    systemd.services.kea-dhcp6-server = {
+      description = "Kea DHCP6 Server";
+      documentation = [
+        "man:kea-dhcp6(8)"
+        "https://kea.readthedocs.io/en/kea-${package.version}/arm/dhcp6-srv.html"
+      ];
+
+      after = [
+        "network-online.target"
+        "time-sync.target"
+      ];
+      wants = [
+        "network-online.target"
+      ];
+      wantedBy = [
+        "multi-user.target"
+      ];
+
+      environment = {
+        KEA_PIDFILE_DIR = "/run/kea";
+        KEA_LOCKFILE_DIR = "/run/kea";
+      };
+
+      restartTriggers = [
+        dhcp6Config
+      ];
+
+      serviceConfig = {
+        ExecStart = "${package}/bin/kea-dhcp6 -c /etc/kea/dhcp6-server.conf ${lib.escapeShellArgs cfg.dhcp6.extraArgs}";
+        # Kea does not request capabilities by itself
+        AmbientCapabilities = [
+          "CAP_NET_BIND_SERVICE"
+        ];
+        CapabilityBoundingSet = [
+          "CAP_NET_BIND_SERVICE"
+        ];
+      } // commonServiceConfig;
+    };
+  })
+
+  (mkIf cfg.dhcp-ddns.enable {
+    assertions = [{
+        assertion = xor (cfg.dhcp-ddns.settings == null) (cfg.dhcp-ddns.configFile == null);
+        message = "Either services.kea.dhcp-ddns.settings or services.kea.dhcp-ddns.configFile must be set to a non-null value.";
+    }];
+
+    environment.etc."kea/dhcp-ddns.conf".source = dhcpDdnsConfig;
+
+    systemd.services.kea-dhcp-ddns-server = {
+      description = "Kea DHCP-DDNS Server";
+      documentation = [
+        "man:kea-dhcp-ddns(8)"
+        "https://kea.readthedocs.io/en/kea-${package.version}/arm/ddns.html"
+      ];
+
+      wants = [ "network-online.target" ];
+      after = [
+        "network-online.target"
+        "time-sync.target"
+      ];
+      wantedBy = [
+        "multi-user.target"
+      ];
+
+      environment = {
+        KEA_PIDFILE_DIR = "/run/kea";
+        KEA_LOCKFILE_DIR = "/run/kea";
+      };
+
+      restartTriggers = [
+        dhcpDdnsConfig
+      ];
+
+      serviceConfig = {
+        ExecStart = "${package}/bin/kea-dhcp-ddns -c /etc/kea/dhcp-ddns.conf ${lib.escapeShellArgs cfg.dhcp-ddns.extraArgs}";
+        AmbientCapabilities = [
+          "CAP_NET_BIND_SERVICE"
+        ];
+        CapabilityBoundingSet = [
+          "CAP_NET_BIND_SERVICE"
+        ];
+      } // commonServiceConfig;
+    };
+  })
+
+  ]);
+
+  meta.maintainers = with maintainers; [ hexa ];
+}

--- a/pkgs/fc/agent/fc/manage/kea.py
+++ b/pkgs/fc/agent/fc/manage/kea.py
@@ -1,0 +1,301 @@
+"""Create Kea configuration based on directory data."""
+
+import argparse
+import json
+import sys
+
+import fc.util.configfile
+import fc.util.dhcp
+import fc.util.directory
+import netaddr
+
+
+class ConfigRenderer(object):
+    @staticmethod
+    def get_class(ipversion):
+        """Factory which generates suitable shared network formatter."""
+        if ipversion == 4:
+            return Config4Renderer
+        elif ipversion == 6:
+            return Config6Renderer
+        else:
+            raise NotImplementedError("unsupported IP version", ipversion)
+
+    def render(self):
+        config = {}
+        config["name"] = self.vlan
+        config[self.subnet_keyword] = [
+            self.render_subnet(subnet) for subnet in self.shared_network
+        ]
+
+        return config
+
+
+class Config4Renderer(ConfigRenderer):
+    subnet_keyword = "subnet4"
+
+    def __init__(self, vlan, shared_network, _domain):
+        self.vlan = vlan
+        self.shared_network = shared_network
+
+    def render_subnet(self, subnet):
+        reservations = []
+        for host in subnet.hostaddrs_unique_mac:
+            reservations.append(
+                {
+                    "hw-address": str(host.mac),
+                    "ip-address": str(host.ip.ip),
+                    "hostname": host.name,
+                }
+            )
+
+        config = {}
+        config["subnet"] = str(subnet.network)
+        config["reservations"] = reservations
+        config["option-data"] = [
+            # the default router always gets the first IP address;
+            # additionally provides NTP service
+            {"name": name, "data": str(subnet.network.cidr[1])}
+            for name in ["routers", "ntp-servers"]
+        ]
+
+        if subnet.dynamic:
+            # calculate ranges available for dynamic allocation
+            ranges = []
+            range_start = subnet.network.cidr[4]  # floating gw + 2 routers
+            hostaddrs = sorted(subnet.hostaddrs, key=lambda x: x.ip.ip)
+            for hostaddr in hostaddrs:
+                if hostaddr.ip.ip < subnet.network.cidr[4]:
+                    continue
+                range_end = hostaddr.ip.ip - 1
+                if range_end >= range_start:
+                    ranges.append((range_start, range_end))
+                range_start = hostaddr.ip.ip + 1
+            if range_start <= subnet.network.cidr[-2]:
+                ranges.append((range_start, subnet.network.cidr[-2]))
+
+            config["pools"] = [
+                {"pool": f"{start} - {end}"} for start, end in ranges
+            ]
+
+        return config
+
+
+class Config6Renderer(ConfigRenderer):
+    subnet_keyword = "subnet6"
+
+    def __init__(self, vlan, shared_network, domain):
+        self.vlan = vlan
+        self.shared_network = shared_network
+        self.domain = domain
+
+    def render_subnet(self, subnet):
+        reservations = []
+        for host in subnet.hostaddrs_unique_mac:
+            hostname = (
+                f"{host.name}.{self.domain}" if self.domain else host.name
+            )
+            reservations.append(
+                {
+                    "hw-address": str(host.mac),
+                    "ip-addresses": [str(host.ip.ip)],
+                    "hostname": hostname,
+                }
+            )
+
+        config = {}
+        config["subnet"] = str(subnet.network)
+        config["reservations"] = reservations
+
+        if subnet.dynamic:
+            # grab a random portion of address space
+            range_ = netaddr.IPNetwork(
+                (
+                    (
+                        subnet.network.cidr.ip
+                        | netaddr.IPAddress("::d1c0:0:0:0")
+                    ).value,
+                    80,
+                )
+            )
+
+            config["pools"] = [{"pool": str(range_)}]
+
+        return config
+
+
+class Kea(object):
+    """Kea configuration generator.
+
+    This class retrieves information about configured hosts from the
+    directory and creates a Kea configuration segment representing
+    that information.
+    """
+
+    def __init__(self, args):
+        self.location = args.location
+        self.ipversion = args.ipversion
+        self.domain = args.domain
+        self.directory = fc.util.directory.connect(ring="max")
+        self.hosts = fc.util.dhcp.Hosts()
+        self.requested_networks = args.network if args.network else None
+        self.excluded_networks = args.exclude
+        self.networks = {}
+
+    def query_directory(self):
+        # Query all networks and their subnet declarations
+        vlans = self.directory.lookup_networks_details(
+            self.location, self.ipversion
+        )
+        # Only retain explicitly requested networks
+        if self.requested_networks:
+            vlans = {
+                vlan: networks
+                for vlan, networks in vlans.items()
+                if vlan in self.requested_networks
+            }
+
+        for vlan, networks in vlans.items():
+            self.networks[vlan] = fc.util.dhcp.SharedNetwork()
+            for network in networks:
+                subnet = fc.util.dhcp.Subnet(
+                    netaddr.IPNetwork(network["cidr"]),
+                    network["dhcp"],
+                    self.hosts,
+                )
+                self.networks[vlan].register(subnet)
+
+        # Query all hosts
+        for record in self.directory.list_nodes_addresses(
+            self.location, "", self.ipversion
+        ):
+            if (
+                self.requested_networks
+                and record["vlan"] not in self.requested_networks
+            ):
+                continue
+
+            mac = record["mac"]
+            if not mac:
+                print(
+                    "{}/{}: no MAC address".format(
+                        record["name"], record["vlan"]
+                    ),
+                    file=sys.stderr,
+                )
+                continue
+
+            try:
+                hostaddr = fc.util.dhcp.HostAddr(
+                    record["name"],
+                    record["vlan"],
+                    netaddr.EUI(mac, dialect=netaddr.mac_unix_expanded),
+                    netaddr.IPNetwork(record["ip"]),  # XXX: IPAddress?
+                )
+            except (KeyError, ValueError, netaddr.AddrFormatError) as exc:
+                continue
+
+            self.hosts.add(hostaddr)
+
+    def render(self, output):
+        network_configs = []
+        render_class = ConfigRenderer.get_class(self.ipversion)
+        for vlan, shnet in self.networks.items():
+            if vlan in self.excluded_networks:
+                continue
+            renderer = render_class(vlan, shnet, self.domain)
+            network_configs.append(renderer.render())
+
+        config = {"shared-networks": network_configs}
+        json.dump(config, output, indent=2)
+
+
+def main():
+    """Kea config generator main script."""
+
+    parser = argparse.ArgumentParser(
+        prog="fc-kea",
+        description="""\
+Generate Kea configuration. Query the directory for all hosts
+configured for the given networks in LOCATION. Each network gets a
+subnet declaration and each host gets a fixed-address entry in the
+generated configuration file. By default, all networks in the location
+are used, unless one or more networks are given as options.
+""",
+        epilog="""\
+Returns 0 on success and 1 on error. If the --output option is
+present, return 2 to signal the output file has been changed.
+""",
+    )
+
+    address_family = parser.add_mutually_exclusive_group(required=True)
+    address_family.add_argument(
+        "-4",
+        action="store_const",
+        dest="ipversion",
+        const=4,
+        help="Generate configuration for DHCPv4",
+    )
+    address_family.add_argument(
+        "-6",
+        action="store_const",
+        dest="ipversion",
+        const=6,
+        help="Generate configuration for DHCPv6",
+    )
+
+    parser.add_argument(
+        "-o",
+        "--output",
+        metavar="FILE",
+        default=None,
+        help="Write configuration to FILE instead of stdout",
+    )
+    parser.add_argument(
+        "-L",
+        "--location",
+        metavar="LOCATION",
+        required=True,
+        help="Generate configuration for location LOCATION",
+    )
+    parser.add_argument(
+        "-n",
+        "--network",
+        metavar="NETWORK",
+        default=[],
+        action="append",
+        help="Include hosts in NETWORK in the configuration (may be specified multiple times)",
+    )
+    parser.add_argument(
+        "-e",
+        "--exclude",
+        metavar="NETWORK",
+        default=[],
+        action="append",
+        help="Twinned network: do not generate subnet definition for NETWORK, but include host addresses within its subnets e.g. IPMI addresses (may be specified multiple times)",
+    )
+    parser.add_argument(
+        "-d",
+        "--domain",
+        metavar="DOMAIN",
+        default=None,
+        help="Domain name to use as suffix for qualifying hostnames (only used in DHCPv6)",
+    )
+
+    args = parser.parse_args()
+
+    changed = False
+    kea = Kea(args)
+    kea.query_directory()
+    if args.output:
+        conffile = fc.util.configfile.ConfigFile(args.output)
+        kea.render(conffile)
+        changed = conffile.commit()
+    else:
+        kea.render(sys.stdout)
+    if changed:
+        sys.exit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/pkgs/fc/agent/fc/util/dhcp.py
+++ b/pkgs/fc/agent/fc/util/dhcp.py
@@ -78,6 +78,15 @@ class Subnet(object):
                 if hostaddr.ip in self.network:
                     yield hostaddr
 
+    @property
+    def hostaddrs_unique_mac(self):
+        if not self._hosts:
+            return
+        for host in self._hosts.iter_unique_mac():
+            for hostaddr in host:
+                if hostaddr.ip in self.network:
+                    yield hostaddr
+
 
 class SharedNetwork(object):
     """Represents a collection of subnets on the same physical network."""

--- a/pkgs/fc/agent/setup.py
+++ b/pkgs/fc/agent/setup.py
@@ -70,6 +70,7 @@ setup(
             "fc-dhcpd=fc.manage.dhcpd:main",
             "fc-directory=fc.util.directory:directory_cli",
             "fc-graylog=fc.manage.graylog:main",
+            "fc-kea=fc.manage.kea:main",
             "fc-keepalived=fc.manage.keepalived:app",
             "fc-maintenance=fc.maintenance.cli:app",
             "fc-manage=fc.manage.cli:app",

--- a/tests/router/default.nix
+++ b/tests/router/default.nix
@@ -117,25 +117,32 @@ let
         test00                        A       172.22.22.222
       '';
 
-      flyingcircus.services.dhcpd4.localconfig = ''
-        shared-network fe {
-            subnet 172.20.2.0 netmask 255.255.255.128 {
-                range 172.20.2.17 172.20.2.51;
-                range 172.20.2.125 172.20.2.125;
-                option subnet-mask 255.255.255.128;
-                option routers 172.20.2.1;
-                authoritative;
-            }
-        }
-      '';
+      flyingcircus.services.dhcpd4.localconfig = {
+        shared-networks = [{
+          name = "fe";
+          subnet4 = [{
+            subnet = "172.20.2.0/25";
+            option-data = [{
+              name = "routers";
+              data = "172.20.2.1";
+            }];
+            pools = [{
+              pool = "172.20.2.17 - 172.20.2.51";
+            } {
+              pool = "172.20.2.125 - 172.20.2.125";
+            }];
+          }];
+        }];
+      };
 
-      flyingcircus.services.dhcpd6.localconfig = ''
-        shared-network fe {
-            subnet6 2a02:238:f030:1c2::/64 {
-                authoritative;
-            }
-        }
-      '';
+      flyingcircus.services.dhcpd6.localconfig = {
+        shared-networks = [{
+          name = "fe";
+          subnet6 = [{
+            subnet = "2a02:238:f030:1c2::/64";
+          }];
+        }];
+      };
 
       flyingcircus.enc.name = "router${toString id}";
       flyingcircus.enc.parameters = {
@@ -326,14 +333,14 @@ in
       with subtest("bind is running"):
         primary.wait_for_unit("bind")
 
-      with subtest("dhcpd4 is running"):
+      with subtest("kea-dhcp4-server is running"):
         import time
         time.sleep(10)
-        print(primary.execute("journalctl -u dhcpd4")[1])
-        primary.wait_for_unit("dhcpd4")
+        print(primary.execute("journalctl -u kea-dhcp4-server")[1])
+        primary.wait_for_unit("kea-dhcp4-server")
 
-      with subtest("dhcpd6 is running"):
-        primary.wait_for_unit("dhcpd6")
+      with subtest("kea-dhcp6-server is running"):
+        primary.wait_for_unit("kea-dhcp6-server")
 
       with subtest("tftp daemon (atftpd) is running and serves files"):
         primary.wait_for_unit("atftpd")


### PR DESCRIPTION
Forward porting hardware support to 24.11 is currently blocked on isc-dhcp, which is end-of-life and has been removed from Nixpkgs in more recent versions. This change replaces dhcpd with Kea, the designated successor project, which is supported by Nixpkgs upstream.

This includes fc-agent support for generating static lease configuration based on data from the directory. This integration has a few correctness fixes in comparison with the isc-dhcp integration: the NTP server option advertised in DHCP is now set to the subnet router address to match the NixOS host configuration, twinned networks are handled properly to avoid multiple definitions of overlapping subnets, and the hostnames advertised in DHCPv6 are now fully-qualified domain names, as DHCPv6 does not have separate options for hostname and domain name.

PL-133205

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - The new DHCP server implementation should match the behaviour of the old DHCP server implementation.
- [x] Security requirements tested? (EVIDENCE)
  - Kea is actively maintained by upstream and has security support.
  - Tested on a router in DEV. Manually verified that both BIOS and UEFI clients can properly load iPXE, and that the iPXE loader can properly load the boot menu script.