### PR TITLE
[21.05][PL-133327] nixos/platform: make `connect-timeout` configurable

### DIFF
--- a/nixos/platform/default.nix
+++ b/nixos/platform/default.nix
@@ -48,6 +48,14 @@ in {
 
   options = with lib.types; {
 
+    flyingcircus.nix.connectTimeout = mkOption {
+      default = 1;
+      type = types.int;
+      description = ''
+        Corresponds to the `connect-timeout` setting of `nix.conf`.
+      '';
+    };
+
     flyingcircus.activationScripts = mkOption {
       description = ''
         This does the same as system.activationScripts,
@@ -235,7 +243,7 @@ in {
       extraOptions = ''
         fallback = true
         http-connections = 2
-        connect-timeout = 1
+        connect-timeout = ${toString cfg.nix.connectTimeout}
       '';
     };
 


### PR DESCRIPTION
~~__Note:__ this requires testing on a 21.05 machine.~~

PL-133327

On 21.05 we don't `nix.settings` yet, so a custom option it is. Same idea as in #1274.

@flyingcircusio/release-managers

## Release process

- [ ] Created changelog entry using `./changelog.sh`: Followup for https://github.com/flyingcircusio/fc-nixos/pull/1256, no behavioral change.


## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
  - The option nix.settings.connect-timeout is now used. This can overriden to any value with mkForce.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
  - New option with description got added.
 
## Security implications

- [x] [Security requirments](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Maintaining Availability: Being able to quickly change the timeout in case of any issues.
- [x] Security requirements tested? (EVIDENCE):
  - Activated on a test VM
  - Confirmed that overriding works via
```nix
{ lib, ... }: {
flyingcircus.nix.connectTimeout = lib.mkForce 23;
}
```