### PR TITLE
devhost: migrate dnsmasq extraConfig to settings

### DIFF
--- a/changelog.d/20250205_161626_PL-133369-dev-vm-dnsmasq-settings_scriv.md
+++ b/changelog.d/20250205_161626_PL-133369-dev-vm-dnsmasq-settings_scriv.md
@@ -1,0 +1,19 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+
+### NixOS XX.XX platform
+
+- devhost: migrate dnsmasq extraConfig to structured settings (PL-133369)

--- a/nixos/roles/devhost/vm.nix
+++ b/nixos/roles/devhost/vm.nix
@@ -177,13 +177,11 @@ in {
     services.dnsmasq = {
       enable = true;
       resolveLocalQueries = false;
-      extraConfig = ''
-        interface=br-vm-srv
-
-        dhcp-range=10.12.250.10,10.12.254.254,255.255.0.0,24h
-        dhcp-option=option:router,10.12.0.1
-        dhcp-option=option:dns-server,${lib.concatStringsSep "," config.networking.nameservers}
-      '';
+      settings = {
+        interface = "br-vm-srv";
+        dhcp-range="10.12.250.10,10.12.254.254,255.255.0.0,24h";
+        dhcp-option=[ "option:router,10.12.0.1" "option:dns-server,${lib.concatStringsSep "," config.networking.nameservers}"];
+      };
     };
     networking.firewall.interfaces."br-vm-srv".allowedUDPPorts = [ 67 ];
     networking.firewall.interfaces."vm-srv+".allowedUDPPorts = [ 67 ];


### PR DESCRIPTION
extraConfig was removed in 24.11

PL-133369

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`


## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - a mere config format migration, without changing the semantics 
- [x] Security requirements tested? (EVIDENCE)
  - [x] automated tests still pass
  - [x] staging devhosts successfully builds
