### PR TITLE
kvm_host: fix fc-qemu-scrub not working after reboots

### DIFF
--- a/changelog.d/20241211_102932_PL-133211-fix-qemu-scrub-timer_scriv.md
+++ b/changelog.d/20241211_102932_PL-133211-fix-qemu-scrub-timer_scriv.md
@@ -1,0 +1,19 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+
+
+### NixOS XX.XX platform
+
+- kvm_host: fix fc-qemu-scrub timer which was not properly activating
+  after boot. (PL-133211)

--- a/nixos/roles/kvm.nix
+++ b/nixos/roles/kvm.nix
@@ -309,6 +309,7 @@ in
       description = "Runs the Qemu/KVM scrub script regularly.";
       wantedBy = [ "timers.target" ];
       timerConfig = {
+        OnBootSec = "10m";
         OnUnitActiveSec = "10m";
       };
     };

--- a/tests/kvm_host_ceph-nautilus.nix
+++ b/tests/kvm_host_ceph-nautilus.nix
@@ -384,6 +384,14 @@ in
     host1.execute("systemctl stop fc-ceph-mgr")
     host2.execute("systemctl stop fc-ceph-mgr")
 
+    with subtest("fc-qemu-scrub timer is correctly activated"):
+      _, output = host1.execute("systemctl list-timers | grep fc-qemu-scrub")
+      print(output)
+      assert "fc-qemu-scrub" in output
+      assert "min left "
+      assert not output.startswith("n/a")
+      assert output.count("n/a") <= 2
+
     host1.wait_for_unit("consul")
     host2.wait_for_unit("consul")
     host3.wait_for_unit("consul")


### PR DESCRIPTION
The timer was missing an OnBootSec which went unnoticed because KVM servers have rarely seen reboots in the last months.

PL-133211

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`


## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

general reliability

- [x] Security requirements tested? (EVIDENCE)

improved test coverage
