### PR TITLE
Check for convergent forwarding settings in Docker test

### DIFF
--- a/tests/docker.nix
+++ b/tests/docker.nix
@@ -55,6 +55,11 @@ import ./make-test-python.nix (
         # Taken from upstream test
         machine.succeed("grep 1 /proc/sys/net/ipv4/conf/all/forwarding")
         machine.succeed("grep 1 /proc/sys/net/ipv4/conf/default/forwarding")
+
+      with subtest("sysctl forwarding should be enabled after reloading"):
+        machine.succeed("systemctl restart systemd-sysctl.service")
+        machine.succeed("grep 1 /proc/sys/net/ipv4/conf/all/forwarding")
+        machine.succeed("grep 1 /proc/sys/net/ipv4/conf/default/forwarding")
     '';
   }
 )


### PR DESCRIPTION
We've previously accidentally turned off IP forwarding when Docker is enabled without this misconfiguration being caught by an integration test. This was in part due to a mismatch between the host sysctl configuration and the configuration which the Docker daemon applies when it starts – Docker would start and would configure forwarding itself, until the system sysctl configuration was reloaded, which would then turn forwarding off.

This change extends the NixOS test to ensure that forwarding is enabled even after the host sysctl configuration has been reloaded.

PL-133589

@flyingcircusio/release-managers

## Release process

- [x] ~~Created changelog entry using `./changelog.sh`~~

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [x] ensure the merge bot has determined a merge date
- [x] ensure all checks are green
- [x] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Integration test to catch misconfigurations.
- [x] Security requirements tested? (EVIDENCE)
  - Test passes manually under Hydra. I've also tested the patch on top of r2025\_008 with the incorrect forwarding configuration, which causes the test to (correctly) fail.
