### PR TITLE
platform/packages: Keep around one earlier python version

### DIFF
--- a/changelog.d/20250303_183108_os-python-previous-version_scriv.md
+++ b/changelog.d/20250303_183108_os-python-previous-version_scriv.md
@@ -1,0 +1,17 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+
+### NixOS XX.XX platform
+
+- install python-3.11 by default in addition to the default python-3.12

--- a/nixos/platform/packages.nix
+++ b/nixos/platform/packages.nix
@@ -3,7 +3,12 @@
 {
   config = {
 
-    environment.systemPackages = with pkgs; [
+    environment.systemPackages = with pkgs;
+    let
+      previousPythonVersion = ver:
+        "${lib.versions.major ver}${toString (lib.toInt(lib.versions.minor ver) - 1)}";
+      previousPython = pkgs."python${previousPythonVersion pkgs.python3.version}";
+    in [
         apacheHttpd
         atop
         automake
@@ -52,6 +57,8 @@
         psmisc
         pwgen
         (python3.withPackages (ps: with ps; [ setuptools ]))
+        # keep around at least one previous python version for upgrade compatibility
+        (previousPython.withPackages (ps: with ps; [setuptools]))
         python3Packages.virtualenv
         rclone
         ripgrep


### PR DESCRIPTION
To allow easier platform version upgrades, keep around one additional older python version. This is useful e.g. for batou deployments that have not been upgraded yet.
The priorities are already adjusted at nixpkgs side such that `python3` still calls the executable provided by the `python3` package.

For the 24.11 platform, this adds `python311` to the path of all systems.

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`


## PR release workflow (internal)

- [ ] PR has internal ticket
- [ ] internal issue ID (PL-…) part of branch name
- [ ] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - do not introduce any known regression
  - allow easier upgrades by keeping around neighbouring python versions by default
  - prevent stale version over time: don't hardcode a particular old python version
- [x] Security requirements tested? (EVIDENCE)
  - [x] automated tests still pass
  - [x] derive previous python3 version from current python3 default version to prevent version from becoming stale, when forgotten to be updated in new platform releases