### PR TITLE
Ensure forwarding is enabled in the Docker role

### DIFF
--- a/changelog.d/20250401_140923_PL-133589-docker-enable-forwarding_scriv.md
+++ b/changelog.d/20250401_140923_PL-133589-docker-enable-forwarding_scriv.md
@@ -1,0 +1,20 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+
+### NixOS XX.XX platform
+
+- docker: enable IP forwarding when the docker role is enabled, in
+  order to allow containers to access external services. (PL-133589)

--- a/nixos/roles/docker.nix
+++ b/nixos/roles/docker.nix
@@ -23,6 +23,17 @@ in
       flyingcircus.users.serviceUsers.extraGroups = [ "docker" ];
       virtualisation.docker.enable = true;
 
+      boot.kernel.sysctl = {
+        # IPv4 forwarding is enabled by default in the NixOS docker
+        # module, but as the platform overrides the upstream settings
+        # we need to in turn override the platform defaults here.
+        #
+        # Use manual override priorities here to avoid conflicts with
+        # external_net
+        "net.ipv4.conf.all.forwarding" = lib.mkOverride 71 true;
+        "net.ipv4.conf.default.forwarding" = lib.mkOverride 71 true;
+      };
+
       networking.firewall.extraCommands = lib.mkOrder 1200 ''
         # FC docker rules (1200)
         # allow access to host from docker networks, we consider this identical

--- a/nixos/roles/external_net/default.nix
+++ b/nixos/roles/external_net/default.nix
@@ -84,9 +84,13 @@ in
     flyingcircus.roles.vxlan.gateway = true;
 
     boot.kernel.sysctl = {
-      "net.ipv4.ip_forward" = fclib.mkOverridePlatformModule 1;
-      "net.ipv6.conf.all.forwarding" = fclib.mkOverridePlatformModule 1;
-      "net.ipv6.conf.default.forwarding" = fclib.mkOverridePlatformModule 1;
+      # Use manual override priorities here to avoid conflicts with
+      # the docker role.
+      "net.ipv4.ip_forward" = lib.mkOverride 70 true;
+      "net.ipv4.conf.all.forwarding" = lib.mkOverride 70 true;
+      "net.ipv4.conf.default.forwarding" = lib.mkOverride 70 true;
+      "net.ipv6.conf.all.forwarding" = lib.mkOverride 70 true;
+      "net.ipv6.conf.default.forwarding" = lib.mkOverride 70 true;
     };
 
     environment.systemPackages = [ pkgs.mosh ];


### PR DESCRIPTION
This change is a regression fix for #1351, where we disabled IP forwarding by default in the platform. Forwarding is however required by the docker role, as containers may need to be able to access external services.

This change adds the missing forwarding sysctl configuration by overriding the platform defaults, and also updates the forwarding overrides in the external_net role to ensure that these roles can coexist on the same machine without causing evaluation errors.

PL-133589

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [x] ensure the merge bot has determined a merge date
- [x] ensure all checks are green
- [x] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - We've previously identified enabling IP forwarding on all interfaces as a potential security problem, as this may result in hosts inadvertently forwarding packets for other hosts when this isn't intended behaviour. However, the Docker daemon actively manages the forwarding firewall itself, so we rely on Docker doing the correct thing and not generating insecure states.
- [x] Security requirements tested? (EVIDENCE)
  - Manually verified on a test VM, both with only the docker role and with the external_net role added.