### PR TITLE
[PL-133251] fix varnish reload

### DIFF
--- a/changelog.d/20241209_153315_phil-fix-varnish-reload_scriv.md
+++ b/changelog.d/20241209_153315_phil-fix-varnish-reload_scriv.md
@@ -1,0 +1,15 @@
+<!--
+A new changelog entry.
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+-->
+
+### Impact
+
+
+### NixOS XX.XX platform
+
+- Fix a bug in the reload script for the varnish service that only occurs when there are cold VCLs to be discarded. An error in the templating would lead to attempting to run a varnish admin instruction (vcl.discard in this case) as a shell command.

--- a/nixos/services/varnish/default.nix
+++ b/nixos/services/varnish/default.nix
@@ -1,4 +1,9 @@
-{ pkgs, lib, config, ... }: let
+{
+  pkgs,
+  lib,
+  config,
+  ...
+}: let
   cfg = config.flyingcircus.services.varnish;
   vcfg = config.services.varnish;
   vadm = "${vcfg.package}/bin/varnishadm -n ${vcfg.stateDir}";
@@ -128,7 +133,11 @@ in {
       '';
     };
     virtualHosts = mkOption {
-      type = types.attrsOf (types.submodule ({ name, config, ... }: {
+      type = types.attrsOf (types.submodule ({
+        name,
+        config,
+        ...
+      }: {
         options = {
           host = mkOption {
             type = types.str;
@@ -189,7 +198,7 @@ in {
 
         if [ ! -z "$coldvcls" ]; then
           for vcl in "$coldvcls"; do
-            $vadm vcl.discard $vcl
+            ${vadm} vcl.discard $vcl
           done
         fi
       '';


### PR DESCRIPTION
varnish reload was broken before when there was more than 0 cold vcls since the $vadm variable is empty. changing it to ${vadm} properly templates the path to the varnish admin binary using nix.

this does not immediately break varnish but leaves cold vcls lying around. a restart will remove all cold vcls anyways and a consecutive reload would also mark the system as failed but load new vcls as intended besides discarding cold vcls

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`


## PR release workflow (internal)

- [x] PR has internal ticket
- [ ] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - fixes reloads when there is > 0 cold vcls
- [x] Security requirements tested? (EVIDENCE)
  - tested on test vm
