### PR TITLE
fc.agent maintenance reboots: warm -> cold should not require to reschedule

### DIFF
--- a/changelog.d/20241221_120758_PL-133301-reboot-significance_scriv.md
+++ b/changelog.d/20241221_120758_PL-133301-reboot-significance_scriv.md
@@ -1,0 +1,20 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+
+
+### NixOS XX.XX platform
+
+- Changing a planned warm reboot to a cold reboot by merging does not trigger customer notifications and reschedule the maintenance window anymore. (PL-133301)

--- a/pkgs/fc/agent/fc/maintenance/activity/reboot.py
+++ b/pkgs/fc/agent/fc/maintenance/activity/reboot.py
@@ -64,7 +64,7 @@ class RebootActivity(Activity):
                 "merge-reboot-warm-to-cold",
                 help=(
                     "merging a cold reboot into a warm reboot results in a "
-                    "cold reboot. This is a significant change."
+                    "cold reboot."
                 ),
             )
 
@@ -73,6 +73,5 @@ class RebootActivity(Activity):
             return ActivityMergeResult(
                 self,
                 is_effective=True,
-                is_significant=True,
                 changes={"before": RebootType.WARM, "after": RebootType.COLD},
             )

--- a/pkgs/fc/agent/fc/maintenance/activity/tests/test_reboot.py
+++ b/pkgs/fc/agent/fc/maintenance/activity/tests/test_reboot.py
@@ -84,13 +84,13 @@ def test_reboot_merge_warm_is_an_insignificant_update(warm):
     assert not result.changes
 
 
-def test_reboot_merge_cold_is_an_significant_update(warm, cold):
+def test_reboot_merge_cold_is_an_insignificant_update(warm, cold):
     original = warm
     result = original.merge(cold)
     assert result.merged is original
     assert result.merged.reboot_needed == RebootType.COLD
     assert result.is_effective is True
-    assert result.is_significant is True
+    assert result.is_significant is False
     assert result.changes == {"before": "reboot", "after": "poweroff"}
 
 


### PR DESCRIPTION
@ctheune and I have decided that there is no good reason for making the change of a warm to a cold reboot trigger a reschedule and customer notification.

PL-133301

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`


## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - reduce postponing of scheduled maintenances when not necessary
  - no need to notify customers due to implementation specifics (warm and cold reboot have the same apparent consequences for customers)
- [x] Security requirements tested? (EVIDENCE)
  - [x] adjusted unit test
  - [ ] automated tests still pass 
