### PR TITLE
nginx,acme: make sensu checks work for non-HTTPS usage

### DIFF
--- a/changelog.d/20250311_140206_PL-131278-ssl-checks-non-https_scriv.md
+++ b/changelog.d/20250311_140206_PL-131278-ssl-checks-non-https_scriv.md
@@ -1,0 +1,28 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+- A bullet item for the Impact category.
+
+
+### NixOS XX.XX platform
+
+- nginx, monitoring: also check validity of ACME (Letsencrypt) certificates
+  that are not used for nginx HTTPS.
+  There are two separate checks now: all ACME certs are checked via the local
+  file system.
+  Certificates used for nginx HTTPS get an additional check that works like the
+  previous one, using HTTPS requests.
+  We still assume here that nginx is listening for HTTPS on port 443.
+  For special configurations, the sensu check command has to be overridden manually.

--- a/nixos/platform/acme.nix
+++ b/nixos/platform/acme.nix
@@ -1,22 +1,44 @@
 { config, pkgs, lib, ... }:
 let
   inherit (config) fclib;
+  checkCert = pkgs.writeShellScript "check-local-acme-cert" ''
+    certificate_path="$1"
+    critical_sec=$((14 * 24 * 3600))
+    warning_sec=$((25 * 24 * 3600))
+
+    openssl x509 -in "$certificate_path" -noout -enddate
+
+    if ! openssl x509 -checkend $critical_sec -noout -in "$certificate_path" > /dev/null
+    then
+        exit 2
+    fi
+
+    if ! openssl x509 -checkend $warning_sec -noout -in "$certificate_path" > /dev/null
+    then
+        exit 1
+    fi
+  '';
+
 in
 lib.mkMerge [{
+  flyingcircus.passwordlessSudoRules = [
+    {
+      commands = [ "${checkCert}" ];
+      groups = [ "sensuclient" ];
+    }
+  ];
+
   # Generate a sensu check for each acme cert to check its validity and warn
   # when it expires.
+
   flyingcircus.services.sensu-client.checks =
-    lib.listToAttrs
-      (map (n: lib.nameValuePair "ssl_cert_acme_${n}" {
+    lib.mapAttrs'
+      (n: cert: lib.nameValuePair "ssl_cert_acme_${n}" {
         notification = "ACME (Letsencrypt) certificate for ${n} is invalid or will expire soon";
-        # We're using a timeout of 15 seconds because 10 seconds is the timeout
-        # that will trigger if DNS issues occur and giving the check a higher
-        # timeout allows us to see those. Otherwise they get hidden behind
-        # a generic timeout message.
-        command = "check_http -p 443 -S --sni -C 25,14 -H ${n} -t 15";
-        interval = 600;
+        command = "/run/wrappers/bin/sudo ${checkCert} ${cert.directory}/fullchain.pem";
+        interval = 3600;
       })
-      (lib.attrNames config.security.acme.certs));
+      config.security.acme.certs;
 
   systemd.services =
   let

--- a/nixos/services/nginx/default.nix
+++ b/nixos/services/nginx/default.nix
@@ -64,11 +64,11 @@ let
   virtualHosts = lib.mapAttrs mkVanillaVhostFromFCVhost cfg.virtualHosts;
 
   # only email setting supported at the moment
-  acmeSettings =
+  fcioAcmeSettings =
     lib.mapAttrs (name: val: { email = val.emailACME; })
-    (lib.filterAttrs (_: val: val ? emailACME && val.emailACME != null ) cfg.virtualHosts);
+    (lib.filterAttrs (_: val: val ? emailACME && val.emailACME != null) cfg.virtualHosts);
 
-  acmeVhosts = (lib.filterAttrs (_: val: val ? enableACME ) cfg.virtualHosts);
+  acmeVhosts = (lib.filterAttrs (_: vhost: vhost.enableACME) nginxCfg.virtualHosts);
 
   mainConfig = ''
     worker_processes ${toString cfg.workerProcesses};
@@ -428,11 +428,26 @@ in
           interval = 60;
         };
 
-      };
+      } // (
+      lib.listToAttrs
+        (map (n:
+          lib.nameValuePair "nginx_https_${n}" {
+          notification = "HTTPS certificate check failed for vhost ${n}";
+          # We're using a timeout of 15 seconds because 10 seconds is the timeout
+          # that will trigger if DNS issues occur and giving the check a higher
+          # timeout allows us to see those. Otherwise they get hidden behind
+          # a generic timeout message.
+          # Note that we assume that the certificate is reachable via port 443.
+          # Other configurations might need overrides for the sensu check command.
+          command = "check_http -p 443 -S --sni -C 25,14 -H ${n} -t 15";
+          interval = 600;
+        })
+        (lib.attrNames acmeVhosts)));
+
 
       networking.firewall.allowedTCPPorts = [ 80 443 ];
 
-      security.acme.certs = acmeSettings;
+      security.acme.certs = fcioAcmeSettings;
 
       flyingcircus.passwordlessSudoRules = [
         {


### PR DESCRIPTION
There are two separate Sensu checks for ACME certificate validity now:

The existing Sensu check which uses check_http is now generated per Nginx vhost when ACME is enabled. It is renamed to `nginx_https_${vhost_name}`. ACME.

Another Sensu check is generated for all ACME certs, using the openssl command which works in the local file system, independently of  Nginx. This check has the name of the existing check `ssl_cert_${cert_name}`.

PL-131278

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`


## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - limit passwordless sudo permissions to sensuclient (ACME Sensu check needs root permissions via sudo to check certificates in /var/lib/acme) 
- [x] Security requirements tested? (EVIDENCE)
  - verified that passwordless sudo access is limited to sensuclient by looking at /etc/sudoers on a test VM