### PR TITLE
[21.05] Fix VXLAN interface configuration units to reset settings to defaults when deactivated

### DIFF
--- a/changelog.d/20241202_104701_PL-133202-router-flood-suppression_scriv.md
+++ b/changelog.d/20241202_104701_PL-133202-router-flood-suppression_scriv.md
@@ -1,0 +1,25 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+
+
+### NixOS XX.XX platform
+
+- Fix systemd units managing flooding suppression and MAC learning
+  configuration so that settings are restored to their defaults when
+  the units are stopped. (PL-133202)
+
+- Add sensu check on routers to monitor whether flooding suppression
+  is correctly configured on gateway interfaces. (PL-133202)

--- a/nixos/platform/network.nix
+++ b/nixos/platform/network.nix
@@ -658,6 +658,9 @@ in
               reload = ''
                 ip link set ${iface.link} type bridge_slave neigh_suppress on
               '';
+              preStop = ''
+                ip link set ${iface.link} type bridge_slave neigh_suppress off
+              '';
               unitConfig.ReloadPropagatedFrom = [ "${iface.interface}-netdev.service" ];
               serviceConfig = {
                 Type = "oneshot";
@@ -679,6 +682,9 @@ in
               '';
               reload = ''
                 ip link set ${iface.link} type bridge_slave learning off
+              '';
+              preStop = ''
+                ip link set ${iface.link} type bridge_slave learning on
               '';
               unitConfig.ReloadPropagatedFrom = [ "${iface.interface}-netdev.service" ];
               serviceConfig = {

--- a/nixos/roles/router/default.nix
+++ b/nixos/roles/router/default.nix
@@ -14,6 +14,21 @@ let
     runtimeInputs = with pkgs; [ ethtool ];
     text = lib.readFile ./kick-interfaces.sh;
   };
+  checkFloodSuppression = with pkgs; writeScript "check-flood-suppression" ''
+    #! ${runtimeShell}
+    set -euo pipefail
+    IFACE="$1"
+
+    if ip -d -j link show "$IFACE" | jq -e '.[] | .linkinfo.info_slave_data.neigh_suppress' >/dev/null;
+    then
+        echo "CRITICAL: $IFACE: flood suppression enabled on interface -- this should be disabled!"
+        echo
+        echo "Run 'ip link set $IFACE type bridge_slave neigh_suppress off' to fix"
+        exit 2
+    else
+        echo "OK: $IFACE: flood suppression is disabled"
+    fi
+  '';
 
   uplinkInterfaces = map
     (network: fclib.network."${network}".interface)
@@ -258,7 +273,13 @@ in
           interval = 60;
           command = "${pkgs.fc.neighbour-cache-monitor}/bin/neighbour-cache-monitor sensu-check -s /run/sensuclient/neighbour_cache_state.json";
         };
-      };
+      } // (listToAttrs (lib.forEach (filter (iface: iface.policy == "vxlan") gatewayInterfaces)
+        (iface: lib.nameValuePair "flood_suppression_iface_${iface.link}" {
+          notification = "Flood suppression is erroneously enabled";
+          interval = 300;
+          command = "${checkFloodSuppression} ${iface.link}";
+        })
+      ));
 
       expectedConnections = {
         warning = 18000;


### PR DESCRIPTION
The systemd units for configuring the desired flood suppression and MAC learning settings on VXLAN interfaces only had start scripts which applied these settings and did not have stop scripts which would undo these settings when the units were stopped. Flood suppression in particular is disabled by default by the kernel, however we want it enabled on physical hosts -- *unless* those physical hosts are routers. However, due to the lack of stop script in the corresponding systemd unit this means that if a host is not booted with the router role and this is added later, then flood suppression is enabled at boot time but then never disabled, which can cause problems with router failover.

This change adds the corresponding stop script fragments for the respective systemd units. Additionally, I've added a sensu check which monitors whether the flood suppression on routers is correctly configured, as we've had cases where this has not been configured correctly for longer periods of time. 

PL-133202

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`


## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - System settings should apply and un-apply cleanly when roles are added or removed.
  - Routers should be appropriately configured so the platform network functions correctly.
- [x] Security requirements tested? (EVIDENCE)
  - Manually tested on the DEV routers.