### PR TITLE
Ensure that IPv4 forwarding is disabled by default

### DIFF
--- a/changelog.d/20250319_173208_PL-133557-default-forwarding-without-firewall_scriv.md
+++ b/changelog.d/20250319_173208_PL-133557-default-forwarding-without-firewall_scriv.md
@@ -1,0 +1,21 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+
+### NixOS XX.XX platform
+
+- platform: ensure that IPv4 forwarding is properly disabled by
+  default, and is only enabled by roles which explicitly require it
+  (PL-133557).

--- a/nixos/lib/utils.nix
+++ b/nixos/lib/utils.nix
@@ -82,6 +82,10 @@ rec {
   # priority (100), but allow hosts to override further with
   # mkForce. Intentionally verbose.
   mkOverrideUpstreamModule = lib.mkOverride 75;
+  # Override configuration set in platform modules, which may itself
+  # be overridden from upstream, but allow further host customisation
+  # with mkForce.
+  mkOverridePlatformModule = lib.mkOverride 70;
 
   mkDisableDevhostSupport = lib.mkOption {
     type = lib.types.bool;

--- a/nixos/platform/network.nix
+++ b/nixos/platform/network.nix
@@ -996,6 +996,12 @@ in
         # only accept a single bind address.
         "net.ipv6.bindv6only" = "0";
 
+        # Ensure that forwarding is not enabled by default
+        "net.ipv4.conf.all.forwarding" = fclib.mkOverrideUpstreamModule false;
+        "net.ipv4.conf.default.forwarding" = fclib.mkOverrideUpstreamModule false;
+        "net.ipv6.conf.all.forwarding" = fclib.mkOverrideUpstreamModule false;
+        "net.ipv6.conf.default.forwarding" = fclib.mkOverrideUpstreamModule false;
+
         # Ensure that we can use IPv6 as early as possible.
         # This fixes startup race conditions like
         # https://yt.flyingcircus.io/issue/PL-130190

--- a/nixos/roles/devhost/default.nix
+++ b/nixos/roles/devhost/default.nix
@@ -2,6 +2,7 @@
 
 let
   cfg = config.flyingcircus.roles.devhost;
+  fclib = config.fclib;
 in
 {
   imports = [
@@ -40,7 +41,7 @@ in
       flyingcircus.roles.webgateway.enable = true;
 
       boot.kernel.sysctl = {
-        "net.ipv4.ip_forward" = 1;
+        "net.ipv4.ip_forward" = fclib.mkOverridePlatformModule 1;
         # Increase inotify limits to avoid running out of them when
         # running many containers:
         # https://forum.proxmox.com/threads/failed-to-allocate-directory-watch-too-many-open-files.28700/

--- a/nixos/roles/external_net/default.nix
+++ b/nixos/roles/external_net/default.nix
@@ -78,9 +78,9 @@ in
     flyingcircus.roles.vxlan.gateway = true;
 
     boot.kernel.sysctl = {
-      "net.ipv4.ip_forward" = 1;
-      "net.ipv6.conf.all.forwarding" = 1;
-      "net.ipv6.conf.default.forwarding" = 1;
+      "net.ipv4.ip_forward" = fclib.mkOverridePlatformModule 1;
+      "net.ipv6.conf.all.forwarding" = fclib.mkOverridePlatformModule 1;
+      "net.ipv6.conf.default.forwarding" = fclib.mkOverridePlatformModule 1;
     };
 
     environment.systemPackages = [ pkgs.mosh ];

--- a/nixos/roles/router/default.nix
+++ b/nixos/roles/router/default.nix
@@ -113,11 +113,11 @@ in
 
     boot.kernel.sysctl = {
       # It's a router: we want forwarding, obviously
-      "net.ipv4.conf.all.forwarding" = 1;
-      "net.ipv4.conf.default.forwarding" = 1;
-      "net.ipv4.ip_forward" = 1;
-      "net.ipv6.conf.all.forwarding" = 1;
-      "net.ipv6.conf.default.forwarding" = 1;
+      "net.ipv4.conf.all.forwarding" = fclib.mkOverridePlatformModule 1;
+      "net.ipv4.conf.default.forwarding" = fclib.mkOverridePlatformModule 1;
+      "net.ipv4.ip_forward" = fclib.mkOverridePlatformModule 1;
+      "net.ipv6.conf.all.forwarding" = fclib.mkOverridePlatformModule 1;
+      "net.ipv6.conf.default.forwarding" = fclib.mkOverridePlatformModule 1;
 
       # Avoid neighbour discovery table overflow on our relatively large segments
       "net.ipv4.neigh.default.gc_thresh1" = lib.mkOverride 90 4096;

--- a/tests/frr.nix
+++ b/tests/frr.nix
@@ -456,6 +456,12 @@ in {
                 host1.wait_until_succeeds(f"bridge fdb show br br0 | grep -F extern_learn | grep -F {guest_mac}", timeout=10)
 
             with subtest("check remote TAP responder is reachable"):
+                # if ping-on-tap sends its garp before the neighbour entry from the
+                # remote host is withdrawn, then the remotely learned entry will take
+                # precedence and a locally learned entry will not be created. we need to
+                # reprime the local neighbour table to ensure that an entry is learned
+                # which exported to the remote host.
+                host2.succeed(f"ping -A -c5 {guest_ip}")
                 host1.succeed(f"ping -A -c5 {guest_ip}")
 
         with subtest("rib and fib should not have mismatches"):

--- a/tests/frr.nix
+++ b/tests/frr.nix
@@ -11,7 +11,7 @@ let
   makeHostMac = makePrivateMac "42";
   makeTapMac = makePrivateMac "23";
 
-  baseConfig = { lib, ... }: {
+  baseConfig = { lib, config, ... }: {
     imports = [ ../nixos ../nixos/roles ];
     services.telegraf.enable = false;
     networking = {
@@ -20,7 +20,7 @@ let
       firewall.checkReversePath = lib.mkForce false;
     };
 
-    boot.kernel.sysctl."net.ipv4.conf.all.ip_forward" = 1;
+    boot.kernel.sysctl."net.ipv4.conf.all.forwarding" = lib.mkForce 1;
     boot.extraModprobeConfig = "options dummy numdummies=0";
     boot.initrd.availableKernelModules = [ "dummy" ];
 

--- a/tests/network/default.nix
+++ b/tests/network/default.nix
@@ -19,7 +19,7 @@ let
       ];
 
       environment.systemPackages = with pkgs; [ iptables curl ];
-      boot.kernel.sysctl."net.ipv6.conf.all.forwarding" = true;
+      boot.kernel.sysctl."net.ipv6.conf.all.forwarding" = mkForce true;
 
       flyingcircus.enc.parameters.interfaces = encInterfaces "1";
     };

--- a/tests/testlib.nix
+++ b/tests/testlib.nix
@@ -158,7 +158,7 @@ rec {
       firewall.allowPing = lib.mkForce true;
       firewall.checkReversePath = lib.mkForce false;
     };
-    boot.kernel.sysctl."net.ipv4.conf.all.ip_forward" = 1;
+    boot.kernel.sysctl."net.ipv4.conf.all.forwarding" = lib.mkForce 1;
     boot.initrd.availableKernelModules = [ "dummy" ];
     networking.firewall.enable = false;
 


### PR DESCRIPTION
We enable `networking.nat.enable` in the platform in order to ensure that certain iptables change exist which our firewall integration relies upon. However, as an unintended side-effect this also enables IPv4 forwarding. This means that forwarding is enabled on hosts which are not intended to be configured as routers and don't have an appropriate firewall installed. This can lead to effects where unprivileged hosts may be able to configure their local routing tables to abuse more privileged hosts with forwarding enabled in order to access private networks or circumvent firewall restrictions.

This change ensures that IP forwarding is disabled by default, and only enabled in the roles where it is explicitly required.

PL-133557

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`


## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Only routers and VMs providing specific network functions should have IP forwarding enabled, as forwarding requires suitable firewall rules for access control.
- [x] Security requirements tested? (EVIDENCE)
  - Hydra tests for roles which require forwarding to be enabled.