### PR TITLE
[24.11] flake: fix package versions generation script when <nixpkgs> is not available

### DIFF
--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -1,6 +1,6 @@
 self: super:
 let
-  poetry2nixSrc = (import ../versions.nix { }).poetry2nix;
+  poetry2nixSrc = (import ../versions.nix { pkgs = super; }).poetry2nix;
   poetry2nix = import poetry2nixSrc { pkgs = self; };
 
   # import fossar/nix-phps overlay with nixpkgs-unstable's generic.nix copied in
@@ -8,8 +8,8 @@ let
   phps = (import ../nix-phps/pkgs/phps.nix) (../nix-phps)
     {} super;
 
-  nixpkgs-21_05-src = (import ../versions.nix { }).nixpkgs-21_05;
-  fc-nixos-21_05-src = (import ../versions.nix { }).fc-nixos-21_05;
+  nixpkgs-21_05-src = (import ../versions.nix { pkgs = super; }).nixpkgs-21_05;
+  fc-nixos-21_05-src = (import ../versions.nix { pkgs = super; }).fc-nixos-21_05;
   fc-nixos-21_05 = import fc-nixos-21_05-src {inherit (self) config; nixpkgs = nixpkgs-21_05-src; };
 
   inherit (super) fetchpatch fetchFromGitHub fetchurl lib;


### PR DESCRIPTION
PL-133316

@flyingcircusio/release-managers

## Release process

- [ ] Created changelog entry using `./changelog.sh`
  - no, not released yet

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - should work in GHA (i.e. on a machine with nix 2.18 without a `nixpkgs` channel in NIX_PATH)
- [x] Security requirements tested? (EVIDENCE)
  - tested on a machine without a nixpkgs channel
