### PR TITLE
[FC-42506] roles/lamp: make interpreters of all pools available globally

### DIFF
--- a/changelog.d/20250218_125457_fc-24.11-dev_scriv.md
+++ b/changelog.d/20250218_125457_fc-24.11-dev_scriv.md
@@ -1,0 +1,21 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+
+### NixOS XX.XX platform
+
+- lamp: For a phpfpm pool `name`, the executables `php-name` and `composer-name` are available in the VM.
+  `php-name` calls the PHP interpreter that's also used by the phpfpm pool with the `php.ini` configuration
+  of the phpfpm pool.

--- a/doc/src/lamp.md
+++ b/doc/src/lamp.md
@@ -33,6 +33,7 @@ A complete configuration might looks something like this:
     vhosts = [
       { port = 8000;
         docroot = "/srv/s-myserviceuser/application.git/docroot";
+        name = "app-name";
       }
       { port = 8001;
         docroot = "/srv/s-myserviceuser/application.git/other_php_version_root";
@@ -45,6 +46,7 @@ A complete configuration might looks something like this:
         apacheExtraConfig = ''
           IndexOptions FancyIndexing
         '';
+        name = "second-app-name";
       }
     ];
 
@@ -76,6 +78,18 @@ A complete configuration might looks something like this:
 
 The vhost configuration allows you to configure multiple applications per VM
 each running on a separate port. The two options for every vhost thus are:
+
+`name`
+
+: The identifier of the application running here. The phpfpm service
+  will be called `phpfpm-{name}.service` where `{name}` is the value of this
+  option.
+
+  Additionally, wrappers `php-{name}` and `composer-{name}` are available
+  globally that refer to the PHP interpreter and `php.ini` configuration
+  used by the vhost.
+
+  When unset, the `port` will be used as `name`.
 
 `port`
 

--- a/nixos/roles/lamp.nix
+++ b/nixos/roles/lamp.nix
@@ -2,6 +2,25 @@
 let
   role = config.flyingcircus.roles.lamp;
   fclib = config.fclib;
+
+  phpWrappers = map
+    ({ name, ... }: let
+      inherit (config.services.phpfpm.pools.${name}) phpOptions phpPackage;
+    in
+    # The pattern of exposing `php-{project}` is common in existing projects.
+    # Decreasing the priority in systemPackages so that upgrades to newer platform
+    # versions don't fail hard.
+    lib.lowPrio
+      (pkgs.runCommand "wrapped-php-for-${name}" {
+        nativeBuildInputs = [ pkgs.makeWrapper ];
+      } ''
+        mkdir -p $out/bin
+        makeWrapper ${phpPackage}/bin/php $out/bin/php-${name} \
+          --add-flags "-c ${builtins.toFile "php-${name}.ini" phpOptions}"
+
+        ln -sfv ${phpPackage.packages.composer}/bin/composer $out/bin/composer-${name}
+      ''))
+    config.flyingcircus.roles.lamp.vhosts;
 in {
 
   options = with lib; {
@@ -125,7 +144,7 @@ in {
       environment.systemPackages = [
         role.php
         role.php.packages.composer
-      ];
+      ] ++ phpWrappers;
 
       # Provide a similar PHP config for the PHP CLI as for Apache (httpd).
       # The file referenced by PHPRC is loaded together with the php.ini


### PR DESCRIPTION
It's a common pattern in a lot of projects to expose `php-{name}` (or `{name}-php`) which wraps the interpreter used by the phpfpm pool.

This patch adds this behavior to the platform and updates the docs accordingly.

Existing projects are still able to upgrade with `php-{name}` in `systemPackages` since the priority of each wrapper package is set to low.

@flyingcircusio/release-managers
@frlan may also be interested in this.

## Release process

- [x] Created changelog entry using `./changelog.sh`


## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

The wrapper packages use `lib.lowPrio` to avoid conflicts with existing things in `systemPackages`, so it's nothing that interferes with existing configurations.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Provide the same PHP (same version, same config) used by the application for operators on the console and other background services of the application written in PHP.
- [x] Security requirements tested? (EVIDENCE)
  - Activated on a test VM.
  - Made sure that this doesn't break the build if such a thing was implemented already.
  - Checked that the correct phpfpm configuration is used, even if `services.phpfpm.pools.${name}` has manual overides.
