### PR TITLE
ipmi: continuously ensure the admin username

### DIFF
--- a/changelog.d/20250311_112039_PL-132896-ensure-ipmi-admin-username_scriv.md
+++ b/changelog.d/20250311_112039_PL-132896-ensure-ipmi-admin-username_scriv.md
@@ -1,0 +1,17 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### NixOS XX.XX platform
+
+- Ensure the administrator username is always `ADMIN` and does not deviate
+  depending on the vendor/integrator. (PL-133527)

--- a/nixos/platform/ipmi.nix
+++ b/nixos/platform/ipmi.nix
@@ -86,6 +86,7 @@ in {
         sleep 1
         ipmitool sol set volatile-bit-rate 115.2 1
         sleep 1
+        ipmitool user set name 2 ADMIN
         # See https://serverfault.com/questions/361940/configuring-supermicro-ipmi-to-use-one-of-the-lan-interfaces-instead-of-the-ipmi/677087
         # Ensure BMC is set to failover (SuperMicro only)
         if ipmitool mc info | grep Supermicro > /dev/null ; then


### PR DESCRIPTION
Re PL-133527

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`


## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

I'd say "KISS" is a good requirement that motivates this change.

- [x] Security requirements tested? (EVIDENCE)

Relying on test suite and dev. Command has been tested manually.