### PR TITLE
Add update-nixpkgs cleanup action

### DIFF
--- a/.github/workflows/update-nixpkgs-cleanup.yaml
+++ b/.github/workflows/update-nixpkgs-cleanup.yaml
@@ -1,0 +1,46 @@
+name: update-nixpkgs-cleanup
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  update-nixpkgs-on-merge:
+    if: github.event.pull_request.merged == true && startsWith(github.head_ref, 'nixpkgs-auto-update/')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: flyingcircusio/fc-nixos-release-tools
+          path: 'release-tools'
+      - uses: cachix/install-nix-action@v21
+        with:
+          # Nix 2.24 breaks flake update
+          install_url: https://releases.nixos.org/nix/nix-2.18.9/install
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.NIXPKGS_UPDATE_APP_ID }}
+          private-key: ${{ secrets.NIXPKGS_UPDATE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+      - run: |
+          echo "::add-mask::${{steps.app-token.outputs.token}}"
+      - name: Get GitHub App User ID
+        id: get-user-id
+        run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+      - run: |
+          git config --global user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
+          git config --global user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com>'
+      - name: build release tooling
+        run: |
+          nix build ./release-tools#
+      - run: |
+          ./result/bin/update-nixpkgs cleanup \
+            --merged-pr-id ${{ github.event.number }} \
+            --nixpkgs-dir nixpkgs \
+            --nixpkgs-origin-url https://x-access-token:${{steps.app-token.outputs.token}}@github.com/flyingcircusio/nixpkgs.git
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/changelog.d/20241204_152719_PL-133100-update-nixpkgs_scriv.md
+++ b/changelog.d/20241204_152719_PL-133100-update-nixpkgs_scriv.md
@@ -1,0 +1,19 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+
+### NixOS XX.XX platform
+
+- Internal: Introduce automatic nixpkgs update workflow (PL-133100)


### PR DESCRIPTION
This action is part of the update-nixpkgs workflow in fc-nixos-release-tools.

> [!IMPORTANT]  
This requires https://github.com/flyingcircusio/fc-nixos-release-tools/pull/2 to be merged first.

PL-133100

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Should not break 
- [x] Security requirements tested? (EVIDENCE)
  - Tested in fc-nixos-testing repo
    * Action run: https://github.com/flyingcircusio/fc-nixos-testing/actions/runs/12161356428/job/33915768241
    * Update PR: https://github.com/flyingcircusio/fc-nixos-testing/pull/27