### PR TITLE
fc.qemu improvements for test stability

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,14 +12,14 @@ repos:
   - id: check-toml
   - id: detect-private-key
   repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v3.2.0
+  rev: v5.0.0
 - hooks:
   - args: ["--profile", "black", "--filter-files"]
     id: isort
     name: isort (python)
   repo: https://github.com/pycqa/isort
-  rev: 5.13.1
+  rev: 6.0.1
 - hooks:
   - id: black
   repo: https://github.com/psf/black
-  rev: 24.4.2
+  rev: 25.1.0

--- a/changelog.d/20250314_142141_PL-133300-fix-fc-qemu-test-flakiness_scriv.md
+++ b/changelog.d/20250314_142141_PL-133300-fix-fc-qemu-test-flakiness_scriv.md
@@ -1,0 +1,17 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+
+### NixOS XX.XX platform
+
+- Improve test stability of our internal Qemu tooling. (PL-133300)

--- a/nixos/infrastructure/dev-vm.nix
+++ b/nixos/infrastructure/dev-vm.nix
@@ -136,7 +136,7 @@ in {
         service = "nfs_rg_share-server";
       });
 
-      services.redis.bind = lib.mkForce "0.0.0.0 ::";
+      services.redis.servers."".bind = lib.mkForce "0.0.0.0 ::";
 
       users.users.root.password = "";
 

--- a/nixos/lib/ceph-common.nix
+++ b/nixos/lib/ceph-common.nix
@@ -37,6 +37,7 @@ rec {
       pkgs.lz4  # required by image loading task
       pkgs.cryptsetup  # full-disk encryption
       pkgs.mdadm  # fc-luks, backup RAID
+      pkgs.parted # partprobe
     ];
 
     fc-check-ceph = pkgs.fc."check-ceph-${release}";

--- a/nixos/platform/static.nix
+++ b/nixos/platform/static.nix
@@ -95,7 +95,7 @@ with lib;
         # when enabling them, like weird search path confusion that results in
         # arbitrary negative responses, combined with the rotate flag.
         dev = [ "172.20.3.1" ];
-        test = [ "172.20.2.1" ];
+        test = [ "9.9.9.9" "8.8.8.8" ];
         whq = [ "172.16.48.1" ];
         rzob = [ "172.22.48.1" ];
         standalone = [ "9.9.9.9" "8.8.8.8" ];

--- a/nixos/roles/ceph/osd.nix
+++ b/nixos/roles/ceph/osd.nix
@@ -4,18 +4,20 @@ with builtins;
 
 let
   fclib = config.fclib;
-  role = config.flyingcircus.roles.ceph_osd;
+  cfg = config.flyingcircus.roles.ceph_osd;
+  clientConfig = config.flyingcircus.services.ceph.client;
   enc = config.flyingcircus.enc;
+
   inherit (fclib.ceph) expandCamelCaseAttrs expandCamelCaseSection;
 
-  cephPkgs = fclib.ceph.mkPkgs role.cephRelease;
+  cephPkgs = fclib.ceph.mkPkgs cfg.cephRelease;
 
   osdServiceDeps = rec {
     # Ceph requires the IPs to be properly attached to interfaces so it
     # knows where to bind to the public and cluster networks.
     wants = [
-      fclib.network.sto.addressUnit
-      fclib.network.stb.addressUnit
+      clientConfig.network.addressUnit
+      cfg.network.addressUnit
       "fc-blockdev.service"
     ];
     after = wants;
@@ -158,32 +160,41 @@ in
       cephRelease = fclib.ceph.releaseOption // {
         description = "Codename of the Ceph release series used for the the osd package.";
       };
+
+      network = lib.mkOption {
+        type = with lib.types; attrs; # an attrset from fclib.network.<xy>
+        default = fclib.network.stb;
+        description = ''
+          The Ceph cluster (replication) network.
+          '';
+      };
+
     };
 
   };
 
   config = lib.mkMerge [
-      (lib.mkIf role.enable {
+      (lib.mkIf cfg.enable {
 
       assertions = [
         {
           assertion = (
-            ( role.extraSettings != {}
+            ( cfg.extraSettings != {}
             || config.flyingcircus.services.ceph.extraSettings != {}
             || config.flyingcircus.services.ceph.client.extraSettings != {}
-            ) -> role.config == "");
+            ) -> cfg.config == "");
           message = "Mixing the configuration styles (extra)Config and (extra)Settings is unsupported, please use either plaintext config or structured settings for ceph.";
         }
       ];
       flyingcircus.services.ceph = {
         server = {
           enable = true;
-          cephRelease = role.cephRelease;
+          cephRelease = cfg.cephRelease;
         };
 
         fc-ceph.settings = let
           osdSettings =  {
-            release = role.cephRelease;
+            release = cfg.cephRelease;
             path = cephPkgs.fc-ceph-path;
           };
         in {
@@ -196,19 +207,19 @@ in
           };
       };
 
-      flyingcircus.services.ceph.cluster_network = head fclib.network.stb.v4.networks;
+      flyingcircus.services.ceph.cluster_network = head cfg.network.v4.networks;
 
       # Ceph OSDs are using a lot of ports so we're being gratuitous here about
       # the firewall and we want to avoid spamming the connection tracking
       # table.
       networking.firewall = {
 
-        trustedInterfaces = [ fclib.network.stb.interface ];
+        trustedInterfaces = [ cfg.network.interface ];
 
         extraCommands = lib.mkOrder 800 ''
           # Disable STB connection tracking to reduce kernel connection table overhead
-          ip46tables -t raw -A fc-raw-prerouting -i ${fclib.network.stb.interface} -j CT --notrack
-          ip46tables -t raw -A fc-raw-output -o ${fclib.network.stb.interface} -j CT --notrack
+          ip46tables -t raw -A fc-raw-prerouting -i ${cfg.network.interface} -j CT --notrack
+          ip46tables -t raw -A fc-raw-output -o ${cfg.network.interface} -j CT --notrack
         '';
       };
 
@@ -228,7 +239,7 @@ in
           ${cephPkgs.fc-ceph}/bin/fc-ceph osd activate all
         '';
 
-        reload = lib.optionalString role.reactivate ''
+        reload = lib.optionalString cfg.reactivate ''
           ${cephPkgs.fc-ceph}/bin/fc-ceph osd reactivate all
         '';
 
@@ -273,12 +284,12 @@ in
 
 
     })
-    (lib.mkIf (role.enable && role.config == "") {
+    (lib.mkIf (cfg.enable && cfg.config == "") {
       flyingcircus.services.ceph.extraSettingsSections.osd = lib.recursiveUpdate
-        (expandCamelCaseAttrs defaultOsdSettings) (expandCamelCaseAttrs role.extraSettings);
+        (expandCamelCaseAttrs defaultOsdSettings) (expandCamelCaseAttrs cfg.extraSettings);
     })
-    (lib.mkIf (role.enable && role.config != "") {
-      environment.etc."ceph/ceph.conf".text = lib.mkAfter role.config;
+    (lib.mkIf (cfg.enable && cfg.config != "") {
+      environment.etc."ceph/ceph.conf".text = lib.mkAfter cfg.config;
     })
     ];
 }

--- a/nixos/roles/consul/default.nix
+++ b/nixos/roles/consul/default.nix
@@ -6,19 +6,24 @@ let
   fclib = config.fclib;
   enc = config.flyingcircus.enc;
   secrets = enc.parameters.secrets;
-  public_address = head fclib.network.fe.v6.addressesQuoted;
   public_fqdn = "${enc.name}.fe.${enc.parameters.location}.fcio.net";
   server_secret_script = fclib.python3BinFromFile ./update-server-secrets.py;
+  cfg = config.flyingcircus.roles.consul_server;
 in
 {
   options = {
     flyingcircus.roles.consul_server = {
       enable = lib.mkEnableOption "Enable Consul server role";
       supportsContainers = fclib.mkDisableDevhostSupport;
+
+      publicAddress = lib.mkOption {
+        type = lib.types.str;
+        default = head fclib.network.fe.v6.addressesQuoted;
+      };
     };
   };
 
-  config = lib.mkIf config.flyingcircus.roles.consul_server.enable {
+  config = lib.mkIf cfg.enable {
 
     flyingcircus.services.consul.enable = true;
 
@@ -52,10 +57,10 @@ in
 
     services.nginx = {
       virtualHosts."${public_fqdn}" = {
-        listen = [ { addr = public_address; port = 8500; ssl = true;}
+        listen = [ { addr = cfg.publicAddress; port = 8500; ssl = true;}
                    # allow acme and the certificate checks to work
-                   { addr = public_address; port = 80; ssl = false;}
-                   { addr = public_address; port = 443; ssl = true;} ];
+                   { addr = cfg.publicAddress; port = 80; ssl = false;}
+                   { addr = cfg.publicAddress; port = 443; ssl = true;} ];
         enableACME = true;
         addSSL = true;
         locations."/" = {

--- a/nixos/roles/kvm.nix
+++ b/nixos/roles/kvm.nix
@@ -4,16 +4,23 @@ with builtins;
 
 let
   fclib = config.fclib;
-  role = config.flyingcircus.roles.kvm_host;
+  cfg = config.flyingcircus.roles.kvm_host;
   enc = config.flyingcircus.enc;
 
-  cephPkgs = fclib.ceph.mkPkgs role.cephRelease;
+  cephPkgs = fclib.ceph.mkPkgs cfg.cephRelease;
 
 in
 {
   options = {
     flyingcircus.roles.kvm_host = {
       enable = lib.mkEnableOption "Qemu/KVM server";
+      enableS3Proxy = lib.mkOption {
+        default = true;
+        example = false;
+        description = "Whether to enable the local S3 proxy.";
+        type = lib.types.bool;
+      };
+
       supportsContainers = fclib.mkDisableDevhostSupport;
       mkfsXfsFlags = lib.mkOption {
         type = with lib.types; nullOr str;
@@ -40,10 +47,17 @@ in
       cephRelease = fclib.ceph.releaseOption // {
         description = "Codename of the Ceph release series used by qemu.";
       };
+
+      network = lib.mkOption {
+        type = with lib.types; attrs; # an attrset from fclib.network.<xy>
+        default = fclib.network.sto;
+        description = "Network to use for migration";
+      };
+
     };
   };
 
-  config = lib.mkIf role.enable {
+  config = lib.mkIf cfg.enable {
 
     # Do not enable the watchdog for KVM hosts globally as we dealt with
     # way too many times.
@@ -51,7 +65,7 @@ in
 
     flyingcircus.services.ceph.client = {
       enable = true;
-      cephRelease = role.cephRelease;
+      cephRelease = cfg.cephRelease;
     };
 
     # toolpath for agent (fc-create-vm)
@@ -66,24 +80,24 @@ in
     };
 
     environment.systemPackages = with pkgs; [
-      role.package
+      cfg.package
       cephPkgs.qemu
       bridge-utils
     ];
 
     # Qemu migration coordination uses random ports at the moment, so we
     # trust this completely at the moment.
-    networking.firewall.trustedInterfaces = [ fclib.network.mgm.interface ];
+    networking.firewall.trustedInterfaces = [ cfg.network.interface ];
 
     environment.shellAliases = {
       # alias for observing both running VMs as well as the migration logs at once
-      fc-vm-migration-watch = "watch '${role.package}/bin/fc-qemu ls; echo; grep migration-status /var/log/fc-qemu.log | tail'";
+      fc-vm-migration-watch = "watch '${cfg.package}/bin/fc-qemu ls; echo; grep migration-status /var/log/fc-qemu.log | tail'";
     };
 
     environment.etc."qemu/fc-qemu.conf".text = let
       hostname = config.networking.hostName;
-      migration_address = fclib.fqdn { vlan = "sto"; domain = "gocept.net"; };
-      migration_ctl_address = fclib.fqdn { vlan = "mgm"; domain = "gocept.net"; };
+      migration_address = fclib.fqdn { vlan = cfg.network.vlan; domain = "gocept.net"; };
+      migration_ctl_address = fclib.fqdn { vlan = cfg.network.vlan; domain = "gocept.net"; };
     in ''
         [qemu]
         accelerator = kvm
@@ -96,7 +110,7 @@ in
         timeout-graceful = 120
         migration-address = tcp:${migration_address}:{id}
         migration-ctl-address = ${migration_ctl_address}:0
-        migration-bandwidth = ${toString role.migrationBandwidth}
+        migration-bandwidth = ${toString cfg.migrationBandwidth}
         max-downtime = 4.0
         ; generation 2 = #23965 upgrade to 2.7 due to security issues
         binary-generation = 2
@@ -116,8 +130,8 @@ in
         cluster = ceph
         lock_host = ${hostname}
         create-vm = ${pkgs.fc.agent}/bin/fc-create-vm -I {name}
-     '' + lib.optionalString (role.mkfsXfsFlags != null) ''
-        mkfs-xfs = ${role.mkfsXfsFlags}
+     '' + lib.optionalString (cfg.mkfsXfsFlags != null) ''
+        mkfs-xfs = ${cfg.mkfsXfsFlags}
      '';
 
     # This needs to stay as is because the path is kept alive during live
@@ -157,13 +171,13 @@ in
     flyingcircus.services.consul.enable = true;
     flyingcircus.services.consul.watches = [
       { handler_type = "script";
-        args = ["/run/wrappers/bin/sudo" "${role.package}/bin/fc-qemu" "-v" "handle-consul-event"];
+        args = ["/run/wrappers/bin/sudo" "${cfg.package}/bin/fc-qemu" "-v" "handle-consul-event"];
         type = "keyprefix";
         prefix = "node/";
       }
 
       { handler_type = "script";
-        args = ["/run/wrappers/bin/sudo" "${role.package}/bin/fc-qemu" "-v" "handle-consul-event"];
+        args = ["/run/wrappers/bin/sudo" "${cfg.package}/bin/fc-qemu" "-v" "handle-consul-event"];
         type = "keyprefix";
         prefix = "snapshot/";
       }
@@ -172,13 +186,13 @@ in
     flyingcircus.passwordlessSudoRules = [
       {
         commands = [
-          "${role.package}/bin/fc-qemu -v handle-consul-event"
+          "${cfg.package}/bin/fc-qemu -v handle-consul-event"
           "/home/ctheune/fc.qemu/result/bin/fc-qemu -v handle-consul-event"
            ];
         users = [ "consul" ];
       }
 
-      { commands = [ "${role.package}/bin/fc-qemu check" ];
+      { commands = [ "${cfg.package}/bin/fc-qemu check" ];
         groups = [ "sensuclient" ];
       }
     ];
@@ -236,7 +250,7 @@ in
       wantedBy = [ "multi-user.target" ];
 
       script = ''
-        ${role.package}/bin/fc-qemu report-supported-cpu-models
+        ${cfg.package}/bin/fc-qemu report-supported-cpu-models
       '';
 
       serviceConfig = {
@@ -275,7 +289,7 @@ in
       checks = {
         qemu = {
           notification = "Qemu health check";
-          command = "sudo ${role.package}/bin/fc-qemu check";
+          command = "sudo ${cfg.package}/bin/fc-qemu check";
         };
       };
       # each qemu process connects directly to multiple OSD's in the
@@ -290,14 +304,14 @@ in
       maintenancePreparationSeconds = 1800;
       maintenanceRequestRunnableFor = 3600;
       maintenance.kvm = {
-        enter = "${role.package}/bin/fc-qemu maintenance enter";
-        leave = "${role.package}/bin/fc-qemu maintenance leave";
+        enter = "${cfg.package}/bin/fc-qemu maintenance enter";
+        leave = "${cfg.package}/bin/fc-qemu maintenance leave";
       };
     };
 
     systemd.services.fc-qemu-scrub = {
       description = "Scrub Qemu/KVM VM inventory.";
-      path = [ pkgs.fc.agent role.package ];
+      path = [ pkgs.fc.agent cfg.package ];
       serviceConfig = {
         Type = "oneshot";
         TimeoutStartSec = 600; # PL-132323
@@ -327,7 +341,7 @@ in
 
     # Run a proxy to give VMs running on this host fast access to radosgw.
 
-    flyingcircus.services.haproxy = {
+    flyingcircus.services.haproxy = lib.mkIf cfg.enableS3Proxy {
       enable = true;
       enableStructuredConfig = true;
 

--- a/nixos/services/ceph/client.nix
+++ b/nixos/services/ceph/client.nix
@@ -6,19 +6,17 @@ let
   cfg = config.flyingcircus.services.ceph;
   fclib = config.fclib;
   static = config.flyingcircus.static.ceph;
-  public_network = head fclib.network.sto.v4.networks;
+  network = cfg.client.network;
+  public_network = head network.v4.networks;
   location = config.flyingcircus.enc.parameters.location;
   resource_group = config.flyingcircus.enc.parameters.resource_group;
-  fs_id = static.fsids.${location}.${resource_group};
-  mons = lib.concatMapStringsSep ","
-    (mon: "${head (lib.splitString "." mon.address)}.sto.${location}.ipv4.gocept.net")
-    (fclib.findServices "ceph_mon-mon");
+  mons = (lib.concatStringsSep "," cfg.client.mons);
   inherit (fclib.ceph) expandCamelCaseAttrs expandCamelCaseSection;
 
   cephPkgs = fclib.ceph.mkPkgs cfg.client.cephRelease;
 
   defaultGlobalSettings = {
-    fsid = fs_id;
+    fsid = cfg.client.fsId;
 
     publicNetwork = public_network;
 
@@ -152,6 +150,32 @@ in
             Can override existing default setting values. Configuration keys like `mon osd full ratio` can alternatively be written in camelCase as `monOsdFullRatio`.
             '';
         };
+
+        mons = lib.mkOption {
+          type = with lib.types; listOf str;
+          default = (map
+              (mon: "${head (lib.splitString "." mon.address)}.${cfg.network.vlan}.${location}.ipv4.gocept.net")
+              (fclib.findServices "ceph_mon-mon"));
+          description = ''
+              List of hostnames that are mons in this cluster.
+            '';
+        };
+
+        fsId = lib.mkOption {
+          type = lib.types.str;
+          default = static.fsids.${location}.${resource_group};
+          description = ''
+            The Ceph fsid for this cluster.
+            '';
+        };
+
+        network = lib.mkOption {
+          type = with lib.types; attrs; # an attrset from fclib.network.<xy>
+          default = fclib.network.sto;
+          description = ''
+            The Ceph client network.
+            '';
+        };
       };
     };
   };
@@ -166,6 +190,7 @@ in
       }
     ];
 
+    flyingcircus.services.ceph.fc-ceph.enable = true;
 
     environment.systemPackages = [ cfg.client.package ];
 
@@ -182,12 +207,12 @@ in
     # the firewall and we want to avoid spamming the connection tracking table.
     networking.firewall = {
 
-      trustedInterfaces = [ fclib.network.sto.interface ];
+      trustedInterfaces = [ network.interface ];
 
       extraCommands = lib.mkOrder 800 ''
         # Disable STO connection tracking to reduce kernel connection table overhead
-        ip46tables  -t raw -A fc-raw-prerouting -i ${fclib.network.sto.interface} -j CT --notrack
-        ip46tables  -t raw -A fc-raw-output -o ${fclib.network.sto.interface} -j CT --notrack
+        ip46tables  -t raw -A fc-raw-prerouting -i ${network.interface} -j CT --notrack
+        ip46tables  -t raw -A fc-raw-output -o ${network.interface} -j CT --notrack
       '';
 
     };

--- a/nixos/services/ceph/client.nix
+++ b/nixos/services/ceph/client.nix
@@ -154,7 +154,7 @@ in
         mons = lib.mkOption {
           type = with lib.types; listOf str;
           default = (map
-              (mon: "${head (lib.splitString "." mon.address)}.${cfg.network.vlan}.${location}.ipv4.gocept.net")
+              (mon: "${head (lib.splitString "." mon.address)}.${cfg.client.network.vlan}.${location}.ipv4.gocept.net")
               (fclib.findServices "ceph_mon-mon"));
           description = ''
               List of hostnames that are mons in this cluster.

--- a/nixos/services/consul/default.nix
+++ b/nixos/services/consul/default.nix
@@ -22,6 +22,21 @@ in
           '';
            default = [];
       };
+
+      bindAddr = lib.mkOption {
+        type = with lib.types; str;
+        default = head fclib.network.srv.v6.addresses;
+      };
+
+      advertiseAddr = lib.mkOption {
+        type = with lib.types; str;
+        default = head fclib.network.srv.v6.addresses;
+      };
+
+      dc = lib.mkOption {
+        type = lib.types.str;
+        default = enc.parameters.resource_group;
+      };
     };
   };
 
@@ -32,7 +47,7 @@ in
     };
 
     services.consul.extraConfig = let
-      dc = enc.parameters.resource_group;
+      dc = cfg.dc;
     in {
       primary_datacenter = dc;
       acl.default_policy = "deny";
@@ -47,8 +62,8 @@ in
         (service: service.address)
         (fclib.findServices "consul_server-server");
 
-      bind_addr = head fclib.network.srv.v6.addresses;
-      advertise_addr = head fclib.network.srv.v6.addresses;
+      bind_addr = cfg.bindAddr;
+      advertise_addr =  cfg.advertiseAddr;
     };
 
     systemd.services.consul.restartTriggers = [

--- a/pkgs/fc/agent/fc/maintenance/activity/vm_change.py
+++ b/pkgs/fc/agent/fc/maintenance/activity/vm_change.py
@@ -1,5 +1,4 @@
-"""Handle VM changes that need a cold reboot.
-"""
+"""Handle VM changes that need a cold reboot."""
 
 from typing import Optional
 

--- a/pkgs/fc/agent/fc/util/tests/test_dmi_memory.py
+++ b/pkgs/fc/agent/fc/util/tests/test_dmi_memory.py
@@ -1,4 +1,4 @@
-""" Unit-test for dmidecode parser"""
+"""Unit-test for dmidecode parser"""
 
 from unittest import mock
 

--- a/pkgs/fc/ceph/default.nix
+++ b/pkgs/fc/ceph/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, python3Full, python3Packages, cryptsetup, lz4, blockdev, lvm2, agent }:
+{ lib, stdenv, python3Full, python3Packages, parted, cryptsetup, lz4, blockdev, lvm2, agent }:
 
 let
   py = python3Packages;
@@ -15,6 +15,7 @@ py.buildPythonApplication rec {
     agent
     python3Packages.requests
     cryptsetup
+    parted
   ];
 
   checkInputs = [

--- a/pkgs/fc/ceph/src/fc/ceph/lvm.py
+++ b/pkgs/fc/ceph/src/fc/ceph/lvm.py
@@ -144,6 +144,9 @@ class DiskWithSinglePartition(GenericBlockDevice):
         obj = cls(disk)
         run.sgdisk("-Z", disk)
         run.sgdisk("-a", "8192", "-n", "1:0:0", disk)
+        # Some devices (like loopback) do not automatically cause the
+        # kernel to see the new partitions.
+        run.partprobe(disk)
         return obj
 
     def ensure_partition_type(self, hexcode: str):

--- a/pkgs/fc/ceph/src/fc/ceph/mon/nautilus.py
+++ b/pkgs/fc/ceph/src/fc/ceph/mon/nautilus.py
@@ -81,6 +81,7 @@ class Monitor(object):
             # adjust admin capabilities
             run.ceph_authtool(
                 f"{tmpdir}/keyring",
+                "-n", "client.admin",
                 "--cap", "mds", "allow *",
                 "--cap", "mon", "allow *",
                 "--cap", "osd", "allow *",

--- a/pkgs/fc/ceph/src/fc/ceph/osd/nautilus.py
+++ b/pkgs/fc/ceph/src/fc/ceph/osd/nautilus.py
@@ -15,6 +15,7 @@ from fc.ceph.lvm import (
     XFSVolume,
 )
 from fc.ceph.util import kill, run
+from fc.ceph.util.timeout import TimeOut
 
 TiB = 1024**4
 
@@ -320,11 +321,19 @@ class JournalVG:
 
         # TODO: could be switched to DiskWithSinglePartition as well
         run.sgdisk("-Z", device)
-        run.sgdisk("-a", "8192", "-n", "1:0:0", "-t", "1:8e00", device)
+        run.sgdisk("-n", "1::", "-t", "1:8e00", device)
+        # Some devices (like loopback) do not automatically cause the
+        # kernel to see the new partitions.
+        run.partprobe(device)
 
-        for partition in [f"{device}1", f"{device}p1"]:
-            if os.path.exists(partition):
-                break
+        timeout = TimeOut(30)
+        while timeout.tick():
+            for partition in [f"{device}1", f"{device}p1"]:
+                if os.path.exists(partition):
+                    break
+            else:
+                continue
+            break
         else:
             raise RuntimeError(f"Could not find partition for PV on {device}")
 

--- a/pkgs/fc/ceph/src/fc/ceph/util/timeout.py
+++ b/pkgs/fc/ceph/src/fc/ceph/util/timeout.py
@@ -1,0 +1,45 @@
+import time
+
+
+class TimeoutError(RuntimeError):
+    pass
+
+
+class TimeOut(object):
+    _now = time.time
+
+    def __init__(self, timeout, interval=1, raise_on_timeout=False):
+        self.cutoff = self._now() + timeout
+        self.interval = interval
+        self.timed_out = False
+        self.first = True
+        self.raise_on_timeout = raise_on_timeout
+
+    @property
+    def remaining(self):
+        return int(self.cutoff - self._now())
+
+    def tick(self):
+        """Perform a `tick` for this timeout.
+
+        Returns True if we should keep going or False if not.
+
+        Instead of returning False this can raise an exception
+        if raise_on_timeout is set.
+
+        """
+        remaining = self.remaining  # make atomic within this function
+        self.timed_out = remaining <= 0
+
+        if self.timed_out:
+            if self.raise_on_timeout:
+                raise TimeoutError()
+            else:
+                return False
+
+        if self.first:
+            self.first = False
+        else:
+            time.sleep(self.interval)
+
+        return True

--- a/pkgs/fc/check-ceph/nautilus/fc/check_ceph/check_snapshot_restore.py
+++ b/pkgs/fc/check-ceph/nautilus/fc/check_ceph/check_snapshot_restore.py
@@ -1,7 +1,8 @@
 """Check that the largest RBD image snapshot of each Ceph cluster root can be restored,
 without exceeding the near_full threshold of the cluster capacity.
 Please consider that this is not a guarantee for not getting `OSD_NEARFULL` warnings,
-as individual fill levels of OSDs below a cluster root is not perfectly balanced."""
+as individual fill levels of OSDs below a cluster root is not perfectly balanced.
+"""
 
 import contextlib
 import json
@@ -304,7 +305,7 @@ def categorise_snaps(
 
 
 def eval_report(
-    categorised_snaps: Dict[SensuStatus, List[Snapshot]]
+    categorised_snaps: Dict[SensuStatus, List[Snapshot]],
 ) -> Tuple[SensuStatus, str]:
     # eval total status code _from categorised snaps only_, as it still needs to be
     # combined with potential other status results from the cluster querying functions

--- a/pkgs/fc/default.nix
+++ b/pkgs/fc/default.nix
@@ -49,9 +49,10 @@ rec {
       repo = "fc.qemu";
       # The release tooling didn't upgrade properly so we had to pick a specific
       # commit instead.
-      rev = "8e211f3602cdc3fe4ed33514e277eb27929cce12";
-      hash = "sha256-bnd4RVaB1J0dlz6x1Vdyr29xsqL+QhVCXd2McH+voPk=";
+      rev = "50a6a814283ba6173dfb4f4c98d5f17d85ccfd7d";
+      hash = "sha256-QWfhsO4DLHwKCilL7XvKAOeS9yGR6miatEF0HcLmfN4=";
     };
+    fc-ceph = ceph;
     qemu_ceph = pkgs.qemu-ceph-nautilus;
     ceph_client = pkgs.ceph-nautilus.ceph-client;
     python3Packages = pkgs.python38Packages;
@@ -69,6 +70,7 @@ rec {
   #   src = ../../../../../fc.qemu/.;
   #   # for nix-shell . -A fc.qemu-dev-nautilus
   #   # src = ../../../fc.qemu/.;
+  #   fc-ceph = ceph;
   #   qemu_ceph = pkgs.qemu-ceph-nautilus;
   #   ceph_client = pkgs.ceph-nautilus.ceph-client;
   #   python3Packages = pkgs.python38Packages;

--- a/pkgs/fc/qemu/default.nix
+++ b/pkgs/fc/qemu/default.nix
@@ -6,6 +6,7 @@
   lib,
   libceph,
   ceph_client,
+  fc-ceph,
   fetchFromGitHub,
   utillinux,
   coreutils,
@@ -15,6 +16,7 @@
   parted,
   xfsprogs,
   procps,
+  strace,
   file,
   systemd,
   py_pytest_patterns
@@ -71,6 +73,7 @@ in
       py.structlog
       py_consulate
       py.psutil
+      strace
       py.pyyaml
       py.setuptools
       (py.toPythonModule ceph_client)
@@ -88,7 +91,7 @@ in
       py.pytest-cov
       py.pytest-timeout
       py.mock
-
+      fc-ceph
       # Allow passing through to pytest in the NixOS test.
       (py.buildPythonPackage rec {
         pname = "pytest-flakefinder";

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -54,8 +54,7 @@ in {
   k3s_monitoring = callTest ./k3s/monitoring.nix {};
   kernelconfig = callTest ./kernelconfig.nix {};
   kernelversions = callTest ./kernelversions.nix {};
-  # diabled due to test flakiness PL-133300
-  #kvm_host_ceph-nautilus-nautilus = callTest ./kvm_host_ceph-nautilus.nix {clientCephRelease = "nautilus";};
+  kvm_host_ceph-nautilus-nautilus = callTest ./kvm_host_ceph-nautilus.nix {clientCephRelease = "nautilus";};
   lampVm = callTest ./lamp/vm-test.nix { };
   lampVm72 = callTest ./lamp/vm-test.nix { version = "lamp_php72"; };
   lampVm73 = callTest ./lamp/vm-test.nix { version = "lamp_php73"; };

--- a/tests/kvm_host_ceph-nautilus.nix
+++ b/tests/kvm_host_ceph-nautilus.nix
@@ -2,9 +2,11 @@ import ./make-test-python.nix ({
   testlib,
   useCheckout ? false,
   testOpts ? "",
+  #testOpts ? "--flake-finder --flake-runs=10 -x --no-cov",
   # examples to specify tests
   # "-k mytest"
-  # "--flake-finder --flake-runs=500 -x --no-cov""
+  # "--flake-finder --flake-runs=500 -x --no-cov"
+  # "--show-setup"  # shows which fixtures have been set up / torn down
   clientCephRelease ? "nautilus", ... }:
 with testlib;
 let
@@ -22,8 +24,8 @@ let
       # the amount of operations both Ceph and pytest will pile up memory they
       # can't release between test runs, so this needs to scale.
       virtualisation.memorySize = 8000;
+      virtualisation.diskSize = 10000;
       virtualisation.vlans = with config.flyingcircus.static.vlanIds; [ mgm fe srv sto stb ];
-      virtualisation.emptyDiskImages = [ 4000 4000 ];
       imports = [ <fc/nixos> <fc/nixos/roles> ];
 
       # Use the default flags defined by fc-qemu regardless of
@@ -37,25 +39,14 @@ let
 
       systemd.timers.fc-ceph-load-vm-images.enable = lib.mkForce false;
       systemd.timers.fc-ceph-mon-update-client-keys.enable = lib.mkForce false;
+      systemd.timers.fc-ceph-clean-deleted-vms.enable = lib.mkForce false;
+      systemd.timers.fc-ceph-purge-old-snapshots.enable = lib.mkForce false;
       systemd.timers.logrotate.enable = lib.mkForce false;
-
 
       flyingcircus.encServices = [
         {
           address = "host1.fcio.net";
           ips = [ (getIP6ForVLAN 3 1) ];
-          location = "test";
-          service = "consul_server-server";
-        }
-        {
-          address = "host2.fcio.net";
-          ips = [ (getIP6ForVLAN 3 2) ];
-          location = "test";
-          service = "consul_server-server";
-        }
-        {
-          address = "host3.fcio.net";
-          ips = [ (getIP6ForVLAN 3 3) ];
           location = "test";
           service = "consul_server-server";
         }
@@ -66,6 +57,18 @@ let
           service = "ceph_mon-mon";
         }
       ];
+
+      # DEBUGGING CEPH
+      #
+      # flyingcircus.roles.ceph_mon.extraSettings = {
+      #   logFile = "/dev/console";
+      #   debugDefault = "5/5";
+      # };
+      # flyingcircus.services.ceph.client.extraSettings = {
+      #   logFile = "/dev/console";
+      #   debugDefault = "5/5";
+      #   debugClient = "5/5";
+      # };
 
       systemd.services.fake-directory = rec {
         description = "A fake directory";
@@ -99,29 +102,19 @@ let
           (pkgs.writeShellScriptBin "run-tests" # BEWARE: DO NOT RENAME!
               ''
             set -o pipefail
-            set -x
 
             export PYTHONPATH="${PYTHONPATH}"
             export PATH="${PATH}:${pkgs.openssh}/bin:${pkgs.gnused}/bin"
+            export PYTHONUNBUFFERED=1
+
             cd ${testPackage.src}
 
-            rm /tmp/fc.qemu-report.xml
+            rm -f /tmp/fc.qemu-report.xml
 
-            pytest -vv --cov-config=/etc/coveragerc --cov-append -c ${testPackage.src}/pytest.ini "$@" 2>&1 | tee /dev/kmsg
-            PYTESTRET=$?
+            pytest -vv --cov-config=/etc/coveragerc --cov-append -c ${testPackage.src}/pytest.ini "$@" | tee /dev/console
 
-            ${if testOpts != "" then ''
-            # If we run with custom test options we might be filtering
-            # for tests and due to the live/not live split either phase
-            # might not have any tests. However, we do not want to
-            # accidentally accept the `no tests found` failure in Hydra.
-            echo "Pytest result code: $PYTESTRET"
-            if [ $PYTESTRET -eq 0 ] || [ $PYTESTRET -eq 5 ]; then
-              # 5 means no tests found, which might happen if we have options
-              true;
-            fi
-            '' else ""}
-
+            # We're not looking at the exit code of the above pipe as the
+            # tee to /dev/kmsg sometimes causes a non-zero exit code ...
             if ! ${pkgs.gnugrep}/bin/grep -q 'errors="0" failures="0"' /tmp/fc.qemu-report.xml ; then
               # I've seen weird situations where pytest exited with an error but we exited
               # with a zero return code. This is a safety-belt. If no report file is there
@@ -129,9 +122,9 @@ let
               echo "Pytest exit status: $PYTESTRET"
               echo "Detected failures in unit test report!"
               exit 1
+            else
+              exit 0
             fi
-
-            exit $PYTESTRET
           '')
       ];
 
@@ -168,7 +161,7 @@ let
         cephRelease = "nautilus";
       };
       flyingcircus.roles.ceph_mon = {
-        enable = true;
+        enable = if id == 1 then true else false;
         cephRelease = "nautilus";
       };
       flyingcircus.static.ceph.fsids.test.test = "d118a9a4-8be5-4703-84c1-87eada2e6b60";
@@ -188,7 +181,10 @@ let
       };
 
       # Consul
-      flyingcircus.roles.consul_server.enable = true;
+      flyingcircus.roles.consul_server.enable = if id == 1 then true else false;
+      services.consul.extraConfig = if id ==1 then {
+        bootstrap_expect = lib.mkForce 1;
+      } else {};
       services.nginx.virtualHosts."host${toString id}.fe.test.fcio.net" = {
         enableACME = lib.mkForce false;
         addSSL = true;
@@ -210,7 +206,9 @@ let
           directory_ring = 0;
           location = "test";
           resource_group = "services";
-          secret_salt = "salt-for-host-${toString id}-dhkasjy9";
+          # This secret needs to be kept in sync with the fc-qemu test
+          # fixtures.
+          secret_salt = "salt-for-host-dhkasjy9";
           secrets = { "ceph/admin_key" = "AQBFJa9hAAAAABAAtdggM3mhVBAEYw3+Loehqw==";
                       "consul/encrypt" = "jP68Fxm+m57kpQVYKRoC+lyJ/NcZy7mwvyqLnYm/z1A=";
                       "consul/agent_token" = "ez+W8r+JEywt82Ojin7klSeON97oR6i5rYo3oFxUcLE=";
@@ -222,19 +220,15 @@ let
       networking.extraHosts = ''
         ${getIPForVLAN 1 1} host1.mgm.test.fcio.net host1.mgm.test.gocept.net
         ${getIPForVLAN 1 2} host2.mgm.test.fcio.net host2.mgm.test.gocept.net
-        ${getIPForVLAN 1 3} host3.mgm.test.fcio.net host2.mgm.test.gocept.net
 
         ${getIPForVLAN 3 1} directory.fcio.net host1.fcio.net host1
         ${getIPForVLAN 3 2} host2.fcio.net host2
-        ${getIPForVLAN 3 3} host3.fcio.net host3
 
         ${getIP6ForVLAN 3 1} directory.fcio.net host1.fcio.net
         ${getIP6ForVLAN 3 2} host2.fcio.net
-        ${getIP6ForVLAN 3 3} host3.fcio.net
 
         ${getIPForVLAN 4 1} host1.sto.test.ipv4.gocept.net host1.sto.test.gocept.net
         ${getIPForVLAN 4 2} host2.sto.test.ipv4.gocept.net host2.sto.test.gocept.net
-        ${getIPForVLAN 4 3} host3.sto.test.ipv4.gocept.net host3.sto.test.gocept.net
       '';
 
       flyingcircus.enc.name = "host${toString id}";
@@ -300,7 +294,6 @@ in
   nodes = {
     host1 = makeHostConfig { id = 1; };
     host2 = makeHostConfig { id = 2; };
-    host3 = makeHostConfig { id = 3; };
   };
 
   testScript = ''
@@ -320,46 +313,6 @@ in
           f"Command `cmd` failed with exit code {code}")
       return output.strip()
 
-    def assert_clean_cluster(host, mons, osds, mgrs, pgs):
-      # `osds` can be either of the form `(num_up_osds, num_in_osds)` or a single
-      # integer specifying both up and in osds
-
-      try:
-        (num_up_osds, num_in_osds) = osds
-      except TypeError:
-        num_up_osds = osds
-        num_in_osds = osds
-
-      global time_waiting
-      print("Waiting for clean cluster ...")
-      start = time.time()
-      # Allow HEALTH_WARN as we do not correctly cover clock skew
-      # currently
-      tries = 1
-      while True:
-        status = json.loads(host.execute('ceph -f json-pretty -s')[1])
-        # json status is too verbose, but still show the human-readable status
-        show(host, 'ceph -s')
-        show(host, 'ceph health detail | tail')
-
-        try:
-          assert status["health"]["status"] in ['HEALTH_OK', 'HEALTH_WARN']
-          assert int(status["monmap"]["num_mons"]) == mons
-          osdmap_stat = status["osdmap"]["osdmap"]
-          assert osdmap_stat["num_up_osds"] == num_up_osds and \
-              osdmap_stat["num_in_osds"] == num_in_osds
-          pgstate0 = status["pgmap"]["pgs_by_state"][0]
-          assert pgstate0["count"] == pgs and pgstate0["state_name"] == "active+clean"
-          assert status["mgrmap"]["available"] and \
-              len(status["mgrmap"]["standbys"]) == mgrs-1
-          break
-        except AssertionError as e:
-          if time.time() - start < 60:
-            time_waiting += tries*2
-            time.sleep(tries*2)
-          else:
-             raise
-
     def wait(fun, *args, **kw):
       global time_waiting
       print(f"Waiting for `{fun.__name__}(*{args}, **{kw})` ...")
@@ -375,20 +328,9 @@ in
           else:
             raise
 
+    show(host1, "for x in /etc/ceph/*; do echo $x ; cat $x; echo '========='; done")
     host1.execute("systemctl stop fc-ceph-mon")
-    host2.execute("systemctl stop fc-ceph-mon")
     host1.execute("systemctl stop fc-ceph-mgr")
-    host2.execute("systemctl stop fc-ceph-mgr")
-    host3.execute("systemctl stop fc-ceph-mgr")
-    host3.execute("systemctl stop fc-ceph-mon")
-
-    ########################################################################
-    # NO CEPH INTERACTION - Ceph is not set up properly, yet. Any
-    # interaction with Ceph will hang mysteriously!
-    ########################################################################
-
-    with subtest("Run unit tests"):
-      show(host1, "run-tests ${testOpts} -m 'not live'")
 
     with subtest("fc-qemu-scrub timer is correctly activated"):
       _, output = host1.execute("systemctl list-timers | grep fc-qemu-scrub")
@@ -398,77 +340,21 @@ in
       assert not output.startswith("n/a")
       assert output.count("n/a") <= 2
 
+    host1.execute("systemctl stop fc-qemu-scrub.timer")
+    host2.execute("systemctl stop fc-qemu-scrub.timer")
+
     host1.wait_for_unit("consul")
     host2.wait_for_unit("consul")
-    host3.wait_for_unit("consul")
-
-    time.sleep(5)
-    show(host1, "journalctl -u consul")
 
     wait(show, host1, "consul members")
     wait(show, host2, "consul members")
-    wait(show, host3, "consul members")
 
-    host1.wait_for_unit("nginx", timeout=5)
-    host2.wait_for_unit("nginx", timeout=5)
-    host3.wait_for_unit("nginx", timeout=5)
+    host1.wait_for_unit("nginx", timeout=10)
 
-    with subtest("Initialize mons"):
-      host1.succeed('fc-ceph osd prepare-journal /dev/vdb')
-      host1.execute('systemctl stop fc-ceph-mon')
-      host1.execute('systemctl reset-failed fc-ceph-mon')
-      host1.execute('fc-ceph mon create --no-encrypt --size 500m --bootstrap-cluster > /dev/kmsg 2>&1')
-      host1.sleep(5)
-      host1.succeed('ceph -s > /dev/kmsg 2>&1')
-      host1.succeed('fc-ceph keys mon-update-single-client host1 ceph_osd,ceph_mon,kvm_host salt-for-host-1-dhkasjy9')
-      host1.succeed('fc-ceph keys mon-update-single-client host2 kvm_host salt-for-host-2-dhkasjy9')
+    with subtest("Run tests"):
+      host1.succeed("run-tests ${testOpts}", timeout=20*60)
 
-      # mgr keys rely on 'fc-ceph keys' to be executed first
-      host1.execute('fc-ceph mgr create --no-encrypt --size 500m > /dev/kmsg 2>&1')
-
-    with subtest("Initialize OSD"):
-      host1.execute('fc-ceph osd create-bluestore --no-encrypt /dev/vdc')
-      host1.succeed('ceph osd crush move host1 root=default')
-
-    with subtest("Create pools and images"):
-      # The blank RBD pool is required for maintenance operations
-      host1.succeed("ceph osd pool create rbd 32")
-      host1.succeed("ceph osd pool set rbd size 1")
-      host1.succeed("ceph osd pool set rbd min_size 1")
-      host1.succeed("ceph osd pool create rbd.ssd 32")
-      host1.succeed("ceph osd pool set rbd.ssd size 1")
-      host1.succeed("ceph osd pool set rbd.ssd min_size 1")
-      host1.succeed("ceph osd pool create rbd.hdd 32")
-      host1.succeed("ceph osd pool set rbd.hdd size 1")
-      host1.succeed("ceph osd pool set rbd.hdd min_size 1")
-      show(host1, "ceph osd lspools")
-
-      # new in jewel: RBD pools are supposed to be initialised
-      host1.succeed("rbd pool init rbd.ssd")
-      host1.succeed("rbd pool init rbd.hdd")
-
-      host1.succeed("rbd create --size 500 rbd.hdd/fc-21.05-dev")
-      host1.succeed("rbd map rbd.hdd/fc-21.05-dev")
-      host1.succeed("sgdisk /dev/rbd0 -o -a 2048 -n 1:8192:0 -c 1:ROOT -t 1:8300")
-      host1.succeed("partprobe")
-      host1.succeed("mkfs.xfs /dev/rbd0p1")
-      host1.succeed("rbd unmap /dev/rbd0")
-      host1.succeed("rbd snap create rbd.hdd/fc-21.05-dev@v1")
-      host1.succeed("rbd snap protect rbd.hdd/fc-21.05-dev@v1")
-
-    # Let things settle for a bit, otherwise things are in weird
-    # intermediate states like pgs not created, time not in sync,
-    # mons not accessible, ...
-    assert_clean_cluster(host1, 1, 1, 1, 96)
-
-    print("Time spent waiting", time_waiting)
-
-    with subtest("Run integration tests"):
-      show(host1, "run-tests ${testOpts} -m 'live'")
-
-    show(host1, "df -h")
-    show(host1, "rbd ls rbd.hdd")
-    show(host1, "rbd ls rbd.ssd")
+    # XXX the following tests should be migrated to fc.qemu at some point
     show(host1, "rbd rm rbd/.fc-qemu.maintenance || true")
 
     with subtest("Check maintenance enter/exit works"):
@@ -498,11 +384,12 @@ in
       result = show(host1, "fc-qemu --help")
       assert result.startswith("usage: fc-qemu"), "Unexpected help output"
 
-      result = show(host1, "fc-qemu ls")
-      assert "I simplevm              offline" in result, repr(result)
+      # host1.succeed("cp /etc/simplevm.cfg /etc/qemu/vm/")
+      # result = show(host1, "fc-qemu ls")
+      # assert "I simplevm              offline" in result, repr(result)
 
-      result = show(host1, "fc-qemu check")
-      assert result == "OK - 1 VMs - 0 MiB used - 0 MiB expected", result
+      # result = show(host1, "fc-qemu check")
+      # assert result == "OK - 1 VMs - 0 MiB used - 0 MiB expected", result
 
       result = show(host1, "fc-qemu report-supported-cpu-models")
       assert "I supported-cpu-model            architecture='x86' description=''' id='qemu64-v1'" in result, result
@@ -513,5 +400,5 @@ in
     host1.copy_from_vm('/tmp/coverage', './')
     host1.copy_from_vm('/tmp/fc.qemu-report.xml', './')
 
-  '';
+    '';
 })

--- a/tests/kvm_host_ceph-nautilus.nix
+++ b/tests/kvm_host_ceph-nautilus.nix
@@ -113,8 +113,6 @@ let
 
             pytest -vv --cov-config=/etc/coveragerc --cov-append -c ${testPackage.src}/pytest.ini "$@" | tee /dev/console
 
-            # We're not looking at the exit code of the above pipe as the
-            # tee to /dev/kmsg sometimes causes a non-zero exit code ...
             if ! ${pkgs.gnugrep}/bin/grep -q 'errors="0" failures="0"' /tmp/fc.qemu-report.xml ; then
               # I've seen weird situations where pytest exited with an error but we exited
               # with a zero return code. This is a safety-belt. If no report file is there


### PR DESCRIPTION
- make the ceph roles easier to adapt to simpler network environments

- make it possible to disable the s3 proxy

- provide system-wide access to tools that are generally needed

- improve ceph setup routines

Re PL-133300

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`


## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

no security relevant changes

- [x] Security requirements tested? (EVIDENCE)

nothing to tests, improving overall test quality
