### PR TITLE
[24.11] matomo: fix quoting in cleanup shell script

### DIFF
--- a/changelog.d/20250219_193309_PL-133012-matomo-remove-unexpected-files_scriv.md
+++ b/changelog.d/20250219_193309_PL-133012-matomo-remove-unexpected-files_scriv.md
@@ -1,0 +1,17 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+
+### NixOS XX.XX platform
+
+- matomo: improve cleanup of unwanted files after upgrading from matomo4 to matomo5 (PL-133012)

--- a/nixos/services/matomo/matomo-delete-unwanted-files.sh
+++ b/nixos/services/matomo/matomo-delete-unwanted-files.sh
@@ -191,9 +191,18 @@ files=(\
   "/var/lib/matomo/share/node_modules/angular-sanitize/README.md"\
   "/var/lib/matomo/share/node_modules/angular-sanitize/angular-sanitize.min.js"\
   "/var/lib/matomo/share/node_modules/angular-sanitize/index.js"\
+  "/var/lib/matomo/share/libs/Zend/Session/SaveHandler/DbTable.php"\
+  "/var/lib/matomo/share/libs/Zend/Session/SaveHandler/Exception.php"\
+  "/var/lib/matomo/share/libs/Zend/Session/SaveHandler/Interface.php"\
+  "/var/lib/matomo/share/plugins/CoreHome/javascripts/numberFormatter.js"\
+  "/var/lib/matomo/share/plugins/CoreHome/vue/src/getFormattedEvolution.ts"\
+  "/var/lib/matomo/share/plugins/Installation/FormDatabaseSetup.php.orig"\
+  "/var/lib/matomo/share/plugins/TagManager/stylesheets/gettingStarted.less"\
+  "/var/lib/matomo/share/plugins/TagManager/templates/gettingStarted.twig"\
+  "/var/lib/matomo/share/plugins/TagManager/templates/trackingHelp.twig"\
 )
 
-for file in "''${files[@]}";do
+for file in "${files[@]}";do
   if [ -f "$file" ]; then
     rm -v "$file"
   fi
@@ -214,7 +223,7 @@ directories=(\
   "/var/lib/matomo/share/vendor/symfony/monolog-bridge/Symfony"\
 )
 
-for dir in "''${directories[@]}";do
+for dir in "${directories[@]}";do
   if [ -d "$dir" ]; then
     rm -Rvf "$dir"
   fi


### PR DESCRIPTION
Forward-port of #1279 to the correct intended branch. As it accidentally went to an earlier NixOS platform release branch earlier, we've reverted it in #1301.
The changes are designed for an environment where matomo-4 does not play a role anymore. This is the case in 24.11, but not yet in 24.05.

PL-133012

@flyingcircusio/release-managers

## Release process

- [ ] Created changelog entry using `./changelog.sh`


## PR release workflow (internal)

- [ ] PR has internal ticket
- [ ] internal issue ID (PL-…) part of branch name
- [ ] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - [x] forwardport of an alread approved change
- [x] Security requirements tested? (EVIDENCE)
  - [ ] automated tests still pass