### PR TITLE
[21.05] Fix RIB monitoring script to handle unspecified address as next hop

### DIFF
--- a/changelog.d/20241127_101712_PL-133199-rib-monitor-nokia-nexthop_scriv.md
+++ b/changelog.d/20241127_101712_PL-133199-rib-monitor-nokia-nexthop_scriv.md
@@ -1,0 +1,21 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+
+### NixOS XX.XX platform
+
+- pkgs: fix the monitoring script for the IPv4 underlay network to
+  correctly handle next hop addresses sent by Nokia SR Linux
+  switches. (PL-133199)

--- a/pkgs/fc/check-rib-integrity/check_rib_integrity.py
+++ b/pkgs/fc/check-rib-integrity/check_rib_integrity.py
@@ -207,7 +207,7 @@ def check_unicast_rib(args):
             continue
 
         nexthops = [
-            IPv6Address(n["ip"])
+            IPv6Address(p["peerId"] if n["ip"] == "::" else n["ip"])
             for p in paths
             for n in p["nexthops"]
             if "used" in n and n["used"]


### PR DESCRIPTION
The BGP implementation in Nokia SR Linux sends the unspecified address `::` as the next hop for IPv4-via-IPv6 routes on BGP sessions with NixOS hosts. FRR interprets this correctly, however this causes the monitoring script to incorrectly report an error. This change updates the monitoring script to handle this special case properly.

PL-133199

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`


## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Monitoring correctness.
- [x] Security requirements tested? (EVIDENCE)
  - Tested manually on a machine in DEV, manually verified the Hydra tests pass.