### PR TITLE
logrotate: relax hardening of service to fix postrotate scripts

### DIFF
--- a/changelog.d/20250218_163706_PL-133439-logrotate-unhardening_scriv.md
+++ b/changelog.d/20250218_163706_PL-133439-logrotate-unhardening_scriv.md
@@ -1,0 +1,18 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+
+### NixOS XX.XX platform
+
+- Fix rotation of some service logs by relaxing logrotate service hardening (haproxy, mysql, ceph, …) [PL-133439]
+    - The affected services might need to be restarted, but this will also happen as a side affect of the machine reboot scheduled by this release.

--- a/nixos/services/haproxy/default.nix
+++ b/nixos/services/haproxy/default.nix
@@ -55,8 +55,6 @@ let
     (lib.splitString "\n" cfg.extraConfig)
   ];
 
-  haproxyCfg = pkgs.writeText "haproxy.conf" config.services.haproxy.config;
-
   configFiles = filter (lib.hasSuffix ".cfg") (fclib.files /etc/local/haproxy);
 
   # This was included in our old example config. Breaks on 20.09 because HAProxy

--- a/nixos/services/logrotate/default.nix
+++ b/nixos/services/logrotate/default.nix
@@ -114,18 +114,11 @@ in
           # and 100 to place them even before the header.
           fcio = platformSettings // { global = true; priority = 900; };
         };
+        # part of our un-hardening, we at least require Unix socket communications
+        # to daemons like MySQL or Ceph (admin socket)
+        # TODO: consider restricting to these address families only
+        allowNetworking = true;
       };
-
-      # We create one directory for each service user. I decided not to remove
-      # old directories as this may be manually placed data that I don't want
-      # to delete accidentally.
-      flyingcircus.localConfigDirs = let
-        cfgDir = u:
-          lib.nameValuePair
-            "logrotate-${u.name}"
-            { dir = "${localDir}/${u.name}"; user = u.name; permissions = "0755"; };
-
-        in listToAttrs (map cfgDir serviceUsers);
 
       systemd.services = {
         # XXX logrotate does not allow setting options and I need to rebuild the
@@ -139,7 +132,15 @@ in
           config = {
             # Upstream puts logrotate in multi-user.target which triggers unwanted
             # service starts on fc-manage. It should only be activated by the timer.
-             wantedBy = lib.mkForce [ ];
+            wantedBy = lib.mkForce [ ];
+
+            # The upstream service is a bit too hardened for what we want to do in
+            # the platform. Only necessary for the system logrotate, the user units
+            # are not hardened yet as they are not running as privileged users.
+            serviceConfig = with config.fclib; {
+              # our MySQL logic relies on config files in the home directory
+              ProtectHome = mkOverrideUpstreamModule false;
+            };
           };
         };
       } // listToAttrs (
@@ -155,6 +156,18 @@ in
           stopIfChanged = false;
         })
         serviceUsers);
+
+      # We create one directory for each service user. I decided not to remove
+      # old directories as this may be manually placed data that I don't want
+      # to delete accidentally.
+      flyingcircus.localConfigDirs = let
+        cfgDir = u:
+          lib.nameValuePair
+            "logrotate-${u.name}"
+            { dir = "${localDir}/${u.name}"; user = u.name; permissions = "0755"; };
+
+        in listToAttrs (map cfgDir serviceUsers);
+
 
       systemd.timers =
         listToAttrs (


### PR DESCRIPTION
Logrotate was broken for several services lika haproxy, ceph, or mysql: the postrotate script was not properly executed, causing the log stream not being switched over to the current file.

This happened due to hardening of the systemd service being increased in NixOS 24.11. This hardening is a bit too tight for our platform, so we need to relax some aspects again.

This change alone does not fix an incorrect log file descriptor assignment of running services. As it is going to be rolled out together with a kernel update, the resulting system reboot will make services start from a fresh state again.

@flyingcircusio/release-managers

PL-133439

## Release process

- [x] Created changelog entry using `./changelog.sh`


## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
  -  user logrotate services not affected

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - fix a regression in log rotation to avoid machines running out of disk space
  - test coverage might need to be extended as this regression went uncaught
  - must not cause any known regressions
- [ ] Security requirements tested? (EVIDENCE)
  - [ ] automated tests still pass
  - [x] tested the change manually on affected machines with haproxy, ceph, mysql
  - [x] follow-up ticket to extend test case coverage
