### PR TITLE
Add cloud-init compatibility for Ubuntu VMs

### DIFF
--- a/changelog.d/20250124_092043_PL-133325-ubuntu-vms_scriv.md
+++ b/changelog.d/20250124_092043_PL-133325-ubuntu-vms_scriv.md
@@ -1,0 +1,21 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+
+### NixOS XX.XX platform
+
+- Add support for cloud-init compatability or Ubuntu VMs (PL-133325, PL-133372)
+  Fetch users of all resource groups in qemu scrub to local filesystem.
+  Fetch ubuntu VMs from a `ubuntu` namespace in ceph

--- a/changelog.d/20250124_092043_PL-133325-ubuntu-vms_scriv.md
+++ b/changelog.d/20250124_092043_PL-133325-ubuntu-vms_scriv.md
@@ -16,6 +16,8 @@ branches.
 
 ### NixOS XX.XX platform
 
-- Add support for cloud-init compatability or Ubuntu VMs (PL-133325, PL-133372)
+- Add support Ubuntu VMs (and pave the way for general cloud-init based distributions) (PL-133325, PL-133372)
+
   Fetch users of all resource groups in qemu scrub to local filesystem.
-  Fetch ubuntu VMs from a `ubuntu` namespace in ceph
+
+  Fetch Ubuntu VM images from the `ubuntu` namespace in Ceph.

--- a/pkgs/fc/agent/fc/manage/createvm.py
+++ b/pkgs/fc/agent/fc/manage/createvm.py
@@ -57,13 +57,19 @@ class Node(object):
     def setup(self):
         """Decide which setup mode to use and run it."""
         p = self.enc["parameters"]
-        image = p["environment"]
+
+        # TODO: cleanup after image migration
+        environment_class = p["environment_class"].lower()
+        if environment_class == "ubuntu":
+            image_path = f"images-{environment_class}/{p['environment']}"
+        else:
+            image_path = p["environment"]
 
         # use json command output as its output is more stable between Ceph releases
         snapshots = run.json.rbd(
             # fmt: off
             "--id", self.disk.ceph_id,
-            "snap", "ls", f"{IMAGE_POOL}/{image}"
+            "snap", "ls", f"{IMAGE_POOL}/{image_path}"
             # fmt: on
         )
         # Note: The rbd cli returns snapshots ordered by their ID (which
@@ -81,14 +87,16 @@ class Node(object):
             last_snap_name = snapshots[-1]["name"]
         except IndexError:
             raise RuntimeError(
-                "Could not find a valid snapshot for image {}.".format(image)
+                "Could not find a valid snapshot for image {}.".format(
+                    image_path
+                )
             )
         run.rbd(
             # fmt: off
             "--id", self.disk.ceph_id,
             "clone",
-            f"{IMAGE_POOL}/{image}@{last_snap_name}",
-            f"{self.enc['parameters']['rbd_pool']}/{self.name}.root"
+            f"{IMAGE_POOL}/{image_path}@{last_snap_name}",
+            f"{p['rbd_pool']}/{self.name}.root"
             # fmt: on
         )
 

--- a/pkgs/fc/agent/fc/manage/qemu.py
+++ b/pkgs/fc/agent/fc/manage/qemu.py
@@ -12,8 +12,10 @@ import subprocess
 import sys
 import syslog
 from multiprocessing.pool import ThreadPool
+from pathlib import Path
 
 import fc.util.directory
+import fc.util.enc
 
 _log = logging.getLogger(__name__)
 
@@ -54,10 +56,34 @@ def delete_configs():
             VM(name).unlink()
 
 
+def update_all_rg_users():
+    directory = fc.util.directory.connect(ring="max")
+    _log.info("retrieve-all-rg-users")
+    Path("/etc/qemu/users").mkdir(exist_ok=True)
+    try:
+        rgs = directory.list_resource_groups()
+    except Exception:
+        _log.warning("retrieve-all-resource-groups-failed", exc_info=True)
+        return
+    for rg in rgs:
+        try:
+            users = directory.list_users(rg)
+        except Exception:
+            _log.warning("retrieve-all-rg-users-failed", exc_info=True)
+            continue
+        try:
+            fc.util.enc.conditional_update(
+                f"/etc/qemu/users/{rg}.json", users, 0o640
+            )
+        except (IOError, OSError):
+            fc.util.enc.inplace_update(f"/etc/qemu/users/{rg}.json", users)
+
+
 def main():
     h = logging.handlers.SysLogHandler(facility=syslog.LOG_LOCAL4)
     logging.basicConfig(level=logging.DEBUG, handlers=[h])
 
+    update_all_rg_users()
     results = []
     pool = ThreadPool(5)
     for cfg in glob.glob("/etc/qemu/vm/*.cfg"):

--- a/pkgs/fc/default.nix
+++ b/pkgs/fc/default.nix
@@ -52,8 +52,8 @@ rec {
       repo = "fc.qemu";
       # The release tooling didn't upgrade properly so we had to pick a specific
       # commit instead.
-      rev = "50a6a814283ba6173dfb4f4c98d5f17d85ccfd7d";
-      hash = "sha256-QWfhsO4DLHwKCilL7XvKAOeS9yGR6miatEF0HcLmfN4=";
+      rev = "0cf50af2ee3436de3d2cfbc9051d5b30fdda24b0";
+      hash = "sha256-BKQUa+nk8p+7mBFk4JeEJyaYq4rIyhLKSsr1hd9vqVw=";
     };
     fc-ceph = ceph;
     qemu_ceph = pkgs.qemu-ceph-nautilus;

--- a/pkgs/fc/default.nix
+++ b/pkgs/fc/default.nix
@@ -52,8 +52,8 @@ rec {
       repo = "fc.qemu";
       # The release tooling didn't upgrade properly so we had to pick a specific
       # commit instead.
-      rev = "0cf50af2ee3436de3d2cfbc9051d5b30fdda24b0";
-      hash = "sha256-BKQUa+nk8p+7mBFk4JeEJyaYq4rIyhLKSsr1hd9vqVw=";
+      rev = "5672728c27c09bbcabb58e8944e4b2dc2ed20be4";
+      hash = "sha256-+duAZCCRCqFqF2TIJHtRtYrmXfgvlxLEvFZH82G2GSg=";
     };
     fc-ceph = ceph;
     qemu_ceph = pkgs.qemu-ceph-nautilus;

--- a/pkgs/fc/qemu/default.nix
+++ b/pkgs/fc/qemu/default.nix
@@ -15,6 +15,7 @@
   gptfdisk,
   parted,
   xfsprogs,
+  dosfstools,
   procps,
   strace,
   file,
@@ -67,6 +68,7 @@ py.buildPythonPackage rec {
     systemd
     utillinux
     xfsprogs
+    dosfstools
     py.requests
     py.future
     py.colorama


### PR DESCRIPTION
@flyingcircusio/release-managers

PL-133325 and more specifically PL-133372

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] ~~All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.~~ (will be done later, is noted)

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

* attack surface/least privilege: we now keep user/permission mappings on kvm hosts, but they're kept at root:root/0o6400
* fail securely: if we're blocked updating, then we do keep running with the previous data, this could in theory lead to outdated permissions being kept for a long time. however, not having data could easily cause us to interfer with existing access during e.g. network or directory reachability issues. we've noted this as a future task in (PL-133325)
*  ring0/ring1 separation: API composition is secure, but has a bug at the moment: ring1 kvm hosts will receive too little information (noted in PL-133325) 

- [x] Security requirements tested? (EVIDENCE)

* manual testing and code review
