### PR TITLE
[24.05] rabbitmq-server: 3.12.13 -> 3.13.7

### DIFF
--- a/changelog.d/20250318_115307_PL-133542-rabbitmq-update_scriv.md
+++ b/changelog.d/20250318_115307_PL-133542-rabbitmq-update_scriv.md
@@ -1,0 +1,21 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+- rabbitmq users: When running multiple VMs with the `rabbitmq` role in the same RG, [feature flags need to be enabled manually](https://doc.flyingcircus.io/roles/fc-24.05-production/rabbitmq.html#feature-flags-and-upgrading) after the upgrade to prepare for later updates.
+
+### NixOS XX.XX platform
+
+- rabbitmq-server: 3.12.13 -> 3.13.7
+  - necessary preparation for the update to rabbitmq-server 4.x in NixOS 24.11

--- a/flake.lock
+++ b/flake.lock
@@ -410,11 +410,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1735875014,
-        "narHash": "sha256-ys7e77NGXA02h4oz5/r0BWq24z6IEJ3An1U5WwKm1uY=",
+        "lastModified": 1742314834,
+        "narHash": "sha256-rlBZsybnvtQa4F2hP6SwTDYiCZH9Mc0LWUl//Lxe5mo=",
         "owner": "flyingcircusio",
         "repo": "nixpkgs",
-        "rev": "9c9d7506c8f0883338ed9737dd8c886c64768ad2",
+        "rev": "09ffa23f4ce10d4af5abe3b506f74fa21bef2dba",
         "type": "github"
       },
       "original": {

--- a/release/package-versions.json
+++ b/release/package-versions.json
@@ -946,7 +946,7 @@
     "version": "8.2.7"
   },
   "rabbitmq-server": {
-    "name": "rabbitmq-server-3.12.13",
+    "name": "rabbitmq-server-3.13.7",
     "pname": "rabbitmq-server",
     "version": "3.12.13"
   },

--- a/release/versions.json
+++ b/release/versions.json
@@ -8,9 +8,9 @@
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/"
   },
   "nixpkgs": {
-    "hash": "sha256-ys7e77NGXA02h4oz5/r0BWq24z6IEJ3An1U5WwKm1uY=",
+    "hash": "sha256-rlBZsybnvtQa4F2hP6SwTDYiCZH9Mc0LWUl//Lxe5mo=",
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "9c9d7506c8f0883338ed9737dd8c886c64768ad2"
+    "rev": "09ffa23f4ce10d4af5abe3b506f74fa21bef2dba"
   }
 }


### PR DESCRIPTION
Necessary to enable all **stable** feature flags before the upgrade to version 4.x in NixOS 24.11. In 3.12.x, the required flag `stream_filtering` was not stable yet, hence not automatically enabled.

The only changes pulled in are the update of rabbitmq-server and a NixOS
adaptation for the used Erlang version.

PL-131360

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`


## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - provide necessary intermediate steps for automatic updates, to simplify upgrades to latest supported versions
- [x] Security requirements tested? (EVIDENCE)
  - [x] automated tests still pass
  - [x] checked changelog for unrelated breaking changes and incompatibilities: https://github.com/rabbitmq/rabbitmq-server/releases/tag/v3.13.0
    - e.g. client libraries remain compatible
