### PR TITLE
[24.11] Re-enable zebra integration in keepalived config

### DIFF
--- a/changelog.d/20250109_164804_PL-132122-keepalived-frr-integration_scriv.md
+++ b/changelog.d/20250109_164804_PL-132122-keepalived-frr-integration_scriv.md
@@ -1,0 +1,21 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+
+
+### NixOS XX.XX platform
+
+- router: adapt and re-enable zebra integration in keepalived
+  configuration. (PL-132122)

--- a/nixos/roles/router/keepalived/default.nix
+++ b/nixos/roles/router/keepalived/default.nix
@@ -62,8 +62,7 @@ lib.mkIf role.enable {
 
   environment.etc."keepalived/check-default-route-v4".source = "${checkDefaultRoute4}/bin/check-default-route-v4";
   environment.etc."keepalived/check-default-route-v6".source = "${checkDefaultRoute6}/bin/check-default-route-v6";
-  # XXX: not compatible with 24.11 frr module, zebra is no longer a separate system service
-  #environment.etc."keepalived/check-zebra-liveness".source = "${checkZebraLiveness}/bin/check-zebra-liveness";
+  environment.etc."keepalived/check-zebra-liveness".source = "${checkZebraLiveness}/bin/check-zebra-liveness";
   environment.etc."keepalived/fc-keepalived".source = "${pkgs.fc.agent}/bin/fc-keepalived";
   environment.etc."keepalived/keepalived.conf".source = keepalivedConf;
 

--- a/nixos/roles/router/keepalived/default.nix
+++ b/nixos/roles/router/keepalived/default.nix
@@ -28,9 +28,9 @@ let
 
   checkZebraLiveness= fclib.writeShellApplication {
     name = "check-zebra-liveness";
-    runtimeInputs = with pkgs; [ systemd ];
+    runtimeInputs = with pkgs; [ frr ];
     text = ''
-      systemctl -q is-active zebra
+      vtysh -d zebra -c ""
     '';
   };
 

--- a/nixos/roles/router/keepalived/dev.conf
+++ b/nixos/roles/router/keepalived/dev.conf
@@ -12,12 +12,12 @@ vrrp_script check_default_route_v6 {
       rise 2
 }
 
-# vrrp_script check_zebra_liveness {
-#       script "/etc/keepalived/check-zebra-liveness"
-#       interval 1
-#       fall 2
-#       rise 2
-# }
+vrrp_script check_zebra_liveness {
+      script "/etc/keepalived/check-zebra-liveness"
+      interval 1
+      fall 2
+      rise 2
+}
 
 track_file check_stop_file {
   # Allow admins to locally send keepalive into FAIL state by adding
@@ -46,7 +46,7 @@ vrrp_sync_group router {
     track_script {
         check_default_route_v4 weight 10
         check_default_route_v6 weight 5
-        #check_zebra_liveness
+        check_zebra_liveness
     }
 
     track_file {

--- a/nixos/roles/router/keepalived/rzob.conf
+++ b/nixos/roles/router/keepalived/rzob.conf
@@ -12,12 +12,12 @@ vrrp_script check_default_route_v6 {
       rise 2
 }
 
-# vrrp_script check_zebra_liveness {
-#       script "/etc/keepalived/check-zebra-liveness"
-#       interval 1
-#       fall 2
-#       rise 2
-# }
+vrrp_script check_zebra_liveness {
+      script "/etc/keepalived/check-zebra-liveness"
+      interval 1
+      fall 2
+      rise 2
+}
 
 track_file check_stop_file {
   # Allow admins to locally send keepalive into FAIL state by adding
@@ -46,7 +46,7 @@ vrrp_sync_group router {
     track_script {
         check_default_route_v4 weight 10
         check_default_route_v6 weight 5
-        #check_zebra_liveness
+        check_zebra_liveness
     }
 
     track_file {

--- a/nixos/roles/router/keepalived/whq.conf
+++ b/nixos/roles/router/keepalived/whq.conf
@@ -12,12 +12,12 @@ vrrp_script check_dev_route_v6 {
       rise 2
 }
 
-# vrrp_script check_zebra_liveness {
-#       script "/etc/keepalived/check-zebra-liveness"
-#       interval 1
-#       fall 2
-#       rise 2
-# }
+vrrp_script check_zebra_liveness {
+      script "/etc/keepalived/check-zebra-liveness"
+      interval 1
+      fall 2
+      rise 2
+}
 
 track_file check_stop_file {
   # Allow admins to locally send keepalive into FAIL state by adding
@@ -46,7 +46,7 @@ vrrp_sync_group router {
     track_script {
         check_dev_route_v4 weight 10
         check_dev_route_v6 weight 5
-        #check_zebra_liveness
+        check_zebra_liveness
     }
 
     track_file {


### PR DESCRIPTION
Previously we disabled the zebra integration in the keepalived configuration in the process of porting hardware to 24.11, as upstream had changed the way FRR is packaged in NixOS. This change adapts the script which checks for zebra's liveness to use vtysh to connect to the zebra socket directly instead of using systemd, and re-enables the check script in all the site-specific keepalived configs.

PL-132122

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`


## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Adapting existing integrations to work with changed upstream packaging.
- [x] Security requirements tested? (EVIDENCE)
  - Manually tested in DEV. With a router running 24.11 as the site primary, `pkill -TERM zebra` correctly causes keepalived to demote itself into the fault state, triggering a failover.