### PR TITLE
services.redis: remove ifd for password

### DIFF
--- a/changelog.d/20250324_095007_PL-133563-redis-remove-ifd_scriv.md
+++ b/changelog.d/20250324_095007_PL-133563-redis-remove-ifd_scriv.md
@@ -1,0 +1,25 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+- If you access `services.redis."".password` in your NixOS config, please change this to
+  `flyingcircus.services.redis.password`.
+
+### NixOS XX.XX platform
+
+- redis: restructure internal password handling
+  The password file /etc/local/redis/password now gets written as systemd ExecStartPre. (PL-133653)
+
+- telegraf: Add new option `environmentVariablesFromFile` that allows users to store
+  passwords in files and using them as substituted environment variable in a telegraf input. (PL-133563)

--- a/nixos/roles/gitlab.nix
+++ b/nixos/roles/gitlab.nix
@@ -143,7 +143,7 @@ in
         databaseCreateLocally = fclib.mkPlatform true;
         databasePasswordFile = "${cfg.secretsDir}/db_password";
         initialRootPasswordFile = "${cfg.secretsDir}/root_password";
-        redisUrl = "redis://:${config.services.redis.servers."".requirePass}@localhost:6379/";
+        redisUrl = "redis://:${config.flyingcircus.services.redis.password}@localhost:6379/";
         statePath = "/srv/gitlab/state";
         https = true;
         port = 443;

--- a/nixos/services/redis.nix
+++ b/nixos/services/redis.nix
@@ -11,17 +11,6 @@ let
   cfg = config.flyingcircus.services.redis;
   fclib = config.fclib;
 
-  generatedPassword = lib.removeSuffix "\n" (
-    readFile (pkgs.runCommand "redis.password" { } "${pkgs.apg}/bin/apg -a 1 -M lnc -n 1 -m 32 > $out")
-  );
-
-  password = lib.removeSuffix "\n" (
-    if cfg.password == null then
-      (fclib.configFromFile /etc/local/redis/password generatedPassword)
-    else
-      cfg.password
-  );
-
   extraConfig = fclib.configFromFile /etc/local/redis/custom.conf "";
 
 in
@@ -110,7 +99,7 @@ in
         "" = {
           bind = concatStringsSep " " cfg.listenAddresses;
           enable = true;
-          requirePass = password;
+          requirePassFile = "/etc/local/redis/password";
           settings = lib.mkMerge [
             (lib.mkIf (cfg.maxmemory-policy != null) {
               inherit (cfg) maxmemory-policy;
@@ -123,17 +112,32 @@ in
       };
     };
 
-    systemd.services.redis.serviceConfig.Restart = "always";
-
-    flyingcircus.activationScripts.redis = lib.stringAfter [ "fc-local-config" ] ''
-      if [[ ! -e /etc/local/redis/password ]]; then
-        ( umask 007;
-          echo ${lib.escapeShellArg password} > /etc/local/redis/password
-          chown redis:service /etc/local/redis/password
-        )
-      fi
-      chmod 0660 /etc/local/redis/password
-    '';
+    systemd.services.redis.serviceConfig =
+      let
+        preStart = pkgs.writeShellScript "redis-prestart" (
+          ''
+            if [[ ! -e /etc/local/redis/password ]]; then (
+            umask 007;
+          ''
+          + lib.optionalString (cfg.password == null) ''
+            ${pkgs.apg}/bin/apg -a 1 -M lnc -n 1 -m 32 > /etc/local/redis/password
+          ''
+          + lib.optionalString (cfg.password != null) ''
+            echo ${lib.escapeShellArg cfg.password} > /etc/local/redis/password
+          ''
+          + ''
+            ) fi
+            chmod 0660 /etc/local/redis/password
+            chown redis:service /etc/local/redis/password
+          ''
+        );
+      in
+      {
+        ExecStartPre = lib.mkBefore [
+          ("+" + preStart)
+        ];
+        Restart = "always";
+      };
 
     flyingcircus.localConfigDirs.redis = {
       dir = "/etc/local/redis";
@@ -143,16 +147,21 @@ in
     flyingcircus.services = {
       sensu-client.checks.redis = {
         notification = "Redis alive";
-        command = ''
-          ${pkgs.sensu-plugins-redis}/bin/check-redis-ping.rb \
-            -h localhost -P ${lib.escapeShellArg password}
-        '';
+        command = toString (
+          pkgs.writeShellScript "redis-sensu-check" ''
+            password=$(</etc/local/redis/password)
+            ${pkgs.sensu-plugins-redis}/bin/check-redis-ping.rb -h localhost -P $password
+          ''
+        );
       };
 
+      telegraf.environmentVariablesFromFile = {
+        REDIS_PASSWORD = "/etc/local/redis/password";
+      };
       telegraf.inputs.redis = [
         {
           servers = [
-            "tcp://:${password}@localhost:${toString config.services.redis.servers."".port}"
+            "tcp://:$REDIS_PASSWORD@localhost:${toString config.services.redis.servers."".port}"
           ];
           # Drop string fields. They are converted to labels in Prometheus
           # which blows up the number of metrics.
@@ -175,8 +184,8 @@ in
     environment.etc."local/redis/README.txt".text = ''
       Redis is running on this machine.
 
-      You can find the password for the redis in the `password`. You can also change
-      the redis password by changing the `password` file.
+      You can find the password for the redis in the `password` file.
+      You can also change the redis password by changing the `password` file.
 
       Changing the config via custom.conf is not supported anymore. Please use a NixOS module
       with the option `services.redis.servers."".settings` instead.

--- a/nixos/services/telegraf/default.nix
+++ b/nixos/services/telegraf/default.nix
@@ -12,7 +12,8 @@
 with lib;
 
 let
-  cfg = config.services.telegraf;
+  upstreamCfg = config.services.telegraf;
+  cfg = config.flyingcircus.services.telegraf;
   fclib = config.fclib;
 
   telegrafShowConfig = pkgs.writeScriptBin "telegraf-show-config" ''
@@ -24,7 +25,7 @@ let
   '';
 
   settingsFormat = pkgs.formats.toml { };
-  configFile = settingsFormat.generate "config.toml" cfg.extraConfig;
+  configFile = settingsFormat.generate "config.toml" upstreamCfg.extraConfig;
 
 in
 {
@@ -61,11 +62,23 @@ in
           See https://github.com/influxdata/telegraf/blob/master/plugins/inputs/prometheus/README.md#metric-format-configuration
         '';
       };
+      environmentVariablesFromFile = mkOption {
+        default = { };
+        type = types.attrsOf types.str;
+        description = ''
+          Sets environment variables based on the content of given files.
+          These will be interpolated into the config file using envsubst
+          with this syntax: `$ENVIRONMENT` or `''${VARIABLE}`.
+        '';
+        example = {
+          REDIS_PASSWORD = "/etc/local/redis/password";
+        };
+      };
     };
   };
 
   config = mkMerge [
-    (mkIf cfg.enable {
+    (mkIf upstreamCfg.enable {
 
       # merge in our platform configs
       services.telegraf.extraConfig.inputs = config.flyingcircus.services.telegraf.inputs;
@@ -90,10 +103,28 @@ in
 
       systemd.services.telegraf = {
         serviceConfig = {
+          LoadCredential = lib.mapAttrsToList (
+            name: file: "${name}:${file}"
+          ) cfg.environmentVariablesFromFile;
+          ExecStartPre =
+            let
+              envInvocation = builtins.concatStringsSep "\n" (
+                lib.mapAttrsToList (
+                  name: file: "export ${name}=$(<$CREDENTIALS_DIRECTORY/${name})"
+                ) cfg.environmentVariablesFromFile
+              );
+            in
+            [
+              (pkgs.writeShellScript "telegraf-pre-start" ''
+                ${envInvocation}
+                umask 077
+                ${pkgs.envsubst}/bin/envsubst -i "${configFile}" > /var/run/telegraf/config.toml
+              '')
+            ];
           ExecStart = mkOverride 90 (
             concatStringsSep " " (
               lib.flatten [
-                [ "${cfg.package}/bin/telegraf -config \"${configFile}\"" ]
+                [ "${upstreamCfg.package}/bin/telegraf -config '/var/run/telegraf/config.toml'" ]
                 (
                   if builtins.pathExists /etc/local/telegraf then
                     [ "-config-directory ${/etc/local/telegraf}" ]
@@ -108,15 +139,15 @@ in
       };
 
     })
-    (mkIf (config.flyingcircus.services.telegraf.inputs ? prometheus) {
+    (mkIf (cfg.inputs ? prometheus) {
       # only set when that plugin is configured to be used, to not accidentally enable it without use
       services.telegraf.extraConfig.inputs.prometheus = builtins.map (
         attr:
         attr
         // {
-          metric_version = config.flyingcircus.services.telegraf.prometheus-metric_version;
+          metric_version = cfg.prometheus-metric_version;
         }
-      ) config.flyingcircus.services.telegraf.inputs.prometheus;
+      ) cfg.inputs.prometheus;
     })
   ];
 }

--- a/tests/gitlab.nix
+++ b/tests/gitlab.nix
@@ -52,7 +52,7 @@ import ./make-test-python.nix (
 
           flyingcircus.roles.postgresql14.enable = true;
 
-          services.redis.servers."".requirePass = lib.mkForce "test";
+          flyingcircus.services.redis.password = lib.mkForce "test";
 
           services.gitlab = lib.mkForce {
             databasePasswordFile = pkgs.writeText "dbPassword" dbPassword;


### PR DESCRIPTION
@flyingcircusio/release-managers

Also adds a new option `flyingcircus.services.telegraf.environmentVariablesFromFile` that allows users to store
  passwords in files and using them as substituted environment variable in a telegraf input.

## Release process

- [x] Created changelog entry using `./changelog.sh`


## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
   - Security: Improved. Passwords per default not stored in nix-store
- [x] Security requirements tested? (EVIDENCE)
  - Tested sensu and telegraf on dev VM 
  - Tested nixos password gets set when local file doesn't exist