### PR TITLE
mailserver: remove ix.dnsbl.manitu.net blacklist

### DIFF
--- a/changelog.d/20250307_094305_PL-133519-dnsbl_scriv.md
+++ b/changelog.d/20250307_094305_PL-133519-dnsbl_scriv.md
@@ -1,0 +1,21 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+- A bullet item for the Impact category.
+
+
+### NixOS XX.XX platform
+
+- Remove anti-spam DNS blacklist ix.dnsbl.manitu.net Manitu, which has been discontinued. (PL-133519)

--- a/nixos/services/mail/default.nix
+++ b/nixos/services/mail/default.nix
@@ -320,7 +320,6 @@ in {
           sender_canonical_classes = "envelope_sender";
           smtpd_client_restrictions = [
             "permit_mynetworks"
-            "reject_rbl_client ix.dnsbl.manitu.net"
             "reject_unknown_client_hostname"
           ];
           smtpd_data_restrictions = "reject_unauth_pipelining";


### PR DESCRIPTION
Has been shut down, now causes all incoming mails to be rejected

PL-133519

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`


## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
  - hotfix, in case we add a new list that should be configurable via NixOS options 
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - availability: hotfix the accidental rejection of incoming mails
- [x] Security requirements tested? (EVIDENCE)
  - [x] manually tested on a mailserver that this unbreaks incoming mails