### PR TITLE
Add audit logging implementation based on Alloy and go-audit

### DIFF
--- a/nixos/platform/audit.nix
+++ b/nixos/platform/audit.nix
@@ -2,6 +2,10 @@
 
 with lib;
 
+let
+  cfg = config.flyingcircus.audit;
+in
+
 {
   /* XXX after beta
     imports = [
@@ -11,9 +15,10 @@ with lib;
 
   options.flyingcircus.audit = {
     enable = mkEnableOption "auditing (beta)";
+    useAlloy = mkEnableOption "auditing implementation using grafana alloy and loki";
   };
 
-  config = (mkIf (config.flyingcircus.audit.enable) {
+  config = (mkIf cfg.enable {
     security.audit = {
       enable = true;
       rules = [

--- a/nixos/platform/auditbeat.nix
+++ b/nixos/platform/auditbeat.nix
@@ -5,6 +5,7 @@ with lib;
 let
   fclib = config.fclib;
   cfg = config.flyingcircus.auditbeat;
+  cfgAudit = config.flyingcircus.audit;
 
 in
 {
@@ -21,7 +22,7 @@ in
   };
 
   # TODO: remove mkIf after beta
-  config = mkIf (config.flyingcircus.audit.enable) {
+  config = mkIf (cfgAudit.enable && !cfgAudit.useAlloy) {
     flyingcircus.filebeat.inputs.auditbeat = {
       type = "log";
       enabled = true;

--- a/nixos/platform/default.nix
+++ b/nixos/platform/default.nix
@@ -25,6 +25,7 @@ in {
     ./alloy.nix
     ./audit.nix
     ./auditbeat.nix
+    ./go-audit.nix
     ./beats.nix
     ./filebeat.nix
     ./enc.nix

--- a/nixos/platform/go-audit.nix
+++ b/nixos/platform/go-audit.nix
@@ -1,0 +1,64 @@
+{ pkgs, lib, config, ... }:
+
+let
+  fclib = config.fclib;
+  cfg = config.flyingcircus.go-audit;
+  cfgAudit = config.flyingcircus.audit;
+
+in
+{
+  options.flyingcircus.go-audit = with lib; {
+    package = mkOption {
+      type = types.package;
+      default = pkgs.go-audit;
+      defaultText = "pkgs.go-audit";
+      example = "pkgs.go-audit";
+      description = "The go-audit package to use.";
+    };
+  };
+
+  # TODO: remove mkIf after beta
+  config = lib.mkIf (cfgAudit.enable && cfgAudit.useAlloy) {
+    environment.etc."alloy/go-audit.alloy".text = ''
+      loki.source.gelf "go_audit" {
+        listen_address = "127.0.0.1:12201"
+        forward_to = [loki.process.go_audit.receiver]
+      }
+
+      loki.process "go_audit" {
+        forward_to = [loki.write.fcio_rg_loki.receiver]
+
+        stage.json {
+          expressions = {
+            message = "short_message",
+          }
+        }
+
+        stage.output {
+          source = "message"
+        }
+      }
+    '';
+    systemd.services.alloy.restartTriggers = [ config.environment.etc."alloy/go-audit.alloy".source ];
+
+    systemd.services.go-audit = let
+      configFile = pkgs.writeText "go-audit.yaml" (lib.generators.toJSON {} {
+        rules = config.security.audit.rules;
+        output.gelf = {
+          enabled = true;
+          address = "127.0.0.1:12201";
+        };
+      });
+    in {
+      description = "go-audit";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      conflicts = [ "auditd.service" ];
+      path = [ pkgs.audit ];
+      serviceConfig = {
+        Restart = "always";
+        ExecStart = "${cfg.package}/bin/go-audit -config ${configFile}";
+      };
+    };
+  };
+}

--- a/pkgs/go-audit/0001-Split-audit-message-into-key-value-pairs-for-better-.patch
+++ b/pkgs/go-audit/0001-Split-audit-message-into-key-value-pairs-for-better-.patch
@@ -1,0 +1,67 @@
+From 5d975a9446cf77e5393b489fd3b2e291d6595dee Mon Sep 17 00:00:00 2001
+From: Molly Miller <mm@flyingcircus.io>
+Date: Mon, 3 Feb 2025 10:06:00 +0100
+Subject: [PATCH 1/4] Split audit message into key-value pairs for better JSON
+ parsing
+
+---
+ parser.go | 27 ++++++++++++++++++++++-----
+ 1 file changed, 22 insertions(+), 5 deletions(-)
+
+diff --git a/parser.go b/parser.go
+index ffb241f..82e86ab 100644
+--- a/parser.go
++++ b/parser.go
+@@ -21,10 +21,11 @@ const (
+ )
+ 
+ type AuditMessage struct {
+-	Type      uint16 `json:"type"`
+-	Data      string `json:"data"`
+-	Seq       int    `json:"-"`
+-	AuditTime string `json:"-"`
++	Type      uint16            `json:"type"`
++	Data      string            `json:"data_raw"`
++	DataMap   map[string]string `json:"data"`
++	Seq       int               `json:"-"`
++	AuditTime string            `json:"-"`
+ 
+ 	Containers map[string]string `json:"containers,omitempty"`
+ 	Extras     *AuditExtras      `json:"extras,omitempty"`
+@@ -61,9 +62,11 @@ func NewAuditMessageGroup(am *AuditMessage) *AuditMessageGroup {
+ // Creates a new go-audit message from a netlink message
+ func NewAuditMessage(nlm *syscall.NetlinkMessage) *AuditMessage {
+ 	aTime, seq := parseAuditHeader(nlm)
++	rawData := string(nlm.Data)
+ 	return &AuditMessage{
+ 		Type:      nlm.Header.Type,
+-		Data:      string(nlm.Data),
++		Data:      rawData,
++		DataMap:   splitMessageData(rawData),
+ 		Seq:       seq,
+ 		AuditTime: aTime,
+ 	}
+@@ -91,6 +94,20 @@ func parseAuditHeader(msg *syscall.NetlinkMessage) (time string, seq int) {
+ 	return time, seq
+ }
+ 
++// Splits the data string into key-value pairs
++func splitMessageData(data string) map[string]string {
++	s := make(map[string]string)
++	for _, v := range strings.Fields(data) {
++		splits := strings.SplitAfterN(v, "=", 2)
++		if len(splits) == 2 {
++			splits[0] = strings.Trim(splits[0], "=")
++			splits[1] = strings.TrimPrefix(splits[1], "=")
++			s[splits[0]] = splits[1]
++		}
++	}
++	return s
++}
++
+ // Add a new message to the current message group
+ func (amg *AuditMessageGroup) AddMessage(am *AuditMessage) {
+ 	amg.Msgs = append(amg.Msgs, am)
+-- 
+2.39.5 (Apple Git-154)
+

--- a/pkgs/go-audit/0002-Decode-audit-message-type-number-into-string-constan.patch
+++ b/pkgs/go-audit/0002-Decode-audit-message-type-number-into-string-constan.patch
@@ -1,0 +1,145 @@
+From c871410d5e79eb4a0a0df9496ec3a1bed0d4413e Mon Sep 17 00:00:00 2001
+From: Molly Miller <mm@flyingcircus.io>
+Date: Mon, 3 Feb 2025 10:17:02 +0100
+Subject: [PATCH 2/4] Decode audit message type number into string constants
+
+---
+ parser.go | 106 ++++++++++++++++++++++++++++++++++++++++++++++++------
+ 1 file changed, 96 insertions(+), 10 deletions(-)
+
+diff --git a/parser.go b/parser.go
+index 82e86ab..f19b899 100644
+--- a/parser.go
++++ b/parser.go
+@@ -21,11 +21,12 @@ const (
+ )
+ 
+ type AuditMessage struct {
+-	Type      uint16            `json:"type"`
+-	Data      string            `json:"data_raw"`
+-	DataMap   map[string]string `json:"data"`
+-	Seq       int               `json:"-"`
+-	AuditTime string            `json:"-"`
++	Type       uint16            `json:"type_raw"`
++	TypeString string            `json:"type"`
++	Data       string            `json:"data_raw"`
++	DataMap    map[string]string `json:"data"`
++	Seq        int               `json:"-"`
++	AuditTime  string            `json:"-"`
+ 
+ 	Containers map[string]string `json:"containers,omitempty"`
+ 	Extras     *AuditExtras      `json:"extras,omitempty"`
+@@ -62,13 +63,15 @@ func NewAuditMessageGroup(am *AuditMessage) *AuditMessageGroup {
+ // Creates a new go-audit message from a netlink message
+ func NewAuditMessage(nlm *syscall.NetlinkMessage) *AuditMessage {
+ 	aTime, seq := parseAuditHeader(nlm)
++	rawType := nlm.Header.Type
+ 	rawData := string(nlm.Data)
+ 	return &AuditMessage{
+-		Type:      nlm.Header.Type,
+-		Data:      rawData,
+-		DataMap:   splitMessageData(rawData),
+-		Seq:       seq,
+-		AuditTime: aTime,
++		Type:       rawType,
++		TypeString: decodeMessageType(rawType),
++		Data:       rawData,
++		DataMap:    splitMessageData(rawData),
++		Seq:        seq,
++		AuditTime:  aTime,
+ 	}
+ }
+ 
+@@ -108,6 +111,89 @@ func splitMessageData(data string) map[string]string {
+ 	return s
+ }
+ 
++// Decode the message type into a symbolic string
++func decodeMessageType(val uint16) string {
++	// Audit message types from include/uapi/linux/audit.h
++	switch val {
++	case 1300:
++		return "SYSCALL"
++	case 1302:
++		return "PATH"
++	case 1303:
++		return "IPC"
++	case 1304:
++		return "SOCKETCALL"
++	case 1305:
++		return "CONFIG_CHANGE"
++	case 1306:
++		return "SOCKADDR"
++	case 1307:
++		return "CWD"
++	case 1309:
++		return "EXECVE"
++	case 1311:
++		return "IPC_SET_PERM"
++	case 1312:
++		return "MQ_OPEN"
++	case 1313:
++		return "MQ_SENDRECV"
++	case 1314:
++		return "MQ_NOTIFY"
++	case 1315:
++		return "MQ_GETSETATTR"
++	case 1316:
++		return "KERNEL_OTHER"
++	case 1317:
++		return "FD_PAIR"
++	case 1318:
++		return "OBJ_PID"
++	case 1319:
++		return "TTY"
++	case 1320:
++		return "EOE"
++	case 1321:
++		return "BPRM_FCAPS"
++	case 1322:
++		return "CAPSET"
++	case 1323:
++		return "MMAP"
++	case 1324:
++		return "NETFILTER_PKT"
++	case 1325:
++		return "NETFILTER_CFG"
++	case 1326:
++		return "SECCOMP"
++	case 1327:
++		return "PROCTITLE"
++	case 1328:
++		return "FEATURE_CHANGE"
++	case 1329:
++		return "REPLACE"
++	case 1330:
++		return "KERN_MODULE"
++	case 1331:
++		return "FANOTIFY"
++	case 1332:
++		return "TIME_INJOFFSET"
++	case 1333:
++		return "TIME_ADJNTPVAL"
++	case 1334:
++		return "BPF"
++	case 1335:
++		return "EVENT_LISTENER"
++	case 1336:
++		return "URINGOP"
++	case 1337:
++		return "OPENAT2"
++	case 1338:
++		return "DM_CTRL"
++	case 1339:
++		return "DM_EVENT"
++	default:
++		return strconv.FormatUint(uint64(val), 10)
++	}
++}
++
+ // Add a new message to the current message group
+ func (amg *AuditMessageGroup) AddMessage(am *AuditMessage) {
+ 	amg.Msgs = append(amg.Msgs, am)
+-- 
+2.39.5 (Apple Git-154)
+

--- a/pkgs/go-audit/0003-Disaggregate-audit-events-into-separate-log-entries.patch
+++ b/pkgs/go-audit/0003-Disaggregate-audit-events-into-separate-log-entries.patch
@@ -1,0 +1,79 @@
+From 82cd14c67a4a77625f4b39af2bc000d504826712 Mon Sep 17 00:00:00 2001
+From: Molly Miller <mm@flyingcircus.io>
+Date: Mon, 3 Feb 2025 11:13:23 +0100
+Subject: [PATCH 3/4] Disaggregate audit events into separate log entries
+
+---
+ marshaller.go |  9 ++++++---
+ parser.go     | 17 +++++++++++++++++
+ writer.go     |  2 +-
+ 3 files changed, 24 insertions(+), 4 deletions(-)
+
+diff --git a/marshaller.go b/marshaller.go
+index 7d02051..2f1be09 100644
+--- a/marshaller.go
++++ b/marshaller.go
+@@ -125,9 +125,12 @@ func (a *AuditMarshaller) completeMessage(seq int) {
+ 		return
+ 	}
+ 
+-	if err := a.writer.Write(msg); err != nil {
+-		el.Println("Failed to write message. Error:", err)
+-		os.Exit(1)
++	logs := msg.Flatten()
++	for _, item := range logs {
++		if err := a.writer.Write(item); err != nil {
++			el.Println("Failed to write message. Error:", err)
++			os.Exit(1)
++		}
+ 	}
+ 
+ 	delete(a.msgs, seq)
+diff --git a/parser.go b/parser.go
+index f19b899..9b0f412 100644
+--- a/parser.go
++++ b/parser.go
+@@ -45,6 +45,13 @@ type AuditMessageGroup struct {
+ 	Syscall       string            `json:"-"`
+ }
+ 
++type AuditLogMessage struct {
++	Seq       int               `json:"sequence"`
++	AuditTime string            `json:"timestamp"`
++	Msg       *AuditMessage     `json:"message"`
++	UidMap    map[string]string `json:"uid_map"`
++}
++
+ // Creates a new message group from the details parsed from the message
+ func NewAuditMessageGroup(am *AuditMessage) *AuditMessageGroup {
+ 	//TODO: allocating 6 msgs per group is lame and we _should_ know ahead of time roughly how many we need
+@@ -292,3 +299,13 @@ func getUsername(uid string) string {
+ 
+ 	return uname
+ }
++
++func (amg *AuditMessageGroup) Flatten() []*AuditLogMessage {
++	msgs := []*AuditLogMessage{}
++
++	for _, msg := range amg.Msgs {
++		msgs = append(msgs, &AuditLogMessage{amg.Seq, amg.AuditTime, msg, amg.UidMap})
++	}
++
++	return msgs
++}
+diff --git a/writer.go b/writer.go
+index e3b3a69..5ed2e05 100644
+--- a/writer.go
++++ b/writer.go
+@@ -20,7 +20,7 @@ func NewAuditWriter(w io.Writer, attempts int) *AuditWriter {
+ 	}
+ }
+ 
+-func (a *AuditWriter) Write(msg *AuditMessageGroup) (err error) {
++func (a *AuditWriter) Write(msg *AuditLogMessage) (err error) {
+ 	for i := 0; i < a.attempts; i++ {
+ 		err = a.e.Encode(msg)
+ 		if err == nil {
+-- 
+2.39.5 (Apple Git-154)
+

--- a/pkgs/go-audit/0004-Provide-a-human-readable-decoded-view-for-selected-a.patch
+++ b/pkgs/go-audit/0004-Provide-a-human-readable-decoded-view-for-selected-a.patch
@@ -1,0 +1,192 @@
+From 54e29375729569f43ef58e569c5481730a903920 Mon Sep 17 00:00:00 2001
+From: Molly Miller <mm@flyingcircus.io>
+Date: Mon, 3 Feb 2025 12:00:57 +0100
+Subject: [PATCH 4/4] Provide a human-readable decoded view for selected audit
+ events
+
+---
+ extras_readable.go | 159 +++++++++++++++++++++++++++++++++++++++++++++
+ parser.go          |   1 +
+ 2 files changed, 160 insertions(+)
+ create mode 100644 extras_readable.go
+
+diff --git a/extras_readable.go b/extras_readable.go
+new file mode 100644
+index 0000000..5bc2bac
+--- /dev/null
++++ b/extras_readable.go
+@@ -0,0 +1,159 @@
++package main
++
++import (
++	"encoding/hex"
++	"strconv"
++	"strings"
++
++	"github.com/spf13/viper"
++)
++
++func init() {
++	RegisterExtraParser(func(config *viper.Viper) (ExtraParser, error) {
++		return &ReadableMessageParser{}, nil
++	})
++}
++
++const kernelHexChars = "0123456789abcdefABCDEF"
++
++type ReadableMessageParser struct {
++}
++
++func (p *ReadableMessageParser) Parse(am *AuditMessage) {
++	switch am.Type {
++	case 1309: // AUDIT_EXECVE
++		p.formatExecve(am)
++	case 1319: // AUDIT_TTY
++		p.formatTty(am)
++	case 1327: // AUDIT_PROCTITLE
++		p.formatProctitle(am)
++		// decode: audit_proctitle, *maybe* audit_tty, at least in strconv.Quote form
++	default:
++		am.Readable = am.Data
++	}
++}
++
++func (p *ReadableMessageParser) formatExecve(am *AuditMessage) {
++	argc, ok := am.DataMap["argc"]
++	if !ok {
++		return
++	}
++
++	count, err := strconv.ParseUint(argc, 10, 32)
++	if err != nil || count == 0 {
++		return
++	}
++
++	rawArgs := []string{}
++	for idx := uint64(0); idx < count; idx++ {
++		key := "a" + strconv.FormatUint(idx, 10)
++		value, ok := am.DataMap[key]
++		if !ok {
++			break
++		}
++		rawArgs = append(rawArgs, value)
++	}
++
++	args := []string{}
++	for _, raw := range rawArgs {
++		decoded, ok := renderString(raw, true)
++		if !ok {
++			decoded = raw
++		}
++		args = append(args, decoded)
++	}
++
++	am.Readable = strings.Join(args, " ")
++}
++
++func (p *ReadableMessageParser) formatTty(am *AuditMessage) {
++	// only interested in making the raw keystrokes visible in the
++	// readable message here. the process and user id reading the
++	// keystrokes are still available as metadata on the message
++	// line.
++	keystrokes, ok := am.DataMap["data"]
++	if !ok {
++		return
++	}
++
++	keystrokes, ok = renderString(keystrokes, true)
++	if !ok {
++		return
++	}
++
++	am.Readable = keystrokes
++}
++
++func (p *ReadableMessageParser) formatProctitle(am *AuditMessage) {
++	proctitle, ok := am.DataMap["proctitle"]
++	if !ok {
++		return
++	}
++
++	proctitle, ok = renderString(proctitle, false)
++	if !ok {
++		return
++	}
++
++	am.Readable = proctitle
++}
++
++func renderString(data string, nils bool) (string, bool) {
++	var started, ishex = false, true
++	var first, last rune
++	for _, r := range data {
++		if !started {
++			first = r
++			started = true
++		}
++		last = r
++		ishex = ishex && strings.ContainsRune(kernelHexChars, r)
++	}
++
++	if first == '"' && last == '"' {
++		data = strings.TrimPrefix(data, "\"")
++		data = strings.TrimSuffix(data, "\"")
++		return data, true
++	}
++
++	if ishex {
++		return escapeBytes(data, nils)
++	}
++
++	return "", false
++}
++
++// Convert a byte slice into a readable string with escaping. This
++// first converts the byte slice into a Go string literal using
++// strconv.Quote, and then processes the string to reduce the quoting
++// to improve readability.
++func escapeBytes(encoded string, nils bool) (string, bool) {
++	var builder strings.Builder
++
++	decodedBytes, err := hex.DecodeString(encoded)
++	if err != nil {
++		return "", false
++	}
++
++	if !nils {
++		for idx, _ := range decodedBytes {
++			if decodedBytes[idx] == 0 {
++				decodedBytes[idx] = 0x20
++			}
++		}
++	}
++
++	builder.Write(decodedBytes)
++	decoded := builder.String()
++	decoded = strconv.Quote(decoded)
++
++	// undo the quoting to leave a bare string with escape
++	// sequences
++	decoded = strings.TrimPrefix(decoded, "\"")
++	decoded = strings.TrimSuffix(decoded, "\"")
++	decoded = strings.Replace(decoded, "\\\"", "\"", -1)
++	decoded = strings.Replace(decoded, "\\\\", "\\", -1)
++
++	return decoded, true
++}
++
+diff --git a/parser.go b/parser.go
+index 9b0f412..4f85ac4 100644
+--- a/parser.go
++++ b/parser.go
+@@ -30,6 +30,7 @@ type AuditMessage struct {
+ 
+ 	Containers map[string]string `json:"containers,omitempty"`
+ 	Extras     *AuditExtras      `json:"extras,omitempty"`
++	Readable   string            `json:"readable,omitempty"`
+ }
+ 
+ type AuditExtras struct {
+-- 
+2.39.5 (Apple Git-154)
+

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -126,6 +126,15 @@ builtins.mapAttrs (_: patchPhps (fetchpatch {
     ];
   });
 
+  go-audit = super.go-audit.overrideAttrs (goSelf: goSuper: {
+    patches = [
+      ./go-audit/0001-Split-audit-message-into-key-value-pairs-for-better-.patch
+      ./go-audit/0002-Decode-audit-message-type-number-into-string-constan.patch
+      ./go-audit/0003-Disaggregate-audit-events-into-separate-log-entries.patch
+      ./go-audit/0004-Provide-a-human-readable-decoded-view-for-selected-a.patch
+    ];
+  });
+
   innotop = super.callPackage ./percona/innotop.nix { };
 
   ipmitool = super.ipmitool.overrideAttrs(a: a // {


### PR DESCRIPTION
This change adds a proof-of-concept implementation of the beta platform audit feature based on Alloy and go-audit, which should eventually replaced the implementation based on auditbeat. In particular, this feature adds an additional `flyingcircus.audit.useAlloy` flag, which defaults to false, which when set will enable go-audit to read audit events from the kernel and enable additional Alloy configuration to read log data from go-audit and forward this to Loki.

Currently the GELF protocol is used as a lingua franca between go-audit and Alloy with a UDP port on localhost. We don't consider this suitable for production use, as a network port on localhost is not secure against interference from other processes on the same machine. This change also includes a number of patches against go-audit, to make the generated log messages easier to handle in Alloy.

PL-129625

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh` => none, proof-of-concept for a beta platform feature.

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
  - The new auditing implementation requires setting the new `flyingcircus.audit.useAlloy` flag in order to enable the functionality added in this PR. By default it is not enabled.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - The loopback UDP port mentioned above does not protect against interference from other processes, which may be able to inject falsified log data. This change isn't intended for production use, so this is okay while we evaluate other options for our audit logs pipeline.
  - See PL-133438 as a follow-up for evaluating other options for log transport.
- [x] Security requirements tested? (EVIDENCE)
  - Does the right thing in a test VM.