### PR TITLE
Unload USB XHCI driver at shutdown on hardware

### DIFF
--- a/changelog.d/20250311_172519_PL-133421-shutdown-unload-xhci-driver_scriv.md
+++ b/changelog.d/20250311_172519_PL-133421-shutdown-unload-xhci-driver_scriv.md
@@ -1,0 +1,21 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+
+### NixOS XX.XX platform
+
+- hardware: unload the XHCI USB driver at shutdown to work around a
+  problem with certain kernel and hardware combinations improperly
+  deconfiguring USB devices at shutdown (PL-133421).

--- a/nixos/infrastructure/flyingcircus-physical.nix
+++ b/nixos/infrastructure/flyingcircus-physical.nix
@@ -141,6 +141,15 @@ mkIf (cfg.infrastructureModule == "flyingcircus-physical") (lib.mkMerge [
         '';
     };
 
+    # PL-133421: some hardware+kernel combinations don't seem to
+    # deconfigure USB devices properly at shutdown time, which can
+    # lead to devices getting stuck and then failing to reappear on
+    # the bus after a reboot. unloading the driver in late shutdown
+    # before userland ends avoids this problem.
+    systemd.shutdown."unload-xhci-driver.shutdown" = pkgs.writeShellScript "rmmod-xhci" ''
+      ${pkgs.kmod}/bin/modprobe -v -r xhci_pci
+    '';
+
     flyingcircus.ipmi.enable = true;
 
     flyingcircus.passwordlessSudoPackages = [


### PR DESCRIPTION
Since upgrading to 24.11, we've observed that some of our storage servers with certain motherboard revisions don't deconfigure USB devices properly at shutdown, which results in the LUKS key stick getting lost and not reappearing on the bus again after a reboot. This means that these storage servers aren't able to automatically decrypt their data disks when performing maintenance.

This change introduces a workaround to unload the XHCI driver from the kernel very late in the shutdown process just before userland ends, which appears to avoid this problem.

PL-133421

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`


## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
  - This change sets the upstream NixOS `systemd.shutdown` option to configure the script which removes the kernel module at shutdown time. This can be disabled by overriding the NixOS option in the local host configuration.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - This only runs at shutdown time, and has no impact on the running system.
- [x] Security requirements tested? (EVIDENCE)
  - Experimentally verified with several of the production Ceph hosts which were having the issue of losing their key sticks.