### PR TITLE
[21.05] Add new IPv6 address ranges to our reverse DNS configuration

### DIFF
--- a/changelog.d/20250108_153431_PL-133322-reverse-dns-new-ranges_scriv.md
+++ b/changelog.d/20250108_153431_PL-133322-reverse-dns-new-ranges_scriv.md
@@ -1,0 +1,20 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+
+### NixOS XX.XX platform
+
+- router: add new IPv6 ranges to the reverse DNS
+  configuration. (PL-133322)

--- a/nixos/roles/router/bind/default.nix
+++ b/nixos/roles/router/bind/default.nix
@@ -90,6 +90,31 @@ lib.mkIf role.enable {
       2a02:2028:1007:8000::/56 =
       2a02:2028:ff00::2:8:0/112 =
       2a02:248:0:1032::/125 =
+
+      # bug: fc-zones does not correctly support ipv6 prefixes which don't lie on a
+      # nibble boundary, so we have to round the prefix length up to the next nibble
+      # and then split the prefixes into subnets there. see also:
+      # https://docs.db.ripe.net/Database-Support/Configuring-Reverse-DNS/#dealing-with-multiple-zones-for-one-address-block
+
+      # 2a06:3a80::/29
+      2a06:3a80::/32 =
+      2a06:3a81::/32 =
+      2a06:3a82::/32 =
+      2a06:3a83::/32 =
+      2a06:3a84::/32 =
+      2a06:3a85::/32 =
+      2a06:3a86::/32 =
+      2a06:3a87::/32 =
+
+      # 2a07:ed00::/29
+      2a07:ed00::/32 =
+      2a07:ed01::/32 =
+      2a07:ed02::/32 =
+      2a07:ed03::/32 =
+      2a07:ed04::/32 =
+      2a07:ed05::/32 =
+      2a07:ed06::/32 =
+      2a07:ed07::/32 =
     '';
   };
 


### PR DESCRIPTION
We're starting to use new IPv6 address ranges for numbering our hosts, so add these to the configuration file for `fc-zones` on the routers so they get included in the generated reverse DNS zones.

PL-133322

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Configuration change for new IP addresses
- [x] Security requirements tested? (EVIDENCE)
  - Manually verified on a dev router.
