### PR TITLE
fc.agent.s3users: add timeouts, silence errors after user was deleted, monitoring

### DIFF
--- a/changelog.d/20250217_160137_PL-133447-s3-management-improvements_scriv.md
+++ b/changelog.d/20250217_160137_PL-133447-s3-management-improvements_scriv.md
@@ -16,4 +16,4 @@ branches.
 
 ### NixOS XX.XX platform
 
-- fc.agent.s3users: add timeouts, silence errors after user was deleted (PL-133447)
+- fc.agent.s3users: add timeouts, silence errors after user was deleted and add monitoring (PL-133447)

--- a/changelog.d/20250217_160137_PL-133447-s3-management-improvements_scriv.md
+++ b/changelog.d/20250217_160137_PL-133447-s3-management-improvements_scriv.md
@@ -1,0 +1,19 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+
+### NixOS XX.XX platform
+
+- fc.agent.s3users: add timeouts, silence errors after user was deleted (PL-133447)

--- a/nixos/roles/ceph/rgw.nix
+++ b/nixos/roles/ceph/rgw.nix
@@ -177,7 +177,12 @@ in
       systemd.services.fc-ceph-rgw-users = rec {
         description = "Sync S3 users and accounting with directory";
         path = [ cephPkgs.ceph ];
-        serviceConfig.Type = "oneshot";
+        serviceConfig = {
+          Type = "oneshot";
+          # The unit gets run every 10 minutes, so stop the unit after 9 minutes runtime
+          # This protects against not terminating radosgw-admin calls.
+          TimeoutStartSec = 9 * 60;
+        };
         wants = [ fclib.network.sto.addressUnit ];
         after = wants;
         script = "${pkgs.fc.agent}/bin/fc-s3users --enc ${config.flyingcircus.encPath}";

--- a/nixos/roles/ceph/rgw.nix
+++ b/nixos/roles/ceph/rgw.nix
@@ -239,6 +239,20 @@ in
         };
       };
 
+      systemd.tmpfiles.rules = [
+        "f /var/log/fc-ceph-rgw-users-stamp.log"
+      ];
+
+      flyingcircus.services.sensu-client = {
+        checks.fc-ceph-rgw-users = {
+          notification = "fc-ceph-rgw-users stamp recent";
+          command =
+            "${pkgs.monitoring-plugins}/bin/check_file_age"
+            + " -f /var/log/fc-ceph-rgw-users-stamp.log -w 1500 -c 2700";
+          interval = 300;
+        };
+      };
+
     })
 
   ];

--- a/pkgs/fc/agent/fc/manage/s3users.py
+++ b/pkgs/fc/agent/fc/manage/s3users.py
@@ -10,12 +10,15 @@ import json
 import logging
 import sys
 from dataclasses import dataclass
+from pathlib import Path
 from subprocess import CalledProcessError
 
 from fc.util.directory import connect
 from fc.util.runners import run
 
 log = logging.getLogger()
+
+STAMP_FILE_PATH = Path("/var/log/fc-ceph-rgw-users-stamp.log")
 
 
 def list_radosgw_users() -> list[str]:
@@ -370,6 +373,9 @@ def main() -> int:
     )
     user_manager.sync_users()
     got_errors = got_errors or user_manager.processing_errors
+
+    if not got_errors:
+        STAMP_FILE_PATH.write_text(str(datetime.datetime.now()) + "\n")
 
     # on errors, the service shall return a non-zero exit code to be caught by
     # our monitoring

--- a/pkgs/fc/agent/fc/manage/s3users.py
+++ b/pkgs/fc/agent/fc/manage/s3users.py
@@ -60,9 +60,22 @@ class RGWState:
     def __init__(self, uid):
         self.uid = uid
 
-    def update(self):
+    def update(self, previously_deleted=False):
         try:
-            state = run.json.radosgw_admin("user", "info", "--uid", self.uid)
+            state = run.json.radosgw_admin(
+                "user",
+                "info",
+                "--uid",
+                self.uid,
+                # silence error when the user was previously deleted
+                silent_errors=(
+                    lambda code, stdout, stderr: previously_deleted
+                    and code == 22
+                    and b"could not fetch user info: no user info saved"
+                    in stderr
+                ),
+            )
+
         except Exception:
             self.exists = False
             self.display_name = None
@@ -103,7 +116,7 @@ class RGWState:
                 pass
             else:
                 raise
-        self.update()
+        self.update(previously_deleted=True)
 
     def ensure_exists(
         self, display_name: str, access_key: str, secret_key: str | None = None


### PR DESCRIPTION
PL-133447

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`


## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Timeouts could forcefully end a good execution of the program. This shouldn't happen in any of our DCs
  - Timeouts + silencing should be effective
  - Monitoring should work
- [x] Security requirements tested? (EVIDENCE)
  - In our largest RGW cluster the script currently runs <1min. With our normal monitoring procedures, we already ensure that we would detect a failed systemd unit (timed-out units are in the failed status)
  - Tested timeouts (added a `sleep` to the script) + silencing
  - Tested monitoring in dev