### PR TITLE
[24.05] fix changelog.sh

### DIFF
--- a/changelog.d/scriv.ini
+++ b/changelog.d/scriv.ini
@@ -1,6 +1,6 @@
 [scriv]
 format = md
 entry_title_template =
-categories = Impact, NixOS platform
+categories = Impact, NixOS XX.XX platform
 output_file = changelog.d/CHANGELOG.md.tmp
 skip_fragments = CHANGELOG.*

--- a/changelog.sh
+++ b/changelog.sh
@@ -2,9 +2,20 @@
 
 set -e
 
+if [ -z "$EDITOR" ]; then
+  echo "Error: \$EDITOR is not set or empty"
+  exit 1
+fi
+
 base="./changelog.d"
 branch=$(git rev-parse --abbrev-ref HEAD)
 
-new_item="${base}/$(date '+%Y%m%d_%H%M%S')_${branch/\//\-}_scriv.md"
-cp "${base}/new_fragment.md.j2" ${new_item}
-$EDITOR $new_item
+new_item="${base}/$(date '+%Y%m%d_%H%M%S')_${branch/\//-}_scriv.md"
+template="${base}/new_fragment.md.j2"
+
+cp "$template" "$new_item"
+
+if ! $EDITOR "$new_item" || diff -q "$template" "$new_item" > /dev/null; then
+  echo "Editor failed or content not changed. Deleting fragment..."
+  rm "${new_item}"
+fi


### PR DESCRIPTION
PL-133226
@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`
- n/a


## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
  - n/a
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
  - n/a

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - bugfix
- [x] Security requirements tested? (EVIDENCE)
  - manually
