### PR TITLE
Sanitise interface altnames generated from LLDP

### DIFF
--- a/pkgs/fc/lldp-to-altname/fc-lldp-to-altname.py
+++ b/pkgs/fc/lldp-to-altname/fc-lldp-to-altname.py
@@ -19,7 +19,10 @@ def has_known_prefix(name):
 
 
 def quote_altname(name):
-    return re.sub(r"[^a-z0-9A-Z]+", "-", name)
+    name = re.sub(r"[^a-z0-9A-Z]+", "-", name)
+    name = name.strip("-")
+    name = re.sub(f"--+", "-", name)
+    return name
 
 
 class Runner(object):


### PR DESCRIPTION
On physical hosts, we set altnames on the kernel network devices based on the information exposed by the peer device over LLDP. Some of our switches however send port descriptions with an extra trailing space character, which results in an altname which has a trailing dash. This commit strips out leading or trailing dashes, and replaces consecutive dashes with a single dash to improve the readability of the generated altnames.

PL-132921

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh` => none, cosmetic internal change

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Cosmetic change to internal utility script.
- [x] Security requirements tested? (EVIDENCE)
  - Tested on physical staging host.