### PR TITLE
nginx: make HTTPS sensu check work for vhost name != serverName

### DIFF
--- a/nixos/services/nginx/default.nix
+++ b/nixos/services/nginx/default.nix
@@ -83,7 +83,16 @@ let
     lib.filterAttrs (_: val: val ? emailACME && val.emailACME != null) cfg.virtualHosts
   );
 
-  acmeVhosts = (lib.filterAttrs (_: vhost: vhost.enableACME) nginxCfg.virtualHosts);
+  acmeVhostsWithTLS = (
+    lib.filterAttrs (
+      _: vhost:
+      let
+        onlySSL = vhost.onlySSL || vhost.enableSSL;
+        hasSSL = onlySSL || vhost.addSSL || vhost.forceSSL;
+      in
+      vhost.enableACME && hasSSL
+    ) nginxCfg.virtualHosts
+  );
 
   mainConfig = ''
     worker_processes ${toString cfg.workerProcesses};
@@ -478,22 +487,23 @@ in
           };
 
         }
-        // (lib.listToAttrs (
-          map (
-            n:
-            lib.nameValuePair "nginx_https_${n}" {
-              notification = "HTTPS certificate check failed for vhost ${n}";
-              # We're using a timeout of 15 seconds because 10 seconds is the timeout
-              # that will trigger if DNS issues occur and giving the check a higher
-              # timeout allows us to see those. Otherwise they get hidden behind
-              # a generic timeout message.
-              # Note that we assume that the certificate is reachable via port 443.
-              # Other configurations might need overrides for the sensu check command.
-              command = "check_http -p 443 -S --sni -C 25,14 -H ${n} -t 15";
-              interval = 600;
-            }
-          ) (lib.attrNames acmeVhosts)
-        ));
+        // (lib.mapAttrs' (
+          n: vhost:
+          let
+            host = if vhost.serverName != null then vhost.serverName else n;
+          in
+          lib.nameValuePair "nginx_https_${n}" {
+            notification = "HTTPS certificate check failed for vhost ${n}";
+            # We're using a timeout of 15 seconds because 10 seconds is the timeout
+            # that will trigger if DNS issues occur and giving the check a higher
+            # timeout allows us to see those. Otherwise they get hidden behind
+            # a generic timeout message.
+            # Note that we assume that the certificate is reachable via port 443.
+            # Other configurations might need overrides for the sensu check command.
+            command = "check_http -p 443 -S --sni -C 25,14 -H ${host} -t 15";
+            interval = 600;
+          }
+        ) acmeVhostsWithTLS);
 
       networking.firewall.allowedTCPPorts = [
         80


### PR DESCRIPTION
The assumption that server names are always determined by the attribute name of the vhost was wrong. The check now prefers to talk to the host identified by vhost.serverName, falling back to the attribute name.

Now, we also check if a vhost really uses SSL as there might be non-TLS but ACME-enabled vhosts which just serve the ACME challenge.

PL-131278

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`


## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - just a fix for non-standard nginx configs
  - check should prefer the serverName before using the attribute name of the vhost as fallback
  - check should exclude non-TLS vhost configs
- [x] Security requirements tested? (EVIDENCE)
  - checked of a test VM that standard config with serverName == attribute name still works and that a non-standard config with two attribute sets referring to the same serverName, one HTTP and the other HTTPS generates only one Sensu check