### PR TITLE
testing: show systemd journal output

### DIFF
--- a/nixos/platform/default.nix
+++ b/nixos/platform/default.nix
@@ -261,7 +261,6 @@ in {
         "boot.panic_on_fail"
 
         # Output management
-        "systemd.journald.forward_to_console=no"
         "systemd.log_target=kmsg"
       ];
 

--- a/nixos/platform/full-disk-encryption.nix
+++ b/nixos/platform/full-disk-encryption.nix
@@ -34,25 +34,28 @@ in
 {
 
   options = {
-    flyingcircus.infrastructure.fullDiskEncryption.fsOptions = lib.mkOption {
-      type = lib.types.attrs;
-      readOnly = true;
-      internal = true;
-      default =  {
-        device = "/dev/vgkeys/keys";
-        fsType = "xfs";
-        options = [ "nofail" "auto" "noexec" "nosuid" "nodev" "nouser"];
-        neededForBoot = false;    # change this when introducing rootfs encryption
+    flyingcircus.infrastructure.fullDiskEncryption = {
+      enable = lib.mkOption {
+        default = config.flyingcircus.infrastructureModule == "flyingcircus-physical";
+        defaultText = lib.literalExpression ''config.flyingcircus.infrastructureModule == "flyingcircus-physical"'';
+        description = "Whether to enable full disk encryption compatability.";
+        type = lib.types.bool;
+      };
+      fsOptions = lib.mkOption {
+        type = lib.types.attrs;
+        readOnly = true;
+        internal = true;
+        default =  {
+          device = "/dev/vgkeys/keys";
+          fsType = "xfs";
+          options = [ "nofail" "auto" "noexec" "nosuid" "nodev" "nouser"];
+          neededForBoot = false;    # change this when introducing rootfs encryption
+        };
       };
     };
   };
 
-  config = lib.mkIf (config.flyingcircus.infrastructureModule == "flyingcircus-physical" ||
-    # TODO: When merging nixos-hardware with our regular VM branch, we need to refine this
-    # to avoid that all regular VM tests (e.g. PHP) get fc-luks cruft added.
-    config.flyingcircus.infrastructureModule == "testing"
-    )
-  {
+  config = lib.mkIf (config.flyingcircus.infrastructure.fullDiskEncryption.enable) {
     environment.systemPackages = with pkgs; [
       cryptsetup
     ];

--- a/nixos/platform/systemd.nix
+++ b/nixos/platform/systemd.nix
@@ -27,10 +27,12 @@ in
       "admins"
     ];
 
-    services.journald.extraConfig = ''
+    # Gets overwritten by nixpkgs test tooling
+    services.journald.extraConfig = fclib.mkPlatform ''
       SystemMaxUse=2G
       MaxLevelConsole=notice
       ForwardToWall=no
+      ForwardToConsole=no
     '';
 
     services.journald.forwardToSyslog = lib.mkOverride 90 false;

--- a/nixos/roles/jitsi/default.nix
+++ b/nixos/roles/jitsi/default.nix
@@ -290,7 +290,7 @@ in {
 
           locations = {
             "= /xmpp-websocket" = {
-              proxyPass = http://127.0.0.1:5280/xmpp-websocket;
+              proxyPass = "http://127.0.0.1:5280/xmpp-websocket";
               extraConfig = ''
                 proxy_buffer_size 128k;
                 proxy_buffers 4 256k;

--- a/tests/backy_volumes.nix
+++ b/tests/backy_volumes.nix
@@ -18,6 +18,7 @@ let
       (testlib.fcConfig { net.fe = false; })
     ];
 
+    flyingcircus.infrastructure.fullDiskEncryption.enable = true;
     flyingcircus.roles.backyserver = {
       enable = true;
     } // backyserverRoleConfig;

--- a/tests/ceph-nautilus.nix
+++ b/tests/ceph-nautilus.nix
@@ -15,6 +15,7 @@ let
       virtualisation.emptyDiskImages = diskSizes;
       imports = [ ../nixos ../nixos/roles ];
 
+      flyingcircus.infrastructure.fullDiskEncryption.enable = true;
       flyingcircus.static.mtus.sto = 1500;
       flyingcircus.static.mtus.stb = 1500;
 

--- a/tests/fde-tooling.nix
+++ b/tests/fde-tooling.nix
@@ -19,6 +19,7 @@ import ./make-test-python.nix ({ pkgs, testlib, ... }:
       virtualisation.fileSystems."/mnt/keys" = config.flyingcircus.infrastructure.fullDiskEncryption.fsOptions;
       virtualisation.fileSystems."/srv/backy" = config.flyingcircus.roles.backyserver.fsOptions;
 
+      flyingcircus.infrastructure.fullDiskEncryption.enable = true;
       flyingcircus.roles.backyserver.enable = true;
       flyingcircus.services.ceph.client.enable = lib.mkForce false;
       flyingcircus.services.consul.enable = lib.mkForce false;


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`
  no, internal testing framework only

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Should not influence logging on VMs
- [x] Security requirements tested? (EVIDENCE)
  - NixOS Tests successful
  - Tested that systemd logs don't show up on test vm in dmesg and not in log file on kvm host after reboot
