### PR TITLE
[24.11] Remove fc-kea from activation scripts

### DIFF
--- a/nixos/roles/router/kea.nix
+++ b/nixos/roles/router/kea.nix
@@ -93,9 +93,6 @@ let
     ];
   };
 
-  # The script is embedded in two locations: before the start of the
-  # kea server, to ensure that we have a known-good configuration and in
-  # the agent to update it continuously from the directory data.
   configUpdateScript = pkgs.writeShellScript "update-kea-config" ''
       # Generate DHCP server configuration
       ${pkgs.fc.agent}/bin/fc-kea -4 -L ${location} -o /etc/nixos/localconfig-dhcpd4.json -e ipmi ${lib.concatMapStringsSep " " (net: "-n ${net}") dhcpNetworks}
@@ -117,10 +114,6 @@ in
 
   config = lib.mkIf role.enable {
     flyingcircus.agent.extraPreCommands = ''
-      ${configUpdateScript}
-    '';
-
-    system.activationScripts.kea-config = ''
       ${configUpdateScript}
     '';
 


### PR DESCRIPTION
As a workaround for problems when upgrading from 21.05, extra calls to the fc-kea script which generates parts of the Kea DHCP configuration were added to the activation scripts. However, the activation scripts may be executed without network connectivity (especially when performing large system updates which restart lots of network-related systemd units) -- this means that fc-kea will fail when attempting to connect to the directory, which will cause the system activation to fail. This is a failure mode observed when attempting to upgrade routers from 21.05 to 24.11 automatically, as due to changes in FRR the EVPN control plane will be stopped completely before the activation scripts are run.

This change removes fc-kea from the activation scripts.

PL-133387

@flyingcircusio/release-managers

## Release process

- [ ] Created changelog entry using `./changelog.sh`


## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Reliability and robustness of upgrade paths.
- [x] Security requirements tested? (EVIDENCE)
  - Tested successfully on the staging router which had become stuck after failing to activate 24.11 for the first time.