### PR TITLE
rabbitmq: add sensu check

### DIFF
--- a/changelog.d/20241212_005619_PL-132311-pre-upgrade-checks_scriv.md
+++ b/changelog.d/20241212_005619_PL-132311-pre-upgrade-checks_scriv.md
@@ -1,0 +1,19 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+
+### NixOS XX.XX platform
+
+- rabbitmq: add sensu check whether all feature-flags are enabled

--- a/nixos/services/rabbitmq/default.nix
+++ b/nixos/services/rabbitmq/default.nix
@@ -283,20 +283,31 @@ in {
 
     flyingcircus.services = {
 
-      sensu-client.checks.rabbitmq-alive = {
-        notification = "rabbitmq amqp alive";
-        command = ''
-          ${pkgs.sensu-plugins-rabbitmq}/bin/check-rabbitmq-amqp-alive.rb \
-            -u fc-sensu -w ${cfg.listenAddress} -p ${sensuPassword}
-        '';
-      };
+      sensu-client.checks = {
+        rabbitmq-alive = {
+          notification = "rabbitmq amqp alive";
+          command = ''
+            ${pkgs.sensu-plugins-rabbitmq}/bin/check-rabbitmq-amqp-alive.rb \
+              -u fc-sensu -w ${cfg.listenAddress} -p ${sensuPassword}
+          '';
+        };
 
-      sensu-client.checks.rabbitmq-node-health = {
-        notification = "rabbitmq node healthy";
-        command = ''
-          ${pkgs.sensu-plugins-rabbitmq}/bin/check-rabbitmq-node-health.rb \
-            -u fc-sensu -w ${cfg.listenAddress} -p ${sensuPassword}
-        '';
+        rabbitmq-node-health = {
+          notification = "rabbitmq node healthy";
+          command = ''
+            ${pkgs.sensu-plugins-rabbitmq}/bin/check-rabbitmq-node-health.rb \
+              -u fc-sensu -w ${cfg.listenAddress} -p ${sensuPassword}
+          '';
+        };
+
+        rabbitmq-feature-flags-enabled = {
+          notification = "rabbitmq all stable feature flags enabled";
+          command = ''
+            ! sudo -u rabbitmq ${pkgs.rabbitmq-server}/bin/rabbitmqctl list_feature_flags state stability |
+              ${pkgs.gnugrep}/bin/grep stable | ${pkgs.gnugrep}/bin/grep  disabled
+          '';
+          interval = 600;
+        };
       };
 
       telegraf.inputs.rabbitmq = [

--- a/tests/rabbitmq.nix
+++ b/tests/rabbitmq.nix
@@ -5,7 +5,7 @@ let
 
 in {
   name = "rabbitmq";
-  machine =
+  nodes.machine =
     { ... }:
     {
       imports = [ ../nixos ../nixos/roles ];
@@ -31,6 +31,7 @@ in {
     sensuOpts = "-u fc-sensu -w ${ipv4} -p ${testlib.derivePasswordForHost "sensu"}";
     amqpAliveCheck = "${pkgs.sensu-plugins-rabbitmq}/bin/check-rabbitmq-amqp-alive.rb ${sensuOpts}";
     nodeHealthCheck = "${pkgs.sensu-plugins-rabbitmq}/bin/check-rabbitmq-node-health.rb ${sensuOpts}";
+    featureFlagCheck = "! sudo -u rabbitmq ${pkgs.rabbitmq-server}/bin/rabbitmqctl list_feature_flags state stability |${pkgs.gnugrep}/bin/grep stable | ${pkgs.gnugrep}/bin/grep  disabled";
   in ''
     machine.wait_for_unit("rabbitmq.service")
     machine.wait_until_succeeds("${amqpPortCheck}")
@@ -49,6 +50,7 @@ in {
 
     with subtest("sensu checks should be green"):
       machine.succeed("${amqpAliveCheck}")
+      machine.succeed("${featureFlagCheck}")
       machine.wait_until_succeeds("${nodeHealthCheck}")
       machine.systemctl("stop rabbitmq.service")
       machine.wait_until_fails("${amqpPortCheck}")


### PR DESCRIPTION
@flyingcircusio/release-managers

PL-132311
## Release process

- [x] Created changelog entry using `./changelog.sh`


## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - admins should know which feature flags to enable _before_ they upgrade again, when required feature flags aren't enabled, updates can lead to a breakage.
- [x] Security requirements tested? (EVIDENCE)
  - deployed the check to pntest00 with rabbitmq without all stable feature flags enabled -> check failed
  - enabled all feature stable flags -> check succeeded.
