### PR TITLE
fc-slurm check: don't crash on non-"slurm-node"s

### DIFF
--- a/changelog.d/20250116_194543_PL-133153-slurm-check_scriv.md
+++ b/changelog.d/20250116_194543_PL-133153-slurm-check_scriv.md
@@ -1,0 +1,21 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+- A bullet item for the Impact category.
+
+
+### NixOS XX.XX platform
+
+- `fc-slurm check` does not crash anymore on hosts that are not a core slurm-node, but provides a helpful warning (PL-133153)

--- a/pkgs/fc/agent/fc/util/slurm.py
+++ b/pkgs/fc/agent/fc/util/slurm.py
@@ -4,6 +4,7 @@ import time
 from collections import Counter
 from enum import Enum
 from functools import reduce
+from itertools import chain
 from typing import NamedTuple, Optional
 
 import pyslurm
@@ -733,16 +734,35 @@ def check(log, hostname) -> CheckResult:
 
     try:
         controller_names = pyslurm.get_controllers()
+        slurm_nodes = pyslurm.node().get()
     except ValueError as e:
         return CheckResult(errors=[e.args[0]], warnings=[])
 
     if hostname in controller_names:
         results.append(check_controller(log, hostname))
 
-    if hostname in pyslurm.node().get():
+    if hostname in slurm_nodes:
         results.append(check_node(log, hostname))
 
-    return reduce(CheckResult.merge, results)
+    if not results:
+        # No results being available could have 2 reasons:
+        # - core slurm node: an issue with the cluster data
+        # - helper node in the slurm cluster, e.g. a `slurm-external-dependency`:
+        #   not managed by the slurm-controller, so rightfully no data available
+        # Helper nodes still have `fc-slurm` in path as they're part of the coordinated
+        # maintenance logic, but this check is not automatically invoked.
+        # And to better diagnose the situation when it is indeed a core slurm node
+        # and data *should* be available, we list all available data.
+        # We can then spot in the warning what data is missing – instead of
+        # just observing a crash.
+        return CheckResult(
+            warnings=[
+                f"No data available for this node `{hostname}`. Is this a `slurm-node`?\n"
+                f"Got data for nodes {set(chain(controller_names, slurm_nodes))}."
+            ]
+        )
+    else:
+        return reduce(CheckResult.merge, results)
 
 
 def get_account_metrics(account, running, pending, suspended) -> dict:

--- a/pkgs/fc/agent/fc/util/tests/test_slurm.py
+++ b/pkgs/fc/agent/fc/util/tests/test_slurm.py
@@ -1,6 +1,7 @@
 import sys
 import unittest.mock
 from itertools import chain, repeat
+from textwrap import dedent
 from unittest.mock import MagicMock
 
 import pytest
@@ -9,6 +10,7 @@ from pytest import fixture, raises
 
 pyslurm = type(sys)("pyslurm")
 pyslurm.node = MagicMock()
+pyslurm.get_controllers = MagicMock()
 pyslurm.NODE_STATE_DRAIN = 1
 pyslurm.NODE_STATE_DOWN = 2
 pyslurm.NODE_RESUME = 3
@@ -412,4 +414,30 @@ def test_ready_many_timeout(logger, log, monkeypatch):
         "ready-many-timeout",
         timeout=3,
         remaining_node_states=remaining_node_states,
+    )
+
+
+def test_fc_slurm_check_returns_fallback_warning_on_no_data(logger):
+
+    from fc.util.checks import CheckResult
+
+    pyslurm.node.return_value.get.return_value = {
+        "test20": {"state": "IDLE"},
+        "test21": {"state": "ALLOCATED"},
+        "test22": {"state": "MIXED"},
+    }
+    pyslurm.get_controllers.return_value = ["test20"]
+
+    check_result = fc.util.slurm.check("logger", "somehost")
+
+    assert check_result == CheckResult(
+        errors=[],
+        ok_info=[],
+        warnings=[
+            dedent(
+                """\
+                No data available for this node `somehost`. Is this a `slurm-node`?
+                Got data for nodes {'test22', 'test20', 'test21'}."""
+            )
+        ],
     )


### PR DESCRIPTION
When executing `fc-slurm check` on a host that does not have the `slurm-node` or `slurm-controller` role, but is e.g. a `slurm-external-dependency`, the `fc-slurm check` command used to crash due to no available node data.

This implements a fallback warning message to better understand the situation and, if this was about to happen on an actual slurm cluster node, better debug the available cluster information.

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`


## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - user-facing commands shall not crash on common szenarios with invalid data
  - provide helpful debugging information in case of unexpected data
  - increase test coverage for newly-added functionality
- [x] Security requirements tested? (EVIDENCE)
  - [x] new code covered by a unit test
  - [x] NixOS tests still pass
