### PR TITLE
update-nixpkgs: update for the new fc-release-tools versions

### DIFF
--- a/.github/workflows/update-nixpkgs-cleanup.yaml
+++ b/.github/workflows/update-nixpkgs-cleanup.yaml
@@ -1,7 +1,7 @@
 name: update-nixpkgs-cleanup
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - closed
 
@@ -10,6 +10,11 @@ jobs:
     if: github.event.pull_request.merged == true && startsWith(github.head_ref, 'nixpkgs-auto-update/')
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: 'fc-nixos'
+          fetch-depth: 0
       - uses: actions/checkout@v4
         with:
           repository: flyingcircusio/fc-nixos-release-tools
@@ -40,7 +45,9 @@ jobs:
       - run: |
           ./result/bin/update-nixpkgs cleanup \
             --merged-pr-id ${{ github.event.number }} \
+            --fc-nixos-dir fc-nixos \
             --nixpkgs-dir nixpkgs \
             --nixpkgs-origin-url https://x-access-token:${{steps.app-token.outputs.token}}@github.com/flyingcircusio/nixpkgs.git
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          MATRIX_HOOKSHOT_URL: ${{ secrets.MATRIX_HOOKSHOT_URL }}

--- a/changelog.d/20241218_151938_PL-133100-nixpkgs-updates-hookshot-hard-reset_scriv.md
+++ b/changelog.d/20241218_151938_PL-133100-nixpkgs-updates-hookshot-hard-reset_scriv.md
@@ -1,0 +1,19 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+
+### NixOS XX.XX platform
+
+- Internal: Prepare update-nixpkgs for new fc-release-tools versions


### PR DESCRIPTION
This version sends matrix notifications on graceful failures and hard-resets nixpkgs with a safety belt instead of rebasing. This fixes the problems when a manual rebase conflict resolution is required.

PL-133100

> [!NOTE]  
> * [x] Requires https://github.com/flyingcircusio/fc-nixos-release-tools/pull/3
>
> * [x] Requires MATRIX_HOOKSHOT_URL in secrets to be set.

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`


## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Should work in these scenarios:
    - Normal: No merge conflict, straight forward rebase
    - Conflict: Send notification, don't create PR
    - Moved nixpkgs while PR open: reject hard-rebase
- [x] Security requirements tested? (EVIDENCE)
  - Tested in fc-nixos-testing
