### PR TITLE
Add auto merge workflow

### DIFF
--- a/.github/workflows/auto-merge-check-pr.yaml
+++ b/.github/workflows/auto-merge-check-pr.yaml
@@ -1,0 +1,30 @@
+name: "Check auto-mergeability of PR"
+on:
+  # use pull_request_target to also run on PRs with merge conflict
+  pull_request_target:
+    types: [labeled, unlabeled, ready_for_review, opened, synchronize]
+  pull_request_review:
+    types: [submitted, dismissed]
+
+permissions:
+  contents: read
+  statuses: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  action:
+    name: check-auto-mergeability-of-pr
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: flyingcircusio/fc-nixos-release-tools
+      - uses: cachix/install-nix-action@v30
+      - name: build release tooling
+        run: |
+          nix build .#
+      - run: |
+          ./result/bin/auto-merge check-pr ${{ github.event.number }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
PL-133248

@flyingcircusio/release-managers

## Release process

- [ ] Created changelog entry using `./changelog.sh`
  - no: internal change without effect on VMs
 

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Visibility: Tooling shows it's actions with a comment (merge date).
  - Don't disturb work: It's always possible to override the actions by this tool by manually merging
- [x] Security requirements tested? (EVIDENCE)
  - Tested with automatic tests and fc-nixos-testing
