### PR TITLE
Router: provide gateway services for layer 3 routed networks

### DIFF
--- a/changelog.d/20250410_150528_PL-133324-routed-pub-router-support_scriv.md
+++ b/changelog.d/20250410_150528_PL-133324-routed-pub-router-support_scriv.md
@@ -1,0 +1,20 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+
+### NixOS XX.XX platform
+
+- router: add support for providing gateway services on layer 3 routed
+  networks using VRFs. (PL-133324)

--- a/nixos/infrastructure/flyingcircus-physical.nix
+++ b/nixos/infrastructure/flyingcircus-physical.nix
@@ -9,6 +9,7 @@ with lib;
 
 let
   cfg = config.flyingcircus;
+  fclib = config.fclib;
 in
 mkIf (cfg.infrastructureModule == "flyingcircus-physical") (
   lib.mkMerge [
@@ -49,11 +50,18 @@ mkIf (cfg.infrastructureModule == "flyingcircus-physical") (
           "igb.InterruptThrottleRate=1"
         ];
 
-        # Wanted by backy and Ceph servers
-        kernel.sysctl."vm.vfs_cache_pressure" = 10;
-
-        kernel.sysctl."vm.swappiness" = config.fclib.mkPlatform 0;
-
+        kernel.sysctl = {
+          # We don't want to allow VMs with routed pub interfaces to
+          # be able to connect to e.g. the sshd on the KVM server from
+          # within the VRF. This is the kernel default, but we ensure
+          # that it's set here correctly anyway. (Compare the
+          # corresponding configuration in the router role.)
+          "net.ipv4.tcp_l3mdev_accept" = fclib.mkPlatform false;
+          "net.ipv4.udp_l3mdev_accept" = fclib.mkPlatform false;
+          "vm.swappiness" = fclib.mkPlatform 0;
+          # Wanted by backy and Ceph servers
+          "vm.vfs_cache_pressure" = 10;
+        };
       };
 
       flyingcircus.activationScripts = {
@@ -96,14 +104,14 @@ mkIf (cfg.infrastructureModule == "flyingcircus-physical") (
 
       networking = {
         domain = "fcio.net";
-        hostName = config.fclib.mkPlatform (attrByPath [ "name" ] "default" cfg.enc);
+        hostName = fclib.mkPlatform (attrByPath [ "name" ] "default" cfg.enc);
       };
 
       services.irqbalance.enable = true;
 
       users.users.root = {
         # Overriden in local.nix
-        hashedPassword = config.fclib.mkPlatform "*";
+        hashedPassword = fclib.mkPlatform "*";
         openssh.authorizedKeys.keys = attrValues cfg.static.adminKeys;
       };
 
@@ -194,7 +202,7 @@ mkIf (cfg.infrastructureModule == "flyingcircus-physical") (
 
     (lib.mkIf (config.flyingcircus.boot-style == "bios") {
       boot.loader.grub = {
-        device = config.fclib.mkPlatform "/dev/sda";
+        device = fclib.mkPlatform "/dev/sda";
         fsIdentifier = "provided";
         gfxmodeBios = "text";
       };

--- a/nixos/platform/network.nix
+++ b/nixos/platform/network.nix
@@ -10,6 +10,7 @@ with builtins;
 
 let
   cfg = config.flyingcircus;
+  cfgNet = config.flyingcircus.networking;
 
   fclib = config.fclib;
 
@@ -125,6 +126,11 @@ in
     flyingcircus.networking.physicalHostNetworking = lib.mkOption {
       type = lib.types.bool;
       description = "Use a network configuration profile suitable for physical hosts";
+      default = false;
+    };
+    flyingcircus.networking.assignVrfRoutes = lib.mkOption {
+      type = lib.types.bool;
+      description = "Assign routes in the default routing table on VRF interfaces";
       default = false;
     };
   };
@@ -275,6 +281,18 @@ in
                 iface:
                 lib.nameValuePair iface.vrfInterface {
                   tempAddress = "disabled";
+                  ipv4.routes = lib.optionals cfgNet.assignVrfRoutes (
+                    map (net: {
+                      address = net.network;
+                      inherit (net) prefixLength;
+                    }) iface.v4.networkAttrs
+                  );
+                  ipv6.routes = lib.optionals cfgNet.assignVrfRoutes (
+                    map (net: {
+                      address = net.network;
+                      inherit (net) prefixLength;
+                    }) iface.v6.networkAttrs
+                  );
                 }
               ) vxlanVrfInterfaces)
 
@@ -311,7 +329,7 @@ in
         wireguard.enable = true;
 
         firewall.trustedInterfaces = lib.optionals (
-          !isNull fclib.underlay && cfg.networking.physicalHostNetworking
+          !isNull fclib.underlay && cfgNet.physicalHostNetworking
         ) (map (l: l.link) fclib.underlay.links or [ ]);
 
         firewall.extraCommands =
@@ -355,7 +373,7 @@ in
 
       };
 
-      flyingcircus.services.telegraf.inputs = lib.optionalAttrs (cfg.networking.physicalHostNetworking) {
+      flyingcircus.services.telegraf.inputs = lib.optionalAttrs (cfgNet.physicalHostNetworking) {
         exec = [
           {
             commands = [ "${pkgs.fc.telegraf-routes-summary}/bin/telegraf-routes-summary" ];
@@ -1144,10 +1162,10 @@ in
           # as a reasonable size and I'd suggest generalizing this number to all machines.
           "net.netfilter.nf_conntrack_max" = 262144;
         }
-        (lib.mkIf (!cfg.networking.physicalHostNetworking) {
+        (lib.mkIf (!cfgNet.physicalHostNetworking) {
           "net.core.rmem_max" = 8388608;
         })
-        (lib.mkIf (cfg.networking.physicalHostNetworking) {
+        (lib.mkIf (cfgNet.physicalHostNetworking) {
           "vm.min_free_kbytes" = "513690";
 
           "net.core.netdev_max_backlog" = 300000;

--- a/nixos/platform/network.nix
+++ b/nixos/platform/network.nix
@@ -109,6 +109,17 @@ let
 
   quoteLabel = replaceStrings [ "/" ] [ "-" ];
 
+  concatFuncWithIndent =
+    func: indent:
+    let
+      spaces = lib.strings.replicate indent " ";
+      sep = "\n" + spaces;
+    in
+    func sep;
+  concatLinesIndent = concatFuncWithIndent lib.concatStringsSep;
+  concatMapLinesIndent = concatFuncWithIndent lib.concatMapStringsSep;
+  concatMapLines = lib.concatMapStringsSep "\n";
+
 in
 {
 
@@ -401,7 +412,7 @@ in
           frr version 8.5.1
           frr defaults datacenter
           !
-          ${lib.concatMapStringsSep "\n" (iface: ''
+          ${concatMapLines (iface: ''
             vrf vrf${iface.vlan}
              vni ${toString iface.vlanId}
             exit-vrf
@@ -415,7 +426,7 @@ in
            neighbor switches remote-as external
            neighbor switches capability extended-nexthop
            neighbor switches bfd
-           ${lib.concatMapStringsSep "\n " (
+           ${concatMapLinesIndent 1 (
              iface: "neighbor ${iface.link} interface peer-group switches"
            ) fclib.underlay.links}
            !
@@ -436,9 +447,9 @@ in
             ${
               # Workaround for FRR not advertising SVI IP when
               # globally configured
-              lib.concatMapStringsSep "\n  " (
+              concatMapLinesIndent 2 (
                 iface:
-                concatStringsSep "\n  " [
+                concatLinesIndent 2 [
                   ("vni " + (toString iface.vlanId))
                   " advertise-svi-ip"
                   "exit-vni"
@@ -449,7 +460,7 @@ in
            !
           exit
           !
-          ${lib.concatMapStringsSep "\n"
+          ${concatMapLines
             # `kernel` routes are mostly those routes we insert into the
             # kernel routing table through fc-qemu for our virtual machines.
             # `connected` routes are for those (special) cases where the host

--- a/nixos/roles/router/bird2-vrf-bridge.nix
+++ b/nixos/roles/router/bird2-vrf-bridge.nix
@@ -1,0 +1,198 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+with builtins;
+
+let
+  inherit (config) fclib;
+  inherit (config.flyingcircus) location;
+
+  enableVrfBridge = any (net: net.routed or false) (attrValues fclib.network);
+
+  role = config.flyingcircus.roles.router;
+  package = pkgs.bird2-vrf;
+
+  # The set of networks on which we provide floating gateways in this
+  # location is a good proxy for a list of networks whose routes we
+  # should copy into VRF routing tables. On one hand, it accounts for
+  # location-specific details like an access network, so that
+  # e.g. hosts inside VRFs can reach Hydra. On the other hand, it also
+  # provides reverse path routes pointing back to all the places we
+  # otherwise have machines running which might want to reach services
+  # hosted inside a VRF.
+  sourceNetworks = config.flyingcircus.static.floatingGatewayNetworks."${location}";
+  sourceInterfaces = map (net: fclib.network."${net}".interface) sourceNetworks;
+
+  configText =
+    ''
+      log stderr all;
+
+      ipv4 table master4;
+      ipv6 table master6;
+
+      define RTPROT_BIRD = 12;
+      define PRIMARY = ${if role.isPrimary then "true" else "false"};
+
+      protocol device {
+        scan time 60;
+      }
+
+    ''
+    # As well as copying the default route from the main routing
+    # table, we also copy over routes managed by the main Bird
+    # instance. This handles cases like WHQ where keepalived manages
+    # the active default route instead of Bird and Bird manages routes
+    # to DEV.
+    + ''
+      protocol kernel kernel_host_v4 {
+        ipv4 {
+          table master4;
+          export none;
+          import where net = 0.0.0.0/0 || krt_source = RTPROT_BIRD;
+        };
+        learn on;
+      }
+      protocol kernel kernel_host_v6 {
+        ipv6 {
+          table master6;
+          export none;
+          import where net = ::/0 || krt_source = RTPROT_BIRD;
+        };
+        learn on;
+      }
+
+      protocol direct iface_routes {
+        ipv4 {
+          table master4;
+          export none;
+          import all;
+        };
+        ipv6 {
+          table master6;
+          export none;
+          import all;
+        };
+
+        interface ${lib.concatMapStringsSep ", " (name: "\"${name}\"") sourceInterfaces};
+      }
+
+    ''
+    # Bird does not pick up routes pointing to VRF interfaces from the
+    # kernel, so we need to teach it about them ourselves. This means
+    # that if we terminate more than one VRF on a router then we
+    # *should* automatically get inter-VRF routing.
+    + (lib.concatMapStringsSep "\n" (net: ''
+      ipv4 table tbl_${net.vrfInterface}_v4;
+      ipv6 table tbl_${net.vrfInterface}_v6;
+
+      protocol static static_${net.vrfInterface}_v4 {
+        ipv4 {
+          table master4;
+          import all;
+          export none;
+        };
+      ${lib.concatMapStringsSep "\n" (pfx: "  route ${pfx} via \"${net.vrfInterface}\";") net.v4.networks}
+      }
+      protocol static static_${net.vrfInterface}_v6 {
+        ipv6 {
+          table master6;
+          import all;
+          export none;
+        };
+      ${lib.concatMapStringsSep "\n" (pfx: "  route ${pfx} via \"${net.vrfInterface}\";") net.v6.networks}
+      }
+
+      protocol pipe pipe_${net.vrfInterface}_v4 {
+        table tbl_${net.vrfInterface}_v4;
+        peer table master4;
+        import where PRIMARY && proto != "static_${net.vrfInterface}_v4";
+        export none;
+      }
+      protocol pipe pipe_${net.vrfInterface}_v6 {
+        table tbl_${net.vrfInterface}_v6;
+        peer table master6;
+        import where PRIMARY && proto != "static_${net.vrfInterface}_v6";
+        export none;
+      }
+
+      protocol kernel ktable_${net.vrfInterface}_v4 {
+        ipv4 {
+          table tbl_${net.vrfInterface}_v4;
+          import none;
+          export all;
+        };
+
+        kernel table ${toString net.vrfTable};
+      }
+      protocol kernel ktable_${net.vrfInterface}_v6 {
+        ipv6 {
+          table tbl_${net.vrfInterface}_v6;
+          import none;
+          export all;
+        };
+
+        kernel table ${toString net.vrfTable};
+      }
+
+    '') (filter (n: n.routed or false) (attrValues fclib.network)));
+
+in
+{
+  config = lib.mkIf enableVrfBridge {
+    environment.systemPackages = [ package ];
+
+    environment.etc."bird/bird2-vrf.conf".source = pkgs.writeTextFile {
+      name = "bird2-vrf";
+      text = configText;
+      derivationArgs.nativeBuildInputs = [ package ];
+      checkPhase = ''
+        ln -s $out bird2.conf
+        vrf-bird -d -p -c bird2.conf
+      '';
+    };
+
+    environment.etc."iproute2/rt_protos.d/bird-vrf.conf".text = ''
+      201 bird-vrf
+    '';
+
+    systemd.services.bird2-vrf-bridge = {
+      description = "BIRD Internet Routing Daemon (VRF Bridge)";
+      wantedBy = [ "multi-user.target" ];
+      reloadTriggers = [
+        config.environment.etc."bird/bird2-vrf.conf".source
+      ];
+      serviceConfig = {
+        Type = "forking";
+        Restart = "on-failure";
+        User = "bird2";
+        Group = "bird2";
+        ExecStart = "${lib.getExe' package "vrf-bird"} -c /etc/bird/bird2-vrf.conf";
+        ExecReload = "${lib.getExe' package "vrf-birdc"} configure";
+        ExecStop = "${lib.getExe' package "vrf-birdc"} down";
+        RuntimeDirectory = "bird-vrf";
+        CapabilityBoundingSet = [
+          "CAP_NET_ADMIN"
+          "CAP_NET_BIND_SERVICE"
+          "CAP_NET_RAW"
+        ];
+        AmbientCapabilities = [
+          "CAP_NET_ADMIN"
+          "CAP_NET_BIND_SERVICE"
+          "CAP_NET_RAW"
+        ];
+        ProtectSystem = "full";
+        ProtectHome = "yes";
+        ProtectKernelTunables = true;
+        ProtectControlGroups = true;
+        PrivateTmp = true;
+        PrivateDevices = true;
+        SystemCallFilter = "~@cpu-emulation @debug @keyring @module @mount @obsolete @raw-io";
+        MemoryDenyWriteExecute = "yes";
+      };
+    };
+  };
+}

--- a/nixos/roles/router/default.nix
+++ b/nixos/roles/router/default.nix
@@ -103,6 +103,7 @@ in
     ./bind
     ./bird2
     ./keepalived
+    ./bird2-vrf-bridge.nix
     ./chrony.nix
     ./kea.nix
     ./pmacctd.nix

--- a/nixos/roles/router/default.nix
+++ b/nixos/roles/router/default.nix
@@ -73,6 +73,8 @@ let
   ) null config.flyingcircus.encServices;
 
   sensuSourceAddress = head (filter (i: fclib.isIp4 i) (locationSensuServer.ips));
+
+  routedVrfsEnabled = any (net: net.routed or false) (attrValues fclib.network);
 in
 {
   options = {
@@ -114,39 +116,49 @@ in
   config = lib.mkIf role.enable {
 
     flyingcircus.networking.enableInterfaceDefaultRoutes = false;
-    flyingcircus.networking.assignVrfRoutes = any (net: net.routed or false) (attrValues fclib.network);
+    flyingcircus.networking.assignVrfRoutes = routedVrfsEnabled;
 
-    boot.kernel.sysctl = {
-      # It's a router: we want forwarding, obviously
-      "net.ipv4.conf.all.forwarding" = fclib.mkOverridePlatformModule 1;
-      "net.ipv4.conf.default.forwarding" = fclib.mkOverridePlatformModule 1;
-      "net.ipv4.ip_forward" = fclib.mkOverridePlatformModule 1;
-      "net.ipv6.conf.all.forwarding" = fclib.mkOverridePlatformModule 1;
-      "net.ipv6.conf.default.forwarding" = fclib.mkOverridePlatformModule 1;
+    boot.kernel.sysctl =
+      {
+        # It's a router: we want forwarding, obviously
+        "net.ipv4.conf.all.forwarding" = fclib.mkOverridePlatformModule 1;
+        "net.ipv4.conf.default.forwarding" = fclib.mkOverridePlatformModule 1;
+        "net.ipv4.ip_forward" = fclib.mkOverridePlatformModule 1;
+        "net.ipv6.conf.all.forwarding" = fclib.mkOverridePlatformModule 1;
+        "net.ipv6.conf.default.forwarding" = fclib.mkOverridePlatformModule 1;
 
-      # Avoid neighbour discovery table overflow on our relatively large segments
-      "net.ipv4.neigh.default.gc_thresh1" = lib.mkOverride 90 4096;
-      "net.ipv4.neigh.default.gc_thresh2" = lib.mkOverride 90 16384;
-      "net.ipv4.neigh.default.gc_thresh3" = lib.mkOverride 90 32768;
-      "net.ipv6.neigh.default.gc_thresh1" = lib.mkOverride 90 4096;
-      "net.ipv6.neigh.default.gc_thresh2" = lib.mkOverride 90 16384;
-      "net.ipv6.neigh.default.gc_thresh3" = lib.mkOverride 90 32768;
+        # Avoid neighbour discovery table overflow on our relatively large segments
+        "net.ipv4.neigh.default.gc_thresh1" = lib.mkOverride 90 4096;
+        "net.ipv4.neigh.default.gc_thresh2" = lib.mkOverride 90 16384;
+        "net.ipv4.neigh.default.gc_thresh3" = lib.mkOverride 90 32768;
+        "net.ipv6.neigh.default.gc_thresh1" = lib.mkOverride 90 4096;
+        "net.ipv6.neigh.default.gc_thresh2" = lib.mkOverride 90 16384;
+        "net.ipv6.neigh.default.gc_thresh3" = lib.mkOverride 90 32768;
 
-      # fair queuing + codel to avoid buffer bloat in WAN
-      "net.core.default_qdisc" = "fq_codel";
+        # fair queuing + codel to avoid buffer bloat in WAN
+        "net.core.default_qdisc" = "fq_codel";
 
-      # Ensure proper conntracking configuration: if we run out of entries then
-      # packets will get dropped.
-      #
-      # TODO wrong URL
-      # See https://stats.flyingcircus.io/grafana/dashboard/db/kenny01-conntrack
-      # for current usage statistics
-      #
-      # This should use about 300-500 MiB with ~32 entries in each bucket
-      # https://johnleach.co.uk/words/372/netfilter-conntrack-memory-usage
-      "net.netfilter.nf_conntrack_max" = lib.mkOverride 90 1048576;
-      "net.netfilter.nf_conntrack_buckets" = 32768;
-    };
+        # Ensure proper conntracking configuration: if we run out of entries then
+        # packets will get dropped.
+        #
+        # TODO wrong URL
+        # See https://stats.flyingcircus.io/grafana/dashboard/db/kenny01-conntrack
+        # for current usage statistics
+        #
+        # This should use about 300-500 MiB with ~32 entries in each bucket
+        # https://johnleach.co.uk/words/372/netfilter-conntrack-memory-usage
+        "net.netfilter.nf_conntrack_max" = lib.mkOverride 90 1048576;
+        "net.netfilter.nf_conntrack_buckets" = 32768;
+      }
+      // lib.optionalAttrs routedVrfsEnabled {
+        # Accept incoming connections received in VRFs (i.e. not in the
+        # default routing table). This means that e.g. DNS requests to
+        # the resolver received from hosts connected through a VRF
+        # network will be accepted instead of being rejected as if the
+        # port were unreachable.
+        "net.ipv4.tcp_l3mdev_accept" = true;
+        "net.ipv4.udp_l3mdev_accept" = true;
+      };
 
     services.openssh.extraConfig = ''
       # Protect routers more aggressively against DOS on the MaxStartup settings.

--- a/nixos/roles/router/default.nix
+++ b/nixos/roles/router/default.nix
@@ -113,6 +113,7 @@ in
   config = lib.mkIf role.enable {
 
     flyingcircus.networking.enableInterfaceDefaultRoutes = false;
+    flyingcircus.networking.assignVrfRoutes = any (net: net.routed or false) (attrValues fclib.network);
 
     boot.kernel.sysctl = {
       # It's a router: we want forwarding, obviously

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -161,6 +161,29 @@ builtins.mapAttrs (_: patchPhps phpLogPermissionPatch) {
     };
   });
 
+  # Sidecar bird for managing VRF routes on routers
+  bird2-vrf = self.bird2.overrideAttrs (old: {
+    configureFlags = [
+      "--localstatedir=/var"
+      "--runstatedir=/run/bird-vrf"
+    ];
+
+    # Bird will not import routes in the kernel which are tagged with
+    # the "proto bird" flag, as these are considered bird's own
+    # routes. So let's change the VRF Bird's idea of what its "own"
+    # routes are so it can interoperate with the main Bird instance.
+    postPatch = ''
+      echo Updating native route protocol flag
+      ${self.gnused}/bin/sed -i -E -e 's/RTPROT_BIRD/201/g' sysdep/linux/netlink.c
+    '';
+
+    postInstall = ''
+      for prog in bird birdc birdcl; do
+          mv $out/sbin/$prog $out/sbin/vrf-$prog
+      done
+    '';
+  });
+
   inherit (super.callPackage ./boost { }) boost159;
 
   busybox = super.busybox.overrideAttrs (oldAttrs: {


### PR DESCRIPTION
This change extends the router role to support providing gateway services to layer 3 routed networks with VRFs. This includes (yet another) Bird instance which copies relevant routes from the main routing table into VRF routing tables in order to provide external connectivity to hosts connected via VRFs.

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [x] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - This change increases the complexity of the router role, as we now have potentially multiple routing tables which are dynamically managed.
  - The existing forwarding firewall should ensure that the management VLAN remains protected, as this uses interface names for matching packets.
- [x] Security requirements tested? (EVIDENCE)
  - Tested in dev. After updating the default routes on some test VMs to point over the pub network, external services remained reachable.