### PR TITLE
ipmi: make changing the IPMI admin username optional

### DIFF
--- a/changelog.d/20250325_175057_PL-133561-make-managing-ipmi-admin-names-optional_scriv.md
+++ b/changelog.d/20250325_175057_PL-133561-make-managing-ipmi-admin-names-optional_scriv.md
@@ -1,0 +1,19 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+
+### NixOS XX.XX platform
+
+- Make managing the IPMI admin username optional. Some machines do not support changing the name. (PL-133561)

--- a/nixos/platform/ipmi.nix
+++ b/nixos/platform/ipmi.nix
@@ -38,6 +38,11 @@ in
         description = "Additional options to pass to `check_ipmi_sensor`.";
         type = types.str;
       };
+      manageAdminUserName = mkOption {
+        default = true;
+        description = "Manage the admin user name (setting it to `ADMIN`).";
+        type = types.bool;
+      };
     };
   };
 
@@ -82,26 +87,31 @@ in
       serviceConfig.RemainAfterExit = true;
       path = [ pkgs.ipmitool ];
       wantedBy = [ "basic.target" ];
-      script = ''
-        ipmitool lan set 1 ipsrc static
-        sleep 1
-        ipmitool lan set 1 ipaddr ${ipmi_addr}
-        sleep 1
-        ipmitool lan set 1 netmask ${ipmi_netmask}
-        sleep 1
-        ipmitool lan set 1 defgw ipaddr ${ipmi_gw}
-        sleep 1
-        ipmitool sol set non-volatile-bit-rate 115.2 1
-        sleep 1
-        ipmitool sol set volatile-bit-rate 115.2 1
-        sleep 1
-        ipmitool user set name 2 ADMIN
-        # See https://serverfault.com/questions/361940/configuring-supermicro-ipmi-to-use-one-of-the-lan-interfaces-instead-of-the-ipmi/677087
-        # Ensure BMC is set to failover (SuperMicro only)
-        if ipmitool mc info | grep Supermicro > /dev/null ; then
-          ipmitool raw 0x30 0x70 0x0c 1 2 || true
-        fi
-      '';
+      script =
+        ''
+          ipmitool lan set 1 ipsrc static
+          sleep 1
+          ipmitool lan set 1 ipaddr ${ipmi_addr}
+          sleep 1
+          ipmitool lan set 1 netmask ${ipmi_netmask}
+          sleep 1
+          ipmitool lan set 1 defgw ipaddr ${ipmi_gw}
+          sleep 1
+          ipmitool sol set non-volatile-bit-rate 115.2 1
+          sleep 1
+          ipmitool sol set volatile-bit-rate 115.2 1
+          sleep 1
+        ''
+        + (lib.optionalString cfg.ipmi.manageAdminUserName ''
+          ipmitool user set name 2 ADMIN
+        '')
+        + ''
+          # See https://serverfault.com/questions/361940/configuring-supermicro-ipmi-to-use-one-of-the-lan-interfaces-instead-of-the-ipmi/677087
+          # Ensure BMC is set to failover (SuperMicro only)
+          if ipmitool mc info | grep Supermicro > /dev/null ; then
+            ipmitool raw 0x30 0x70 0x0c 1 2 || true
+          fi
+        '';
     };
 
     flyingcircus.passwordlessSudoPackages = [


### PR DESCRIPTION
Some machines do not support changing the name.

Fixes PL-133561

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`


## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Examples: **rate limiting**, **code applied unconditionally to all or a large class of machines**, ...

We missed this previously and it's a toggle now.

- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

n/a

- [x] Security requirements tested? (EVIDENCE)

n/a, but functionality tested on affected hosts.