### PR TITLE
tests/router: remove superfluous assertions

### DIFF
--- a/tests/router/default.nix
+++ b/tests/router/default.nix
@@ -9,18 +9,6 @@ let
       inherit (config) fclib;
     in
     {
-      assertions = [
-        # XXX: so in the test we're expecting the interface names ethfe and ethsrv,
-        # but on real routers it's brfe and brsrv?
-        {
-          assertion = config.fclib.network.fe.interface == "ethfe";
-          message = "router test: Expected the fe interface to be named `ethfe`, got `${config.fclib.network.fe.interface}`";
-        }
-        {
-          assertion = config.fclib.network.srv.interface == "ethsrv";
-          message = "router test: Expected the srv interface to be named `ethsrv`, got `${config.fclib.network.srv.interface}`";
-        }
-      ];
       virtualisation.vlans = with config.flyingcircus.static.vlanIds; [ mgm fe srv tr ];
       virtualisation.memorySize = 2048;
 


### PR DESCRIPTION
Follow-up of #1312.

According to @ctheune, there is no need to be alerted through an assertion when test harness interface naming logic changes. Other tests implicitly already sufficiently cover wrong interface naming consequences.

@flyingcircusio/release-managers

PL-133497

## Release process

- [ ] Created changelog entry using `./changelog.sh`
  - completely internal follow-up to change that has not been released yet


## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - None, removal of a superfluous VM test assertion
- [x] Security requirements tested? (EVIDENCE)
