### PR TITLE
fix syntax error in docstring

### DIFF
--- a/nixos/platform/firewall.nix
+++ b/nixos/platform/firewall.nix
@@ -62,7 +62,7 @@ in
       default = "10/second";
       description = "average rate limit to use for logging refused IPtables matches,"
         + " see `--limit` in `man 8 iptables-extensions`.\n"
-        "Disabled when `null`.";
+        + "Disabled when `null`.";
     };
     logBurstLimit = lib.mkOption {
       type = lib.types.ints.positive;


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`
  - n/a


## PR release workflow (internal)

- [ ] PR has internal ticket
- [ ] internal issue ID (PL-…) part of branch name
- [ ] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - none 
- [ ] Security requirements tested? (EVIDENCE)
  - automated tests still pass, no known regressions 
