### PR TITLE
devhost: stop VMs gracefully

### DIFF
--- a/changelog.d/20250313_104234_PL-133536-stop-devhost-vms-gracefully_scriv.md
+++ b/changelog.d/20250313_104234_PL-133536-stop-devhost-vms-gracefully_scriv.md
@@ -1,0 +1,20 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+Devhost VMs get restarted
+
+### NixOS XX.XX platform
+
+- devhost: stop VMs gracefully (PL-133536)

--- a/nixos/roles/devhost/vm.nix
+++ b/nixos/roles/devhost/vm.nix
@@ -63,22 +63,34 @@ let
     enable = vmCfg.enable;
     wantedBy = [ "machines.target" ];
 
-    serviceConfig.ExecStart = (lib.escapeShellArgs
-      [
-        "${pkgs.qemu_kvm}/bin/qemu-system-x86_64"
-        "-name" name
-        "-enable-kvm"
-        "-cpu" "host"
-        "-smp" vmCfg.cpu
-        "-m" vmCfg.memory
-        "-nodefaults"
-        "-no-user-config"
-        "-nographic"
-        "-drive" "id=root,format=qcow2,file=/var/lib/devhost/vms/${name}/rootfs.qcow2,if=virtio,aio=threads"
-        "-netdev" "tap,id=ethsrv-${name},ifname=vm-srv-${name},script=${ifaceUpScript},downscript=${ifaceDownScript}"
-        "-device" "virtio-net,netdev=ethsrv-${name},mac=${vmCfg.srvMac}"
-        "-serial" "file:/var/lib/devhost/vms/${name}/log"
-      ]);
+    serviceConfig = {
+      ExecStart = (lib.escapeShellArgs
+        [
+          "${pkgs.qemu_kvm}/bin/qemu-system-x86_64"
+          "-name" name
+          "-enable-kvm"
+          "-cpu" "host"
+          "-smp" vmCfg.cpu
+          "-m" vmCfg.memory
+          "-nodefaults"
+          "-no-user-config"
+          "-nographic"
+          "-drive" "id=root,format=qcow2,file=/var/lib/devhost/vms/${name}/rootfs.qcow2,if=virtio,aio=threads"
+          "-netdev" "tap,id=ethsrv-${name},ifname=vm-srv-${name},script=${ifaceUpScript},downscript=${ifaceDownScript}"
+          "-device" "virtio-net,netdev=ethsrv-${name},mac=${vmCfg.srvMac}"
+          "-serial" "file:/var/lib/devhost/vms/${name}/log"
+          "-qmp" "unix:/var/lib/devhost/vms/${name}/qmp.sock,server,nowait"
+        ]);
+      ExecStop = pkgs.writeShellScript "shutdown-devhost-vm" ''
+        (
+          ${pkgs.coreutils}/bin/echo '{"execute": "qmp_capabilities" } { "execute": "system_powerdown" }'
+          # wait for shutdown
+          cat
+        ) | \
+        ${pkgs.socat}/bin/socat STDIO UNIX:/var/lib/devhost/vms/${name}/qmp.sock,shut-none
+      '';
+      TimeoutStopSec = 180;
+     };
   });
 
   # We unfortunately cannot use writePython3Bin as that only supports


### PR DESCRIPTION
PL-133536

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`


## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Feature should work
- [x] Security requirements tested? (EVIDENCE)
  - tested on largo00 with manual `systemctl stop` and see that the ssh session is terminated gracefully
