### PR TITLE
Update FRR to recent stable release

### DIFF
--- a/pkgs/fc/check-rib-integrity/check_rib_integrity.py
+++ b/pkgs/fc/check-rib-integrity/check_rib_integrity.py
@@ -40,10 +40,7 @@ def ip_route_json(net):
 
 
 def bridge_macs(bridge, vxlan):
-    # XXX: newer versions of iproute2 support bridge -j for json
-    # output
-    data = subprocess.check_output(["bridge", "fdb", "show", "br", bridge])
-    data = [item.split() for item in data.decode("utf-8").splitlines()]
+    data = json_cmd(["bridge", "-j", "fdb", "show", "br", bridge])
     data = [
         item
         for item in data
@@ -52,23 +49,32 @@ def bridge_macs(bridge, vxlan):
     ]
 
     local_macs = {
-        item[0]: (item[2] if item[2] != vxlan else bridge)
+        item["mac"]: (item["ifname"] if item["ifname"] != vxlan else bridge)
         for item in data
-        # extern_learn records managed by zebra, self records handled
-        # internally by device drivers
-        if "extern_learn" not in item and "self" not in item
-        # ignore the mac addresses assigned to the host side of tap
-        # interfaces, but include the mac address assigned to the
-        # bridge interface
-        and ("permanent" not in item or item[2] == vxlan)
+        # extern_learn records managed by zebra
+        if "extern_learn" not in item["flags"]
+        # self records handled internally by device drivers
+        and "self" not in item["flags"]
+        # ignore mac addresses assigned to the host side of tap
+        # interfaces (marked permanent), but include the mac address
+        # assigned to the bridge interface itself
+        and (item["state"] != "permanent" or item["ifname"] == vxlan)
     }
 
     remote_macs = {
-        mac[0]: IPv4Address(dest[4])
-        for mac in data
-        if mac[2] == vxlan and mac[4] == "master" and mac[5] == bridge
+        lladdr["mac"]: IPv4Address(dest["dst"])
+        for lladdr in data
+        # entries indicating the vxlan interface as the port on the
+        # bridge for a given mac address
+        if lladdr["ifname"] == vxlan
+        and "master" in lladdr
+        and lladdr["master"] == bridge
+        # join with entries associating the same mac address with a
+        # remote vtep address
         for dest in data
-        if dest[0] == mac[0] and dest[2] == vxlan and dest[3] == "dst"
+        if dest["mac"] == lladdr["mac"]
+        and dest["ifname"] == vxlan
+        and "dst" in dest
     }
 
     return local_macs, remote_macs

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -113,12 +113,12 @@ builtins.mapAttrs (_: patchPhps (fetchpatch {
   });
 
   frr = super.frr.overrideAttrs (old: rec {
-    version = "8.5.7";
+    version = "10.1.2";
     src = super.fetchFromGitHub {
       owner = "FRRouting";
       repo = old.pname;
       rev = "${old.pname}-${version}";
-      hash = "sha256-2ViapJNLO+jwtORtarj+UTdHN/uE2PqyJTwf4dkXBmg=";
+      hash = "sha256-yenWMFHQ8F3/GJ+BVnoi5t//6qtFqH8i3uNq4X0/qdI==";
     };
 
     patches = [

--- a/tests/frr.nix
+++ b/tests/frr.nix
@@ -173,7 +173,7 @@ let
       };
     };
 
-  makeEvpnHost = { idx, taps }: { pkgs, lib, ... }:
+  makeEvpnHost = { idx, taps, tapsEnabled ? true }: { pkgs, lib, ... }:
     let
       underlayAddr = makeUnderlayAddress idx;
       bridgeMac = makeHostMac idx;
@@ -185,7 +185,7 @@ let
         macaddr = makeTapMac tapidx;
       in lib.nameValuePair "ping-${iface}" (rec {
         description = "Respond to ping and arp on ${iface}";
-        wantedBy = [ "multi-user.target" ];
+        wantedBy = if tapsEnabled then [ "multi-user.target" ] else [];
         requires = [ "network-addresses-${iface}.service" ];
         after = requires;
         serviceConfig.ExecStart = "${pkgs.fc.ping-on-tap}/bin/ping-on-tap ${iface} ${macaddr} ${ipaddr}";
@@ -395,6 +395,73 @@ in {
             # allow frr to reset the fib automatically
             host1.succeed("bridge fdb del 06:00:00:00:23:03 dev vxlan0")
             host1.wait_until_succeeds("check_rib_integrity check-evpn-rib -n 23")
+      '';
+    };
+    migration = {
+      name = "migration";
+      nodes = {
+        host1 = makeEvpnHost { idx = 1; taps = [ 1 ]; tapsEnabled = false; };
+        switch1 = makeFrrHost { idx = 2; redistribute = true; evpn = true; };
+        host2 = makeEvpnHost { idx = 3; taps = [ 1 ]; tapsEnabled = false; };
+        switch2 = makeFrrHost { idx = 4; redistribute = true; evpn = true; };
+      };
+
+      testScript = ''
+        start_all()
+        all_vms = [host1, host2, switch1, switch2]
+        for vm in all_vms:
+            vm.wait_for_unit("network-online.target")
+
+        for vm in all_vms:
+            x = vm.succeed("vtysh -c 'show version'")
+
+        guest_mac = "06:00:00:00:23:01"
+        guest_ip = "192.168.23.101"
+
+        with subtest("wait for peer SVI MAC addresses to appear"):
+            for host, addr in [(host1, "06:00:00:00:42:03"), (host2, "06:00:00:00:42:01")]:
+                host.wait_until_succeeds(f"bridge fdb show br br0 | grep -F {addr}", timeout=10)
+
+        with subtest("checking SVI addresses are reachable"):
+            host1.succeed("ping -c1 192.168.23.3")
+            host2.succeed("ping -c1 192.168.23.1")
+
+        with subtest("start guest TAP responder"):
+            host1.succeed("systemctl start ping-tap0")
+            with subtest("wait for local mac to appear"):
+                host1.wait_until_succeeds(f"bridge fdb show br br0 | grep -F '{guest_mac} dev tap0'", timeout=10)
+            with subtest("wait for remote mac to appear"):
+                host2.wait_until_succeeds(f"bridge fdb show br br0 | grep -F extern_learn | grep -F {guest_mac}", timeout=10)
+
+            with subtest("check TAP responder is reachable"):
+                # ensure the neighbour tables on both hosts are primed.
+                host1.succeed(f"ping -A -c5 {guest_ip}")
+                host2.succeed(f"ping -A -c5 {guest_ip}")
+
+        with subtest("rib and fib should not have mismatches"):
+            for host in [host2, host1]:
+                host.wait_until_succeeds("check_rib_integrity check-unicast-rib -p 192.168.42.0/24", timeout=10)
+                host.wait_until_succeeds("check_rib_integrity check-evpn-rib -n 23", timeout=10)
+
+
+        with subtest("migrate guest TAP responder"):
+            # pathological case: the guest interface starts on the receiving
+            # host before it stops on the sending host.
+            host2.succeed("systemctl start ping-tap0")
+            host1.succeed("systemctl stop ping-tap0")
+
+            with subtest("wait for local mac to appear"):
+                host2.wait_until_succeeds(f"bridge fdb show br br0 | grep -F '{guest_mac} dev tap0'", timeout=10)
+            with subtest("wait for remote mac to appear"):
+                host1.wait_until_succeeds(f"bridge fdb show br br0 | grep -F extern_learn | grep -F {guest_mac}", timeout=10)
+
+            with subtest("check remote TAP responder is reachable"):
+                host1.succeed(f"ping -A -c5 {guest_ip}")
+
+        with subtest("rib and fib should not have mismatches"):
+            for host in [host2, host1]:
+                host.wait_until_succeeds("check_rib_integrity check-unicast-rib -p 192.168.42.0/24", timeout=10)
+                host.wait_until_succeeds("check_rib_integrity check-evpn-rib -n 23", timeout=10)
       '';
     };
   };


### PR DESCRIPTION
Due to recurring problems with FRR since we upgraded most of our hardware from 21.05 to 24.11, we've decided to update our pinned FRR version from 8.5.7 to the much more recent 10.1.2. Nixpkgs stable currently only has 10.1, and this has some bugs in the handling of IPv4-via-IPv6 nexthops which render it unsuitable for our use case, so this change retains our version pinning with the newer version.

I've additionally refactored the RIB integrity check script to use the new JSON interface of the `bridge` command (new since 21.05) to improve the robustness of the script, and I've written an additional FRR test with a (very simple) sanity check for working MAC mobility functionality.

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh` => none, internal change.


## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Software version update.
  - Refactoring tools for changing interfaces of third party software.
- [x] Security requirements tested? (EVIDENCE)
  - The Hydra tests are clean.
  - Manually tested on a development host.
  - We're relying on our development and staging environments in order to test the new FRR version under real workloads, as this requires greater scale and resources than we have in the integration test environment.