### PR TITLE
[DO NOT MERGE][HOTFIX] Ensure that IPv4 forwarding is enabled in the Docker role

### DIFF
--- a/nixos/roles/docker.nix
+++ b/nixos/roles/docker.nix
@@ -23,6 +23,14 @@ in
       flyingcircus.users.serviceUsers.extraGroups = [ "docker" ];
       virtualisation.docker.enable = true;
 
+      boot.kernel.sysctl = {
+        # IPv4 forwarding is enabled by default in the NixOS docker
+        # module, but as the platform overrides the upstream settings
+        # we need to in turn override the platform defaults here.
+        "net.ipv4.conf.all.forwarding" = fclib.mkOverridePlatformModule true;
+        "net.ipv4.conf.default.forwarding" = fclib.mkOverridePlatformModule true;
+      };
+
       networking.firewall.extraCommands = lib.mkOrder 1200 ''
         # FC docker rules (1200)
         # allow access to host from docker networks, we consider this identical


### PR DESCRIPTION
See commit message.

PL-133589

@flyingcircusio/release-managers

## Release process

- [ ] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Enabling indiscriminate forwarding is potentially a security risk, as this may result in hosts inadvertently forwarding packets for other hosts when this is not part of their function. However, the Docker daemon manages the iptables firewall itself, so we rely on Docker doing the right thing to prevent any unexpected surprises.
- [x] Security requirements tested? (EVIDENCE)
  - Hydra tests
  - Tested on a staging VM