### PR TITLE
rabbitmq: auto-enable feature flags after upgrade

### DIFF
--- a/doc/src/rabbitmq.md
+++ b/doc/src/rabbitmq.md
@@ -27,13 +27,15 @@ The default monitoring setup checks that the RabbitMQ server is healthy and resp
 RabbitMQ 3.8 introduced [Feature Flags](https://www.rabbitmq.com/feature-flags.html)
 to allow rolling upgrades of clusters. Newer versions can require certain
 feature flags to be enabled before upgrading or they will refuse to start.
+There is a Sensu check which fails when there are disabled feature flags.
 
-After upgrading a cluster, enable all feature flags:
+After upgrading a cluster, all stable feature flags need to be enabled.
+This is done automatically in resource groups where only one node has the `rabbitmq` role.
 
+For larger clusters, enable them manually by running:
 ```shell
 sudo -u rabbitmq rabbitmqctl enable_feature_flag all
 ```
-
 ## Upgrading from NixOS 20.09 while keeping RabbitMQ 3.6.5
 
 To be able to upgrade NixOS 20.09 machines using the `rabbitmq36_5` role,

--- a/nixos/roles/rabbitmq.nix
+++ b/nixos/roles/rabbitmq.nix
@@ -83,5 +83,11 @@ in
         }
       ];
     }
+
+    {
+      systemd.services.rabbitmq.postStart = lib.optionalString ((length (fclib.findServices "rabbitmq-node")) == 1) ''
+          rabbitmqctl enable_feature_flag all
+        '';
+    }
   ];
 }

--- a/tests/rabbitmq.nix
+++ b/tests/rabbitmq.nix
@@ -1,29 +1,44 @@
 import ./make-test-python.nix ({ lib, pkgs, testlib, ... }:
 let
   # Default IP automatically assigned in NixOS tests. Must not be changed here.
-  ipv4 = "192.168.1.1";
+  ipv4 = "192.168.3.1";
+  nodeDefaults = {
+    flyingcircus.roles.rabbitmq.enable = true;
+
+    flyingcircus.encServices = [
+      {
+        address = "machine.gocept.net";
+        location = "test";
+        password = "baz";
+        service = "rabbitmq-node";
+      }
+    ];
+  };
 
 in {
   name = "rabbitmq";
-  machine =
-    { ... }:
-    {
-      imports = [ ../nixos ../nixos/roles ];
-      flyingcircus.roles.rabbitmq.enable = true;
-
-      flyingcircus.enc.parameters = {
-        resource_group = "test";
-        interfaces.srv = {
-          mac = "52:54:00:12:34:56";
-          bridged = false;
-          networks = {
-            "192.168.1.0/24" = [ ipv4 ];
-          };
-          gateways = {};
-        };
-      };
-      virtualisation.diskSize = 1000;
+  nodes = {
+    machine = { ... }: {
+      imports = [
+        nodeDefaults
+        (testlib.fcConfig {id = 1;})
+      ];
     };
+    multiNode =  { ... }: {
+      imports = [
+        nodeDefaults
+        (testlib.fcConfig {id = 2;})
+      ];
+      flyingcircus.encServices = [
+        {
+          address = "multiNode.gocept.net";
+          location = "test";
+          password = "bar";
+          service = "rabbitmq-node";
+        }
+      ];
+    };
+  };
 
   testScript = let
     cli = "sudo -u rabbitmq rabbitmqctl";
@@ -32,6 +47,7 @@ in {
     amqpAliveCheck = "${pkgs.sensu-plugins-rabbitmq}/bin/check-rabbitmq-amqp-alive.rb ${sensuOpts}";
     nodeHealthCheck = "${pkgs.sensu-plugins-rabbitmq}/bin/check-rabbitmq-node-health.rb ${sensuOpts}";
   in ''
+    start_all()
     machine.wait_for_unit("rabbitmq.service")
     machine.wait_until_succeeds("${amqpPortCheck}")
 
@@ -42,11 +58,13 @@ in {
 
     with subtest("settings script must create monitoring users and set their monitoring tag"):
       machine.succeed("${cli} list_users | grep fc-telegraf | grep monitoring")
-      machine.succeed("${cli} list_users | grep fc-sensu | grep monitoring")
+
 
     with subtest("settings script must delete default guest user"):
       machine.fail("${cli} list_users | grep guest");
 
+    with subtest("single-node cluster must auto-activate all feature flags"):
+      machine.succeed("journalctl -g 'Enabling all feature flags'")
     with subtest("sensu checks should be green"):
       machine.succeed("${amqpAliveCheck}")
       machine.wait_until_succeeds("${nodeHealthCheck}")
@@ -59,5 +77,11 @@ in {
 
     with subtest("service user should be able to write to local config dir"):
       machine.succeed('sudo -u rabbitmq touch /etc/local/rabbitmq/rabbitmq.config')
+
+    multiNode.wait_for_unit("rabbitmq.service")
+
+    with subtest("no auto-activation of feature flags on multi-node clusters"):
+      multiNode.fail("journalctl -g 'Enabling all feature flags'")
+
   '';
 })


### PR DESCRIPTION
Autmatically enable all feature flags after an upgrade for single-node rabbitmq clusters.

PL-132311

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - in constellation where this is possible (single-node clusters), all available feature flags should be enabled automatically.
- [x] Security requirements tested? (EVIDENCE)
  - tested manually on pntest00
  - wrote and ran tests

