### PR TITLE
devhost: fix fc-devhost-vm-cleanup.service timezone handling

### DIFF
--- a/changelog.d/20250226_145402_PL-133467-fix-devhost-cleanup_scriv.md
+++ b/changelog.d/20250226_145402_PL-133467-fix-devhost-cleanup_scriv.md
@@ -1,0 +1,17 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+
+### NixOS XX.XX platform
+
+- devhost: fix cleanup of old development VMs (PL-133467)

--- a/nixos/roles/devhost/fc-devhost.py
+++ b/nixos/roles/devhost/fc-devhost.py
@@ -428,23 +428,29 @@ class Manager:
         vm_shut_down = False
         for vm_cfg in list_all_vm_configs():
             if "last_deploy_date" not in vm_cfg:
-                vm_cfg["last_deploy_date"] = (
-                    datetime.datetime.utcnow().isoformat()
-                )
+                vm_cfg["last_deploy_date"] = datetime.datetime.now(
+                    datetime.UTC
+                ).isoformat()
                 with open(
                     CONFIG_DIR / f"{vm_cfg['name']}.json", mode="w"
                 ) as f:
                     f.write(json.dumps(vm_cfg))
 
-            if datetime.datetime.fromisoformat(vm_cfg["last_deploy_date"]) < (
-                datetime.datetime.utcnow() - datetime.timedelta(days=31)
+            # existing VMs might have persisted a timezone-naive timestamp
+            last_deploy_date_parsed = datetime.datetime.fromisoformat(
+                vm_cfg["last_deploy_date"]
+            ).astimezone(datetime.UTC)
+            if last_deploy_date_parsed < (
+                datetime.datetime.now(datetime.UTC)
+                - datetime.timedelta(days=31)
             ):
                 print(f"Deleting VM {vm_cfg['name']}.")
                 Manager(name=vm_cfg["name"]).destroy()
 
-            elif datetime.datetime.fromisoformat(
-                vm_cfg["last_deploy_date"]
-            ) < (datetime.datetime.utcnow() - datetime.timedelta(days=14)):
+            elif last_deploy_date_parsed < (
+                datetime.datetime.now(datetime.UTC)
+                - datetime.timedelta(days=14)
+            ):
                 if vm_cfg["online"] == False:
                     continue
                 print(f"Shutting down VM {vm_cfg['name']}.")


### PR DESCRIPTION
Earlier changes regarding the deprecation of `datetime.utcnow()` had the consequence, that persisted isoformat timestamps now contained a timezone. Parsing these stamps again and comparing them with a naive time resulted in an error.
From now on, always compare timezoned datetime objects. Includes a migration path for naive isoformat timestamps created in earlier releases.

PL-133467

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`


## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - must not introduce known regressions
  - fix regression in fc-devhost
  - deployment and vm cleanup needs to work
  - consider migrations from older state of earlier releases
- [ ] Security requirements tested? (EVIDENCE)
  - [ ] automated tests still pass
  - [x] test-deployment of directory works
  - [x] old vms are successfully cleaned up
  - [x] investigated persisted VM state on platform 21.05
