### PR TITLE
[24.05] nixos/platform: use nix.settings for connect-timeout

### DIFF
--- a/nixos/platform/default.nix
+++ b/nixos/platform/default.nix
@@ -297,7 +297,6 @@ in {
         http-connections = 2
         log-lines = 25
         experimental-features = nix-command flakes fetch-closure
-        connect-timeout = 1
       '';
 
       settings = {
@@ -311,6 +310,8 @@ in {
           "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
           "flyingcircus.io-1:Rr9CwiPv8cdVf3EQu633IOTb6iJKnWbVfCC8x8gVz2o="
         ];
+
+        connect-timeout = 1;
       };
     };
 


### PR DESCRIPTION
backport of #1274

PL-133327

As discussed, it might be useful to have some kind of feature-flag for the connect-timeout since modifying declarations of `nix.extraOptions` is hard.

Instead, decided to just use `nix.settings` here, that way the timeout can be adjusted with primitives of the module system and without an additional option.

@flyingcircusio/release-managers

## Release process

- [ ] Created changelog entry using `./changelog.sh`: Followup for #1256, no behavioral change.



## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Maintaining Availability: Being able to quickly change the timeout in case of any issues.
- [ ] Security requirements tested? (EVIDENCE)
  - backport of #1274, no behavioural changes
  - automated tests still pass 
