### PR TITLE
[24.11] fix postgres update tests

### DIFF
--- a/nixos/services/postgresql/default.nix
+++ b/nixos/services/postgresql/default.nix
@@ -212,7 +212,11 @@ in {
 
       flyingcircus.activationScripts = {
         postgresql-srv = lib.stringAfter [ "users" "groups" ] ''
-          install -d -o postgres /srv/postgresql/${cfg.majorVersion}
+          # postgres data dirs are referenced in the unit as ReadWritePaths and
+          # already need to exist at unit start
+          install -d -o postgres -g postgres -m 0700 /srv/postgresql
+          install -d -o postgres -g postgres -m 0700 /srv/postgresql/${cfg.majorVersion}
+          # keep around required postgres packages for upgrading
           install -d -o postgres /nix/var/nix/gcroots/per-user/postgres
         '';
       };

--- a/pkgs/fc/agent/fc/util/postgresql.py
+++ b/pkgs/fc/agent/fc/util/postgresql.py
@@ -6,6 +6,7 @@ import tempfile
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
+from stat import S_IMODE as modebits
 from subprocess import CalledProcessError, run
 
 MIGRATED_TO_TEMPLATE = """\
@@ -31,13 +32,17 @@ Prepared as new data directory for a migration from {old_data_dir} by
 {initdb_cmd}
 """
 
+# the leading 04 descibes being a directory according to `stat`. Pass through
+# `modebits` before using it for `chmod`
+DATA_DIR_ST_MODE = 0o040700
+
 
 class PGVersion(str, Enum):
-    PG12 = "12"
     PG13 = "13"
     PG14 = "14"
     PG15 = "15"
     PG16 = "16"
+    # PG17 = "17"
 
 
 def run_as_postgres(cmd, **kwargs):
@@ -171,7 +176,7 @@ def create_new_data_dir(
         collate=collate,
         ctype=ctype,
     )
-    new_data_dir.mkdir(mode=0o0700)
+    new_data_dir.mkdir(mode=modebits(DATA_DIR_ST_MODE))
     shutil.chown(new_data_dir, "postgres", "postgres")
     initdb_cmd = [
         new_bin_dir / "initdb",
@@ -294,6 +299,17 @@ class NewDataDirUnusable(Exception):
         self.data_dir = data_dir
 
 
+def fix_permissions(toplevel: Path, filemode: int, dirmode: int):
+    """Recursively adjust file and directory mode."""
+    assert os.path.isdir(toplevel), f"{toplevel} is not a directory"
+    for root, dirs, files in os.walk(toplevel):
+        os.chmod(root, dirmode)
+        for directory in dirs:
+            os.chmod(os.path.join(root, directory), dirmode)
+        for file in files:
+            os.chmod(os.path.join(root, file), filemode)
+
+
 def check_new_data_dir(log, new_data_dir):
     if (new_data_dir / "fcio_upgrade_prepared").exists():
         new_data_dir_mode = new_data_dir.stat().st_mode
@@ -305,8 +321,23 @@ def check_new_data_dir(log, new_data_dir):
             group=new_data_dir.group(),
             mode=oct(new_data_dir_mode)[3:],
         )
-        if new_data_dir_mode != 0o040700:
-            log.error("upgrade-existing-data-dir-wrong-mode")
+        if new_data_dir_mode != DATA_DIR_ST_MODE:
+            log.warn(
+                "upgrade-existing-data-dir-wrong-mode",
+                _replace_msg=f"{new_data_dir} has incorrect permission. Adjusting the permissions recursively now.",
+                new_data_dir_mode=new_data_dir_mode,
+                expected_mode=DATA_DIR_ST_MODE,
+            )
+            try:
+                fix_permissions(
+                    new_data_dir,
+                    modebits(DATA_DIR_ST_MODE),
+                    modebits(DATA_DIR_ST_MODE),
+                )
+            except os.PermissionError:
+                log.exception(
+                    "upgrade-existing-data-dir-insufficient-permissions"
+                )
     else:
         raise NewDataDirUnusable(new_data_dir)
 
@@ -359,6 +390,17 @@ def prepare_upgrade(
         collate=collate,
         ctype=ctype,
     )
+    if new_data_dir.exists() and not any(new_data_dir.iterdir()):
+        # empty directories created at system activation time can be ignored,
+        # just let the upgrade process create a new one.
+        log.info(
+            "existing-empty-data-dir",
+            _replace_msg=(
+                "New data dir {new_data_dir} is empty. Removing and recreating it."
+            ),
+            new_data_dir=new_data_dir,
+        )
+        new_data_dir.rmdir()
     if new_data_dir.exists():
         check_new_data_dir(
             log,

--- a/pkgs/fc/agent/fc/util/postgresql.py
+++ b/pkgs/fc/agent/fc/util/postgresql.py
@@ -33,10 +33,6 @@ Prepared as new data directory for a migration from {old_data_dir} by
 {initdb_cmd}
 """
 
-# the leading 04 descibes being a directory according to `stat`. Pass through
-# `modebits` before using it for `chmod`
-DATA_DIR_ST_MODE = 0o040700
-
 
 class PGVersion(str, Enum):
     PG13 = "13"
@@ -177,7 +173,7 @@ def create_new_data_dir(
         collate=collate,
         ctype=ctype,
     )
-    new_data_dir.mkdir(mode=modebits(DATA_DIR_ST_MODE))
+    new_data_dir.mkdir(mode=0o700)
     shutil.chown(new_data_dir, "postgres", "postgres")
     initdb_cmd = [
         new_bin_dir / "initdb",
@@ -322,19 +318,20 @@ def check_new_data_dir(log, new_data_dir):
             group=new_data_dir.group(),
             mode=oct(new_data_dir_mode)[3:],
         )
-        if new_data_dir_mode != DATA_DIR_ST_MODE:
+        # the leading 04 descibes being a directory according to `stat`.
+        if new_data_dir_mode != 0o040700:
             log.warn(
                 "upgrade-existing-data-dir-wrong-mode",
                 _replace_msg=f"{new_data_dir} has incorrect permission. Adjusting the permissions recursively now.",
                 new_data_dir_mode=new_data_dir_mode,
-                expected_mode=DATA_DIR_ST_MODE,
+                expected_mode=0o040700,
             )
             try:
                 fix_permissions(
                     new_data_dir,
                     # files are not executable
-                    filemode=modebits(DATA_DIR_ST_MODE & ~stat.S_IXUSR),
-                    dirmode=modebits(DATA_DIR_ST_MODE),
+                    filemode=0o600,
+                    dirmode=0o700,
                 )
             except PermissionError:
                 log.exception(

--- a/pkgs/fc/agent/fc/util/postgresql.py
+++ b/pkgs/fc/agent/fc/util/postgresql.py
@@ -2,6 +2,7 @@ import getpass
 import os
 import re
 import shutil
+import stat
 import tempfile
 from datetime import datetime
 from enum import Enum
@@ -331,10 +332,11 @@ def check_new_data_dir(log, new_data_dir):
             try:
                 fix_permissions(
                     new_data_dir,
-                    modebits(DATA_DIR_ST_MODE),
-                    modebits(DATA_DIR_ST_MODE),
+                    # files are not executable
+                    filemode=modebits(DATA_DIR_ST_MODE & ~stat.S_IXUSR),
+                    dirmode=modebits(DATA_DIR_ST_MODE),
                 )
-            except os.PermissionError:
+            except PermissionError:
                 log.exception(
                     "upgrade-existing-data-dir-insufficient-permissions"
                 )

--- a/pkgs/fc/agent/fc/util/postgresql.py
+++ b/pkgs/fc/agent/fc/util/postgresql.py
@@ -296,17 +296,6 @@ class NewDataDirUnusable(Exception):
         self.data_dir = data_dir
 
 
-def fix_permissions(toplevel: Path, filemode: int, dirmode: int):
-    """Recursively adjust file and directory mode."""
-    assert os.path.isdir(toplevel), f"{toplevel} is not a directory"
-    for root, dirs, files in os.walk(toplevel):
-        os.chmod(root, dirmode)
-        for directory in dirs:
-            os.chmod(os.path.join(root, directory), dirmode)
-        for file in files:
-            os.chmod(os.path.join(root, file), filemode)
-
-
 def check_new_data_dir(log, new_data_dir):
     if (new_data_dir / "fcio_upgrade_prepared").exists():
         new_data_dir_mode = new_data_dir.stat().st_mode
@@ -327,12 +316,7 @@ def check_new_data_dir(log, new_data_dir):
                 expected_mode=0o040700,
             )
             try:
-                fix_permissions(
-                    new_data_dir,
-                    # files are not executable
-                    filemode=0o600,
-                    dirmode=0o700,
-                )
+                os.chmod(new_data_dir, 0o700)
             except PermissionError:
                 log.exception(
                     "upgrade-existing-data-dir-insufficient-permissions"

--- a/pkgs/fc/agent/fc/util/tests/test_postgresql.py
+++ b/pkgs/fc/agent/fc/util/tests/test_postgresql.py
@@ -108,7 +108,7 @@ def test_prepare_upgrade_adjusts_permissions(
         os.stat(new_data_dir).st_mode == 0o040700
     ), "Permissions not adjusted correctly"
     assert (
-        os.stat(new_data_dir / "fcio_upgrade_prepared").st_mode == 0o100700
+        os.stat(new_data_dir / "fcio_upgrade_prepared").st_mode == 0o100600
     ), "Permissions not adjusted correctly"
 
 

--- a/pkgs/fc/agent/fc/util/tests/test_postgresql.py
+++ b/pkgs/fc/agent/fc/util/tests/test_postgresql.py
@@ -107,9 +107,6 @@ def test_prepare_upgrade_adjusts_permissions(
     assert (
         os.stat(new_data_dir).st_mode == 0o040700
     ), "Permissions not adjusted correctly"
-    assert (
-        os.stat(new_data_dir / "fcio_upgrade_prepared").st_mode == 0o100600
-    ), "Permissions not adjusted correctly"
 
 
 EXPECTED_EXISTING_DBS = {

--- a/pkgs/fc/agent/fc/util/tests/test_postgresql.py
+++ b/pkgs/fc/agent/fc/util/tests/test_postgresql.py
@@ -1,4 +1,5 @@
 import json
+import os
 from unittest.mock import Mock
 
 import fc.manage.postgresql
@@ -32,7 +33,8 @@ def test_build_new_bin_dir(logger, tmp_path):
     assert (new_bin_dir / "pg_upgrade").exists()
 
 
-def test_prepare_upgrade(logger, old_data_dir, monkeypatch, tmp_path):
+@pytest.fixture
+def patch_prepare(monkeypatch):
     monkeypatch.setattr("shutil.chown", Mock())
     monkeypatch.setattr(
         "fc.util.postgresql.get_existing_dbs",
@@ -49,6 +51,11 @@ def test_prepare_upgrade(logger, old_data_dir, monkeypatch, tmp_path):
     monkeypatch.setattr(
         "fc.util.postgresql.is_service_running", (lambda: True)
     )
+
+
+def test_prepare_upgrade(
+    logger, old_data_dir, monkeypatch, tmp_path, patch_prepare
+):
     new_data_dir = tmp_path / "postgresql/15"
     new_data_dir.mkdir()
     (new_data_dir / "fcio_upgrade_prepared").touch()
@@ -61,6 +68,48 @@ def test_prepare_upgrade(logger, old_data_dir, monkeypatch, tmp_path):
         new_data_dir=new_data_dir,
         expected_databases=[],
     )
+
+
+def test_prepare_upgrade_on_empty_dir(
+    logger, old_data_dir, monkeypatch, tmp_path, patch_prepare
+):
+    monkeypatch.setattr("fc.util.postgresql.run_as_postgres", Mock())
+    new_data_dir = tmp_path / "postgresql/15"
+    new_data_dir.mkdir()
+    new_bin_dir = new_data_dir
+    fc.util.postgresql.prepare_upgrade(
+        logger,
+        old_data_dir=old_data_dir,
+        new_version=PGVersion.PG15,
+        new_bin_dir=new_bin_dir,
+        new_data_dir=new_data_dir,
+        expected_databases=[],
+    )
+    # TODO: check logger for existence of "existing-empty-data-dir"
+
+
+def test_prepare_upgrade_adjusts_permissions(
+    logger, old_data_dir, monkeypatch, tmp_path, patch_prepare
+):
+    new_data_dir = tmp_path / "postgresql/15"
+    new_data_dir.mkdir()
+    (new_data_dir / "fcio_upgrade_prepared").touch()
+    os.chmod(new_data_dir, 0o777)
+    new_bin_dir = new_data_dir
+    fc.util.postgresql.prepare_upgrade(
+        logger,
+        old_data_dir=old_data_dir,
+        new_version=PGVersion.PG15,
+        new_bin_dir=new_bin_dir,
+        new_data_dir=new_data_dir,
+        expected_databases=[],
+    )
+    assert (
+        os.stat(new_data_dir).st_mode == 0o040700
+    ), "Permissions not adjusted correctly"
+    assert (
+        os.stat(new_data_dir / "fcio_upgrade_prepared").st_mode == 0o100700
+    ), "Permissions not adjusted correctly"
 
 
 EXPECTED_EXISTING_DBS = {

--- a/tests/postgresql/upgrade.nix
+++ b/tests/postgresql/upgrade.nix
@@ -62,28 +62,28 @@ in {
             (testlib.fcConfig { net.fe = false; })
           ];
 
-          flyingcircus.roles.postgresql12.enable = lib.mkDefault true;
+          flyingcircus.roles.postgresql13.enable = lib.mkDefault true;
 
           specialisation = {
-            pg13.configuration = {
-              flyingcircus.roles.postgresql12.enable = false;
-              flyingcircus.roles.postgresql13.enable = true;
-            };
             pg14.configuration = {
-              flyingcircus.roles.postgresql12.enable = false;
+              flyingcircus.roles.postgresql13.enable = false;
               flyingcircus.roles.postgresql14.enable = true;
             };
             pg15.configuration = {
-              flyingcircus.roles.postgresql12.enable = false;
+              flyingcircus.roles.postgresql13.enable = false;
               flyingcircus.roles.postgresql15.enable = true;
+            };
+            pg16.configuration = {
+              flyingcircus.roles.postgresql13.enable = false;
+              flyingcircus.roles.postgresql16.enable = true;
             };
           };
 
           system.extraDependencies = with pkgs; [
-            postgresql_12
             postgresql_13
             postgresql_14
             postgresql_15
+            postgresql_16
           ];
         };
       };
@@ -91,36 +91,36 @@ in {
       testScript = ''
         ${testSetup}
         with subtest("prepare-autoupgrade should fail when the option is not enabled"):
-          machine.fail("${fc-postgresql} prepare-autoupgrade --new-version 13")
+          machine.fail("${fc-postgresql} prepare-autoupgrade --new-version 14")
 
         with subtest("prepare should fail with unexpected database employees"):
-          machine.fail('${fc-postgresql} upgrade --new-version 13')
+          machine.fail('${fc-postgresql} upgrade --new-version 14')
 
         print(machine.succeed("${fc-postgresql} list-versions"))
 
-        with subtest("prepare upgrade 12 -> 13"):
-          machine.succeed('${fc-postgresql} upgrade --new-version 13 --expected employees')
-          machine.succeed("stat /srv/postgresql/13/fcio_upgrade_prepared")
+        with subtest("prepare upgrade 13 -> 14"):
+          machine.succeed('${fc-postgresql} upgrade --new-version 14 --expected employees')
+          machine.succeed("stat /srv/postgresql/14/fcio_upgrade_prepared")
           # postgresql should still run
           machine.succeed("systemctl status postgresql")
           print(machine.succeed("${fc-postgresql} list-versions"))
 
-        with subtest("upgrade 12 -> 13 from prepared state"):
-          machine.succeed('${fc-postgresql} upgrade --expected employees --new-version 13 --stop --upgrade-now')
-          machine.succeed("stat /srv/postgresql/12/fcio_migrated_to")
-          machine.succeed("stat /srv/postgresql/13/fcio_migrated_from")
+        with subtest("upgrade 13 -> 14 from prepared state"):
+          machine.succeed('${fc-postgresql} upgrade --expected employees --new-version 14 --stop --upgrade-now')
+          machine.succeed("stat /srv/postgresql/13/fcio_migrated_to")
+          machine.succeed("stat /srv/postgresql/14/fcio_migrated_from")
           # postgresql should be stopped
           machine.fail("systemctl status postgresql")
           print(machine.succeed("${fc-postgresql} list-versions"))
 
-        # Clean up migration and start postgresql12 again for the next round.
-        machine.execute("rm -rf /srv/postgresql/13")
-        machine.execute("rm -rf /srv/postgresql/12/fcio_migrated_to")
+        # Clean up migration and start postgresql13 again for the next round.
+        machine.execute("rm -rf /srv/postgresql/14")
+        machine.execute("rm -rf /srv/postgresql/13/fcio_migrated_to")
         machine.systemctl("start postgresql")
 
-        with subtest("upgrade 12 -> 14 in one step"):
+        with subtest("upgrade 13 -> 14 in one step"):
           machine.succeed('${fc-postgresql} upgrade --expected employees --new-version 14 --stop --upgrade-now')
-          machine.succeed("stat /srv/postgresql/12/fcio_migrated_to")
+          machine.succeed("stat /srv/postgresql/13/fcio_migrated_to")
           machine.succeed("stat /srv/postgresql/14/fcio_migrated_from")
           # postgresql should be stopped
           machine.fail("systemctl status postgresql")
@@ -136,6 +136,14 @@ in {
           switch_to(machine, "pg15")
           machine.wait_for_unit("postgresql")
           print(machine.succeed("${fc-postgresql} list-versions"))
+
+        with subtest("upgrade 15 -> 16 in one step"):
+          machine.succeed('${fc-postgresql} upgrade --expected employees --new-version 16 --stop --upgrade-now')
+          machine.succeed("stat /srv/postgresql/15/fcio_migrated_to")
+          machine.succeed("stat /srv/postgresql/16/fcio_migrated_from")
+          switch_to(machine, "pg16")
+          machine.wait_for_unit("postgresql")
+          print(machine.succeed("${fc-postgresql} list-versions"))
       '';
     };
     automatic = {
@@ -146,37 +154,37 @@ in {
             (testlib.fcConfig { net.fe = false; })
           ];
 
-          flyingcircus.roles.postgresql12.enable = lib.mkDefault true;
+          flyingcircus.roles.postgresql13.enable = lib.mkDefault true;
           flyingcircus.services.postgresql.autoUpgrade = {
             enable = true;
             expectedDatabases = [ "employees" ];
           };
 
           specialisation = {
-            pg13UnexpectedDb.configuration = {
-              flyingcircus.roles.postgresql12.enable = false;
-              flyingcircus.roles.postgresql13.enable = true;
+            pg14UnexpectedDb.configuration = {
+              flyingcircus.roles.postgresql13.enable = false;
+              flyingcircus.roles.postgresql14.enable = true;
               flyingcircus.services.postgresql.autoUpgrade.expectedDatabases = lib.mkForce [];
             };
-            pg13.configuration = {
-              flyingcircus.roles.postgresql12.enable = false;
-              flyingcircus.roles.postgresql13.enable = true;
-            };
             pg14.configuration = {
-              flyingcircus.roles.postgresql12.enable = false;
+              flyingcircus.roles.postgresql13.enable = false;
               flyingcircus.roles.postgresql14.enable = true;
             };
             pg15.configuration = {
-              flyingcircus.roles.postgresql12.enable = false;
+              flyingcircus.roles.postgresql13.enable = false;
               flyingcircus.roles.postgresql15.enable = true;
+            };
+            pg16.configuration = {
+              flyingcircus.roles.postgresql13.enable = false;
+              flyingcircus.roles.postgresql16.enable = true;
             };
           };
 
           system.extraDependencies = with pkgs; [
-            postgresql_12
             postgresql_13
             postgresql_14
             postgresql_15
+            postgresql_16
           ];
         };
       };
@@ -186,29 +194,13 @@ in {
         print(machine.succeed("${fc-postgresql} list-versions"))
 
         with subtest("autoupgrade should refuse when unexpected DB is present"):
-          switch_to(machine, "pg13UnexpectedDb", expect="fail")
+          switch_to(machine, "pg14UnexpectedDb", expect="fail")
           machine.fail("systemctl status postgresql")
           print(machine.succeed("${fc-postgresql} list-versions"))
 
         with subtest("prepare autoupgrade should fail when unexpected DB is present"):
           machine.fail('${fc-postgresql} prepare-autoupgrade --new-version 13')
           print(machine.succeed("${fc-postgresql} list-versions"))
-
-        with subtest("autoupgrade 12 -> 13"):
-          # move to new role and wait for postgresql to start
-          switch_to(machine, "pg13")
-          machine.wait_for_unit("postgresql")
-          machine.succeed("stat /srv/postgresql/12/fcio_migrated_to")
-          machine.succeed("stat /srv/postgresql/13/fcio_migrated_from")
-          print(machine.succeed("${fc-postgresql} list-versions"))
-
-        with subtest("prepare autoupgrade 13 -> 14"):
-          machine.succeed('${fc-postgresql} prepare-autoupgrade --new-version 14')
-          machine.succeed("stat /srv/postgresql/14/fcio_upgrade_prepared")
-          # postgresql should still run
-          machine.succeed("systemctl status postgresql")
-          print(machine.succeed("${fc-postgresql} list-versions"))
-
 
         with subtest("autoupgrade 13 -> 14"):
           # move to new role and wait for postgresql to start
@@ -218,12 +210,28 @@ in {
           machine.succeed("stat /srv/postgresql/14/fcio_migrated_from")
           print(machine.succeed("${fc-postgresql} list-versions"))
 
+        with subtest("prepare autoupgrade 14 -> 15"):
+          machine.succeed('${fc-postgresql} prepare-autoupgrade --new-version 15')
+          machine.succeed("stat /srv/postgresql/15/fcio_upgrade_prepared")
+          # postgresql should still run
+          machine.succeed("systemctl status postgresql")
+          print(machine.succeed("${fc-postgresql} list-versions"))
+
+
         with subtest("autoupgrade 14 -> 15"):
           # move to new role and wait for postgresql to start
           switch_to(machine, "pg15")
           machine.wait_for_unit("postgresql")
           machine.succeed("stat /srv/postgresql/14/fcio_migrated_to")
           machine.succeed("stat /srv/postgresql/15/fcio_migrated_from")
+          print(machine.succeed("${fc-postgresql} list-versions"))
+
+        with subtest("autoupgrade 15 -> 16"):
+          # move to new role and wait for postgresql to start
+          switch_to(machine, "pg16")
+          machine.wait_for_unit("postgresql")
+          machine.succeed("stat /srv/postgresql/15/fcio_migrated_to")
+          machine.succeed("stat /srv/postgresql/16/fcio_migrated_from")
           print(machine.succeed("${fc-postgresql} list-versions"))
       '';
     };


### PR DESCRIPTION
@flyingcircusio/release-managers

Follow-up to #1169. Fixes the postgresql-autoupgrade tests by adjusting the used postgresql versions and handling new behaviour regarding data directories.

development branch, the failing tests are fine and will be taken care of later.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - [x] handle some edgecases in postgres data permissions
- [x] Security requirements tested? (EVIDENCE)
  - [x] fix eval and build of postgres-autoupgrade test