### PR TITLE
fclib.utils.python3BinFromFile: allow passing libraries and executables

### DIFF
--- a/nixos/lib/utils.nix
+++ b/nixos/lib/utils.nix
@@ -174,10 +174,48 @@ rec {
       ${pkgs.jq}/bin/jq . < ${json} > $out
     '';
 
+  /**
+     python3BinFromFile takes a path to a python file and an attributeset with some further options.
+     It outputs a directory with `bin/basename_of_python_file`.
+     Attrset options:
+     - dependencies: list of packages with executables that are added to PATH for the python program
+     - all other options are passed through to `writePython3Bin`.
+
+     # Examples
+     :::{.example}
+     ## `python3BinFromFile` usage example
+
+     ```nix
+     python3BinFromFile ./pkgs/test.py {
+       dependencies = [ pkgs.sl ];
+       libraries = [ pkgs.python3Packages.pyyaml ];
+     }
+     ```
+
+     :::
+  */
   python3BinFromFile =
     path:
-    pkgs.writers.writePython3Bin (removeSuffix ".py" (builtins.baseNameOf path)) { } (
-      lib.readFile path
-    );
+    {
+      dependencies ? [ ],
+      ...
+    }@args:
+    let
+      progname = removeSuffix ".py" (builtins.baseNameOf path);
+      writerArgs = lib.removeAttrs args [ "dependencies" ];
+      python3Writer = pkgs.writers.writePython3Bin progname writerArgs (lib.readFile path);
+      pathWrapper =
+        pkgs.runCommand "wrap-${progname}"
+          {
+            nativeBuildInputs = [ pkgs.makeBinaryWrapper ];
+            meta.mainProgram = progname;
+          }
+          ''
+            mkdir -p $out/bin
+            makeBinaryWrapper ${lib.getExe python3Writer} $out/bin/${progname} \
+              --prefix PATH : "${lib.makeBinPath dependencies}"
+          '';
+    in
+    if dependencies == [ ] then python3Writer else pathWrapper;
 
 }

--- a/nixos/lib/utils.nix
+++ b/nixos/lib/utils.nix
@@ -165,6 +165,8 @@ rec {
       filter (u: any (g: g == group) (getAttr currentRG u.permissions)) config.flyingcircus.users.userData
     );
 
+  # TODO: consider moving writers like this to overlay, such that they are
+  # accessible as a package, not just via `fclib`
   writePrettyJSON =
     name: x:
     let

--- a/nixos/platform/journalbeat.nix
+++ b/nixos/platform/journalbeat.nix
@@ -10,7 +10,7 @@ with lib;
 let
   fclib = config.fclib;
   cfg = config.flyingcircus.journalbeat;
-  journalSetCursor = fclib.python3BinFromFile ./filebeat-journal-set-cursor.py;
+  journalSetCursor = fclib.python3BinFromFile ./filebeat-journal-set-cursor.py { };
 
 in
 {

--- a/nixos/roles/check-varnish-http.py
+++ b/nixos/roles/check-varnish-http.py
@@ -1,0 +1,42 @@
+import subprocess
+import sys
+
+ports = []
+
+for line in (
+    subprocess.check_output(["varnishadm", "debug.listen_address"])
+    .decode("ascii")
+    .splitlines()
+):
+    line = line.strip()
+    if not line:
+        continue
+    _, ip, port = line.split()
+    ports.append((ip, port))
+
+if not ports:
+    print("No listen_address reported by varnishadm")
+    sys.exit(2)
+
+STATUS = 0
+
+for ip, port in ports:
+    if ":" in ip:
+        ip_version = "-6"
+        print(f"Checking [{ip}]:{port} ...")
+    else:
+        ip_version = "-4"
+        print(f"Checking {ip}:{port} ...")
+    proc = subprocess.run(
+        # fmt: off
+        [
+            "check_http", "-H", ip, "-p", port, ip_version,
+            "-c", "10", "-w", "3", "-t", "20",
+            "-e", "HTTP",
+        ]
+        # fmt: on
+    )
+    print()
+    STATUS = max([STATUS, proc.returncode])
+
+sys.exit(STATUS)

--- a/nixos/roles/consul/default.nix
+++ b/nixos/roles/consul/default.nix
@@ -12,7 +12,7 @@ let
   enc = config.flyingcircus.enc;
   secrets = enc.parameters.secrets;
   public_fqdn = "${enc.name}.fe.${enc.parameters.location}.fcio.net";
-  server_secret_script = fclib.python3BinFromFile ./update-server-secrets.py;
+  server_secret_script = fclib.python3BinFromFile ./update-server-secrets.py { };
   cfg = config.flyingcircus.roles.consul_server;
 in
 {

--- a/nixos/roles/webproxy.nix
+++ b/nixos/roles/webproxy.nix
@@ -75,62 +75,17 @@ in
         };
         varnish_http =
           let
-            check-varnish-http =
-              pkgs.writers.writePython3 "check-varnish-http"
-                {
-                  flakeIgnore = [ "E501" ]; # ignore long lines
-                }
-                ''
-                  import subprocess
-                  import sys
-
-                  ports = []
-
-                  for line in (
-                      subprocess.check_output(["${cfg.package}/bin/varnishadm", "debug.listen_address"])
-                      .decode("ascii")
-                      .splitlines()
-                  ):
-                      line = line.strip()
-                      if not line:
-                          continue
-                      _, ip, port = line.split()
-                      ports.append((ip, port))
-
-                  if not ports:
-                      print("No listen_address reported by varnishadm")
-                      sys.exit(2)
-
-                  STATUS = 0
-
-                  for ip, port in ports:
-                      if ":" in ip:
-                          ip_version = "-6"
-                          print(f"Checking [{ip}]:{port} ...")
-                      else:
-                          ip_version = "-4"
-                          print(f"Checking {ip}:{port} ...")
-                      proc = subprocess.run(
-                          [
-                              "${pkgs.monitoring-plugins}/bin/check_http",
-                              "-H", ip,
-                              "-p", port,
-                              ip_version,
-                              "-c", "10",
-                              "-w", "3",
-                              "-t", "20",
-                              "-e", "HTTP",
-                          ]
-                      )
-                      print()
-                      STATUS = max([STATUS, proc.returncode])
-
-                  sys.exit(STATUS)
-                '';
+            check-varnish-http = fclib.python3BinFromFile ./check-varnish-http.py {
+              dependencies = [
+                cfg.package
+                pkgs.monitoring-plugins
+              ];
+              flakeIgnore = [ "E501" ]; # ignore long lines
+            };
           in
           {
             notification = "varnish port 8008 HTTP response";
-            command = toString check-varnish-http;
+            command = lib.getExe check-varnish-http;
           };
       };
 

--- a/nixos/services/consul/default.nix
+++ b/nixos/services/consul/default.nix
@@ -12,7 +12,7 @@ let
   cfg = config.flyingcircus.services.consul;
   enc = config.flyingcircus.enc;
   secrets = enc.parameters.secrets;
-  client_secret_script = fclib.python3BinFromFile ./update-client-secrets.py;
+  client_secret_script = fclib.python3BinFromFile ./update-client-secrets.py { };
 in
 {
   options = {


### PR DESCRIPTION
Extend `python3BinFromFile` to optionally take a list of package
dependencies, whose executables are added to the PATH of the python
script. This facilitates writing more standalone python scripts that
utilise external binaries.
As an example, this is applied to the previously-inlined `check-varnish-http` script.

Also enables the usage of further `writePython3` options like
`libraries`.

Design decisions:
advantages:
- extend an established writer from nixpkgs and benefit from its already
  implemented capabilities
disadvantages:
- yet another wrapping indirection
- something like the `dependencies` arg of `buildPythonPackage` would
  provide an even better UX, but `wrapPythonPrograms` turned out to be
  too complex for this simple use case.

Follow-up for PL-133554.

@flyingcircusio/release-managers

## Release process

- [ ] Created changelog entry using `./changelog.sh`
  - internal, do we need one? 


## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - facilitate writing check scripts using external dependencies, to better manage complexity 
- [x] Security requirements tested? (EVIDENCE)
  - [x] automated tests still pass
  - [x] built some example python scripts with and without external dependencies
  - [x] verified that `check-varnish-http` works correctly on a test vm
