### PR TITLE
Add patch for FRR with regression fix for MAC mobility

### DIFF
--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -123,6 +123,12 @@ builtins.mapAttrs (_: patchPhps (fetchpatch {
 
     patches = [
       ./frr/0001-Don-t-throw-error-when-log-directory-already-exists.patch
+      # issue with best path selection erroneously deleting local mac
+      # addresses during incoming guest migration.
+      (fetchpatch {
+        url = "https://github.com/FRRouting/frr/commit/c3e264e27ac5b682c4647aeeaf4e61f09d5243f9.patch";
+        hash = "sha256-YUNyE2ZeW3q58E+fpFhmMGpp56eba8HUI7pcLLbQDTE=";
+      })
     ];
   });
 


### PR DESCRIPTION
This change introduces a patch to our pinned FRR version which fixes a regression affecting MAC mobility (and hence VM migration) introduced between 10.0 and 10.1.

Depending on ordering between different hosts, a receiving KVM host may learn the MAC address of a migrating guest before the sending host stops announcing it. Due to the regression, bgpd would frequently decide that the remote route was a "better" route than the locally learned route and thus delete the latter, which would mean that when the remote route was withdrawn when the migration completed, bgpd would not announce a route for the locally learned MAC.

This would lead to routes for guest MAC addresses going missing, causing unnecessary flooding from the other hosts in the EVPN fabric and eventually to site-wide network performance degradation.

This regression has been fixed upstream and backported to the stable branch, but is yet to appear in a 10.1.x stable release.

PL-133422

@flyingcircusio/release-managers

## Release process

- [x] ~~Created changelog entry using `./changelog.sh`~~

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - This is a recognised regression upstream, and while the fix has been merged it's not yet in a public release.
- [x] Security requirements tested? (EVIDENCE)
  - Passes the chaos monkey smoke test in dev (which the unpatched version does not pass).