### PR TITLE
roles/kvm: fix option description eval

### DIFF
--- a/nixos/roles/kvm.nix
+++ b/nixos/roles/kvm.nix
@@ -35,7 +35,7 @@ in
           Can be replaced for development and testing purposes.
         '';
         default = cephPkgs.fc-qemu;
-        defaultText = literalExpression "pkgs.fc.qemu [parameterised with cephRelease]";
+        defaultText = lib.literalMD "`pkgs.fc.qemu` *[parameterised with cephRelease]*";
       };
       cephRelease = fclib.ceph.releaseOption // {
         description = "Codename of the Ceph release series used by qemu.";


### PR DESCRIPTION
`literalExpression` was not taken from lib and hence caused the fc-search eval to fail.

I also checked all other occurances of `literalExpressions` in the platform code. Almost all of them ar placed after a global `with lib;` which is bad style but at least causes them to eval fine.

Part of fixing the fc-search eval for 24.11. Not necessarily complete.

PL-133423

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`: no, cosmetic change


## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - ensure proper documentation on search.flyingcircus.io: fc-search needs to eval the 24.11 platform 
- [x] Security requirements tested? (EVIDENCE)
  - [x] existing automated tests still pass
  - [x] fc-search.service displays the first occuring eval failure. This one is fixed, let's move forward one at a time.
