### PR TITLE
agent: fix merging cold RebootActivity into warm reboots

### DIFF
--- a/changelog.d/20241128_114826_PL-133180-agent-fix-cold-reboot-merge_scriv.md
+++ b/changelog.d/20241128_114826_PL-133180-agent-fix-cold-reboot-merge_scriv.md
@@ -1,0 +1,19 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+
+### NixOS 24.05 platform
+
+- agent: fix merging cold boot activities into warm reboots. We noticed maintenance requests that have been postponed multiple times on some machines, causing repeated maintenance notification mails. (PL-133180).

--- a/pkgs/fc/agent/fc/maintenance/activity/reboot.py
+++ b/pkgs/fc/agent/fc/maintenance/activity/reboot.py
@@ -67,6 +67,9 @@ class RebootActivity(Activity):
                     "cold reboot. This is a significant change."
                 ),
             )
+
+            self.reboot_needed = RebootType.COLD
+
             return ActivityMergeResult(
                 self,
                 is_effective=True,

--- a/pkgs/fc/agent/fc/maintenance/activity/tests/test_reboot.py
+++ b/pkgs/fc/agent/fc/maintenance/activity/tests/test_reboot.py
@@ -77,6 +77,7 @@ def test_reboot_merge_warm_into_cold_is_an_insignificant_update(warm, cold):
 def test_reboot_merge_warm_is_an_insignificant_update(warm):
     other_warm = RebootActivity(RebootType.WARM)
     result = warm.merge(other_warm)
+    assert result.merged.reboot_needed == RebootType.WARM
     assert result.merged is warm
     assert result.is_effective is True
     assert result.is_significant is False
@@ -87,6 +88,7 @@ def test_reboot_merge_cold_is_an_significant_update(warm, cold):
     original = warm
     result = original.merge(cold)
     assert result.merged is original
+    assert result.merged.reboot_needed == RebootType.COLD
     assert result.is_effective is True
     assert result.is_significant is True
     assert result.changes == {"before": "reboot", "after": "poweroff"}


### PR DESCRIPTION
Merging RebootActivity("poweroff") into RebootActivity("reboot") resulted in a warm reboot as the original activity was not updated.

The merge was still reported as successful and significant, so maintenance got postponed with every agent run. We noticed this by looking at repeated maintenance announcement mails.

This scenario got more likely because we now trigger cold reboots when KVM environment parameters change (added in
d12e23a58c42cf7dc18d33fcabda6074df351d37) but it's still an exceptional case. Most reboots in practice are triggered by more specific activities, UpdateActivity and VMChangeActivity.

PL-133180

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`


## PR release workflow (internal)

- [ ] PR has internal ticket
- [ ] internal issue ID (PL-…) part of branch name
- [ ] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - maintenance activities should be merged properly 
- [x] Security requirements tested? (EVIDENCE)
  - automated Python test verifies that the warm reboot turns into a cold boot after merge
  - manually checked on a test VM that a cold reboot request is merged into an existing warm reboot request and that the result is a cold boot
