### PR TITLE
[PL-133484] nixos/platform: change default nix to 2.18 (prod) or 2.25 (non-prod)

### DIFF
--- a/changelog.d/20250304_120935_PL-133484-nix-version-changes_scriv.md
+++ b/changelog.d/20250304_120935_PL-133484-nix-version-changes_scriv.md
@@ -1,0 +1,24 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+- Nix: downgrade production VMs to 2.18 (and upgrade the rest to 2.25).
+
+  Due to a significant performance regression in 2.24, Nix will be rolled back
+  to 2.18, the default from 24.05 and 23.11. Staging machines will get Nix 2.25
+  as a preparation for upgrading the entire platform to 2.25.
+
+### NixOS XX.XX platform
+
+- Restart of `nix-daemon`.

--- a/nixos/platform/collect-garbage.nix
+++ b/nixos/platform/collect-garbage.nix
@@ -66,7 +66,7 @@ in {
           SuccessExitStatus = [ 1 2 3 ];
           TimeoutStartSec = "infinity";
         };
-        path = with pkgs; [ fc.userscan nix glibc util-linux ];
+        path = with pkgs; [ fc.userscan glibc util-linux ];
         environment = {
           LANG = "en_US.utf8";
           PYTHONUNBUFFERED = "1";

--- a/nixos/platform/default.nix
+++ b/nixos/platform/default.nix
@@ -37,6 +37,7 @@ in {
     ./kernel.nix
     ./monitoring.nix
     ./network.nix
+    ./nix.nix
     ./packages.nix
     ./shell.nix
     ./static.nix

--- a/nixos/platform/nix.nix
+++ b/nixos/platform/nix.nix
@@ -1,0 +1,35 @@
+{ config, lib, pkgs, ... }:
+
+let
+  production = lib.attrByPath [ "parameters" "production" ] "" config.flyingcircus.enc;
+
+  nixPackage = if config.flyingcircus.nix.useUnstableNix
+    then pkgs.nixVersions.nix_2_25
+    else pkgs.nixVersions.nix_2_18;
+in {
+  options.flyingcircus = {
+    nix.useUnstableNix = lib.mkOption {
+      default = production == false;
+      defaultText = lib.literalExpression ''production == false'';
+      type = lib.types.bool;
+      description = ''
+        Whether to use a known stable Nix (i.e. 2.18) or a
+        newer, potentially unstable version (i.e. 2.25).
+      '';
+    };
+
+    # The option is defined in `<fc-nixos/nixos/platform/agent.nix>`.
+    # This injects a function that makes sure that the agent uses the correct
+    # Nix version.
+    #
+    # It's not feasible to modify `config.flyingcircus.agent.package` for this,
+    # since downstream consumers may do that already, e.g. for slurm support.
+    agent.package = lib.mkOption {
+      apply = package: package.override { nix = config.nix.package; };
+    };
+  };
+
+  config = {
+    nix.package = nixPackage;
+  };
+}

--- a/nixos/services/sensu/client.nix
+++ b/nixos/services/sensu/client.nix
@@ -609,7 +609,7 @@ in {
         glibc
         lm_sensors
         monitoring-plugins
-        nix
+        config.nix.package
         openssl
         procps
         python3

--- a/pkgs/fc/default.nix
+++ b/pkgs/fc/default.nix
@@ -3,8 +3,10 @@
 rec {
   recurseForDerivations = true;
 
-  agent = pythonPackages.callPackage ./agent {};
-  agentWithSlurm = pythonPackages.callPackage ./agent { enableSlurm = true; };
+  agent = pythonPackages.callPackage ./agent {
+    nix = pkgs.nixVersions.nix_2_18;
+  };
+  agentWithSlurm = agent.override { enableSlurm = true; };
 
   blockdev = callPackage ./blockdev {};
 

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -91,6 +91,7 @@ in {
   network = callSubTests ./network {};
   nfs = callTest ./nfs.nix {};
   nginx = callTest ./nginx.nix {};
+  nix-version = callTest ./nix-version.nix {};
   nodejs = callTest ./nodejs.nix {};
   opensearch = callTest ./opensearch.nix {};
   opensearch_dashboards = callTest ./opensearch_dashboards.nix {};

--- a/tests/nix-version.nix
+++ b/tests/nix-version.nix
@@ -1,0 +1,116 @@
+import ./make-test-python.nix ({ ... }: {
+  name = "nixversions";
+  nodes = let
+    mkTestVM = { location, withSlurm ? false, production ? true }: { lib, pkgs, ... }: {
+      imports = [ ../nixos ../nixos/roles ];
+      flyingcircus.agent.package = lib.mkIf withSlurm pkgs.fc.agentWithSlurm;
+      flyingcircus.enc.parameters = {
+        inherit location production;
+        resource_group = "test";
+        interfaces.srv = {
+          mac = "52:54:00:12:34:56";
+          bridged = false;
+          networks = {
+            "192.168.101.0/24" = [ "192.168.101.7" ];
+            "2001:db8:f030:1c3::/64" = [ "2001:db8:f030:1c3::7" ];
+          };
+          gateways = {};
+        };
+      };
+    };
+  in {
+    production = mkTestVM { location = "rzob"; };
+    nonProd = mkTestVM { location = "rzob"; production = false; };
+    slurmOnProduction = mkTestVM { location = "rzob"; withSlurm = true; };
+    slurmOnNonProd = mkTestVM { location = "rzob"; withSlurm = true; production = false; };
+
+    devVM = mkTestVM { location = "dev"; };
+    devVMNonProd = mkTestVM { location = "dev"; production = false; };
+    whqVM = mkTestVM { location = "whq"; };
+    whqVMNonProd = mkTestVM { location = "whq"; production = false; };
+  };
+
+  testScript = ''
+    import os.path
+    import re
+
+    relevant_nix_versions = [
+      # the default on production
+      "2.18",
+      # default Nix in 24.11
+      "2.24",
+      # the default on staging
+      "2.25",
+    ]
+
+    def strip_hash(store_path):
+        basename = os.path.basename(store_path)
+        return basename.split("-", 1)[1]
+
+    def verify_nix_versions(vm, expected_nix="2.25", expect_slurm=False):
+        vm.start()
+        version = vm.succeed("nix --version")
+        assert version.startswith(f"nix (Nix) {expected_nix}."), f"""
+          Expected Nix version to start with
+            nix (Nix) {expected_nix}.
+          Full output:
+            {version}
+        """
+        nix = os.path.dirname(os.path.dirname(vm.succeed("readlink -f $(type -P nix)")))
+        fc_agent = vm.succeed("readlink -f $(type -P fc-manage)")
+
+        # no `nix why-depends` here since it always gives 0 as exit code and we'd have to
+        # match the stderr.
+        agent_closure = vm.succeed(f"nix-store -qR {fc_agent}").rstrip("\n").split("\n")
+        assert nix in agent_closure, f"""
+          Expected Nix {expected_nix} (i.e. store-path {nix}) to be in
+          the agent closure:
+
+          {agent_closure}
+        """
+
+        nix_versions_not_used = [x for x in relevant_nix_versions if x != expected_nix]
+        assert all(
+            not strip_hash(p).startswith(f"nix-{majorminor}.")
+            for p in agent_closure
+            for majorminor in nix_versions_not_used
+        ), f"""
+          Expected Nix versions {", ".join(nix_versions_not_used)} to NOT be in the agent closure:
+
+          {agent_closure}
+        """
+
+        assert any(strip_hash(p).startswith("slurm-") for p in agent_closure) == expect_slurm, """
+          Expected no `slurm` in agent closure:
+
+          {agent_closure}
+        """
+
+        vm.shutdown()
+
+
+    with subtest("rzob production vm"):
+        verify_nix_versions(production, "2.18")
+
+    with subtest("rzob non-prod vm"):
+        verify_nix_versions(nonProd, "2.25")
+
+    with subtest("rzob prod vm with slurm"):
+        verify_nix_versions(slurmOnProduction, "2.18", expect_slurm=True)
+
+    with subtest("rzob non-prod vm with slurm"):
+        verify_nix_versions(slurmOnNonProd, "2.25", expect_slurm=True)
+
+    with subtest("whq vm"):
+        verify_nix_versions(whqVM, "2.18")
+
+    with subtest("whq vm with non-prod flag"):
+        verify_nix_versions(whqVMNonProd, "2.25")
+
+    with subtest("dev vm prod"):
+        verify_nix_versions(devVM, "2.18")
+
+    with subtest("dev vm non-prod"):
+        verify_nix_versions(devVMNonProd, "2.25")
+  '';
+})


### PR DESCRIPTION
Nix 2.24's inefficient Git tarball cache is a major problem for VMs[1] with low IOPS (default is 250). The way forward is

* switch back to Nix 2.18 on all production VMs.
* roll out Nix 2.25 as designated successor to all non-production VMs (approach derived from the verification kernel topic from eba8be36bd4c5490dbf23ed9265f44fea92e3e42).

The challenge here is that `flyingcircus.agent.package` is supposed to be modified by downstream consumers, e.g. for Slurm support. Hence, the option isn't modified directly, but each agent package is post-processed via `apply` to use `config.nix.package`.

A nice side-effect of this is that setting `nix.package` also changes the Nix used by the agent, so `nix.package` behaves as I'd expect it. Please note that this also means that setting `nix.package` to e.g. Nix 2.26 implies a rebuild of the agent now.

I decided against overriding `pkgs.nix` with an overlay since there are a bunch of packages out there that explicitly require a specific Nix version, so the potential fallout from that is higher than modifying `nix.package`.

Additionally I changed the usage of Nix 2.24 in the following places:

* The PATH of `fc-collect-garbage.service` doesn't have a Nix at all anymore. The agent package already prefers its own Nix, so this had no effect at all.

* The agent isn't built against 2.24 in pkgs/fc: I see no reason to do that since there's zero usage of this. It's now built with Nix 2.18 since that's what the majority of all VMs will use for now.

  The variant with 2.25 is also built by Hydra because of the VM-test, so staging VMs don't have to build their own agent.

* The sensu check-env uses the default Nix as well.

[1] See PL-133484 for measurements with Nix versions and related
    upstream bugs.

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`


## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
  - 2.18/2.25 can be toggled with a newly introduced option. An arbitrary Nix version can be selected with `nix.package` (that also changes the Nix used by the agent now).
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Availability: Nix 2.24 has a major performance regression regarding the unpacking/caching of tarballs which is especially a problem on VMs with low IOPS.
- [x] Security requirements tested? (EVIDENCE)
  - Measurements from PL-133484 show that Nix 2.25 and Nix 2.18 are equivalent in terms of performance and are faster than 2.24. Hence, 2.18 is being rolled out as known-good version for production and 2.25 on staging to discover potential problems with it before switching the entire platform to 2.25.