### PR TITLE
mailserver: add ip_blocklists option and sensu checks

### DIFF
--- a/changelog.d/20250318_115032_PL-133519-email-blocklist_scriv.md
+++ b/changelog.d/20250318_115032_PL-133519-email-blocklist_scriv.md
@@ -1,0 +1,20 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+
+
+### NixOS XX.XX platform
+
+- Add anti-spam DNS blocklist option with sensu checks and default to bl.spamcop.net. (PL-133519)

--- a/nixos/roles/mailserver.nix
+++ b/nixos/roles/mailserver.nix
@@ -206,6 +206,15 @@ in
         default = 5;
       };
 
+      ipDNSBLs = mkOption {
+        type = with types; listOf str;
+        description = ''
+          IP-oriented DNS-based lists (block lists) to use. Applied in the specified order.
+        '';
+        default = [ "bl.spamcop.net" ];
+        example = [ "bl.spamcop.net" "b.barracudacentral.org" ];
+      };
+
       passwdFile = mkOption {
         type = types.str;
         description = "Virtual mail user passwd file (shared Postfix/Dovecot)";

--- a/nixos/services/mail/default.nix
+++ b/nixos/services/mail/default.nix
@@ -157,6 +157,11 @@ in {
         plug = "${pkgs.monitoring-plugins}/bin";
         mailq = "${pkgs.postfix}/bin/mailq";
         checkMailq = "${pkgs.fc.check-postfix}/bin/check_mailq";
+        check_blocklist = pkgs.writeShellScript "check_blocklist" ''
+          set -euo pipefail
+          ${plug}/check_dns -H 1.0.0.127.$1 --expect-nxdomain
+          ${plug}/check_dns -H 2.0.0.127.$1 -a 127.0.0.0/8
+        '';
       in {
         postfix_mailq = {
           command = "sudo ${checkMailq} -w 200 -c 2000 --mailq ${mailq}";
@@ -180,7 +185,10 @@ in {
           notification = "Dovecot listening on IMAPs port 993";
           command = "${plug}/check_imap -H ${role.mailHost} -p 993 -S -w 5 -c 30";
         };
-      };
+      } // listToAttrs (map (host: nameValuePair "ipDNSBL_${host}" {
+        notification = "DNSBL health (${host})";
+        command = "${check_blocklist} ${host}";
+      }) role.ipDNSBLs);
 
       flyingcircus.passwordlessSudoPackages = [
         {
@@ -320,6 +328,7 @@ in {
           sender_canonical_classes = "envelope_sender";
           smtpd_client_restrictions = [
             "permit_mynetworks"
+          ] ++ lib.map (e: "reject_rbl_client ${e}") role.ipDNSBLs ++ [
             "reject_unknown_client_hostname"
           ];
           smtpd_data_restrictions = "reject_unauth_pipelining";


### PR DESCRIPTION
Defaults to bl.spamcop.net.

RFC6471 Section 3.3 specifies that most ip based blocklists list 127.0.0.2 to indicate that they are operating correctly and must never list 127.0.0.1.

https://www.rfc-editor.org/rfc/rfc6471

PL-133519

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`


## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
  - adds the `flyingcircus.roles.mailserver.ipDNSBLs` option with a default value.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - availability: a failing blocklist may list the whole internet
- [x] Security requirements tested? (EVIDENCE)
  - [x] automated tests still pass
  - [x] sensu checks the blocklist health
