### PR TITLE
KVM: integration for guests with interfaces in layer 3 routed networks

### DIFF
--- a/changelog.d/20250331_113818_PL-133324-kvm-routed-fe-integration_scriv.md
+++ b/changelog.d/20250331_113818_PL-133324-kvm-routed-fe-integration_scriv.md
@@ -1,0 +1,21 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+
+
+### NixOS XX.XX platform
+
+- kvm: add support for VMs which have interfaces in layer 3 routed
+  networks. (PL-133324)

--- a/nixos/lib/network.nix
+++ b/nixos/lib/network.nix
@@ -366,6 +366,19 @@ rec {
           bridgedLink = "br${vlan}"; # the kernel device with type `bridge`
           taggedLink = "eth${vlan}"; # the kernel device with type `vlan`
 
+          vrfInterface = "vrf${vlan}"; # the kernel device with type `vrf`
+          vrfTable =
+            assert
+              # the routing tables 0, 253, 254, and 255 are reserved by the
+              # kernel.
+              !(elem vlanId [
+                0
+                253
+                254
+                255
+              ]);
+            vlanId;
+
           # The basic link that provides connectivity to the outside world.
           # In simple cases this can be the plain physical ethernet device/
           # interface like `ethmgm` or `ethmgm`.

--- a/nixos/platform/network.nix
+++ b/nixos/platform/network.nix
@@ -108,20 +108,6 @@ let
 
   quoteLabel = replaceStrings [ "/" ] [ "-" ];
 
-  vrfName = iface: "vrf${iface.vlan}";
-  vrfTable =
-    iface:
-    # the routing tables 0, 253, 254, and 255 are reserved by the
-    # kernel.
-    assert
-      !(elem iface.vlanId [
-        0
-        253
-        254
-        255
-      ]);
-    iface.vlanId;
-
 in
 {
 
@@ -287,7 +273,7 @@ in
                 ) vxlanVrfInterfaces)
               ++ (map (
                 iface:
-                lib.nameValuePair (vrfName iface) {
+                lib.nameValuePair iface.vrfInterface {
                   tempAddress = "disabled";
                 }
               ) vxlanVrfInterfaces)
@@ -906,7 +892,7 @@ in
                   (map (
                     iface:
                     let
-                      name = vrfName iface;
+                      name = iface.vrfInterface;
                       interfaceUnit = "${iface.interface}-netdev.service";
                       addressUnit = "network-addresses-${iface.interface}.service";
                     in
@@ -935,7 +921,7 @@ in
                         ip link show dev "${name}" >/dev/null 2>&1 && ip link del dev "${name}"
 
                         echo "Adding VRF ${name}..."
-                        ip link add ${name} type vrf table ${toString (vrfTable iface)}
+                        ip link add ${name} type vrf table ${toString iface.vrfTable}
 
                         # add child interfaces. no need to set up, the network-addresses
                         # unit will do that.

--- a/nixos/roles/kvm.nix
+++ b/nixos/roles/kvm.nix
@@ -304,6 +304,40 @@ in
 
     };
 
+    systemd.services.fc-qemu-reattach-vrf-taps = lib.mkIf (fclib.network ? pub) {
+      description = "Reattach all VM taps to VRF devices if needed.";
+
+      path = [
+        pkgs.jq
+        pkgs.iproute2
+      ];
+
+      script = ''
+        for interface in $(ip -j link show |  jq '.[] | .ifname' -r | egrep '^tpub'); do
+          echo "Ensuring attachment of $interface"
+          /etc/kvm/kvm-ifup-vrf $interface || true
+        done
+      '';
+
+      wantedBy = [ "multi-user.target" ];
+      bindsTo = [
+        "vrfpub-netdev.service"
+      ];
+      after = [
+        "vrfpub-netdev.service"
+      ];
+
+      # trigger a scrub when the vrf netdev changes to ensure that the
+      # host routes for the guest interfaces are also set up properly.
+      wants = [ "fc-qemu-scrub.service" ];
+      before = [ "fc-qemu-scrub.service" ];
+
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+      };
+    };
+
     systemd.services.fc-qemu-clean-logs =
       let
         fcQemuCleanLogScript = (

--- a/nixos/roles/kvm.nix
+++ b/nixos/roles/kvm.nix
@@ -108,6 +108,10 @@ in
       fc-vm-migration-watch = "watch '${cfg.package}/bin/fc-qemu ls; echo; grep migration-status /var/log/fc-qemu.log | tail'";
     };
 
+    # iproute2 configuration required by fc-qemu
+    environment.etc."iproute2/rt_protos.d/fc-qemu.conf".source =
+      "${cfg.package}/share/iproute2/rt_protos";
+
     environment.etc."qemu/fc-qemu.conf".text =
       let
         hostname = config.networking.hostName;

--- a/nixos/roles/kvm.nix
+++ b/nixos/roles/kvm.nix
@@ -8,6 +8,7 @@
 with builtins;
 
 let
+  inherit (config.flyingcircus) location;
   fclib = config.fclib;
   cfg = config.flyingcircus.roles.kvm_host;
   enc = config.flyingcircus.enc;
@@ -20,6 +21,7 @@ let
   virtualGatewayV6 = "fe80::1";
 
   vrfInterfaces = lib.filterAttrs (n: v: v.routed or false) fclib.network;
+  locationNameserver = head config.flyingcircus.static.nameservers."${location}";
 
 in
 {
@@ -558,6 +560,18 @@ in
       ip46tables -D FORWARD -j fc-kvm-forward || true
       ip46tables -F fc-kvm-forward 2>/dev/null || true
       ip46tables -X fc-kvm-forward 2>/dev/null || true
+    '';
+
+    networking.nat.extraCommands = lib.optionalString (vrfInterfaces != { }) ''
+      # Use destination NAT to allow guests to use the virtual
+      # gateway address as their DNS resolver, and forward queries
+      # to the location-wide resolver
+      ${lib.concatStringsSep "\n" (
+        lib.mapAttrsToList (name: _: ''
+          iptables -t nat -A nixos-nat-pre -i t${name}+ -d ${virtualGatewayV4} -p udp --dport 53 -j DNAT --to-destination ${locationNameserver}
+          iptables -t nat -A nixos-nat-pre -i t${name}+ -d ${virtualGatewayV4} -p tcp --dport 53 -j DNAT --to-destination ${locationNameserver}
+        '') vrfInterfaces
+      )}
     '';
 
   };

--- a/nixos/roles/kvm.nix
+++ b/nixos/roles/kvm.nix
@@ -19,6 +19,8 @@ let
   virtualGatewayV4 = "169.254.83.168";
   virtualGatewayV6 = "fe80::1";
 
+  vrfInterfaces = lib.filterAttrs (n: v: v.routed or false) fclib.network;
+
 in
 {
   options = {
@@ -456,15 +458,41 @@ in
       };
     };
 
-    boot.kernel.sysctl = {
-      # Agressively try to reclaim memory on the local NUMA node if a slub cache runs
-      # empty. Note that we still don't allow disk I/O to happen to satisfy kernel
-      # memory allocations.
-      "vm.zone_reclaim_mode" = "1";
+    boot.kernel.sysctl =
+      {
+        # Agressively try to reclaim memory on the local NUMA node if a slub cache runs
+        # empty. Note that we still don't allow disk I/O to happen to satisfy kernel
+        # memory allocations.
+        "vm.zone_reclaim_mode" = "1";
 
-      # Qemu hosts tend to cycle PIDs pretty fast
-      "kernel.pid_max" = lib.mkForce "999999"; # mkForce to avoid conflict with ceph role
-    };
+        # Qemu hosts tend to cycle PIDs pretty fast
+        "kernel.pid_max" = lib.mkForce "999999"; # mkForce to avoid conflict with ceph role
+      }
+      // (lib.optionalAttrs (vrfInterfaces != { }) {
+        # When we have guests which are attached to layer 3 routed VRFs,
+        # we need to enable forwarding for traffic from the guest tap
+        # interfaces and the bridge interface for the associated
+        # L3VNI.
+        #
+        # For IPv4 this is easy, as the kernel provides per-interface
+        # sysctls which control whether packets received on specific
+        # interfaces should be forwarded or not.
+        #
+        # Under IPv6 however, the per-interface sysctls named
+        # "forwarding" don't actually have any control over whether
+        # packets received on specific interfaces are forwarded or
+        # not. Instead, there is a single *global* sysctl which controls
+        # forwarding for *all* interfaces, and the administrator is
+        # expected to use a firewall to enforce forwarding policy.
+        #
+        # In the interests of keeping IPv4 and IPv6 configuration
+        # reasonably symmetric, we'll turn on global forwarding and set
+        # a firewall for both protocols here.
+        "net.ipv4.conf.all.forwarding" = fclib.mkOverridePlatformModule 1;
+        "net.ipv4.conf.default.forwarding" = fclib.mkOverridePlatformModule 1;
+        "net.ipv6.conf.all.forwarding" = fclib.mkOverridePlatformModule 1;
+        "net.ipv6.conf.default.forwarding" = fclib.mkOverridePlatformModule 1;
+      });
 
     # Run a proxy to give VMs running on this host fast access to radosgw.
 
@@ -503,6 +531,34 @@ in
       ''
         # Accept traffic to the radosgw service
         ${fclib.iptables "127.0.0.1"} -A nixos-fw -p tcp --dport 7480 -i ${srvDevice} -j nixos-fw-accept
-      '';
+      ''
+      + (lib.optionalString (vrfInterfaces != { }) ''
+        # Set up KVM server forwarding firewall
+        ip46tables -N fc-kvm-forward || true
+        ip46tables -A FORWARD -j fc-kvm-forward
+
+        # Allow traffic between the VM pub interfaces and the bridge
+        # for the pub VNI. This internally traverses "through" the
+        # VRF interface, so this needs to be included in the firewall
+        # here as well.
+        ${lib.concatStringsSep "\n" (
+          lib.mapAttrsToList (name: net: ''
+            ip46tables -A fc-kvm-forward -i t${name}+ -o ${net.vrfInterface} -j ACCEPT
+            ip46tables -A fc-kvm-forward -i ${net.vrfInterface} -o t${name}+ -j ACCEPT
+            ip46tables -A fc-kvm-forward -i ${net.bridgedLink} -o ${net.vrfInterface} -j ACCEPT
+            ip46tables -A fc-kvm-forward -i ${net.vrfInterface} -o ${net.bridgedLink} -j ACCEPT
+          '') vrfInterfaces
+        )}
+
+        # Block all further forwarding traffic
+        ip46tables -A fc-kvm-forward -j nixos-fw-refuse
+      '');
+
+    networking.firewall.extraStopCommands = lib.optionalString (fclib.network ? pub) ''
+      ip46tables -D FORWARD -j fc-kvm-forward || true
+      ip46tables -F fc-kvm-forward 2>/dev/null || true
+      ip46tables -X fc-kvm-forward 2>/dev/null || true
+    '';
+
   };
 }

--- a/nixos/roles/kvm.nix
+++ b/nixos/roles/kvm.nix
@@ -262,7 +262,6 @@ in
       {
         commands = [
           "${cfg.package}/bin/fc-qemu -v handle-consul-event"
-          "/home/ctheune/fc.qemu/result/bin/fc-qemu -v handle-consul-event"
         ];
         users = [ "consul" ];
       }

--- a/nixos/roles/kvm.nix
+++ b/nixos/roles/kvm.nix
@@ -14,6 +14,11 @@ let
 
   cephPkgs = fclib.ceph.mkPkgs cfg.cephRelease;
 
+  # virtual ipv4 gateway address selected by 254-169=85, with each
+  # octet +85 mod 256 the preceding octet
+  virtualGatewayV4 = "169.254.83.168";
+  virtualGatewayV6 = "fe80::1";
+
 in
 {
   options = {
@@ -138,6 +143,12 @@ in
         rbd.hdd = 250
         rbd.ssd = 10000
 
+        [network]
+        tap-ifup-bridge = /etc/kvm/kvm-ifup
+        tap-ifdown-bridge = /etc/kvm/kvm-ifdown
+        tap-ifup-vrf = /etc/kvm/kvm-ifup-vrf
+        tap-ifdown-vrf = /etc/kvm/kvm-ifdown-vrf
+
         [consul]
         access-token = ${enc.parameters.secrets."consul/master_token"}
         event-threads = 10
@@ -182,6 +193,36 @@ in
 
         ${pkgs.bridge-utils}/bin/brctl delif $BRIDGE $INTERFACE
         ${pkgs.iproute2}/bin/ip link set $INTERFACE down
+      '';
+      mode = "0744";
+    };
+
+    environment.etc."kvm/kvm-ifup-vrf" = {
+      text = ''
+        #!${pkgs.stdenv.shell}
+        INTERFACE="$1"
+        VLAN=$(echo $INTERFACE | sed 's/t\([a-zA-Z]\+\)[0-9]\+/\1/')
+        VRF="vrf''${VLAN}"
+
+        ${pkgs.iproute2}/bin/ip link set $INTERFACE master $VRF
+
+        # add addresses idempotently
+        ${pkgs.iproute2}/bin/ip address replace ${virtualGatewayV4}/16 dev $INTERFACE
+        ${pkgs.iproute2}/bin/ip address replace ${virtualGatewayV6}/64 dev $INTERFACE
+
+        ${pkgs.iproute2}/bin/ip link set $INTERFACE up
+      '';
+      mode = "0744";
+    };
+
+    environment.etc."kvm/kvm-ifdown-vrf" = {
+      text = ''
+        #!${pkgs.stdenv.shell}
+        INTERFACE="$1"
+
+        ${pkgs.iproute2}/bin/ip link set $INTERFACE down
+        ${pkgs.iproute2}/bin/ip address flush dev $INTERFACE
+        ${pkgs.iproute2}/bin/ip link set $INTERFACE nomaster
       '';
       mode = "0744";
     };

--- a/pkgs/ceph/nautilus/rbd-locktool.py
+++ b/pkgs/ceph/nautilus/rbd-locktool.py
@@ -84,7 +84,7 @@ def main():
     argp.add_argument(
         "-f",
         "--force",
-        help="unlock even if we are not the " "locker",
+        help="unlock even if we are not the locker",
         action="store_true",
         default=False,
     )

--- a/pkgs/fc/default.nix
+++ b/pkgs/fc/default.nix
@@ -52,8 +52,8 @@ rec {
       repo = "fc.qemu";
       # The release tooling didn't upgrade properly so we had to pick a specific
       # commit instead.
-      rev = "2108a743de7acd681e58a86a0a2f148d0e00a231";
-      hash = "sha256-croWgJsUaNVh/24AxmPrnGv9MTRuq/MVdyhtyYkPajI=";
+      rev = "76db32082dbd72676d1d5be343b7496045037ff8";
+      hash = "sha256-1fJPKQtavp4MOLUuhBQJ04yPcfayZYvq0xUIsYDpBdM=";
     };
     fc-ceph = ceph;
     qemu_ceph = pkgs.qemu-ceph-nautilus;

--- a/pkgs/fc/qemu/default.nix
+++ b/pkgs/fc/qemu/default.nix
@@ -9,6 +9,7 @@
   file,
   gnused,
   gptfdisk,
+  iproute2,
   lib,
   libceph,
   openssh,
@@ -66,6 +67,7 @@ py.buildPythonPackage rec {
     dosfstools
     gnused
     gptfdisk
+    iproute2
     parted
     procps
     qemu_ceph
@@ -87,6 +89,10 @@ py.buildPythonPackage rec {
   passthru = {
     inherit py nativeCheckInputs;
   };
+
+  postInstall = ''
+    cp -Pr $src/share $out/share
+  '';
 
   nativeCheckInputs = [
     file

--- a/pkgs/gptfdisk-dont-sleep.patch
+++ b/pkgs/gptfdisk-dont-sleep.patch
@@ -1,0 +1,13 @@
+diff --git a/diskio-unix.cc b/diskio-unix.cc
+index 0897c56..c6260d1 100644
+--- a/diskio-unix.cc
++++ b/diskio-unix.cc
+@@ -291,7 +291,7 @@ int DiskIO::DiskSync(void) {
+       platformFound++;
+ #endif
+ #ifdef __linux__
+-      sleep(1); // Theoretically unnecessary, but ioctl() fails sometimes if omitted....
++      sleep(0); // Theoretically unnecessary, but ioctl() fails sometimes if omitted....
+       fsync(fd);
+       i = ioctl(fd, BLKRRPART);
+       if (i) {

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -300,6 +300,16 @@ builtins.mapAttrs (_: patchPhps phpLogPermissionPatch) {
     }
   );
 
+  gptfdisk = super.gptfdisk.overrideAttrs (
+    a:
+    a
+    // {
+      patches = a.patches or [ ] ++ [
+        ./gptfdisk-dont-sleep.patch
+      ];
+    }
+  );
+
   imagemagick7 =
     assert lib.versions.major super.imagemagick.version == "7";
     lib.warn "'imagemagick7' has been renamed to/replaced by 'imagemagick'" super.imagemagick;

--- a/tests/fakedirectory.py
+++ b/tests/fakedirectory.py
@@ -19,6 +19,9 @@ class Directory(object):
     def deletions(self, type_=""):
         return {}
 
+    def list_resource_groups(self):
+        return []
+
 
 # Create server
 with SimpleXMLRPCServer(

--- a/tests/kvm_host_ceph-nautilus.nix
+++ b/tests/kvm_host_ceph-nautilus.nix
@@ -32,7 +32,10 @@ import ./make-test-python.nix (
         # We need a lot of RAM specifically if we use the flake finder as due to
         # the amount of operations both Ceph and pytest will pile up memory they
         # can't release between test runs, so this needs to scale.
-        virtualisation.memorySize = 8000;
+        virtualisation.cores = 6;
+        virtualisation.writableStore = false;
+        virtualisation.useNixStoreImage = true;
+        virtualisation.memorySize = 12000;
         virtualisation.diskSize = 10000;
         virtualisation.vlans = with config.flyingcircus.static.vlanIds; [
           mgm
@@ -390,7 +393,7 @@ import ./make-test-python.nix (
       host1.wait_for_unit("nginx", timeout=10)
 
       with subtest("Run tests"):
-        host1.succeed("run-tests ${testOpts}", timeout=20*60)
+        host1.succeed("run-tests ${testOpts}", timeout=30*60)
 
       # XXX the following tests should be migrated to fc.qemu at some point
       show(host1, "rbd rm rbd/.fc-qemu.maintenance || true")
@@ -432,6 +435,7 @@ import ./make-test-python.nix (
         result = show(host1, "fc-qemu report-supported-cpu-models")
         assert "I supported-cpu-model            architecture='x86' description=''' id='qemu64-v1'" in result, result
 
+        host1.execute("rm /etc/qemu/vm/simplepubvm* /etc/qemu/vm/.simplepubvm.*")
         result = show(host1, "fc-qemu-scrub")
         assert "I simplevm              running-ensure                 generation=0" in result, result
 


### PR DESCRIPTION
This change is the companion to flyingcircusio/fc.qemu#23. This change extends the KVM role to support guest VMs which have interfaces attached to layer 3 routed networks, implemented as EVPN-VXLAN L3VNIs.

- Provide fc.qemu with extra scripts for configuring guest interfaces connected to VRFs (as these are set up differently to interfaces connected to bridges) and specify the script paths in the configuration file.
- Assign virtual gateway addresses to the host side of the guest tap interfaces. These addresses are used as the default gateway in the guest network configuration in order to route through the point-to-point layer 2 connection between host and guest to reach other destinations.
- Reattach guest interfaces to VRF kernel device when the latter is restarted, analogue to the existing configuration for handling restarts of `brfe` and `brsrv`.
- Enable forwarding in order to provide layer 3 connectivity to guests on routed networks, with forwarding policy enforced by iptables.
- Provide DNS resolver services on the IPv4 virtual gateway address using DNAT in the host firewall to forward queries to the site-wide resolver address.

TODO: once the fc.qemu PR is merged, bump the version pin of the fc.qemu package here.

PL-133324

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`


## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - The KVM role now turns on IP forwarding globally on all interfaces (due to the kernel configuration interface for IPv6 forwarding). This has been a source of security problems in the past, however this change also includes a restrictive firewall to ensure that only guest traffic inside VRFs is forwarded.
- [x] Security requirements tested? (EVIDENCE)
  - Developed and tested on a pair of hosts in dev.