### PR TITLE
[21.05] Fix radvd config to use the correct interface name

### DIFF
--- a/changelog.d/20241127_112609_PL-133201-radvd-fix-interface-names_scriv.md
+++ b/changelog.d/20241127_112609_PL-133201-radvd-fix-interface-names_scriv.md
@@ -1,0 +1,21 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+
+
+### NixOS XX.XX platform
+
+- router: fix radvd config generation to use the correct derived
+  interface name. (PL-133201)

--- a/nixos/roles/router/radvd.nix
+++ b/nixos/roles/router/radvd.nix
@@ -6,6 +6,7 @@ let
 
   role = config.flyingcircus.roles.router;
   inherit (config) fclib;
+  inherit (config.flyingcircus) location static;
   blockIndent = width: text:
     let
       # Create a string of `width` number of spaces.
@@ -15,15 +16,15 @@ let
       fclib.unlines
         ([(head lines)] ++ (fclib.indentWith spaces (tail lines)));
 
-  vlans =
-    lib.filterAttrs
-      (vlan: networkAttrs: networkAttrs != [])
-      (lib.mapAttrs
-        (vlan: interface:
-          if lib.elem vlan ["lo" "ipmi" "tr" "sto" "stb"]
-          then []
-          else (filter (na: na.addresses != []) interface.v6.networkAttrs))
-        fclib.network);
+  ifaces = listToAttrs
+    (filter (iface: iface.value.networkAttrs != [])
+      (map (vlan: lib.nameValuePair vlan (
+        let iface = fclib.network."${vlan}";
+        in {
+          inherit (iface) interface;
+          networkAttrs = filter (attr: attr.addresses != []) iface.v6.networkAttrs;
+        }
+      )) static.floatingGatewayNetworks."${location}"));
 
   mkPrefixBlock = { network, prefixLength, ... }: ''
     prefix ${network}/${toString prefixLength} {
@@ -32,24 +33,24 @@ let
     };
   '';
 
-  mkInterfaceBlock = vlan: networkAttrs:
+  mkInterfaceBlock = vlan: iface:
     let
-      interfaceName = if vlan == "ws" then "br${vlan}" else "eth${vlan}";
-      prefixConfigurations = lib.concatMapStringsSep "\n\n" mkPrefixBlock networkAttrs;
+      prefixConfigurations = lib.concatMapStringsSep "\n\n" mkPrefixBlock iface.networkAttrs;
     in ''
-      # ${vlan} VLAN
-      interface ${interfaceName} {
+      # ${vlan} network
+      interface ${iface.interface} {
         AdvSendAdvert on;
         AdvOtherConfigFlag on;
         ${blockIndent 2 prefixConfigurations}
       };
     '';
+
 in
 {
   config = lib.mkIf (role.enable && role.isPrimary) {
     services.radvd = {
       enable = true;
-      config = lib.concatStringsSep "\n\n" (lib.mapAttrsToList mkInterfaceBlock vlans);
+      config = lib.concatStringsSep "\n\n" (lib.mapAttrsToList mkInterfaceBlock ifaces);
     };
   };
 }


### PR DESCRIPTION
The radvd configuration contains some hard-coded assumptions that downstream interfaces are always `ethXXX`, however since the move to VXLAN this is no longer correct. Use the interface name derived by the platform code directly. Additionally, use the static list of networks with floating gateways for generating the configuration instead of excluding an (outdated) list of networks from all which are available.

PL-133201

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Correcting typos in configuration.
- [x] Security requirements tested? (EVIDENCE)
  - Manually verified in DEV.