### PR TITLE
fc-ipmitool: convenience - use `shell` as the default command

### DIFF
--- a/changelog.d/20250227_153706_ctheune-ipmitool-shell-default_scriv.md
+++ b/changelog.d/20250227_153706_ctheune-ipmitool-shell-default_scriv.md
@@ -1,0 +1,17 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+
+### NixOS XX.XX platform
+
+- fc-ipmitool: use `shell` as the default command.

--- a/pkgs/fc/ipmitool/fc-ipmitool.py
+++ b/pkgs/fc/ipmitool/fc-ipmitool.py
@@ -30,6 +30,10 @@ if "." not in args.host:
     location = os.environ["FCIO_LOCATION"]
     host = f"{host}.ipmi.{location}.gocept.net"
 
+ipmi_args = args.args
+if not ipmi_args:
+    ipmi_args = ["shell"]
+
 exec_args = [
     "ipmitool",
     "-4",
@@ -39,9 +43,10 @@ exec_args = [
     "lanplus",
     "-H",
     host,
-    *args.args,
+    *ipmi_args,
 ]
 
 exec_path = shutil.which("ipmitool")
+assert exec_path
 print(exec_path, " ".join(exec_args))
 os.execve(exec_path, exec_args, os.environ)


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`


## PR release workflow (internal)

- [ ] PR has internal ticket
- [ ] internal issue ID (PL-…) part of branch name
- [ ] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

no applicable requirements

- [x] Security requirements tested? (EVIDENCE)

nothing to test
