### PR TITLE
codestyle-template: update

### DIFF
--- a/.pre-commit-config-local.yaml
+++ b/.pre-commit-config-local.yaml
@@ -1,4 +1,4 @@
-exclude: "pkgs/fc/sensusyntax/fixtures/(syntaxerror|empty).json|(tests/testlib.nix|nixos/roles/devhost/vm.nix|tests/physical-installer.nix)"
+exclude: "pkgs/fc/sensusyntax/fixtures/(syntaxerror|empty).json|(tests/testlib.nix|nixos/roles/devhost/vm.nix|tests/physical-installer.nix)|^changelog.d/new_fragment.md.j2$"
 repos:
 - repo: local
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,20 +1,27 @@
 exclude: ^secrets/|^appenv$|pkgs/fc/sensusyntax/fixtures/(syntaxerror|empty).json|(tests/testlib.nix|nixos/roles/devhost/vm.nix|tests/physical-installer.nix)|^changelog.d/new_fragment.md.j2$
 repos:
 - hooks:
+  - id: detect-private-key
+  - id: check-added-large-files
   - exclude: "(?x)^(\n  secrets/|environments/.*/secret.*|\n  .*\\.patch\n)$\n"
     id: trailing-whitespace
   - exclude: "(?x)^(\n  environments/.*/secret.*|\n  .*\\.patch\n)$\n"
     id: end-of-file-fixer
-  - id: check-yaml
-  - id: check-added-large-files
-  - id: check-json
-  - id: check-xml
-  - id: check-toml
-  - id: detect-private-key
+  - exclude: "(?x)^(\n  environments/.*/secret.*|\n  .*\\.patch\n)$\n"
+    id: check-yaml
+  - exclude: "(?x)^(\n  environments/.*/secret.*|\n  .*\\.patch\n)$\n"
+    id: check-json
+  - exclude: "(?x)^(\n  environments/.*/secret.*|\n  .*\\.patch\n)$\n"
+    id: check-xml
+  - exclude: "(?x)^(\n  environments/.*/secret.*|\n  .*\\.patch\n)$\n"
+    id: check-toml
   repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v5.0.0
 - hooks:
-  - args: ["--profile", "black", "--filter-files"]
+  - args:
+    - --profile
+    - black
+    - --filter-files
     id: isort
     name: isort (python)
   repo: https://github.com/pycqa/isort


### PR DESCRIPTION
**precondition**: already based on https://github.com/flyingcircusio/codestyle-template/pull/11, merge that first

required manual interventions:
- keep nixfmt install in github CI
- remove ruff (too strict for fc-nixos, see PL-133414)

Follow-up for PL-131360

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`
  - no, entirely internal


## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - update the internal enforced standard code checks to stay in sync with guidelines 
- [x] Security requirements tested? (EVIDENCE)
  - [x] automated tests still pass