### PR TITLE
Add new VLAN definition for routed frontend network

### DIFF
--- a/nixos/platform/static.nix
+++ b/nixos/platform/static.nix
@@ -68,6 +68,8 @@ with lib;
         "dhp" = 19;
         # underlay: EVPN-VXLAN network virtualisation underlay
         "ul" = 20;
+        # routed frontend: frontend network using routed layer 3 transport
+        "pub" = 21;
         # video surveillance
         "video" = 23;
         # access network for unmanaged hosts


### PR DESCRIPTION
This change adds the required static VLAN definition in order to support interfaces on the routed frontend network.

PL-133324

@flyingcircusio/release-managers

## Release process

- [x] ~~Created changelog entry using `./changelog.sh`~~ => internal change


## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Update static configuration data.
- [x] Security requirements tested? (EVIDENCE)
  - Manually verified on dev machines.