### PR TITLE
Activate fail2ban sshd ddos jail for all machines as protection against SSH DHeat attacks

### DIFF
--- a/changelog.d/20241128_094013_fc-24.05-dev_scriv.md
+++ b/changelog.d/20241128_094013_fc-24.05-dev_scriv.md
@@ -1,0 +1,22 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+- Activate DDoS SSH rules in fail2ban for production machines.
+
+### NixOS XX.XX platform
+
+- Activate DDoS SSH rules in fail2ban for all machines as protection against SSH DHeat attacks. (PL-132477)
+  This may have impact if you have multiple unauthenticated SSH connections in a short time.
+  We tested this change on non-production machines over the last 3 weeks and got no reports of problems.

--- a/nixos/platform/default.nix
+++ b/nixos/platform/default.nix
@@ -377,12 +377,10 @@ in {
       # overrides it
       cron.enable = fclib.mkPlatform true;
 
-      fail2ban = let
-        production = lib.attrByPath [ "parameters" "production" ] false config.flyingcircus.enc;
-      in {
+      fail2ban = {
         enable = fclib.mkPlatform true;
         maxretry = fclib.mkPlatform 5;
-        jails.sshd.settings.mode = lib.mkIf production (fclib.mkPlatform "ddos");
+        jails.sshd.settings.mode = fclib.mkPlatform "ddos";
         ignoreIP =
           [
             # loopback


### PR DESCRIPTION
PL-132477

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`


## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Should not interfere with customer processes
  - Should effectively block DHeat Attacks
- [x] Security requirements tested? (EVIDENCE)
  - tested for 3+ weeks on all staging machines with no problems
  - tested with ssh-audit on test47
