### PR TITLE
fc.qemu: update to python3.11, remove C-level dependency on Ceph

### DIFF
--- a/changelog.d/20250401_085904_PL-133553-fc-qemu-upgrade-python-remove-bindings_scriv.md
+++ b/changelog.d/20250401_085904_PL-133553-fc-qemu-upgrade-python-remove-bindings_scriv.md
@@ -1,0 +1,19 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+
+### NixOS XX.XX platform
+
+- Update our virtualisation tooling to Python 3.11 and remove C-level Ceph dependencies. (FC-133553)

--- a/pkgs/fc/default.nix
+++ b/pkgs/fc/default.nix
@@ -52,33 +52,25 @@ rec {
       repo = "fc.qemu";
       # The release tooling didn't upgrade properly so we had to pick a specific
       # commit instead.
-      rev = "5672728c27c09bbcabb58e8944e4b2dc2ed20be4";
-      hash = "sha256-+duAZCCRCqFqF2TIJHtRtYrmXfgvlxLEvFZH82G2GSg=";
+      rev = "2108a743de7acd681e58a86a0a2f148d0e00a231";
+      hash = "sha256-croWgJsUaNVh/24AxmPrnGv9MTRuq/MVdyhtyYkPajI=";
     };
     fc-ceph = ceph;
     qemu_ceph = pkgs.qemu-ceph-nautilus;
     ceph_client = pkgs.ceph-nautilus.ceph-client;
-    python3Packages = pkgs.python38Packages;
-    py_pytest_patterns = pkgs.py38_pytest_patterns;
+    python3Packages = pkgs.python311Packages;
   };
 
   # Enable this temporarily during development, but DO NOT commit this as
   # it will break hydra and we can't cleanly filter it out of the automatic
   # test discovery at the moment.
   #
-  # qemu-dev-nautilus = callPackage ./qemu {
-  #   version = "dev";
-  #   # builtins.toPath (testPath + "/.")
+  # qemu-dev-nautilus = qemu-nautilus.overrideAttrs (old: {
   #   # for tests:
   #   src = ../../../../../fc.qemu/.;
   #   # for nix-shell . -A fc.qemu-dev-nautilus
   #   # src = ../../../fc.qemu/.;
-  #   fc-ceph = ceph;
-  #   qemu_ceph = pkgs.qemu-ceph-nautilus;
-  #   ceph_client = pkgs.ceph-nautilus.ceph-client;
-  #   python3Packages = pkgs.python38Packages;
-  #   py_pytest_patterns = pkgs.py38_pytest_patterns;
-  # };
+  # });
 
   roundcube-chpasswd = callPackage ./roundcube-chpasswd { };
   roundcube-chpasswd-py = callPackage ./roundcube-chpasswd-py { };

--- a/pkgs/fc/qemu/default.nix
+++ b/pkgs/fc/qemu/default.nix
@@ -1,26 +1,26 @@
 {
   version,
   src,
-  pkgs,
-  python3Packages,
-  lib,
-  libceph,
   ceph_client,
+  coreutils,
+  dosfstools,
   fc-ceph,
   fetchFromGitHub,
-  utillinux,
-  coreutils,
+  file,
+  gnused,
+  gptfdisk,
+  lib,
+  libceph,
+  openssh,
+  parted,
+  procps,
+  python3Packages,
   qemu_ceph,
   stdenv,
-  gptfdisk,
-  parted,
-  xfsprogs,
-  dosfstools,
-  procps,
   strace,
-  file,
   systemd,
-  py_pytest_patterns,
+  utillinux,
+  xfsprogs,
 }:
 
 let
@@ -59,8 +59,12 @@ py.buildPythonPackage rec {
 
   dontStrip = true;
 
+  pyproject = true;
+
   propagatedBuildInputs = [
     coreutils
+    dosfstools
+    gnused
     gptfdisk
     parted
     procps
@@ -68,26 +72,26 @@ py.buildPythonPackage rec {
     systemd
     utillinux
     xfsprogs
-    dosfstools
     py.requests
     py.future
     py.colorama
     py.structlog
     py_consulate
     py.psutil
-    strace
     py.pyyaml
     py.setuptools
-    (py.toPythonModule ceph_client)
+    py.websockets
+    ceph_client
   ];
 
   passthru = {
-    inherit py checkInputs;
+    inherit py nativeCheckInputs;
   };
 
-  checkInputs = [
+  nativeCheckInputs = [
     file
-    py_pytest_patterns
+    openssh
+    py.pytest_patterns
     py.pytest
     py.pytest-xdist
     py.pytest-cov

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -175,6 +175,7 @@ builtins.mapAttrs (_: patchPhps phpLogPermissionPatch) {
   inherit (self.ceph-nautilus) ceph ceph-client libceph;
   # upstream ceph packaging switched to offering a reduced client tooling set, let's see how that works
   ceph-nautilus = lib.dontRecurseIntoAttrs fc-nixos-21_05.ceph-nautilus;
+
   consul = builtins.trace "using 21_05 consul" (
     fc-nixos-21_05.consul.overrideAttrs (old: {
       meta.mainProgram = "consul";

--- a/tests/kvm_host_ceph-nautilus.nix
+++ b/tests/kvm_host_ceph-nautilus.nix
@@ -106,8 +106,19 @@ import ./make-test-python.nix (
         };
 
         environment.systemPackages =
+          # This is a horrible dance for two reasons:
+          # 1. pytest doesn't properly inherit the PATH environment from the propagatedBuildInputs.
+          #    We might want to reconsider using an additional buildPythonApplication with pytest
+          #    added to the primary dependencies (propagatedBuildInputs)
+          # 2. There's a bug(?) in stdenv.mkDerivation that causes external access to the
+          #    attribute's items to end up with their .dev outputs ... -_-
           let
-            testPackages = ([ testPackage ] ++ testPackage.propagatedBuildInputs ++ testPackage.checkInputs);
+
+            testPackages = (
+              [ testPackage ]
+              ++ (map (x: builtins.removeAttrs x [ "outputSpecified" ]) testPackage.propagatedBuildInputs)
+              ++ testPackage.nativeCheckInputs
+            );
             PYTHONPATH = testPackage.py.makePythonPath testPackages;
             PATH = lib.makeBinPath testPackages;
           in
@@ -123,7 +134,7 @@ import ./make-test-python.nix (
                 set -o pipefail
 
                 export PYTHONPATH="${PYTHONPATH}"
-                export PATH="${PATH}:${pkgs.openssh}/bin:${pkgs.gnused}/bin"
+                export PATH="${PATH}:$PATH"
                 export PYTHONUNBUFFERED=1
 
                 cd ${testPackage.src}


### PR DESCRIPTION
@flyingcircusio/release-managers

PL-133553

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

No changed requirements, this is a pure internal refactoring.

- [x] Security requirements tested? (EVIDENCE)

automated tests still work and have been adapted where needed