### PR TITLE
flyingcircus.services.rabbitmq: enable prometheus exporter, through telegraf

### DIFF
--- a/changelog.d/20250314_174504_PL-133391-rabbitmq-prometheus_exporter_scriv.md
+++ b/changelog.d/20250314_174504_PL-133391-rabbitmq-prometheus_exporter_scriv.md
@@ -1,0 +1,18 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+
+### NixOS XX.XX platform
+
+- rabbitmq: provide metrics from native prometheus exporter as well (PL-133391)
+  - the existing metrics remain in place for now, this is in preparation for a later deprecation of `management_metrics_collection` in rabbitmq

--- a/nixos/platform/monitoring.nix
+++ b/nixos/platform/monitoring.nix
@@ -103,7 +103,9 @@ in {
         outputs = {
           prometheus_client = map
             (a: {
-              listen = "${a}:${telegrafPort}"; })
+              listen = "${a}:${telegrafPort}";
+              metric_version = config.flyingcircus.services.telegraf.prometheus-metric_version;
+            })
             (fclib.network.srv.dualstack.addressesQuoted);
         };
         inputs = telegrafInputs;

--- a/nixos/services/rabbitmq/default.nix
+++ b/nixos/services/rabbitmq/default.nix
@@ -61,6 +61,17 @@ in {
         type = types.int;
       };
 
+      prometheusPort = mkOption {
+        default = 9125;
+        description = ''
+          Listening port for the RabbitMQ Prometheus exporter. Is exposed via
+          telegraf again, only change this value of the default port is used otherwise.
+          '';
+        type = types.port;
+        internal = true;
+        apply = builtins.toString;
+      };
+
       dataDir = mkOption {
         type = types.path;
         default = "/var/lib/rabbitmq";
@@ -176,10 +187,14 @@ in {
 
     flyingcircus.services.rabbitmq.configItems = {
       "listeners.tcp.1" = mkDefault "${cfg.listenAddress}:${toString cfg.port}";
+      "prometheus.tcp.ip" = fclib.mkPlatform (head fclib.network.srv.dualstack.addresses);
+      "prometheus.tcp.port" = cfg.prometheusPort;
+      # recommended by https://www.rabbitmq.com/docs/prometheus#prometheus-configuration
+      "collect_statistics_interval" = mkDefault "10000"; # 10s
     };
 
     flyingcircus.services.rabbitmq = {
-      plugins = [ "rabbitmq_management" ];
+      plugins = [ "rabbitmq_management" "rabbitmq_prometheus" ];
       # XXX: can we have more than one IP?
       listenAddress = fclib.mkPlatform (head fclib.network.srv.dualstack.addresses);
       config = fclib.configFromFile /etc/local/rabbitmq/rabbitmq.config "";
@@ -251,6 +266,7 @@ in {
         rabbitmqctl list_users | grep guest && \
           rabbitmqctl delete_user guest
 
+        # TODO: We can remove the fc-telegraf user when having migrated to prometheus only (PL-133391)
         # Create user for telegraf, if it does not exist and make sure that the password is set
         rabbitmqctl list_users | grep fc-telegraf || \
           rabbitmqctl add_user fc-telegraf ${telegrafPassword}
@@ -312,21 +328,27 @@ in {
         };
       };
 
-      telegraf.inputs.rabbitmq = [
-        {
-          client_timeout = "10s";
-          header_timeout = "10s";
-          url = "http://${config.networking.hostName}:15672";
-          username = "fc-telegraf";
-          password = telegrafPassword;
-          nodes = [ "rabbit@${config.networking.hostName}" ];
-          # Drop string fields. They are converted to labels in Prometheus
-          # which blows up the number of metrics.
-          fielddrop = [ "idle_since" ];
-          # The federation plugin is optional and causing spurious logging.
-          metric_exclude = [ "federation" ];
-        }
-      ];
+      telegraf.inputs = {
+        prometheus = [{
+          urls = [ "http://${config.networking.hostName}:${cfg.prometheusPort}" ];
+        }];
+        # TODO: remove once we have a new dashboard ready
+        rabbitmq = [
+          {
+            client_timeout = "10s";
+            header_timeout = "10s";
+            url = "http://${config.networking.hostName}:15672";
+            username = "fc-telegraf";
+            password = telegrafPassword;
+            nodes = [ "rabbit@${config.networking.hostName}" ];
+            # Drop string fields. They are converted to labels in Prometheus
+            # which blows up the number of metrics.
+            fielddrop = [ "idle_since" ];
+            # The federation plugin is optional and causing spurious logging.
+            metric_exclude = [ "federation" ];
+          }
+        ];
+      };
 
     };
   };

--- a/nixos/services/telegraf/default.nix
+++ b/nixos/services/telegraf/default.nix
@@ -44,41 +44,58 @@ in {
           }];
         };
       };
-
-    };
-  };
-
-  config = mkIf cfg.enable {
-
-    environment.systemPackages = [
-      telegrafShowConfig
-    ];
-
-    environment.etc."local/telegraf/README.txt".text = ''
-      There is a telegraf daemon running on this machine to gather statistics.
-      To gather additional or custom statistics add a proper configuration file
-      here. `*.conf` will be loaded.
-
-      See https://github.com/influxdata/telegraf/blob/master/docs/CONFIGURATION.md
-      for details on how to configure telegraf.
-    '';
-
-    systemd.tmpfiles.rules = [
-      "d /etc/local/telegraf 2775 root service"
-      "d /run/telegraf 0755 telegraf"
-    ];
-
-    systemd.services.telegraf = {
-      serviceConfig = {
-        ExecStart = mkOverride 90 (concatStringsSep " " (lib.flatten [
-          ["${cfg.package}/bin/telegraf -config \"${configFile}\""]
-          (if builtins.pathExists /etc/local/telegraf then ["-config-directory ${/etc/local/telegraf}"] else [])
-        ]));
-        Nice = -10;
-      # merge in our platform configs
-      services.telegraf.extraConfig.inputs = config.flyingcircus.services.telegraf.inputs;
+      prometheus-metric_version = mkOption {
+        default = 1;
+        type = types.int;
+        description = ''
+          `metric_version` used by prometheus input and output plugin. Needs to
+          be the same version for both plugins.
+          See https://github.com/influxdata/telegraf/blob/master/plugins/inputs/prometheus/README.md#metric-format-configuration
+        '';
       };
     };
-
   };
+
+  config = mkMerge [
+    (mkIf cfg.enable {
+
+      # merge in our platform configs
+      services.telegraf.extraConfig.inputs = config.flyingcircus.services.telegraf.inputs;
+
+      environment.systemPackages = [
+        telegrafShowConfig
+      ];
+
+      environment.etc."local/telegraf/README.txt".text = ''
+        There is a telegraf daemon running on this machine to gather statistics.
+        To gather additional or custom statistics add a proper configuration file
+        here. `*.conf` will be loaded.
+
+        See https://github.com/influxdata/telegraf/blob/master/docs/CONFIGURATION.md
+        for details on how to configure telegraf.
+      '';
+
+      systemd.tmpfiles.rules = [
+        "d /etc/local/telegraf 2775 root service"
+        "d /run/telegraf 0755 telegraf"
+      ];
+
+      systemd.services.telegraf = {
+        serviceConfig = {
+          ExecStart = mkOverride 90 (concatStringsSep " " (lib.flatten [
+            ["${cfg.package}/bin/telegraf -config \"${configFile}\""]
+            (if builtins.pathExists /etc/local/telegraf then ["-config-directory ${/etc/local/telegraf}"] else [])
+          ]));
+          Nice = -10;
+        };
+      };
+
+    })
+    (mkIf (config.flyingcircus.services.telegraf.inputs ? prometheus) {
+      # only set when that plugin is configured to be used, to not accidentally enable it without use
+      services.telegraf.extraConfig.inputs.prometheus = builtins.map (attr: attr // {
+        metric_version = config.flyingcircus.services.telegraf.prometheus-metric_version;
+        } ) config.flyingcircus.services.telegraf.inputs.prometheus;
+    })
+  ];
 }

--- a/nixos/services/telegraf/default.nix
+++ b/nixos/services/telegraf/default.nix
@@ -10,10 +10,6 @@ let
   cfg = config.services.telegraf;
   fclib = config.fclib;
 
-  unifiedConfig = lib.recursiveUpdate
-    cfg.extraConfig
-    { inputs = config.flyingcircus.services.telegraf.inputs; };
-
   telegrafShowConfig = pkgs.writeScriptBin "telegraf-show-config" ''
     cat $(systemctl cat telegraf | grep "ExecStart=" | cut -d" " -f3 | tr -d '"')
     echo ""
@@ -22,16 +18,8 @@ let
     cat ${if builtins.pathExists /etc/local/telegraf then "${/etc/local/telegraf}/*.conf" else ""}
   '';
 
-  # Partially copied from nixos/modules/services/monitoring/telegraf.nix.
-  configFile = pkgs.runCommand "config.toml" {
-    buildInputs = [ pkgs.remarshal ];
-  } ''
-    remarshal -if json -of toml \
-      < ${pkgs.writeText "config.json" (builtins.toJSON unifiedConfig)} \
-      > $out
-  '';
-
-
+    settingsFormat = pkgs.formats.toml { };
+    configFile = settingsFormat.generate "config.toml" cfg.extraConfig;
 
 in {
 
@@ -87,6 +75,8 @@ in {
           (if builtins.pathExists /etc/local/telegraf then ["-config-directory ${/etc/local/telegraf}"] else [])
         ]));
         Nice = -10;
+      # merge in our platform configs
+      services.telegraf.extraConfig.inputs = config.flyingcircus.services.telegraf.inputs;
       };
     };
 


### PR DESCRIPTION
In preparation for the deprecation of the management_metrics_collection feature, we *additionally* expose rabbitmq metrics via the prometheus exporter.
To unify metrics discovery, we funnel that prometheus exporter through the local telegraf instance to collect all node metrics before providing them via a prometheus export again.

So far, the old metrics collection exists in parallal to provide a transition period for dashboard changes.

PL-133391

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`


## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
  - the rabbitmq prometheus exporter utilises and additional port number. That port can be customised via NixOS config if necessary 
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - ensure availability of metrics: provide a parallel metrics export in the face of an impending deprecation of the existing metrics export route
- [x] Security requirements tested? (EVIDENCE)
  - [x] no regressions: automated tests still pass
  - [x] did a quick plausibility check via curl on the telegraf and native rabbitmq exporter endpoint