### PR TITLE
move package-, version update scripts to flake apps

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -67,6 +67,19 @@
             };
           };
 
+        apps.buildVersionsJson = {
+          type = "app";
+          program = "${pkgs.writeShellScript "update-versions-json" ''
+            jq < $(nix build .#versionsJson --print-out-paths) > release/versions.json
+          ''}";
+        };
+        apps.buildPackageVersionsJson = {
+          type = "app";
+          program = "${pkgs.writeShellScript "update-package-versions-json" ''
+            jq < $(nix build .#packageVersions --print-out-paths) > release/package-versions.json
+          ''}";
+        };
+
         packages = {
           # These are packages that work on all systems.
           # Also see release/flake-part-linux-only-packages.nix
@@ -153,11 +166,11 @@
               # only build this script on Linux. It just produces an error
               # message on Non-Linux because packageVersions is missing.
               build_package_versions_json.exec = ''
-                jq < $(nix build .#packageVersions --print-out-paths) > release/package-versions.json
+                nix run .#buildPackageVersionsJson
               '';
 
               build_versions_json.exec = ''
-                jq < $(nix build .#versionsJson --print-out-paths) > release/versions.json
+                nix run .#buildVersionsJson
               '';
 
               build_channels_dir.exec = ''


### PR DESCRIPTION
This is to support the update-nixpkgs workflow without a devenv shell.

@flyingcircusio/release-managers

## Release process

- [ ] Created changelog entry using `./changelog.sh`
  - No: this is a internal follow up to the unreleased #1186.

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - works
- [x] Security requirements tested? (EVIDENCE)
  - tested locally with `nix run .#{buildVersionsJson, buildPackageVersionsJson}`
