### PR TITLE
routers: fix pmacctd traffic accounting bind to interface

### DIFF
--- a/changelog.d/20250228_165417_PL-133497-pmacctd-interface-hotfix_scriv.md
+++ b/changelog.d/20250228_165417_PL-133497-pmacctd-interface-hotfix_scriv.md
@@ -1,0 +1,17 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+
+### NixOS XX.XX platform
+
+- routers: fix traffic accounting with pmacctd by binding to correct interface again (PL-133497)

--- a/nixos/roles/router/pmacctd.nix
+++ b/nixos/roles/router/pmacctd.nix
@@ -23,6 +23,7 @@ let
     description = "Collect traffic accounting data";
     wantedBy = [ "multi-user.target" ];
     requires = [ "network-addresses-${interface}.service" ];
+    after = [ "network-addresses-${interface}.service" ];
     stopIfChanged = false;
     script = ''
       ${pkgs.pmacct}/bin/pmacctd -f ${mkConfig interface}

--- a/nixos/roles/router/pmacctd.nix
+++ b/nixos/roles/router/pmacctd.nix
@@ -7,7 +7,7 @@ let
   role = config.flyingcircus.roles.router;
   mkConfig = interface:
     pkgs.writeText "pmacctd-${interface}.conf" ''
-      interface: ${interface}
+      pcap_interface: ${interface}
       aggregate: src_host,dst_host
 
       plugins: print

--- a/tests/router/default.nix
+++ b/tests/router/default.nix
@@ -9,6 +9,18 @@ let
       inherit (config) fclib;
     in
     {
+      assertions = [
+        # XXX: so in the test we're expecting the interface names ethfe and ethsrv,
+        # but on real routers it's brfe and brsrv?
+        {
+          assertion = config.fclib.network.fe.interface == "ethfe";
+          message = "router test: Expected the fe interface to be named `ethfe`, got `${config.fclib.network.fe.interface}`";
+        }
+        {
+          assertion = config.fclib.network.srv.interface == "ethsrv";
+          message = "router test: Expected the srv interface to be named `ethsrv`, got `${config.fclib.network.srv.interface}`";
+        }
+      ];
       virtualisation.vlans = with config.flyingcircus.static.vlanIds; [ mgm fe srv tr ];
       virtualisation.memorySize = 2048;
 
@@ -329,7 +341,11 @@ in
     extraPythonPackages = ps: [ ps.rich ];
     skipTypeCheck = true; # due to cursed importing of helpers
 
-    testScript = { nodes, ... }: mkTestScript nodes ''
+    testScript = { nodes, ... }:
+      let
+      feInterface = nodes.primary.fclib.network.fe.interface;
+      srvInterface = nodes.primary.fclib.network.srv.interface;
+      in mkTestScript nodes ''
       pp = rich.print
       primary.wait_for_unit("default.target")
 
@@ -377,8 +393,18 @@ in
         primary.succeed("stat undionly.kpxe")
 
       with subtest("pmacctd should be running for fe and srv interfaces"):
-        primary.wait_for_unit("pmacctd-ethfe")
-        primary.wait_for_unit("pmacctd-ethsrv")
+        primary.wait_for_unit("pmacctd-${feInterface}")
+        primary.wait_for_unit("pmacctd-${srvInterface}")
+
+      with subtest("pmacctd does not issue warnings and binds to correct interfaces"):
+        print(primary.execute("journalctl -b -u pmacctd*")[1])
+        # deliberately broad condition: We'd like to know about each warning for now.
+        # the one we actually want to ensure to not exist for PL-133497 is:
+        # WARN: [/nix/store/9pa54fv0jksk9kx4zlq98y3mh3676hk1-pmacctd-brsrv.conf:1] Unknown key: interface. Ignored.
+        primary.fail('journalctl -b -u pmacctd* --grep "WARN:"')
+
+        primary.succeed('journalctl -b -u pmacctd-${feInterface} | tee | grep "\[${feInterface},0\] link type is: 1"')
+        primary.succeed('journalctl -b -u pmacctd-${srvInterface} --grep "\[${srvInterface},0\] link type is: 1"')
 
       with subtest("trafficclient timer should be active"):
         primary.wait_for_unit("fc-trafficclient.timer")
@@ -408,7 +434,11 @@ in
 
     extraPythonPackages = ps: [ ps.rich ];
     skipTypeCheck = true; # due to cursed importing of helpers
-    testScript = { nodes, ... }: mkTestScript nodes ''
+    testScript = { nodes, ... }:
+    let
+      feInterface = nodes.secondary.fclib.network.fe.interface;
+      srvInterface = nodes.secondary.fclib.network.srv.interface;
+    in mkTestScript nodes ''
       pp = rich.print
       secondary.wait_for_unit("default.target")
 
@@ -420,8 +450,11 @@ in
         pp(secondary.succeed("systemctl status -l firewall"))
 
       with subtest("pmacctd should be running for fe and srv interfaces"):
-        secondary.wait_for_unit("pmacctd-ethfe")
-        secondary.wait_for_unit("pmacctd-ethsrv")
+        print(secondary.execute("systemctl status pmacctd*")[1])
+        print(secondary.execute("journalctl -b -u pmacctd*")[1])
+
+        secondary.wait_for_unit("pmacctd-${feInterface}")
+        secondary.wait_for_unit("pmacctd-${srvInterface}")
 
       with subtest("trafficclient timer should be active"):
         secondary.wait_for_unit("fc-trafficclient.timer")

--- a/tests/router/default.nix
+++ b/tests/router/default.nix
@@ -160,6 +160,12 @@ let
         }];
       };
 
+      # fc-trafficclient tries to connect to the directory. So far we do not test
+      # any actual functionality of that service here, so just mock it away to avoid
+      # - having to expose an /etc/nixos/enc.json
+      # - having to provide a fake directory to connect and report to
+      systemd.services.fc-trafficclient.serviceConfig.ExecStart = lib.mkForce "${pkgs.coreutils}/bin/true";
+
       flyingcircus.enc.name = "router${toString id}";
       flyingcircus.enc.parameters = {
         location = "test";


### PR DESCRIPTION
Fix a regression in pmacctd after it was updated from 1.7.5 (NixOS 21.05) to 24.11 (1.7.9), where the `interface` config key was removed. The same functionality can now be configured with `pcap_interface`. The change can be narrowed down to pmacct-1.7.7, revision 8583beaadc4b8d559b84edc0f7273e59aea842d8, but was never properly documented by the upstream project.

This had the effect that pmacctd ignored that config option and fell back to accounting *all* interfaces. As a result, traffic was accounted 3 times (incoming physical, vx… bridge).
As we are running 2 instances of this service, originally designated to account only fe and srv each, we get 2*3 = 6x.

Additionally to updating the config key name, our NixOS test now checks for any warning issued by pmacctd, and also verifies that log output confirms binding to the correct interface.

PL-133497

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`


## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - is a hotfix for a regression => include regression test
  - must not impact remaining router functionality
- [x] Security requirements tested? (EVIDENCE)
  - [x] automated tests still pass
  - [x] extended test suite to ensure absence of warnings (negative match) and logging of correct interface binding (positive match)
  - [x] rolled out to a development router
  - [x] on a testvm utilising that router, downloaded file of known size, and
    - verified it is only accounted on the correct interface
    - verified the accounted size is correct
    - done for ethsrv and ethfe 