### PR TITLE
add tracing for when evaluation recurses into 21.05 nixpkgs instance

### DIFF
--- a/changelog.d/20250310_143121_PL-133522-trace-2105-usage_scriv.md
+++ b/changelog.d/20250310_143121_PL-133522-trace-2105-usage_scriv.md
@@ -1,0 +1,18 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+
+### NixOS XX.XX platform
+
+- issue trace messages when nixpkgs-21.05 is evaluated (PL-33522)
+    - We still use parts of nixpkgs-21.05 for certain hardware and infrastructure features. As we generally do not expect it to be used in virtual machines though, emit a trace during evaluation to discover cases that differ.

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -10,7 +10,7 @@ let
 
   nixpkgs-21_05-src = (import ../versions.nix { pkgs = super; }).nixpkgs-21_05;
   fc-nixos-21_05-src = (import ../versions.nix { pkgs = super; }).fc-nixos-21_05;
-  fc-nixos-21_05 = import fc-nixos-21_05-src {inherit (self) config; nixpkgs = nixpkgs-21_05-src; };
+  fc-nixos-21_05 = builtins.trace "using fc-nixos-21:05" (import fc-nixos-21_05-src {inherit (self) config; nixpkgs = nixpkgs-21_05-src; });
 
   inherit (super) fetchpatch fetchFromGitHub fetchurl lib;
   inherit (builtins) hasAttr storePath;
@@ -102,9 +102,9 @@ builtins.mapAttrs (_: patchPhps (fetchpatch {
   inherit (self.ceph-nautilus) ceph ceph-client libceph;
   # upstream ceph packaging switched to offering a reduced client tooling set, let's see how that works
   ceph-nautilus = lib.dontRecurseIntoAttrs fc-nixos-21_05.ceph-nautilus;
-  consul = fc-nixos-21_05.consul.overrideAttrs (old:
+  consul = builtins.trace "using 21_05 consul" (fc-nixos-21_05.consul.overrideAttrs (old:
     { meta.mainProgram = "consul"; }
-  );
+  ));
 
   docsplit = super.callPackage ./docsplit { };
 
@@ -448,8 +448,8 @@ builtins.mapAttrs (_: patchPhps (fetchpatch {
     ];
   });
 
-  python38 = lib.dontRecurseIntoAttrs fc-nixos-21_05.python38;
-  python38Packages = lib.dontRecurseIntoAttrs fc-nixos-21_05.python38Packages;
+  python38 = builtins.trace "using 21_05 python38" (lib.dontRecurseIntoAttrs fc-nixos-21_05.python38);
+  python38Packages = builtins.trace "using 21_05 python38Packages" (lib.dontRecurseIntoAttrs fc-nixos-21_05.python38Packages);
   py38_pytest_patterns = fc-nixos-21_05.py_pytest_patterns;
 
   qemu-ceph-nautilus = fc-nixos-21_05.qemu-ceph-nautilus;


### PR DESCRIPTION
When the evaluation traverses into the nixpkgs 21.05 revision we still ship for certain hardware and infrastructure features, issue a trace message. This helps debugging the eval depth and discover cases where that path is evaluated unexpectedly, we don't expect that to be the case on virtual machines.

part of PL-133522

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`


## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - availability: provide tracing for a potential cause of higher memory consumption of system evalutaions
  - introduce no know regressions 
- [ ] Security requirements tested? (EVIDENCE)
  - [ ] automated tests still pass
  - [x] tested on physical infrastructure host and test VM that traces appear as expected