### PR TITLE
Update Bird configuration for RZOB

### DIFF
--- a/nixos/roles/router/bird2/default.nix
+++ b/nixos/roles/router/bird2/default.nix
@@ -35,9 +35,17 @@ let
 
     ipv4 table master4;
     ipv6 table master6;
+
+    # Flag for operating BGP session migration from NixOS config
+    define MIGRATION_STATE=${toString role.migrationState};
   '';
 in
 {
+  options.flyingcircus.roles.router.migrationState = lib.mkOption {
+    type = lib.types.ints.unsigned;
+    default = 0;
+  };
+
   config = lib.mkIf role.enable {
     services.bird2 = {
       enable = true;

--- a/nixos/roles/router/bird2/rzob.conf
+++ b/nixos/roles/router/bird2/rzob.conf
@@ -1,22 +1,3 @@
-protocol static local_rzob_4 {
-  ipv4 {
-    table master4;
-  };
-
-  route 185.105.252.0/24 unreachable;
-  route 185.105.253.0/24 unreachable;
-  route 195.62.125.0/24 unreachable;
-  route 195.62.126.0/24 unreachable;
-}
-
-protocol static local_rzob_6 {
-  ipv6 {
-    table master6;
-  };
-
-  route 2a02:248:101::/48 unreachable;
-}
-
 protocol device {
   scan time 60;
 }
@@ -26,33 +7,128 @@ protocol bfd {
   interface "ethtr-kamp-a", "ethtr-kamp-b";
 }
 
-filter net_rzob_4 {
-  if net ~ [ 195.62.125.0/24, 195.62.126.0/24 ]
-    then bgp_community.add((65535, 65281));  # No export because those are KAMP-owned
+# migration states:
+# 1. only announce existing networks over the kamp sessions
+# 2. as above, also announce new networks over g1 sessions
+# 3. announce kamp space to kamp and fcio space to g1
+# 4. announce all subnets over the g1 sessions only
 
-  if net ~ [ 185.105.252.0/24, 185.105.253.0/24, 195.62.125.0/24, 195.62.126.0/24 ] then {
-    bgp_med = UPLINK_MED;
-    accept;
-  } else reject;
+define MIGRATION_KAMP_ONLY = 1;
+define MIGRATION_G1_NEWNETS = 2;
+define MIGRATION_G1_ALLFCIO = 3;
+define MIGRATION_G1_ONLY = 4;
+
+attribute int public_export;
+attribute int announce_g1_only;
+
+protocol static local_rzob_kamp_4 {
+  ipv4 {
+    table master4;
+    import filter {
+      public_export = 0;
+      accept;
+    };
+  };
+
+  route 195.62.125.0/24 unreachable;
+  route 195.62.126.0/24 unreachable;
 }
 
-filter net_rzob_6 {
-  if net ~ [ 2a02:248:101::/48+ ]
-    then bgp_community.add((65535, 65281));  # No export because those are KAMP-owned
+protocol static local_rzob_kamp_6 {
+  ipv6 {
+    table master6;
+    import filter {
+      public_export = 0;
+      accept;
+    };
+  };
 
-  if net ~ [ 2a02:248:101::/48+ ] then {
-    bgp_med = UPLINK_MED;
-    accept;
-  } else reject;
+  route 2a02:248:101::/48 unreachable;
 }
 
-filter default_route_4 {
-  if net = 0.0.0.0/0 then accept; else reject;
+protocol static local_rzob_fcio_4 {
+  ipv4 {
+    table master4;
+    import filter {
+      public_export = 1;
+      accept;
+    };
+  };
+
+  route 185.105.252.0/24 unreachable;
+  route 185.105.253.0/24 unreachable;
 }
 
-filter default_route_6 {
-  if net = ::/0 then accept; else reject;
+protocol static local_rzob_fcio_6 {
+  ipv6 {
+    table master6;
+    import filter {
+      public_export = 1;
+      announce_g1_only = 1;
+      accept;
+    };
+  };
+
+  route 2a06:3a80:0200::/40 unreachable;
 }
+
+# route filter logic
+
+function is_default_route() {
+  if (net.type = NET_IP4 && net = 0.0.0.0/0) then return true;
+  if (net.type = NET_IP6 && net = ::/0) then return true;
+  return false;
+}
+
+filter kamp_route_import {
+  if (MIGRATION_STATE != MIGRATION_G1_ONLY && is_default_route()) then accept;
+  reject;
+}
+
+filter g1_priv_route_import {
+  if (MIGRATION_STATE = MIGRATION_G1_ONLY && is_default_route()) then accept;
+  reject;
+}
+
+filter g1_pub_route_import {
+  if (MIGRATION_STATE != MIGRATION_KAMP_ONLY && is_default_route()) then accept;
+  reject;
+}
+
+filter kamp_route_export {
+  if !defined(public_export) then reject;
+  if defined(announce_g1_only) then reject;
+
+  if (MIGRATION_STATE = MIGRATION_G1_ALLFCIO && public_export = 1) then reject;
+  if MIGRATION_STATE = MIGRATION_G1_ONLY then reject;
+
+  if public_export = 0 then bgp_community.add((65535, 65281)); # no-export because these are kamp owned
+  else bgp_med = UPLINK_MED;
+  accept;
+}
+
+filter g1_priv_route_export {
+  if !defined(public_export) then reject;
+  if public_export != 0 then reject;
+
+  if (MIGRATION_STATE != MIGRATION_G1_ONLY) then reject;
+
+  bgp_med = UPLINK_MED;
+  accept;
+}
+
+filter g1_pub_route_export {
+  if !defined(public_export) then reject;
+  if public_export != 1 then reject;
+
+  if MIGRATION_STATE = MIGRATION_KAMP_ONLY then reject;
+  if (MIGRATION_STATE = MIGRATION_G1_NEWNETS && !defined(announce_g1_only)) then reject;
+
+  bgp_med = UPLINK_MED;
+  accept;
+}
+
+# kernel integration
 
 protocol kernel kernel_4 {
   ipv4 {
@@ -76,42 +152,106 @@ protocol kernel kernel_6 {
   merge paths on;
 }
 
-template bgp peer_kamp {
-  local as 64514;
+# bgp template definitions
 
+template bgp peer_rzob {
   bfd;
   connect retry time 15;
   error wait time 5,10;
 }
 
-template bgp peer_kamp_4 from peer_kamp {
+template bgp peer_rzob_aspriv from peer_rzob {
+  local as 64514;
+  neighbor as 8648;
+}
+
+template bgp peer_rzob_aspub from peer_rzob {
+  local as 41981;
+  neighbor as 8648;
+}
+
+template bgp peer_rzob_kamp_4 from peer_rzob_aspriv {
   ipv4 {
     table master4;
-    import filter default_route_4;
-    export filter net_rzob_4;
+    import filter kamp_route_import;
+    export filter kamp_route_export;
   };
 }
-
-template bgp peer_kamp_6 from peer_kamp {
+template bgp peer_rzob_kamp_6 from peer_rzob_aspriv {
   ipv6 {
     table master6;
-    import filter default_route_6;
-    export filter net_rzob_6;
+    import filter kamp_route_import;
+    export filter kamp_route_export;
   };
 }
 
-protocol bgp peer_kamp_bbr_ob_01_4 from peer_kamp_4 {
-  neighbor 195.62.112.81 as 8648;
+template bgp peer_rzob_g1priv_4 from peer_rzob_aspriv {
+  ipv4 {
+    table master4;
+    import filter g1_priv_route_import;
+    export filter g1_priv_route_export;
+  };
+}
+template bgp peer_rzob_g1priv_6 from peer_rzob_aspriv {
+  ipv6 {
+    table master6;
+    import filter g1_priv_route_import;
+    export filter g1_priv_route_export;
+  };
 }
 
-protocol bgp peer_kamp_bbr_ob_02_4 from peer_kamp_4 {
-  neighbor 195.62.112.89 as 8648;
+template bgp peer_rzob_g1pub_4 from peer_rzob_aspub {
+  ipv4 {
+    table master4;
+    import filter g1_pub_route_import;
+    export filter g1_pub_route_export;
+  };
+}
+template bgp peer_rzob_g1pub_6 from peer_rzob_aspub {
+  ipv6 {
+    table master6;
+    import filter g1_pub_route_import;
+    export filter g1_pub_route_export;
+  };
 }
 
-protocol bgp peer_kamp_bbr_ob_01_6 from peer_kamp_6 {
-  neighbor 2a02:248:0:1040::1 as 8648;
+# bgp session definitions
+
+protocol bgp peer_rzob_kamp_01_4 from peer_rzob_kamp_4 {
+  neighbor 195.62.112.81;
+}
+protocol bgp peer_rzob_kamp_02_4 from peer_rzob_kamp_4 {
+  neighbor 195.62.112.89;
+}
+protocol bgp peer_rzob_kamp_01_6 from peer_rzob_kamp_6 {
+  neighbor 2a02:248:0:1040::1;
+}
+protocol bgp peer_rzob_kamp_02_6 from peer_rzob_kamp_6 {
+  neighbor 2a02:248:0:1041::1;
 }
 
-protocol bgp peer_kamp_bbr_ob_02_6 from peer_kamp_6 {
-  neighbor 2a02:248:0:1041::1 as 8648;
+protocol bgp peer_rzob_g1priv_01_4 from peer_rzob_g1priv_4 {
+  neighbor 185.84.83.145;
+}
+protocol bgp peer_rzob_g1priv_02_4 from peer_rzob_g1priv_4 {
+  neighbor 185.84.83.146;
+}
+protocol bgp peer_rzob_g1priv_01_6 from peer_rzob_g1priv_6 {
+  neighbor 2a02:248:ffff:640::1;
+}
+protocol bgp peer_rzob_g1priv_02_6 from peer_rzob_g1priv_6 {
+  neighbor 2a02:248:ffff:640::2;
+}
+
+protocol bgp peer_rzob_g1pub_01_4 from peer_rzob_g1pub_4 {
+  neighbor 185.84.83.137;
+}
+protocol bgp peer_rzob_g1pub_02_4 from peer_rzob_g1pub_4 {
+  neighbor 185.84.83.138;
+}
+protocol bgp peer_rzob_g1pub_01_6 from peer_rzob_g1pub_6 {
+  neighbor 2a02:248:ffff:639::1;
+}
+protocol bgp peer_rzob_g1pub_02_6 from peer_rzob_g1pub_6 {
+  neighbor 2a02:248:ffff:639::2;
 }

--- a/nixos/roles/router/bird2/rzob.conf
+++ b/nixos/roles/router/bird2/rzob.conf
@@ -57,6 +57,7 @@ protocol static local_rzob_fcio_4 {
 
   route 185.105.252.0/24 unreachable;
   route 185.105.253.0/24 unreachable;
+  route 185.105.254.0/24 unreachable;
 }
 
 protocol static local_rzob_fcio_6 {


### PR DESCRIPTION
This change includes the updated Bird config which is currently deployed (though a dev checkout) in RZOB.

PL-133260

@flyingcircusio/release-managers

## Release process

- [x] ~~Created changelog entry using `./changelog.sh`~~

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - This change affects the configuration of the uplink in RZOB.
- [x] Security requirements tested? (EVIDENCE)
  - This change includes the currently active Bird config rebased on top of the current dev branch – merging this config into a released platform version means we can unpin the routers from a dev checkout.
