### PR TITLE
Add tests to check forwarding sysctls

### DIFF
--- a/tests/default.nix
+++ b/tests/default.nix
@@ -59,6 +59,7 @@ in
   collect-garbage = callTest ./collect-garbage.nix { };
   gitlab = callTest ./gitlab.nix { };
   haproxy = callTest ./haproxy.nix { };
+  ip-forward = callTest ./ip-forward.nix { };
   ipv6-autoconfig = callSubTests ./ipv6-autoconfig.nix { };
   java = callTest ./java.nix { };
   journal = callTest ./journal.nix { };

--- a/tests/ip-forward.nix
+++ b/tests/ip-forward.nix
@@ -1,0 +1,85 @@
+import ./make-test-python.nix (
+  { pkgs, testlib, ... }:
+  let
+    assertZeroSysctl = pkgs.writeScriptBin "assert_zero_sysctl" ''
+      set -eu
+      sysctl="$1"
+
+      value="$(${pkgs.procps}/bin/sysctl -n -b "$sysctl")"
+
+      [ "$value" == "0" ]
+    '';
+  in
+  {
+    name = "ip-forward";
+    nodes = {
+      middle =
+        { ... }:
+        {
+          imports = [ (testlib.fcConfig { id = 1; }) ];
+          environment.systemPackages = [ assertZeroSysctl ];
+        };
+      left =
+        { ... }:
+        {
+          imports = [
+            (testlib.fcConfig {
+              id = 2;
+              net.fe = false;
+            })
+          ];
+          environment.systemPackages = [ assertZeroSysctl ];
+        };
+      right =
+        { ... }:
+        {
+          imports = [
+            (testlib.fcConfig {
+              id = 3;
+              net.srv = false;
+            })
+          ];
+          environment.systemPackages = [ assertZeroSysctl ];
+          services.telegraf.enable = false;
+        };
+    };
+    testScript = ''
+      hosts = [left, middle, right]
+
+      start_all()
+      for host in hosts:
+          host.wait_for_unit("multi-user.target")
+
+      with subtest("check host routes"):
+          for host in hosts:
+              out = host.succeed("ip route")
+              print(out)
+              out = host.succeed("ip -6 route")
+              print(out)
+
+      # first check whether in practice forwarding is evidentially disabled
+      with subtest("check that intermediate host does not forward ipv4 packets"):
+          left.succeed("ip route add 192.168.2.3/32 via 192.168.3.1")
+          right.succeed("ip route add 192.168.3.2/32 via 192.168.2.1")
+
+          left.fail("ping -A -c5 192.168.2.3")
+          right.fail("ping -A -c5 192.168.3.2")
+
+      with subtest("check that intermediate host does not forward ipv6 packets"):
+          left.succeed("ip route add 2001:db8:2::3/128 via 2001:db8:3::1")
+          right.succeed("ip route add 2001:db8:3::2/128 via 2001:db8:2::1")
+
+          left.fail("ping -A -c5 2001:db8:2::3")
+          right.fail("ping -A -c5 2001:db8:3::2")
+
+      # then check that the sysctls are set correctly in the kernel
+      with subtest("check that forwarding sysctls are disabled"):
+          for host in hosts:
+              host.succeed("assert_zero_sysctl net.ipv4.ip_forward")
+              host.succeed("assert_zero_sysctl net.ipv4.conf.all.forwarding")
+              host.succeed("assert_zero_sysctl net.ipv4.conf.default.forwarding")
+              host.succeed("assert_zero_sysctl net.ipv6.conf.all.forwarding")
+              host.succeed("assert_zero_sysctl net.ipv6.conf.default.forwarding")
+    '';
+  }
+)

--- a/tests/testlib.nix
+++ b/tests/testlib.nix
@@ -258,7 +258,7 @@ rec {
 
   fcVlanIfaces = mapAttrs' (vlan: vid: {
     name = "eth${vlan}";
-    value = { vlan = vid; assignIP = true; };
+    value = { vlan = vid; assignIP = false; };
   });
 
   fcIPMap = listToAttrs (concatLists (mapAttrsToList (name: vid: [

--- a/tests/testlib.nix
+++ b/tests/testlib.nix
@@ -87,8 +87,10 @@ rec {
     location ? "test",
     secrets ? {},
     extraEncParameters ? {},
-  }: { config, ... }:
+  }: { lib, config, nodes, ... }:
   let
+    fclib = config.fclib;
+
     # This is a dance around enabling/disabling and defining defaults of 
     # which VLANs/interface to enable in a test that can be overriden.
     network_options = mapAttrs (name: val: false) vlans;
@@ -101,6 +103,51 @@ rec {
     # vlan. however, this might be a different id from the one we use
     # for generating ip addresses.
     test_node_id = config.virtualisation.test.nodeNumber;
+
+    # Set options in the test harness to indicate our "primary" IP
+    # addresses. Take the first v4/v6 addresses from FE, otherwise
+    # falling back to SRV if configured.
+    primaryAddresses = let
+      ifaces = config.flyingcircus.enc.parameters.interfaces;
+      iface = ifaces.fe or ifaces.srv or null;
+
+      networks = if iface == null then [] else attrsToList (iface.networks);
+      networksV4 = filter (net: fclib.isIp4 net.name) networks;
+      networksV6 = filter (net: fclib.isIp6 net.name) networks;
+
+      primaryAddr = nets:
+        if nets == []
+        then null
+        else
+          let net = head nets;
+          in if net.value == []
+             then null
+             else head net.value;
+      in {
+        v4 = primaryAddr networksV4;
+        v6 = primaryAddr networksV6;
+      };
+
+    # Read the configs of other VMs in this test to configure the
+    # hosts file.
+    hostEntries = let
+      go = prev: name: cfg:
+        let
+          host = (lib.optionalString (cfg.networking.domain != null)
+            "${cfg.networking.hostName}.${cfg.networking.domain} "
+          ) + "${cfg.networking.hostName}";
+
+        in lib.foldr (hself: hprev:
+          if hself == ""
+          then hprev
+          else [ "${hself} ${host}" ] ++ hprev
+        ) prev [
+          cfg.networking.primaryIPAddress
+          cfg.networking.primaryIPv6Address
+        ];
+    in lib.foldlAttrs go [] nodes;
+
+    extraHosts = lib.concatStringsSep "\n" hostEntries;
   in
   {
     imports = [
@@ -118,6 +165,15 @@ rec {
       virtualisation.interfaces =
         fcVlanIfaces (listToAttrs (map (vlan: nameValuePair vlan vlans.${vlan})
           (attrNames config.flyingcircus.enc.parameters.interfaces)));
+
+      networking = {
+        inherit extraHosts;
+        
+        primaryIPAddress = fclib.mkOverrideUpstreamModule
+          (lib.optionalString (primaryAddresses.v4 != null) primaryAddresses.v4);
+        primaryIPv6Address = fclib.mkOverrideUpstreamModule
+          (lib.optionalString (primaryAddresses.v4 != null) primaryAddresses.v6);
+      };
 
       flyingcircus.enc.parameters = (lib.recursiveUpdate {
         inherit resource_group location secrets;


### PR DESCRIPTION
This change is a follow-up to #1351, which adds a NixOS to check if the default platform sysctl configuration correctly disables IP forwarding.

PL-133557

@flyingcircusio/release-managers

## Release process

- [x] ~~Created changelog entry using `./changelog.sh`~~ => not necessary


## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - This is a regression test which should compliment a previous change.
- [x] Security requirements tested? (EVIDENCE)
  - Hydra tests.