### PR TITLE
[PL-133259] disable SSL stapling configuration for OCSP

### DIFF
--- a/changelog.d/20250326_102514_PL-133259_disable-ocsp-config_scriv.md
+++ b/changelog.d/20250326_102514_PL-133259_disable-ocsp-config_scriv.md
@@ -1,0 +1,19 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+
+### NixOS XX.XX platform
+
+- Remove SSL Stapling from the default Nginx configuration since the default CA for NixOS provisioned certificates (Let's Encrypt) is ending OCSP support in 2025 (PL-133259)

--- a/nixos/services/nginx/base-module.nix
+++ b/nixos/services/nginx/base-module.nix
@@ -256,10 +256,6 @@ let
           # We don't enable insecure ciphers by default, so this allows
           # clients to pick the most performant, per https://github.com/mozilla/server-side-tls/issues/260
           ssl_prefer_server_ciphers off;
-
-          # OCSP stapling
-          ssl_stapling on;
-          ssl_stapling_verify on;
         ''}
 
         ${optionalString (cfg.legacyTlsSettings) ''
@@ -269,10 +265,6 @@ let
           ssl_session_cache shared:SSL:10m;
           ssl_session_tickets off;
           ssl_prefer_server_ciphers on;
-
-          # OCSP stapling
-          ssl_stapling on;
-          ssl_stapling_verify on;
         ''}
 
         ${optionalString cfg.recommendedBrotliSettings ''


### PR DESCRIPTION
PL-133259

The default CA for certificates provisioned via NixOS's `security.acme` option e.g. via the nginx module Let's Encrypt is ending OCSP support this year (https://letsencrypt.org/2024/12/05/ending-ocsp/) so any relevant configuration should be removed beforehand. OCSP was never widely adopted and all modern browsers ship with some form of CRL support.


> We plan to end support for OCSP primarily because it represents a considerable risk to privacy on the Internet. When someone visits a website using a browser or other software that checks for certificate revocation via OCSP, the Certificate Authority (CA) operating the OCSP responder immediately becomes aware of which website is being visited from that visitor’s particular IP address. Even when a CA intentionally does not retain this information, as is the case with Let’s Encrypt, CAs could be legally compelled to collect it. CRLs do not have this issue.

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`


## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
 
Proper SSL security is not impacted by this change.

- [x] Security requirements tested? (EVIDENCE)

https client implement several ways to validate if certificates provided by a server are valid, for example CRL. Removing OCSP configuration will not lead to clients unintentionally accepting revoked certificates. 
