### PR TITLE
Fix auto-merge check pr workflow when triggered by pull_request_review

### DIFF
--- a/.github/workflows/auto-merge-check-pr.yaml
+++ b/.github/workflows/auto-merge-check-pr.yaml
@@ -2,7 +2,7 @@ name: "Check auto-mergeability of PR"
 on:
   # use pull_request_target to also run on PRs with merge conflict
   pull_request_target:
-    types: [labeled, unlabeled, ready_for_review, opened, synchronize]
+    types: [labeled, unlabeled, ready_for_review, opened, reopened, synchronize]
   pull_request_review:
     types: [submitted, dismissed]
 
@@ -25,6 +25,6 @@ jobs:
         run: |
           nix build .#
       - run: |
-          ./result/bin/auto-merge check-pr ${{ github.event.number }}
+          ./result/bin/auto-merge check-pr ${{ github.event.pull_request.number }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
By https://docs.github.com/en/webhooks/webhook-events-and-payloads `event.pull_request.number` is set on `pull_request_review` and `pull_request_target`.

PL-133248

@flyingcircusio/release-managers

## Release process

- [ ] Created changelog entry using `./changelog.sh`
  - no: internal only

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Functionality
- [x] Security requirements tested? (EVIDENCE)
  - Documentation shows this to work
  - A review here with a non-failing check shows that the workflow now works
