### PR TITLE
varnish: fix check-varnish-http check

### DIFF
--- a/changelog.d/20250319_160130_PL-133554-varnish_http_awk_scriv.md
+++ b/changelog.d/20250319_160130_PL-133554-varnish_http_awk_scriv.md
@@ -1,0 +1,17 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+
+### NixOS XX.XX platform
+
+- varnish: fix `varnish_http` sensu check execution, also check IPv6 bind addresses (PL-133554)

--- a/nixos/roles/webproxy.nix
+++ b/nixos/roles/webproxy.nix
@@ -61,18 +61,59 @@ in
           command = "${cfg.package}/bin/varnishadm status";
           timeout = 180;
         };
-        varnish_http = {
-          notification = "varnish port 8008 HTTP response";
-          command = "${pkgs.writeShellScript "check-varnish-http" ''
-            ADDRS=$(${cfg.package}/bin/varnishadm debug.listen_address | awk '/([0-9.]+\.)+/ { print $2":"$3; }')
-            for ADDR in $ADDRS; do
-              host=$(echo $ADDR | cut -d ":" -f 1)
-              port=$(echo $ADDR | cut -d ":" -f 2)
+        varnish_http = let
+          check-varnish-http = pkgs.writers.writePython3 "check-varnish-http" {
+            flakeIgnore = [ "E501" ]; # ignore long lines
+          } ''
+            import subprocess
+            import sys
 
-              echo "checking host '$host' on port '$port'"
-              ${pkgs.monitoring-plugins}/bin/check_http -H $host -p $port -c 10 -w 3 -t 20 -e HTTP
-            done
-          ''}";
+            ports = []
+
+            for line in (
+                subprocess.check_output(["${cfg.package}/bin/varnishadm", "debug.listen_address"])
+                .decode("ascii")
+                .splitlines()
+            ):
+                line = line.strip()
+                if not line:
+                    continue
+                _, ip, port = line.split()
+                ports.append((ip, port))
+
+            if not ports:
+                print("No listen_address reported by varnishadm")
+                sys.exit(2)
+
+            STATUS = 0
+
+            for ip, port in ports:
+                if ":" in ip:
+                    ip_version = "-6"
+                    print(f"Checking [{ip}]:{port} ...")
+                else:
+                    ip_version = "-4"
+                    print(f"Checking {ip}:{port} ...")
+                proc = subprocess.run(
+                    [
+                        "${pkgs.monitoring-plugins}/bin/check_http",
+                        "-H", ip,
+                        "-p", port,
+                        ip_version,
+                        "-c", "10",
+                        "-w", "3",
+                        "-t", "20",
+                        "-e", "HTTP",
+                    ]
+                )
+                print()
+                STATUS = max([STATUS, proc.returncode])
+
+            sys.exit(STATUS)
+          '';
+          in {
+          notification = "varnish port 8008 HTTP response";
+          command = toString check-varnish-http;
         };
       };
 


### PR DESCRIPTION
The check failed because `awk` is not PATH of the sensuclient.
Replacing the old bash script with a less brittle
python-batteries-included script to reduce complexity.
And while we're at it, now also check the IPv6 addresses.

PL-133554 PL-133556

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`


## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - availability checks should work correctly
  - a partial check failure should not accidentally produce the outcome of an apparent success 
- [x] Security requirements tested? (EVIDENCE)
  - tested happy case on a test VM
  - added additional safety belt for the regression fixed. Manually tested that service belt by messing up the `ADDRESSES` gathering step in the script.