### PR TITLE
[FC-42163] fc-postgresql: support upgrades with custom extensions

### DIFF
--- a/changelog.d/20241209_114200_mb_FC_42163_fc_postgresql_extension_support.md
+++ b/changelog.d/20241209_114200_mb_FC_42163_fc_postgresql_extension_support.md
@@ -1,0 +1,22 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+- None.
+
+### NixOS XX.XX platform
+
+- The `fc-postgresql` command now supports upgrades of databases with preinstalled extensions:
+  - When upgrading manually with `fc-postgresql`, add `--extension-names ext1 --extension-names ext2` to the command line. `ext1`/`ext2` must be the package names of the extensions without the `postgresqlPackages.`-prefix. Usually it's the packages in [`services.postgresql.extraPlugins`](https://search.flyingcircus.io/search/options?q=services.postgresql.extraPlugins&channel=fc-24.05-dev#services.postgresql.extraPlugins).
+  - When using automatic upgrades ([`flyingcircus.services.postgresql.autoUpgrade.enable `](https://search.flyingcircus.io/search/options?q=+flyingcircus.services.postgresql.autoUpgrade.enable+&channel=fc-24.11-dev&page=1#flyingcircus.services.postgresql.autoUpgrade.enable)), existing extensions will be discovered automatically. You don't have to do anything in this case.

--- a/doc/src/postgresql.md
+++ b/doc/src/postgresql.md
@@ -152,6 +152,21 @@ Note that this is done while the old role is still active. It's safe to run
 the command while PostgreSQL is running as it does not have an impact on the
 current cluster and downtime is not required.
 
+If custom extensions are enabled with `services.postgresql.extraPlugins`, make sure
+to add those to the `fc-postgresql` invocation. I.e. for
+
+```nix
+{
+  services.postgresql.extraPlugins = plugins: [ plugins.anonymizer plugins.pgvector ];
+}
+```
+
+you'll need
+
+```
+sudo -u postgres fc-postgresql upgrade --new-version 14 --expected mydb --expected otherdb --extension-names anonymizer --extension-names pgvector
+```
+
 The command should automatically find the old data directory for 13, create
 the new data directory for 14, set it up, and succeed if no problems with the
 old cluster were found. Problems may occur if the old cluster has been
@@ -169,6 +184,9 @@ To actually run the upgrade, use:
 ```sh
 sudo -u postgres fc-postgresql upgrade --new-version 14 --expected mydb --expected otherdb --upgrade-now
 ```
+
+Please note that you'll also need the `--extension-names` parameters as described
+above.
 
 This will stop the postgresql service, prevent it from starting during the
 upgrade, migrate data and mark the old data directory as migrated. This data

--- a/pkgs/fc/agent/fc/manage/postgresql.py
+++ b/pkgs/fc/agent/fc/manage/postgresql.py
@@ -150,6 +150,10 @@ def upgrade(
         ),
         default=None,
     ),
+    extension_names: Optional[List[str]] = Option(
+        default=[],
+        help="Extensions that are used in the databases. Must be the package name from https://search.nixos.org without the `postgresqlXXPackages.`-prefix.",
+    ),
     stop: Optional[bool] = Option(default=None),
     nothing_to_do_is_ok: Optional[bool] = False,
 ):
@@ -166,7 +170,7 @@ def upgrade(
             raise Exit(2)
 
         new_bin_dir = fc.util.postgresql.build_new_bin_dir(
-            log, context.pg_data_root, new_version
+            log, context.pg_data_root, new_version, extension_names
         )
         new_data_dir = context.pg_data_root / new_version.value
 
@@ -345,6 +349,10 @@ def prepare_autoupgrade(
         show_choices=True,
         help="PostgreSQL version to upgrade to.",
     ),
+    extension_names: Optional[List[str]] = Option(
+        default=[],
+        help="Extensions that are used in the databases. Must be the package name from https://search.nixos.org without the `postgresqlXXPackages.`-prefix.",
+    ),
     nothing_to_do_is_ok: Optional[bool] = False,
 ):
     with open(config) as f:
@@ -354,7 +362,7 @@ def prepare_autoupgrade(
     log = structlog.get_logger()
 
     new_bin_dir = fc.util.postgresql.build_new_bin_dir(
-        log, context.pg_data_root, new_version
+        log, context.pg_data_root, new_version, extension_names
     )
     new_data_dir = context.pg_data_root / new_version.value
 

--- a/pkgs/fc/agent/fc/manage/tests/test_postgresql.py
+++ b/pkgs/fc/agent/fc/manage/tests/test_postgresql.py
@@ -1,5 +1,6 @@
 import json
 import traceback
+from typing import List
 from unittest.mock import Mock, patch
 
 import fc.manage.postgresql

--- a/pkgs/fc/agent/fc/util/tests/test_postgresql.py
+++ b/pkgs/fc/agent/fc/util/tests/test_postgresql.py
@@ -1,4 +1,5 @@
 import json
+from typing import List
 from unittest.mock import Mock
 
 import fc.manage.postgresql

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -99,6 +99,7 @@ in {
   postgresql15 = callTest ./postgresql { version = "15"; };
   postgresql16 = callTest ./postgresql { version = "16"; };
   postgresql-autoupgrade = callSubTests ./postgresql/upgrade.nix {};
+  postgresql-autoupgrade-exts = callSubTests ./postgresql/upgrade-with-extension.nix {};
   prometheus = callTest ./prometheus.nix {};
   rabbitmq = callTest ./rabbitmq.nix {};
   redis = callTest ./redis.nix {};

--- a/tests/postgresql/upgrade-with-extension.nix
+++ b/tests/postgresql/upgrade-with-extension.nix
@@ -4,20 +4,21 @@ let
   channel = release.release.src;
 
   insertSql = pkgs.writeText "insert.sql" ''
-    CREATE TABLE employee (
-      id INT PRIMARY KEY,
-      name TEXT
-    );
-    INSERT INTO employee VALUES (1, 'John Doe');
+    create extension anon cascade;
+    select anon.init();
+    create table player(id serial, name text, points int);
+    insert into player(id,name,points) values (1,'Foo', 23);
+    insert into player(id,name,points) values (2,'Bar',42);
+    security label for anon on column player.name is 'MASKED WITH FUNCTION anon.fake_last_name();';
+    security label for anon on column player.points is 'MASKED WITH VALUE NULL';
   '';
 
   dataTest = pkgs.writeScript "postgresql-tests" ''
     set -e
-    createdb employees
-    psql --echo-all -d employees < ${insertSql}
+    createdb anonymized
+    psql -v ON_ERROR_STOP=1 --echo-all -d anonymized < ${insertSql}
   '';
 
-  psql = "sudo -u postgres -- psql";
   fc-postgresql = "sudo -u postgres -- fc-postgresql";
 
   testSetup = ''
@@ -45,14 +46,37 @@ let
         else:
           node.succeed(f"{switcher_path} test")
 
+    # helpers from the pg_anonymizer test in nixpkgs
+    def get_player_table_contents():
+        return [
+            x.split(',') for x in machine.succeed("sudo -u postgres psql -d anonymized --csv --command 'select * from player'").splitlines()[1:]
+        ]
+
+    def check_anonymized_row(row, id, original_name):
+        assert row[0] == id, f"Expected first row to have ID {id}, but got {row[0]}"
+        assert row[1] != original_name, f"Expected first row to have a name other than {original_name}"
+        assert not bool(row[2]), "Expected points to be NULL in first row"
+
+    def check_original_data(output):
+        assert output[0] == ['1','Foo','23'], f"Expected first row from player table to be 1,Foo,23; got {output[0]}"
+        assert output[1] == ['2','Bar','42'], f"Expected first row from player table to be 2,Bar,42; got {output[1]}"
+
+    def check_anonymized_rows(output):
+        check_anonymized_row(output[0], '1', 'Foo')
+        check_anonymized_row(output[1], '2', 'Bar')
+
     machine.wait_for_unit("postgresql.service")
     machine.wait_for_open_port(5432)
 
     machine.succeed('sudo -u postgres -- sh ${dataTest}')
+
+    with subtest("Anonymize DB"):
+        check_original_data(get_player_table_contents())
+        machine.succeed("sudo -u postgres psql -d anonymized --command 'select anon.anonymize_database();'")
   '';
 
 in {
-  name = "postgresql-upgrade";
+  name = "postgresql-upgrade-with-extensions";
   testCases = {
     manual = {
       name = "manual";
@@ -63,6 +87,10 @@ in {
           ];
 
           flyingcircus.roles.postgresql12.enable = lib.mkDefault true;
+          services.postgresql = {
+            extraPlugins = ps: with ps; [ anonymizer ];
+            settings.shared_preload_libraries = lib.mkForce "auto_explain, pg_stat_statements, anon";
+          };
 
           specialisation = {
             pg13.configuration = {
@@ -80,6 +108,10 @@ in {
           };
 
           system.extraDependencies = with pkgs; [
+            (postgresql_12.withPackages (ps: with ps; [ anonymizer ]))
+            (postgresql_13.withPackages (ps: with ps; [ anonymizer ]))
+            (postgresql_14.withPackages (ps: with ps; [ anonymizer ]))
+            (postgresql_15.withPackages (ps: with ps; [ anonymizer ]))
             (postgresql_12.withPackages (ps: [ ]))
             (postgresql_13.withPackages (ps: [ ]))
             (postgresql_14.withPackages (ps: [ ]))
@@ -90,23 +122,28 @@ in {
 
       testScript = ''
         ${testSetup}
+
         with subtest("prepare-autoupgrade should fail when the option is not enabled"):
           machine.fail("${fc-postgresql} prepare-autoupgrade --new-version 13")
 
-        with subtest("prepare should fail with unexpected database employees"):
+        with subtest("prepare should fail with unexpected database anonymized"):
           machine.fail('${fc-postgresql} upgrade --new-version 13')
 
         print(machine.succeed("${fc-postgresql} list-versions"))
 
         with subtest("prepare upgrade 12 -> 13"):
-          machine.succeed('${fc-postgresql} upgrade --new-version 13 --expected employees')
+          machine.fail('${fc-postgresql} upgrade --new-version 13 --expected anonymized')
+          machine.succeed("rm -f /srv/postgresql/12/fcio_stopper && systemctl start postgresql")
+          machine.succeed('${fc-postgresql} upgrade --new-version 13 --expected anonymized --extension-names anonymizer')
           machine.succeed("stat /srv/postgresql/13/fcio_upgrade_prepared")
           # postgresql should still run
           machine.succeed("systemctl status postgresql")
           print(machine.succeed("${fc-postgresql} list-versions"))
 
         with subtest("upgrade 12 -> 13 from prepared state"):
-          machine.succeed('${fc-postgresql} upgrade --expected employees --new-version 13 --stop --upgrade-now')
+          machine.succeed("systemctl status postgresql")
+          machine.succeed("rm -f /srv/postgresql/13/pg_upgrade_server.log")
+          print(machine.succeed('${fc-postgresql} upgrade --expected anonymized --new-version 13 --stop --upgrade-now --extension-names anonymizer || cat /srv/postgresql/13/pg_upgrade_server.log'))
           machine.succeed("stat /srv/postgresql/12/fcio_migrated_to")
           machine.succeed("stat /srv/postgresql/13/fcio_migrated_from")
           # postgresql should be stopped
@@ -119,7 +156,7 @@ in {
         machine.systemctl("start postgresql")
 
         with subtest("upgrade 12 -> 14 in one step"):
-          machine.succeed('${fc-postgresql} upgrade --expected employees --new-version 14 --stop --upgrade-now')
+          machine.succeed('${fc-postgresql} upgrade --expected anonymized --new-version 14 --stop --upgrade-now --extension-names anonymizer')
           machine.succeed("stat /srv/postgresql/12/fcio_migrated_to")
           machine.succeed("stat /srv/postgresql/14/fcio_migrated_from")
           # postgresql should be stopped
@@ -128,14 +165,16 @@ in {
           switch_to(machine, "pg14")
           machine.wait_for_unit("postgresql")
           print(machine.succeed("${fc-postgresql} list-versions"))
+          check_anonymized_rows(get_player_table_contents())
 
         with subtest("upgrade 14 -> 15 in one step"):
-          machine.succeed('${fc-postgresql} upgrade --expected employees --new-version 15 --stop --upgrade-now')
+          machine.succeed('${fc-postgresql} upgrade --expected anonymized --new-version 15 --stop --upgrade-now --extension-names anonymizer')
           machine.succeed("stat /srv/postgresql/14/fcio_migrated_to")
           machine.succeed("stat /srv/postgresql/15/fcio_migrated_from")
           switch_to(machine, "pg15")
           machine.wait_for_unit("postgresql")
           print(machine.succeed("${fc-postgresql} list-versions"))
+          check_anonymized_rows(get_player_table_contents())
       '';
     };
     automatic = {
@@ -149,7 +188,11 @@ in {
           flyingcircus.roles.postgresql12.enable = lib.mkDefault true;
           flyingcircus.services.postgresql.autoUpgrade = {
             enable = true;
-            expectedDatabases = [ "employees" ];
+            expectedDatabases = [ "anonymized" ];
+          };
+          services.postgresql = {
+            extraPlugins = ps: with ps; [ anonymizer ];
+            settings.shared_preload_libraries = lib.mkForce "auto_explain, pg_stat_statements, anon";
           };
 
           specialisation = {
@@ -173,6 +216,10 @@ in {
           };
 
           system.extraDependencies = with pkgs; [
+            (postgresql_12.withPackages (ps: with ps; [ anonymizer ]))
+            (postgresql_13.withPackages (ps: with ps; [ anonymizer ]))
+            (postgresql_14.withPackages (ps: with ps; [ anonymizer ]))
+            (postgresql_15.withPackages (ps: with ps; [ anonymizer ]))
             (postgresql_12.withPackages (ps: [ ]))
             (postgresql_13.withPackages (ps: [ ]))
             (postgresql_14.withPackages (ps: [ ]))
@@ -203,7 +250,7 @@ in {
           print(machine.succeed("${fc-postgresql} list-versions"))
 
         with subtest("prepare autoupgrade 13 -> 14"):
-          machine.succeed('${fc-postgresql} prepare-autoupgrade --new-version 14')
+          machine.succeed('${fc-postgresql} prepare-autoupgrade --new-version 14 --extension-names anonymizer')
           machine.succeed("stat /srv/postgresql/14/fcio_upgrade_prepared")
           # postgresql should still run
           machine.succeed("systemctl status postgresql")
@@ -217,6 +264,7 @@ in {
           machine.succeed("stat /srv/postgresql/13/fcio_migrated_to")
           machine.succeed("stat /srv/postgresql/14/fcio_migrated_from")
           print(machine.succeed("${fc-postgresql} list-versions"))
+          check_anonymized_rows(get_player_table_contents())
 
         with subtest("autoupgrade 14 -> 15"):
           # move to new role and wait for postgresql to start
@@ -225,6 +273,7 @@ in {
           machine.succeed("stat /srv/postgresql/14/fcio_migrated_to")
           machine.succeed("stat /srv/postgresql/15/fcio_migrated_from")
           print(machine.succeed("${fc-postgresql} list-versions"))
+          check_anonymized_rows(get_player_table_contents())
       '';
     };
   };


### PR DESCRIPTION
Upgrading postgresql to a new major with fc-postgresql fails when using custom extensions, defined via `services.postgresql.extraPlugins`.

This patch modifies the relevant agent code to use a postgresql package WITH all needed plugins for upgrades:

* for automatic upgrades, these extensions are discovered automatically.
* for manual upgrades, the user must specify those manually with `--extension-names`.

The original use-case of a customer was to upgrade postgresql to a newer version with `postgresqlPackages.anonymizer` installed (FC-42089). This is a little trickier since it requires `anon` to be listed in `shared_preload_libraries`. For this, all `shared_preload_libraries` are now extracted from `postgresql.conf` and passed to `pg_upgrade` via CLI. This code is based on the assumption that the old `postgresql.conf` is generated by Nix and thus ignores all edge-cases, the postgresql config format may have.

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`


## PR release workflow (internal)

- [x] PR has internal ticket
- [ ] internal issue ID (PL-…) part of branch name
- [ ] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Be able to upgrade postgresql, even with custom extensions.
  - Anonymization (`pg_anon` is used) is kept during upgrades.
- [x] Security requirements tested? (EVIDENCE)
  - Implemented an integration test for both automatic and manual upgrades, based on the original one.
  - Verified a manual upgrade (12 -> 14 with inactive anonymization, 14 -> 15 with active anonymization) on test68.
