### PR TITLE
[25.05] fix eval after nixpkgs update

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -1,5 +1,5 @@
 # Collection of own packages
-{ pkgs, pythonPackages }:
+{ pkgs, pyPackages }:
 
 let
   self = {
@@ -7,7 +7,7 @@ let
 
     fc = import ./fc {
       inherit (self) callPackage;
-      inherit pkgs pythonPackages;
+      inherit pkgs pyPackages;
     };
 
   };

--- a/pkgs/fc/agent/default.nix
+++ b/pkgs/fc/agent/default.nix
@@ -9,20 +9,15 @@
   libyaml,
   multipath-tools,
   nix,
-  buildPythonPackage,
-  pythonPackages,
+  pyPackages,
   python,
   util-linux,
   xfsprogs,
-  pytest,
-  structlog,
   enableSlurm ? false,
 }:
 
 let
-  py = pythonPackages;
-
-  pytest-structlog = py.buildPythonPackage rec {
+  pytest-structlog = pyPackages.buildPythonPackage rec {
     pname = "pytest-structlog";
     version = "0.6-cb82f00";
 
@@ -33,13 +28,13 @@ let
       hash = "sha256-ktLsdEtxfiWhCTTaKowBoAAijOF9640m5XV/rdahpl0=";
     };
 
-    buildInputs = [
+    buildInputs = with pyPackages; [
       pytest
       structlog
     ];
   };
 
-  stamina = py.buildPythonPackage rec {
+  stamina = pyPackages.buildPythonPackage rec {
     pname = "stamina";
     version = "23.1.0";
     format = "pyproject";
@@ -49,12 +44,12 @@ let
       hash = "sha256-sWzj1S1liqdduBP8amZht3Cr/qkV9yzaSOMl8qeFR4Y=";
     };
 
-    nativeBuildInputs = with py; [
+    nativeBuildInputs = with pyPackages; [
       hatchling
       hatch-vcs
       hatch-fancy-pypi-readme
     ];
-    propagatedBuildInputs = with py; [
+    propagatedBuildInputs = with pyPackages; [
       structlog
       tenacity
       typing-extensions
@@ -62,41 +57,41 @@ let
   };
 
 in
-buildPythonPackage rec {
+pyPackages.buildPythonPackage rec {
   name = "fc-agent-${version}";
   version = "1.0";
   namePrefix = "";
   src = ./.;
   checkInputs = [
-    py.freezegun
-    py.pytest-cov
-    py.responses
-    py.pytest-mock
-    py.pytest-subprocess
+    pyPackages.freezegun
+    pyPackages.pytest-cov
+    pyPackages.responses
+    pyPackages.pytest-mock
+    pyPackages.pytest-subprocess
     pytest-structlog
   ];
   nativeCheckInputs = [
-    py.pytestCheckHook
+    pyPackages.pytestCheckHook
   ];
   propagatedBuildInputs =
     [
       gitMinimal
       nix
-      py.click
-      py.colorama
-      py.configobj
-      py.python-dateutil
-      py.iso8601
-      py.netaddr
-      py.pendulum
-      py.pytz
-      py.requests
-      py.rich
-      py.setuptools
-      py.shortuuid
-      py.structlog
-      py.typer
-      py.pyyaml
+      pyPackages.click
+      pyPackages.colorama
+      pyPackages.configobj
+      pyPackages.python-dateutil
+      pyPackages.iso8601
+      pyPackages.netaddr
+      pyPackages.pendulum
+      pyPackages.pytz
+      pyPackages.requests
+      pyPackages.rich
+      pyPackages.setuptools
+      pyPackages.shortuuid
+      pyPackages.structlog
+      pyPackages.typer
+      pyPackages.pyyaml
       stamina
       util-linux
     ]
@@ -104,12 +99,12 @@ buildPythonPackage rec {
       dmidecode
       gptfdisk
       multipath-tools
-      py.pystemd
-      py.systemd
+      pyPackages.pystemd
+      pyPackages.systemd
       xfsprogs
     ]
     ++ lib.optionals enableSlurm [
-      py.pyslurm
+      pyPackages.pyslurm
     ];
   dontStrip = true;
   doCheck = true;
@@ -121,7 +116,7 @@ buildPythonPackage rec {
     runHook postCheck
   '';
   passthru.pythonDevEnv = python.withPackages (
-    _: checkInputs ++ [ py.pytest ] ++ propagatedBuildInputs
+    _: checkInputs ++ [ pyPackages.pytest ] ++ propagatedBuildInputs
   );
 
   outputs = [

--- a/pkgs/fc/default.nix
+++ b/pkgs/fc/default.nix
@@ -1,14 +1,15 @@
 {
   pkgs,
-  pythonPackages,
+  pyPackages,
   callPackage,
 }:
 
 rec {
   recurseForDerivations = true;
 
-  agent = pythonPackages.callPackage ./agent {
+  agent = callPackage ./agent {
     nix = pkgs.nixVersions.nix_2_25;
+    pyPackages = pyPackages;
   };
   agentWithSlurm = agent.override { enableSlurm = true; };
 
@@ -16,7 +17,7 @@ rec {
 
   # fc-ceph does not need to be versioned on the Nix-package level as
   # it can be parametrized via config file for each individual subsystem.
-  ceph = pythonPackages.callPackage ./ceph {
+  ceph = pyPackages.callPackage ./ceph {
     inherit agent blockdev;
   };
 
@@ -87,7 +88,7 @@ rec {
   sensusyntax = callPackage ./sensusyntax { };
   telegraf-collect-psi = callPackage ./telegraf-collect-psi { };
   telegraf-routes-summary = callPackage ./telegraf-routes-summary { };
-  trafficclient = pythonPackages.callPackage ./trafficclient.nix { };
+  trafficclient = pyPackages.callPackage ./trafficclient.nix { };
   userscan = callPackage ./userscan.nix { };
   util-physical = callPackage ./util-physical { };
 }

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -139,7 +139,7 @@ builtins.mapAttrs (_: patchPhps phpLogPermissionPatch) {
       pkgs = self;
       # Only used by the agent for now but we should probably use this
       # for all our Python packages and update Python in sync then.
-      pythonPackages = self.python312Packages;
+      pyPackages = self.python312Packages;
     }
   );
 


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/commit/4c69dd5e83277af36bfbac8c21d1dd8196b87012 broke eval.

@flyingcircusio/release-managers

## PR release workflow (internal)

- [ ] PR has internal ticket (no, after update fix) 
- [ ] internal issue ID (PL-…) part of branch name
- [ ] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Builds should work
- [x] Security requirements tested? (EVIDENCE)
  - Assured by Hydra, still in dev