### PR TITLE
monitoring: make port speed monitoring more flexible (and sane)

### DIFF
--- a/changelog.d/20250227_160510_PL-133472-interface-check-minimal-speeds-only_scriv.md
+++ b/changelog.d/20250227_160510_PL-133472-interface-check-minimal-speeds-only_scriv.md
@@ -1,0 +1,23 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+- A bullet item for the Impact category.
+
+
+### NixOS XX.XX platform
+
+- Monitoring for network interface speed: remove the limit for maximum speeds
+  and make a more differentiated expectation around where we expect 1G or 10G+
+  links. (PL-133472)

--- a/nixos/infrastructure/flyingcircus-physical.nix
+++ b/nixos/infrastructure/flyingcircus-physical.nix
@@ -159,7 +159,7 @@ mkIf (cfg.infrastructureModule == "flyingcircus-physical") (lib.mkMerge [
         notification = "Network interfaces are healthy";
         command = "sudo ${fc.sensuplugins}/bin/check_interfaces " + (
            lib.concatMapStringsSep " "
-             (link: "-i ${link.link},${toString (trace link link.minimumPortSpeed)}:")
+             (link: "-i ${link.link},${toString link.minimumPortSpeed}:")
              cfg.networking.monitorLinks
            );
         interval = 60;

--- a/nixos/infrastructure/flyingcircus-physical.nix
+++ b/nixos/infrastructure/flyingcircus-physical.nix
@@ -159,7 +159,7 @@ mkIf (cfg.infrastructureModule == "flyingcircus-physical") (lib.mkMerge [
         notification = "Network interfaces are healthy";
         command = "sudo ${fc.sensuplugins}/bin/check_interfaces " + (
            lib.concatMapStringsSep " "
-             (link: "-i ${link.link},1000:10000")
+             (link: "-i ${link.link},${toString (trace link link.minimumPortSpeed)}:")
              cfg.networking.monitorLinks
            );
         interval = 60;

--- a/nixos/lib/network.nix
+++ b/nixos/lib/network.nix
@@ -260,6 +260,8 @@ rec {
 
         inherit vlan mtu priority bridged;
 
+        minimumPortSpeed = config.flyingcircus.static.minimumPortSpeeds.${vlan} or 1000; # Mbit/s
+
         vlanId = config.flyingcircus.static.vlanIds.${vlan};
 
         # Our nomenclature:
@@ -462,6 +464,7 @@ rec {
           # Unify with the fclib.network. structure
           mac = l.mac;
           mtu = network.ul.mtu;
+          minimumPortSpeed = network.ul.minimumPortSpeed;
           interface = underlayLoopbackLinkName;
           link = (makeName l);
           externalLabel = l.external_label;

--- a/nixos/platform/static.nix
+++ b/nixos/platform/static.nix
@@ -154,6 +154,12 @@ with lib;
         rzob = [ "rzob-router" ];
       };
 
+      minimumPortSpeeds = {
+        sto = 10000;
+        stb = 10000;
+        ul = 10000;
+      };
+
       # VLANs on which we accept connectivity to the outside world
       routerUplinkNetworks = {
         dev = [ "tr" ];


### PR DESCRIPTION
We used to hard code that anything between 1G and 10G is fine.

However, we want some networks (sto/stb in the old world, the underlays in the new world) to always be at least 10G.

However, mgm, fe, srv are fine with 1G.

And last, but not least: we don't want to be alerted if a port is faster. Technology makes progress and we just got critically alerted because a link was now at 25G ... scary!

Fixes PL-133472

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`


## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

n/a

- [x] Security requirements tested? (EVIDENCE)

n/a