### PR TITLE
rabbitmq: fix unit file generation

### DIFF
--- a/nixos/roles/rabbitmq.nix
+++ b/nixos/roles/rabbitmq.nix
@@ -40,6 +40,7 @@ in
     enabledRolesCount = length (lib.attrNames enabledRoles);
     enabled = enabledRolesCount > 0;
     roleVersion = head (lib.attrNames enabledRoles);
+    isSingleNode = length (fclib.findServices "rabbitmq-node") == 1;
   in
   lib.mkMerge [
 
@@ -49,6 +50,15 @@ in
 
     (lib.mkIf (config.flyingcircus.roles.rabbitmq.enable) {
       flyingcircus.services.rabbitmq.enable = true;
+    })
+
+    # For single-node setups of current RabbitMQ versions, set feature flags
+    # automatically after platform upgrades. This is the easy and common case.
+    # Cluster setups require manual intervention for enabling feature flags.
+    # Note that we simply check the number of rabbitmq instances in the RG to be safe,
+    # we don't know here if they actually form a cluster.
+    (lib.mkIf (config.flyingcircus.roles.rabbitmq.enable && isSingleNode) {
+      systemd.services.rabbitmq.postStart = "rabbitmqctl enable_feature_flag all";
     })
 
     (lib.mkIf enabled {
@@ -82,12 +92,6 @@ in
           action = "labeldrop";
         }
       ];
-    }
-
-    {
-      systemd.services.rabbitmq.postStart = lib.optionalString ((length (fclib.findServices "rabbitmq-node")) == 1) ''
-          rabbitmqctl enable_feature_flag all
-        '';
     }
   ];
 }


### PR DESCRIPTION
Fixes changes made in #1242

optionalString generates an empty string if the condition is not met. This resulted in an overides.conf for rabbitmq.service which just contains some auto-generated env vars in [service].

For the "frozen" rabbitmq 3.6 service/role, the new PATH replaced the PATH set by the original unit, leading to a "command not found" for rabbitmqctl in `postStart`.

Setting feature flags isn't possible for rabbitmq 3.6, the rabbitmqctl command must only run for current rabbitmq versions.

For other machines *without* rabbitmq, this also generated an empty unit file because there was no condition to check if rabbitmq is actually enabled on this machine.

We need to limit this to the current Rabbitmq role and use mkIf here to prevent setting the option at all when conditions are not met.

PL-133374

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`
  - not necessary


## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - follow-up to #1242
  - feature flag settings code must not be active for rabbitmq 3.6 
  - other machines without the rabbitmq role must not be affected by rabbitmq role code
- [x] Security requirements tested? (EVIDENCE)
  - checked on a test VM with the `rabbitmq` role that rabbitmq starts and no overrides.conf is present  
  - checked on a test VM without any rabbitmq roles that no rabbitmq.service is present
