### PR TITLE
[24.11] Fix fc-zones for netaddr version 1.0.0 later

### DIFF
--- a/changelog.d/20250108_160032_PL-133322-fix-fc-zones-24.11_scriv.md
+++ b/changelog.d/20250108_160032_PL-133322-fix-fc-zones-24.11_scriv.md
@@ -1,0 +1,20 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+
+### NixOS XX.XX platform
+
+- router: fix reverse DNS zone generation to work with newer library
+  version. (PL-132122)

--- a/pkgs/fc/agent/fc/manage/zones.py
+++ b/pkgs/fc/agent/fc/manage/zones.py
@@ -180,7 +180,7 @@ class ReverseZone(Zone):
         else:
             self.strip_suffix = "." + self.origin + "."
         self.private = (
-            self.prefix[0].is_private() and self.prefix[-1].is_private()
+            not self.prefix[0].is_global() and not self.prefix[-1].is_global()
         )
 
     def add_ptr(self, addr, name):
@@ -280,7 +280,7 @@ class Zones(object):
         self.internal_forward.add_a(rdn, addr)
         for alias in aliases:
             self.internal_forward.add_cname(alias, rdn)
-        if not addr.is_private():
+        if addr.is_global():
             self.external_forward.add_a(rdn, addr)
             for alias in aliases:
                 self.external_forward.add_cname(alias, rdn)


### PR DESCRIPTION
Between 21.05 and 24.11 there is a new major version of the python netaddr library, which has removed methods which were used in `fc-zones` when generating internal and external DNS view configuration. This change updates `fc-zones` to use different methods for compatibility with netaddr 1.0.0.

PL-132122

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`


## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Adjustment of our tools to account for changes in third-party software.
- [x] Security requirements tested? (EVIDENCE)
  - Manually tested on a dev router.