### PR TITLE
bump nixpkgs to include pgvectorscale extension

### DIFF
--- a/changelog.d/20250327_224109_os-pgvector_scriv.md
+++ b/changelog.d/20250327_224109_os-pgvector_scriv.md
@@ -1,0 +1,21 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+- A bullet item for the Impact category.
+
+
+### NixOS XX.XX platform
+
+- postgresql: pgvectorscale extension is now available as a package

--- a/flake.lock
+++ b/flake.lock
@@ -481,11 +481,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1743046813,
-        "narHash": "sha256-YySHiC5I5hjyRKTMzoztczHPVb2haTaXMKHMuKrBqxE=",
+        "lastModified": 1743080814,
+        "narHash": "sha256-7saPejuhLA3xdkk5aLvKwlbMksQgnbovdMizA+FDyi4=",
         "owner": "flyingcircusio",
         "repo": "nixpkgs",
-        "rev": "77fa1485629eaec8726d9c88887392a5ad04dfb7",
+        "rev": "0c09283acb71b15420b048c9461098ce88d8e994",
         "type": "github"
       },
       "original": {

--- a/release/versions.json
+++ b/release/versions.json
@@ -14,10 +14,10 @@
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/"
   },
   "nixpkgs": {
-    "hash": "sha256-YySHiC5I5hjyRKTMzoztczHPVb2haTaXMKHMuKrBqxE=",
+    "hash": "sha256-7saPejuhLA3xdkk5aLvKwlbMksQgnbovdMizA+FDyi4=",
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "77fa1485629eaec8726d9c88887392a5ad04dfb7"
+    "rev": "0c09283acb71b15420b048c9461098ce88d8e994"
   },
   "nixpkgs-21_05": {
     "hash": "sha256-5ufC/t0sUFS/LspiEwU8DW5+uVYM3diZ1IC7KjX9ek4=",


### PR DESCRIPTION
@flyingcircusio/release-managers

FC-43895

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [ ] PR has internal ticket
- [ ] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--->
- [x] set urgency and risk labels
- [x] ensure the merge bot has determined a merge date
- [x] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - adding a new package as a backport from a not-yet-merged but reviewed nixpkgs PR (due to urgency)
- [x] Security requirements tested? (EVIDENCE)
  - [x] existing automated tests still pass, changes did not introduce any known regressions
  - [x] PR review uncovered some improvements, those were already applied -> passed at least one upstream review
