### PR TITLE
add script for updating the nixpkgs lock files manually

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,15 @@ The nixpkgs and nixos-mailserver versions used by the platform are pinned in `fl
 
 We use our [nixpkgs fork](https://github.com/flyingcircusio/nixpkgs) and the nixos-mailserver fork from our Gitlab.
 
+Our nixpkgs fork is automatically updated by the update-nixpkgs GitHub action in fc-nixos-release-tools.
+
+If you need to manually cherry-pick a commit from nixpkgs or add another commit on top of our nixpkgs fork, please add
+the commit to the nixos-xx.xx (replace with the current version) and run
+
+    ./update-nixpkgs-lock.sh
+
+on an x86_64-linux machine and commit the changed files to this repository.
+
 To learn more about our release tooling, look at the fc-nixos-release-tooling repo.
 
 License

--- a/update-nixpkgs-lock.sh
+++ b/update-nixpkgs-lock.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+nix flake update nixpkgs
+nix run .#buildVersionsJson
+nix run .#buildPackageVersionsJson


### PR DESCRIPTION
PL-133100

@flyingcircusio/release-managers

## Release process

- [ ] Created changelog entry using `./changelog.sh`
  - No. I don't see benefit by announcing this internal changes to our customers.

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - The script should update necessary files
- [x] Security requirements tested? (EVIDENCE)
  - The commands are already used in the update-nixpkgs action, and I tested them here again.
