### PR TITLE
tests.gitlab: Try to make the test more stable

### DIFF
--- a/changelog.d/20241218_140308_PL-133133-gitlab-test-more-stable-24.05_scriv.md
+++ b/changelog.d/20241218_140308_PL-133133-gitlab-test-more-stable-24.05_scriv.md
@@ -1,0 +1,19 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+
+### NixOS XX.XX platform
+
+- Internal: make gitlab NixOS test more stable

--- a/tests/gitlab.nix
+++ b/tests/gitlab.nix
@@ -15,8 +15,8 @@ import ./make-test-python.nix ({ pkgs, lib, testlib, ...} : with lib; {
         (testlib.fcConfig { })
       ];
 
-      virtualisation.memorySize = 4096;
-      virtualisation.cores = 4;
+      virtualisation.memorySize = 6144;
+      virtualisation.cores = 6;
       virtualisation.writableStore = false;
 
       flyingcircus.roles.gitlab = {
@@ -54,6 +54,10 @@ import ./make-test-python.nix ({ pkgs, lib, testlib, ...} : with lib; {
           dbFile = pkgs.writeText "dbsecret" "lsGltKWTejOf6JxCVa7nLDenzkO9wPLR";
           jwsFile = pkgs.runCommand "oidcKeyBase" {} "${pkgs.openssl}/bin/openssl genrsa 2048 > $out";
         };
+
+        # less memory consumption
+        sidekiq.concurrency = 1;
+        puma.workers = 2;
       };
 
       systemd.services.gitlab.serviceConfig.Restart = mkForce "no";
@@ -87,7 +91,7 @@ import ./make-test-python.nix ({ pkgs, lib, testlib, ...} : with lib; {
     gitlab.wait_for_unit("gitlab-postgresql.service")
     gitlab.wait_for_unit("gitaly.service")
     gitlab.wait_for_unit("gitlab-workhorse.service")
-    gitlab.wait_for_unit("gitlab.service", timeout=1200)
+    gitlab.wait_for_unit("gitlab.service", timeout=1800)
     gitlab.wait_for_unit("gitlab-sidekiq.service")
     gitlab.wait_for_file("/run/gitlab/gitlab-workhorse.socket")
     gitlab.wait_for_file("/srv/gitlab/state/tmp/sockets/gitlab.socket")


### PR DESCRIPTION
PL-133133

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`


## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - should still work
  - should not modify the test in a security relevant way
- [x] Security requirements tested? (EVIDENCE)
  - tested test manually
  - Added resources and increased timeouts don't impact security
