### PR TITLE
remove go_1_22 from important packages, as removed upstream (EOL)

### DIFF
--- a/release/important_packages.json
+++ b/release/important_packages.json
@@ -57,7 +57,6 @@
   "gnumake",
   "gnupg",
   "go",
-  "go_1_22",
   "go_1_23",
   "grafana",
   "grub2",

--- a/release/package-versions.json
+++ b/release/package-versions.json
@@ -284,11 +284,6 @@
     "pname": "go",
     "version": "1.24.1"
   },
-  "go_1_22": {
-    "name": "go-1.22.12",
-    "pname": "go",
-    "version": "1.22.12"
-  },
   "go_1_23": {
     "name": "go-1.23.7",
     "pname": "go",


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

## PR release workflow (internal)

- [ ] PR has internal ticket (no, general release process)
- [ ] internal issue ID (PL-…) part of branch name
- [ ] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->

Needs to be manually merged as 25.05

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Not important here. Just removed from important packages
- [x] Security requirements tested? (EVIDENCE)
