### PR TITLE
[24.11] update backy(-extract)

### DIFF
--- a/changelog.d/20250219_141234_PL-133195-update-backy-21.05_scriv.md
+++ b/changelog.d/20250219_141234_PL-133195-update-backy-21.05_scriv.md
@@ -1,0 +1,18 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+
+### NixOS XX.XX platform
+
+- Update backup software (backy and backy-extract). Mostly cosmetic changes
+  and minor bug fixes.

--- a/nixos/roles/backyserver.nix
+++ b/nixos/roles/backyserver.nix
@@ -14,8 +14,8 @@ let
       owner = "flyingcircusio";
       repo = "backy-extract";
       # 1.1.0
-      rev = "5fd4c02e757918e22b634b16ae86927b82eb9f2a";
-      sha256 = "1msg4p4h6ksj3vrsshhh5msfwgllai42jczyvd4nvrsqpncg12ik";
+      rev = "3f1efdc6d9d52d13b91b640d8005913efbd80e1c";
+      hash = "sha256-fOM3dvSH6rIXkOK/pKKp1xPeiUYabG8dI65lEhQNZas=";
     };
     in
       pkgs.callPackage src {};

--- a/pkgs/backy/default.nix
+++ b/pkgs/backy/default.nix
@@ -12,8 +12,8 @@ let
   src = fetchFromGitHub {
     owner = "flyingcircusio";
     repo = "backy";
-    rev = "ecfb9849a6516d9fdbd0e0b97fd28216e13f4c91";
-    hash = "sha256-ENtzVjNaouFHySOmQ3KLGQsBL+8YxtIm5PvLiEYq+5E=";
+    rev = "2.5.2";
+    hash = "sha256-Tp6mQ9a/PBocw9unGexLvz55nMX+mnUUiUC6ZCCZ+8w=";
   };
 
   lib = import "${src}/lib.nix" inputs;


### PR DESCRIPTION
@flyingcircusio/release-managers

PL-133195

[backy changes](https://github.com/flyingcircusio/backy/compare/2.5.1...2.5.2)
[backy-extract changes](https://github.com/flyingcircusio/backy-extract/compare/5fd4c02e757918e22b634b16ae86927b82eb9f2a...385af88b0e58aa1dfaee1850d0ad40456ea3da76)

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - release bug fixes
- [x] Security requirements tested? (EVIDENCE)
  - automated tests pass