### PR TITLE
[PL-133327] nixos/platform: use `nix.settings` for connect-timeout

### DIFF
--- a/nixos/platform/default.nix
+++ b/nixos/platform/default.nix
@@ -298,7 +298,6 @@ in {
         http-connections = 2
         log-lines = 25
         experimental-features = nix-command flakes fetch-closure
-        connect-timeout = 1
       '';
 
       settings = {
@@ -312,6 +311,8 @@ in {
           "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
           "flyingcircus.io-1:Rr9CwiPv8cdVf3EQu633IOTb6iJKnWbVfCC8x8gVz2o="
         ];
+
+        connect-timeout = 1;
       };
     };
 


### PR DESCRIPTION
@osnyx this can be backported to 24.05 & 23.11. For 21.05 I'll need to check.

PL-133327

As discussed, it might be useful to have some kind of feature-flag for the connect-timeout since modifying declarations of `nix.extraOptions` is hard.

Instead, decided to just use `nix.settings` here, that way the timeout can be adjusted with primitives of the module system and without an additional option.

@flyingcircusio/release-managers

## Release process

- [ ] Created changelog entry using `./changelog.sh`: Followup for #1256, no behavioral change.


## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
  - The option `nix.settings.connect-timeout` is now used. This can overriden to any value with `mkForce`.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
  - `nix.settings` has documentation already.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Maintaining Availability: Being able to quickly change the timeout in case of any issues.
- [x] Security requirements tested? (EVIDENCE)
  - Activated this change on a test VM. Then, confirmed that I can change the timeout with
```nix
{ lib, ... }: {
  nix.settings.connect-timeout = lib.mkForce 23;
}
```
