### PR TITLE
[PL-133028] reorganize Grafana dashboards in folders based on the source's folder structure

### DIFF
--- a/changelog.d/20250114_103947_PL-133028_grafana-dashboard-folder-structure_scriv.md
+++ b/changelog.d/20250114_103947_PL-133028_grafana-dashboard-folder-structure_scriv.md
@@ -1,0 +1,19 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+
+### NixOS XX.XX platform
+
+- Reorganize the dashboards that are provided for every customer with a statshost component in the Grafana UI into separate folders

--- a/nixos/roles/statshost/default.nix
+++ b/nixos/roles/statshost/default.nix
@@ -497,12 +497,12 @@ in
             providers:
             - name: 'default'
               orgId: 1
-              folder: 'FCIO'
               type: file
               disableDeletion: false
               updateIntervalSeconds: 360
               options:
                 path: ${grafanaJsonDashboardPath}
+                foldersFromFilesStructure: true
           '';
         };
         prometheusDatasource = pkgs.writeTextFile {


### PR DESCRIPTION
PL-133028

The dashboards sourced from the Grafana dashboard repository are organized in file system folders. This structure can be re-used for provisioned dashboards in the Grafana UI for an improved separation between "Core" FCIO Dashboards and "Feature Lab" dashboards that can serve as the basis for custom Dashboards in individual Grafana instances.

NB: the previously provisioned "Basic Loki Logging" dashboard (which is currently in the FCIO Folder in the Grafana webinterface) will need to be modified once in the grafana repo in order to be re-provisioned in the "Feature-Lab" folder. 
Without this modification it will remain in the FCIO folder contrary to the structure in the cloned repository in the filesystem that serves as the source for dashboard provisioning.
Testing showed that e.g. adjusting the dashboard's id will move the dashboard to it's intended folder. 

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`


## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [ ] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [ ] Security requirements tested? (EVIDENCE)
