### PR TITLE
[PL-133327] nixos/platform: set Nix's connect-timeout to 1s

### DIFF
--- a/changelog.d/20250129_192149_PL-133327-low-connect-timeout_scriv.md
+++ b/changelog.d/20250129_192149_PL-133327-low-connect-timeout_scriv.md
@@ -1,0 +1,21 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+- None.
+
+
+### NixOS XX.XX platform
+
+- Set the `download-timeout` for Nix to 1 second.

--- a/nixos/platform/default.nix
+++ b/nixos/platform/default.nix
@@ -298,6 +298,7 @@ in {
         http-connections = 2
         log-lines = 25
         experimental-features = nix-command flakes fetch-closure
+        connect-timeout = 1
       '';
 
       settings = {


### PR DESCRIPTION
__Note:__ after review, this needs a backport to the branches we still build on Hydra, i.e. 24.05, 23.11 and 21.05.

PL-133327

The overall idea is to no longer depend on Hydra itself for management
commands and deployment pipelines to be functional: Hydra will be served
under a new domain soon and `hydra.flyingcircus.io` will only provide the
binary cache and the download URLs for build products such as channel
tarballs. Otherwise we'd have to fix up an unknown number of Nix
expressions on all of our VMs.

The download URLs and binary cache are served by two VMs that proxy
these requests into S3: build products will be synced into S3, the
binary cache is already S3-based. To make sure this setup is still
available when the VM gets into maintenance, we'll use two VMs and
`hydra.flyingcircus.io` will have records for both of them, i.e.
DNS round-robin.

For this to work properly, we have to set `connect-timeout`: otherwise,
Nix would try to connect to the IP of the VM in maintenance for a long
time before trying the other IP. After a few substitutions, Nix would
retry the unavailable IP again. The `connect-timeout` is there to nudge
Nix to try the other IP after a very short amount of time.

The value of 1s is chosen for the following reason: the machines are
running in a datacenter and the ping between rzob and whq (where the
binary cache is hosted) is roughly ~10ms, so a timeout of a second
is pretty much. Nix retries substituters five times (see option
`download-attempts` in `nix.conf(5)`), so if the timeout is reached
regardless, there will be up to five retries before giving up.

Unfortunately it's not possible to set this per substituter. However,
cache.nixos.org is hosted on a CDN (fastly) and the ping is still pretty
low (~4ms from rzob, ~7ms from whq).

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`


## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Availability: we want both management commands and deployment pipelines to remain functional when one of the (to be introduced) binary cache proxy VMs is in maintenance (see above and in PL-133327)
- [x] Security requirements tested? (EVIDENCE)
  - The behavior of these `nix.conf` options has been tested with a test binary cache and a round robin DNS setup to make sure the fallback is made correctly (see comments in PL-133327)
  - The branch with this commit has been activated on test42. Substitutions from both the whq binary cache and cache.nixos.org work correctly.
