### PR TITLE
[FC-43451] nixos/rabbitmq: install rabbitmqadmin-ng by default

### DIFF
--- a/changelog.d/20250305_120319_fc-24.11-dev_scriv.md
+++ b/changelog.d/20250305_120319_fc-24.11-dev_scriv.md
@@ -1,0 +1,19 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+- [`rabbitmqadmin-ng`](https://www.rabbitmq.com/docs/management-cli) is now installed by default on machines with
+  the `rabbitmq` role.
+
+### NixOS XX.XX platform

--- a/doc/src/rabbitmq.md
+++ b/doc/src/rabbitmq.md
@@ -18,6 +18,28 @@ We remove the guest user for security reasons.
 Service users can access the rabbitmq account with {command}`sudo -iu rabbitmq`
 to perform administrative tasks with {command}`rabbitmqctl`.
 
+Alternatively, [`rabbitmqadmin-ng`](https://www.rabbitmq.com/docs/management-cli) may be used
+to interact with the HTTP API. It is installed by default with the `rabbitmq` role.
+
+For this to work, a `~/.rabbitmqadmin.conf` is required with a configuration like this:
+
+```toml
+[default]
+hostname = "localhost"
+port = 15672
+username = "myusername"
+password = "mypassword"
+vhost = '/'
+```
+
+For this, you need a user `myusername` in RabbitMQ with the tags
+`administrator` & `management`. Such a user can be created like this:
+
+```
+rabbitmqctl add_user myusername mypassword
+rabbitmqctl set_user_tags myusername management administrator
+```
+
 ## Monitoring
 
 The default monitoring setup checks that the RabbitMQ server is healthy and responding to AMQP connections.

--- a/nixos/services/rabbitmq/default.nix
+++ b/nixos/services/rabbitmq/default.nix
@@ -142,7 +142,7 @@ in {
   config = mkIf cfg.enable {
 
     # This is needed so we will have 'rabbitmqctl' in our PATH
-    environment.systemPackages = [ cfg.package ];
+    environment.systemPackages = [ cfg.package pkgs.rabbitmqadmin-ng ];
     environment.etc."local/rabbitmq/README.txt".text = ''
       RabbitMQ (${cfg.package.version}) is running on this machine.
 


### PR DESCRIPTION


This uses the HTTP API from RabbitMQ for administrative purposes and looks quite useful so far.

Since it took me a moment to figure out how to configure a user that can interact with this tool, I added the setup part to our manual.

@flyingcircusio/release-managers
@frlan who originally opened the ticket

## Release process

- [x] Created changelog entry using `./changelog.sh`


## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
  - Installs a package that's only there for interactive use and has no other side-effects.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE): Avoid security by obscurity: provide tools to operators that enable them to inspect the state of the rabbitmq installation.
- [x] Security requirements tested? (EVIDENCE): Manually activated the change and configured the tool as documented.