### PR TITLE
[21.05][PL-133165] pkgs/overlay: nix: 2.3.16 -> 2.3.18

### DIFF
--- a/changelog.d/20241212_121806_PL-133165-nix-2.3-backport_scriv.md
+++ b/changelog.d/20241212_121806_PL-133165-nix-2.3-backport_scriv.md
@@ -1,0 +1,7 @@
+### Impact
+
+
+### NixOS XX.XX platform
+
+- Updated Nix to 2.3.18 to be able to download `zstd`-compressed paths from our Hydra. It will
+  switch from `xz` to `zstd` to increase its throughput.

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -326,6 +326,32 @@ in {
     };
   });
 
+  nix = super.nix.overrideAttrs (old: rec {
+    name = "nix-${version}";
+    version = "2.3.18";
+    src = self.fetchFromGitHub {
+      owner = "NixOS";
+      repo = "nix";
+      rev = version;
+      hash = "sha256-jBz2Ub65eFYG+aWgSI3AJYvLSghio77fWQiIW1svA9U=";
+    };
+    nativeBuildInputs = (old.nativeBuildInputs or []) ++ [
+      self.libxslt
+      self.libxml2
+      self.docbook_xsl_ns
+      self.docbook5
+      self.bison
+      self.flex
+      self.jq
+      self.autoconf-archive
+      self.autoreconfHook
+    ];
+    buildInputs = (old.buildInputs or []) ++ [
+      self.libarchive
+      self.zstd
+    ];
+  });
+
   matrix-synapse = super.matrix-synapse.overrideAttrs(orig: rec {
     pname = "matrix-synapse";
     version = "1.47.1";


### PR DESCRIPTION
Step one for PL-133165.

Motivation here is to be able to substitute zstd-compressed paths to increase the total throughput of our Hydra.

The entire diff from 2.3.16 to 2.3.18 can be reviewed at https://github.com/NixOS/nix/compare/2.3.16...2.3.18

I went through the changes and didn't notice any notable changes that I'd expect to be an issue.

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`


## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
  - Hydra will switcht to `zstd` for new paths unconditionally. Hence a feature-toggle is not applicable.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Be able to download and unpack new store-paths on system updates.
- [x] Security requirements tested? (EVIDENCE): I verified the functionality in two ways:
  - Local check (done by hand on hydra01):
  ```bash
  $ nix --version
  nix (Nix) 2.18.5
  $ nix-build '<nixpkgs>' -A hello
  /nix/store/fshn3i2vaarsdwjgrrp7i0ywaic1jkqy-hello-2.12.1
  $ nix copy /nix/store/fshn3i2vaarsdwjgrrp7i0ywaic1jkqy-hello-2.12.1 --to file://$(pwd)/tmp-store?compression=zstd # put store-path into a "local" binary cache
  $ nix shell github:nixos/nixpkgs/nixos-21.05#nix_2_3 # Make sure we're testing the right thing (i.e. 2.3.16 cannot substitute)
  $ nix --version
  nix (Nix) 2.3.16
  $ nix-store -r /nix/store/fshn3i2vaarsdwjgrrp7i0ywaic1jkqy-hello-2.12.1 --option substituters file://$(pwd)/tmp-store --store $(pwd)/nix # substitute hello in a local chroot-store
  [...]
  unknown compression method 'zstd'
  error: build of '/nix/store/fshn3i2vaarsdwjgrrp7i0ywaic1jkqy-hello-2.12.1' failed
  $ exit
  $ nix-build -A nix # build Nix from this branch
  /nix/store/iba9cd7zxbfj8pm44kxcn2p88y56x8f0-nix-2.3.18
  $ ./result/bin/nix-store -r /nix/store/fshn3i2vaarsdwjgrrp7i0ywaic1jkqy-hello-2.12.1 --option substituters file://$(pwd)/tmp-store --store $(pwd)/nix # Call with our 2.3.18 should succeed.
  ```
  - End-to-end check (using my personal, zstd-compressed binary cache into a local chroot store: please note that this is GCed and operated on a best-effort basis, so this check will probably not be repeatble in a few months):
  ```
  $ ./result/bin/nix-store -r /nix/store/46z46rrwd4qck4cd129d0zpj9fqc9kwb-neovim-0.10.2 --substituters https://hydra.ist.nicht-so.sexy --store $(pwd)/nix --option require-sigs false
   ```