### PR TITLE
[24.11] Update FRR version and fix reload/restart behaviour

### DIFF
--- a/changelog.d/20250114_120805_PL-133076-frr-version-update_scriv.md
+++ b/changelog.d/20250114_120805_PL-133076-frr-version-update_scriv.md
@@ -1,0 +1,21 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+
+
+### NixOS XX.XX platform
+
+- pkgs, nixos: update frr to 8.5.7, and fix reload and restart
+  behaviour to handle config changes and package upgrades correctly.

--- a/nixos/platform/network.nix
+++ b/nixos/platform/network.nix
@@ -797,6 +797,20 @@ in
                   requires = fclib.mkOverrideUpstreamModule [ "network-addresses-${fclib.underlay.interface}.service" ];
                   after = fclib.mkOverrideUpstreamModule [ "network.target" "systemd-sysctl.service" "network-addresses-${fclib.underlay.interface}.service" ];
                   # Wants=network.target set in upstream module.
+
+                  # upstream's settings will cause frr to be restarted
+                  # if the configuration is changed, but only reloaded
+                  # if the package changes. we want this to be the
+                  # other way round: reload if only the configuration
+                  # changes, otherwise restart the daemons entirely.
+                  stopIfChanged = false;
+                  reloadIfChanged = fclib.mkOverrideUpstreamModule false;
+                  restartTriggers = fclib.mkOverrideUpstreamModule [ ];
+                  reloadTriggers = fclib.mkOverrideUpstreamModule [
+                    # see upstream module sources
+                    config.environment.etc."frr/frr.conf".source
+                    config.environment.etc."frr/daemons".text
+                  ];
                 }
               )
             ])

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -120,12 +120,12 @@ builtins.mapAttrs (_: patchPhps phpLogPermissionPatch) {
   });
 
   frr = super.frr.overrideAttrs (old: rec {
-    version = "8.5.6";
+    version = "8.5.7";
     src = super.fetchFromGitHub {
       owner = "FRRouting";
       repo = old.pname;
       rev = "${old.pname}-${version}";
-      hash = "sha256-/36R0YXpIZTGe6EQCNNRLBQ0LrKw7ZCDcFKIdiNPhh8=";
+      hash = "sha256-2ViapJNLO+jwtORtarj+UTdHN/uE2PqyJTwf4dkXBmg=";
     };
 
     patches = [


### PR DESCRIPTION
This change updates FRR to the recently released 8.5.7 version. Additionally, this adjusts the configuration of reload and restart behaviour when a new system configuration is activated.

By default, the upstream NixOS module is configured so that FRR is restarted when the configuration is changed, and only reloaded otherwise, even when the package is updated. This is approximately the opposite of the behaviour we want to have, where configuration changes should trigger a reload only, and other changes of the unit file (including package updates) should trigger a restart.

PL-133076

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Software version update.
- [x] Security requirements tested? (EVIDENCE)
  - Verified on a test host. The test host remains reachable on the network after the upgrade to 8.5.7, other regression testing will be found by Hydra.
  - Tested correct restart/reload behaviour for the package update case and for the configuration change case.