### PR TITLE
DO NOT MERGE: set keepalived priorities to prevent router voluntarily becoming primary

### DIFF
--- a/nixos/roles/router/keepalived/dev.conf
+++ b/nixos/roles/router/keepalived/dev.conf
@@ -23,9 +23,8 @@ track_file check_stop_file {
   # Allow admins to locally send keepalive into FAIL state by adding
   # a non "0" entry
   file /etc/keepalived/stop
-  # 0 as default causes FAIL if anything != 0 is in the file
-  weight 0
-  init_file 0
+  weight -16
+  init_file 1 overwrite
 }
 
 track_file check_maint_file {

--- a/nixos/roles/router/keepalived/whq.conf
+++ b/nixos/roles/router/keepalived/whq.conf
@@ -20,12 +20,15 @@ vrrp_script check_zebra_liveness {
 }
 
 track_file check_stop_file {
-  # Allow admins to locally send keepalive into FAIL state by adding
-  # a non "0" entry
   file /etc/keepalived/stop
-  # 0 as default causes FAIL if anything != 0 is in the file
-  weight 0
-  init_file 0
+  # always write the stop file at startup
+  init_file 1 overwrite
+  # this weight ensures that this router stays the backup, even if the
+  # other router changes its priority due to problems with the routes
+  # pointing to dev. however, if the other router enters maintenance,
+  # the priority is high enough for us to take over as the primary for
+  # the duration of the maintenance.
+  weight -16
 }
 
 track_file check_maint_file {


### PR DESCRIPTION
This is dummy change where the keepalived priorities are adjusted to prevent a router from voluntarily becoming the primary router – i.e. the router should only become primary when the second router in the pair enters maintenance, and should return to backup status after the second router leaves maintenance.

PL-133446

