### PR TITLE
Fix configuration of tagged VLAN interfaces on physical hosts

### DIFF
--- a/nixos/platform/network.nix
+++ b/nixos/platform/network.nix
@@ -128,6 +128,13 @@ in
           then cfg.static.nameservers.${location}
           else [];
 
+        vlans = listToAttrs (map (interface:
+          lib.nameValuePair interface.taggedLink {
+            id = interface.vlanId;
+            interface = interface.link;
+          })
+          (filter (interface: interface.policy == "tagged") interfaces));
+
         # Using SLAAC/privacy addresses will cause firewalls to block us
         # internally and also have customers get problems with outgoing
         # connections.


### PR DESCRIPTION
This change re-adds NixOS configuration which ensures that tagged VLAN interfaces are created properly, which was previously missing in this branch.

PL-132122

@flyingcircusio/release-managers

## Release process

- [ ] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - System network configuration functional requirements
- [x] Security requirements tested? (EVIDENCE)
  - Tested on a staging router which has tagged VLAN interfaces configured in the directory.
