### PR TITLE
overlay, php: build php82/83 with patched curl on hydra

### DIFF
--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -44,6 +44,7 @@ builtins.mapAttrs (_: patchPhps phpLogPermissionPatch) {
   inherit (phps) php72 php73 php74 php80;
   # Import NixOS upstream PHPs.
   inherit (super) php81 php82 php83 php84;
+
 }
 //
 builtins.mapAttrs (_: patchPhps (fetchpatch {
@@ -52,6 +53,36 @@ builtins.mapAttrs (_: patchPhps (fetchpatch {
   })) {
     inherit (super) php83 php84;
   }
+# temporarily added to overlay to ensure it is built by hydra.
+# TODO: drop in 25.05
+# Use curl 8.4.0 for PHP
+# FC-40106, FC-40100
+// lib.listToAttrs (map (v: lib.nameValuePair "php${v}-FC-40106" (
+  super."php${v}".override {
+          packageOverrides = final: prev: {
+            extensions = prev.extensions // {
+              curl = prev.extensions.curl.overrideAttrs (_: let
+                curl_8_4 = self.curl.overrideAttrs (_: {
+                  version = "8.4.0";
+                  patches = [];
+                  src = self.fetchurl {
+                    urls = [
+                      "https://curl.haxx.se/download/curl-8.4.0.tar.xz"
+                      "https://github.com/curl/curl/releases/download/curl-${builtins.replaceStrings [ "." ] [ "_" ] "8.4.0"}/curl-8.4.0.tar.xz"
+                    ];
+                    hash = "sha256-FsYqnErw9wPSi9pte783ukcFWtNBTXDexj4uYzbyqC0=";
+                  };
+                });
+              in {
+                buildInputs = [ curl_8_4 ];
+                configureFlags = [ "--with-curl=${curl_8_4.dev}" ];
+              });
+            };
+          };
+        }
+    )
+  ) [ "82" "83"]
+)
 // {
   pythonPackagesExtensions = super.pythonPackagesExtensions ++ [
     (python-self: python-super: {


### PR DESCRIPTION
Due to a regression, we need to override the curl used in php82 and php83 in several customer projects.
To ensure it is built by hydra and available in binary cache instead of having to build it locally, we temporarily add it to the list of packages.

FC-40100 FC-40106

@flyingcircusio/release-managers

## Release process

- [ ] Created changelog entry using `./changelog.sh`
  - no, the packages are mainly designed for internal use 


## PR release workflow (internal)

- [ ] PR has internal ticket
- [ ] internal issue ID (PL-…) part of branch name
- [ ] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - [x] availability: reduce local system load of VMs for common package variations
- [x] Security requirements tested? (EVIDENCE)
  - [x] ensures packages are built by hydra
    - https://hydra.flyingcircus.io/build/4387591
    - https://hydra.flyingcircus.io/build/4387470
  - [x] automated tests still pass