### PR TITLE
Ensure that network configuration remains intact during critical path of switch-to-configuration

### DIFF
--- a/changelog.d/20250410_084648_PL-133570-config-switch-nic-shutdown_scriv.md
+++ b/changelog.d/20250410_084648_PL-133570-config-switch-nic-shutdown_scriv.md
@@ -1,0 +1,21 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+
+### NixOS XX.XX platform
+
+- nfs: fix platform network configuration to prevent machines with NFS
+  mountpoints from hanging when switching to new system
+  configurations. (PL-133570)

--- a/nixos/platform/network.nix
+++ b/nixos/platform/network.nix
@@ -538,6 +538,7 @@ in
                 pkgs.jq
                 pkgs.util-linux
               ];
+              stopIfChanged = false;
               script =
                 ''
                   set -e

--- a/nixos/platform/network.nix
+++ b/nixos/platform/network.nix
@@ -511,6 +511,11 @@ in
           systemd-sysctl.restartTriggers = lib.mkIf (!isNull fclib.underlay) [
             config.environment.etc."sysctl.d/70-fcio-underlay.conf".source
           ];
+          # Stop+starting the network can break
+          # switch-to-configuration on NFS clients by reloading the
+          # systemd config when the NFS server is unreachable. Do an
+          # in-place restart after systemd has reloaded instead.
+          network-setup.stopIfChanged = fclib.mkOverrideUpstreamModule false;
         }
         //
 

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -104,7 +104,7 @@ in
   mongodb42 = callTest ./mongodb.nix { version = "4.2"; };
   mysql57 = callTest ./mysql.nix { rolename = "mysql57"; };
   network = callSubTests ./network { };
-  nfs = callTest ./nfs.nix { };
+  nfs = callSubTests ./nfs.nix { };
   nginx = callTest ./nginx.nix { };
   nix-version = callTest ./nix-version.nix { };
   nodejs = callTest ./nodejs.nix { };

--- a/tests/nfs.nix
+++ b/tests/nfs.nix
@@ -102,190 +102,281 @@ import ./make-test-python.nix (
   in
   {
     name = "nfs";
-    nodes = {
-      client1 = clientConfig 1 {
-        networking.domain = "fcio.net"; # PL-133063
-      };
-      client2 = clientConfig 2 { };
-
-      server =
-        { ... }:
-        {
-          imports = [ (testlib.fcConfig { id = 3; }) ];
-          config = {
-            flyingcircus.roles.nfs_rg_share.enable = true;
-            flyingcircus.encServiceClients = encServiceClients;
-            # XXX: same as upstream test, let's see how they fix this
-            networking.firewall.enable = false;
-            users.users.u = user;
+    testCases = {
+      role = {
+        name = "role";
+        nodes = {
+          client1 = clientConfig 1 {
             networking.domain = "fcio.net"; # PL-133063
-
-            specialisation.withCustomFlags.configuration.flyingcircus.roles.nfs_rg_share.clientFlags = [
-              "rw"
-              "sync"
-              "no_root_squash"
-              "no_subtree_check"
-            ];
           };
+          client2 = clientConfig 2 { };
+
+          server =
+            { ... }:
+            {
+              imports = [ (testlib.fcConfig { id = 3; }) ];
+              config = {
+                flyingcircus.roles.nfs_rg_share.enable = true;
+                flyingcircus.encServiceClients = encServiceClients;
+                # XXX: same as upstream test, let's see how they fix this
+                networking.firewall.enable = false;
+                users.users.u = user;
+                networking.domain = "fcio.net"; # PL-133063
+
+                specialisation.withCustomFlags.configuration.flyingcircus.roles.nfs_rg_share.clientFlags = [
+                  "rw"
+                  "sync"
+                  "no_root_squash"
+                  "no_subtree_check"
+                ];
+              };
+            };
         };
+
+        testScript =
+          { nodes, ... }:
+          ''
+            import io
+            import queue
+            import re
+            import time
+
+            server.start()
+            server.wait_for_unit("nfs-server")
+            server.wait_for_unit("nfs-idmapd")
+            server.wait_for_unit("nfs-mountd")
+
+            def show_succeed_content(machine, cmd, expected_content):
+                code, result = machine.execute(cmd)
+                print(f"$ {cmd}")
+                print(result)
+                assert code == 0, f"ERROR: result code {code}"
+                if result != expected_content:
+                    print(repr(result))
+                    print(repr(expected_content))
+                    result = result.splitlines(keepends=True)
+                    expected_content = expected_content.splitlines(keepends=True)
+                    print(
+                      "".join(difflib.ndiff(result, expected_content)), end="")
+                    assert False, "Expected content does not match"
+
+            show_succeed_content(server,
+              "${pkgs.strace}/bin/strace showmount --exports",
+              """\
+            Export list for server:
+            /srv/nfs/shared client1.fcio.net
+            """)
+
+            client1.start()
+            client2.start()
+
+            server.succeed("chown test ${sdir}")
+
+            # user test on server should be able to write to shared dir
+            server.succeed("sudo -u test sh -c 'echo test_on_server > ${sdir}/test'")
+
+            # share will be mounted after boot
+            client1.wait_for_unit("multi-user.target")
+            client2.wait_for_unit("multi-user.target")
+
+            # enable debugging
+            # client1.execute("rpcdebug -m nfs -s all")
+            # client1.execute("rpcdebug -m rpc -s all")
+            # client2.execute("rpcdebug -m nfs -s all")
+            # client2.execute("rpcdebug -m rpc -s all")
+            # server.execute("rpcdebug -m nfsd -s all")
+            # server.execute("rpcdebug -m rpc -s all")
+
+            # PL-133063
+            with subtest("NFS client and server can be resolved via /etc/hosts"):
+              server_hosts = server.succeed('cat /etc/hosts')
+              print("server_hosts", server_hosts, sep="\n")
+              client1_hosts = client1.succeed('cat /etc/hosts')
+              print("client1_hosts", client1_hosts, sep="\n")
+              client2_hosts = client2.succeed('cat /etc/hosts')
+              print("client2_hosts", client2_hosts, sep="\n")
+              exportinfo = server.succeed('cat /etc/exports')
+              print("exportinfo", exportinfo, sep="\n")
+              mountinfo_client1 = client1.succeed('cat /etc/fstab | grep ${cdir}')
+              print("mountinfo_client1", mountinfo_client1, sep="\n")
+              mountinfo_client2 = client2.succeed('cat /etc/fstab | grep ${cdir}')
+              print("mountinfo_client2", mountinfo_client2, sep="\n")
+
+              assert "client1.fcio.net client1" in server_hosts, "client1.fcio.net missing from server hosts file"
+              assert "server.fcio.net" in client1_hosts, "server missing from client1 host file"
+              assert "server.fcio.net" in mountinfo_client1, "NFS server domain missing from fstab"
+              assert "client1.fcio.net(" in exportinfo, "client1 domain missing from exports file"
+
+              # TODO: For machines without a domain, the mechanism does not fully work as intended:
+              # `client2` only announces itself without a domain in `flyingcircus.encAddresses`
+              # and thus is present only as `client2` in /etc/hosts. But for NFS mounts, its hostname is
+              # appended to the local domain of each other machine locally.
+              # Hence, resolving the NFS domain name is not possible via the hosts file in
+              # this particular edge case, it cannot be exported to successfully, and the NFS mounting fails.
+
+              # As a workaround this is acceptable, as all real machines share the same domain.
+              # The asserts below reflect the *is* state, not the *desired* state:
+              assert "client2" in server_hosts, "client2 missing from server hosts file"
+              assert "client2.fcio.net(" in exportinfo, "client2 missing from exports file"
+              assert "server.fcio.net" in mountinfo_client2, "NFS server domain missing from fstab"
+
+              print(client1.execute("findmnt")[1])
+              print(client2.execute("findmnt")[1])
+              print(client2.execute("systemctl status mnt-nfs-shared.mount")[1])
+
+            with subtest("automount and basic interactions"):
+              client1.execute("grep test_on_server ${cdir}/test")
+              print(client1.execute("mount")[1])
+              print(client1.execute("journalctl -u mnt-nfs-shared.automount")[1])
+              print(server.execute("journalctl -u nfs-server")[1])
+              print(server.execute("journalctl -u nfs-idmapd")[1])
+              print(server.execute("journalctl -u nfs-mountd")[1])
+
+              client1.succeed("sudo -u test sh -c 'echo test_on_client > ${cdir}/test'")
+              server.succeed("grep test_on_client ${sdir}/test")
+
+              client1.fail("echo from_root_user > ${cdir}/test")
+              server.succeed("grep test_on_client ${sdir}/test")
+
+              # Verify proper shutdown while NFS is being used.
+              # See PL-129954
+              client1.wait_for_unit("httpd.service")
+              client1.succeed("cd ${cdir}")
+
+              server.copy_from_host("${php_blocking_script}", "${sdir}/index.php")
+
+              client1.execute('curl -v http://localhost:8000/index.php >&2 &')
+              time.sleep(2)
+              print(client1.execute('lsof -n ${cdir}/test2')[1])
+              print(client1.execute('journalctl -u httpd')[1])
+              content = client1.execute('cat ${cdir}/test2')[1]
+              assert content == "asdf", repr(content)
+
+            deadline = time.time() + 20
+            def wait_for_console_text(self, regex: str) -> str:
+                self.log("waiting for {} to appear on console".format(regex))
+                # Buffer the console output, this is needed
+                # to match multiline regexes.
+                console = io.StringIO()
+                while time.time() < deadline:
+                    try:
+                        console.write(self.last_lines.get(block=False))
+                    except queue.Empty:
+                        time.sleep(1)
+                        continue
+                    console.seek(0)
+                    matches = re.search(regex, console.read())
+                    if matches is not None:
+                        return console.getvalue()
+
+                assert False, "Did not shut down cleanly (timeout)"
+
+            client1.execute("poweroff", check_return=False)
+
+            console = wait_for_console_text(client1, "reboot: Power down")
+
+            assert "Failed unmounting" not in console, "Unmounting NFS cleanly failed, check console output"
+
+            client1.wait_for_shutdown()
+
+            config = server.execute('cat /etc/exports')[1]
+            assert "rw,sync,root_squash,no_subtree_check" in config, "default flags not found"
+
+            server.succeed('${nodes.server.system.build.toplevel}/specialisation/withCustomFlags/bin/switch-to-configuration test')
+
+            config = server.execute('cat /etc/exports')[1]
+            assert "rw,sync,root_squash,no_subtree_check" not in config, "default flags found but not expected"
+            assert "rw,sync,no_root_squash,no_subtree_check" in config, "custom flags not found"
+
+          '';
+
+      };
+      network-switch = {
+        name = "network-switch";
+        nodes = {
+          client =
+            { lib, ... }:
+            {
+              imports = [ (clientConfig 1 { }) ];
+              config = {
+                networking.domain = "fcio.net";
+
+                specialisation = {
+                  withOtherResolver.configuration.networking.nameservers = lib.mkVMOverride [
+                    "192.0.2.1"
+                  ];
+
+                  withOtherAddresses.configuration.networking.interfaces.ethsrv.ipv4.addresses = [
+                    {
+                      address = "198.51.100.42";
+                      prefixLength = 24;
+                    }
+                  ];
+
+                  withOtherLinkConfig.configuration.systemd.services.ethsrv-netdev.script = ''
+                    echo hello world from ethsrv-netdev.service
+                  '';
+                };
+              };
+            };
+
+          server =
+            { ... }:
+            {
+              imports = [ (testlib.fcConfig { id = 2; }) ];
+              config = {
+                flyingcircus.roles.nfs_rg_share.enable = true;
+                flyingcircus.encServiceClients = [
+                  {
+                    node = "client.gocept.net";
+                    service = "nfs_rg_share-server";
+                  }
+                ];
+                # XXX: same as upstream test, let's see how they fix this
+                networking.firewall.enable = false;
+                users.users.u = user;
+                networking.domain = "fcio.net"; # PL-133063
+              };
+            };
+        };
+        testScript = ''
+          server.start()
+          server.wait_for_unit("nfs-server")
+          server.wait_for_unit("nfs-idmapd")
+          server.wait_for_unit("nfs-mountd")
+
+          client.start()
+          client.wait_for_unit("multi-user.target")
+
+          def switch_to_specialisation(spec):
+              try:
+                  client.succeed(f"/run/current-system/specialisation/{spec}/bin/switch-to-configuration test", timeout=20)
+              except Exception:
+                  _, out = client.execute("ps auxf")
+                  print(out)
+                  raise
+
+          def reset_specialisation():
+              client.succeed(f"/run/booted-system/bin/switch-to-configuration test", timeout=20)
+
+          with subtest("nfs automount functions correctly"):
+              server.succeed("echo hello_world > ${sdir}/message")
+              client.succeed("grep -F hello_world ${cdir}/message")
+
+          with subtest("changing interface addresses functions correctly"):
+              switch_to_specialisation("withOtherAddresses")
+
+          reset_specialisation()
+
+          with subtest("changing link configuration functions correctly"):
+              switch_to_specialisation("withOtherLinkConfig")
+
+          reset_specialisation()
+
+          with subtest("changing network-setup.service functions correctly"):
+              switch_to_specialisation("withOtherResolver")
+        '';
+      };
     };
-
-    testScript =
-      { nodes, ... }:
-      ''
-        import io
-        import queue
-        import re
-        import time
-
-        server.start()
-        server.wait_for_unit("nfs-server")
-        server.wait_for_unit("nfs-idmapd")
-        server.wait_for_unit("nfs-mountd")
-
-        def show_succeed_content(machine, cmd, expected_content):
-            code, result = machine.execute(cmd)
-            print(f"$ {cmd}")
-            print(result)
-            assert code == 0, f"ERROR: result code {code}"
-            if result != expected_content:
-                print(repr(result))
-                print(repr(expected_content))
-                result = result.splitlines(keepends=True)
-                expected_content = expected_content.splitlines(keepends=True)
-                print(
-                  "".join(difflib.ndiff(result, expected_content)), end="")
-                assert False, "Expected content does not match"
-
-        show_succeed_content(server,
-          "${pkgs.strace}/bin/strace showmount --exports",
-          """\
-        Export list for server:
-        /srv/nfs/shared client1.fcio.net
-        """)
-
-        client1.start()
-        client2.start()
-
-        server.succeed("chown test ${sdir}")
-
-        # user test on server should be able to write to shared dir
-        server.succeed("sudo -u test sh -c 'echo test_on_server > ${sdir}/test'")
-
-        # share will be mounted after boot
-        client1.wait_for_unit("multi-user.target")
-        client2.wait_for_unit("multi-user.target")
-
-        # enable debugging
-        # client1.execute("rpcdebug -m nfs -s all")
-        # client1.execute("rpcdebug -m rpc -s all")
-        # client2.execute("rpcdebug -m nfs -s all")
-        # client2.execute("rpcdebug -m rpc -s all")
-        # server.execute("rpcdebug -m nfsd -s all")
-        # server.execute("rpcdebug -m rpc -s all")
-
-        # PL-133063
-        with subtest("NFS client and server can be resolved via /etc/hosts"):
-          server_hosts = server.succeed('cat /etc/hosts')
-          print("server_hosts", server_hosts, sep="\n")
-          client1_hosts = client1.succeed('cat /etc/hosts')
-          print("client1_hosts", client1_hosts, sep="\n")
-          client2_hosts = client2.succeed('cat /etc/hosts')
-          print("client2_hosts", client2_hosts, sep="\n")
-          exportinfo = server.succeed('cat /etc/exports')
-          print("exportinfo", exportinfo, sep="\n")
-          mountinfo_client1 = client1.succeed('cat /etc/fstab | grep ${cdir}')
-          print("mountinfo_client1", mountinfo_client1, sep="\n")
-          mountinfo_client2 = client2.succeed('cat /etc/fstab | grep ${cdir}')
-          print("mountinfo_client2", mountinfo_client2, sep="\n")
-
-          assert "client1.fcio.net client1" in server_hosts, "client1.fcio.net missing from server hosts file"
-          assert "server.fcio.net" in client1_hosts, "server missing from client1 host file"
-          assert "server.fcio.net" in mountinfo_client1, "NFS server domain missing from fstab"
-          assert "client1.fcio.net(" in exportinfo, "client1 domain missing from exports file"
-
-          # TODO: For machines without a domain, the mechanism does not fully work as intended:
-          # `client2` only announces itself without a domain in `flyingcircus.encAddresses`
-          # and thus is present only as `client2` in /etc/hosts. But for NFS mounts, its hostname is
-          # appended to the local domain of each other machine locally.
-          # Hence, resolving the NFS domain name is not possible via the hosts file in
-          # this particular edge case, it cannot be exported to successfully, and the NFS mounting fails.
-
-          # As a workaround this is acceptable, as all real machines share the same domain.
-          # The asserts below reflect the *is* state, not the *desired* state:
-          assert "client2" in server_hosts, "client2 missing from server hosts file"
-          assert "client2.fcio.net(" in exportinfo, "client2 missing from exports file"
-          assert "server.fcio.net" in mountinfo_client2, "NFS server domain missing from fstab"
-
-          print(client1.execute("findmnt")[1])
-          print(client2.execute("findmnt")[1])
-          print(client2.execute("systemctl status mnt-nfs-shared.mount")[1])
-
-        with subtest("automount and basic interactions"):
-          client1.execute("grep test_on_server ${cdir}/test")
-          print(client1.execute("mount")[1])
-          print(client1.execute("journalctl -u mnt-nfs-shared.automount")[1])
-          print(server.execute("journalctl -u nfs-server")[1])
-          print(server.execute("journalctl -u nfs-idmapd")[1])
-          print(server.execute("journalctl -u nfs-mountd")[1])
-
-          client1.succeed("sudo -u test sh -c 'echo test_on_client > ${cdir}/test'")
-          server.succeed("grep test_on_client ${sdir}/test")
-
-          client1.fail("echo from_root_user > ${cdir}/test")
-          server.succeed("grep test_on_client ${sdir}/test")
-
-          # Verify proper shutdown while NFS is being used.
-          # See PL-129954
-          client1.wait_for_unit("httpd.service")
-          client1.succeed("cd ${cdir}")
-
-          server.copy_from_host("${php_blocking_script}", "${sdir}/index.php")
-
-          client1.execute('curl -v http://localhost:8000/index.php >&2 &')
-          time.sleep(2)
-          print(client1.execute('lsof -n ${cdir}/test2')[1])
-          print(client1.execute('journalctl -u httpd')[1])
-          content = client1.execute('cat ${cdir}/test2')[1]
-          assert content == "asdf", repr(content)
-
-        deadline = time.time() + 20
-        def wait_for_console_text(self, regex: str) -> str:
-            self.log("waiting for {} to appear on console".format(regex))
-            # Buffer the console output, this is needed
-            # to match multiline regexes.
-            console = io.StringIO()
-            while time.time() < deadline:
-                try:
-                    console.write(self.last_lines.get(block=False))
-                except queue.Empty:
-                    time.sleep(1)
-                    continue
-                console.seek(0)
-                matches = re.search(regex, console.read())
-                if matches is not None:
-                    return console.getvalue()
-
-            assert False, "Did not shut down cleanly (timeout)"
-
-        client1.execute("poweroff", check_return=False)
-
-        console = wait_for_console_text(client1, "reboot: Power down")
-
-        assert "Failed unmounting" not in console, "Unmounting NFS cleanly failed, check console output"
-
-        client1.wait_for_shutdown()
-
-        config = server.execute('cat /etc/exports')[1]
-        assert "rw,sync,root_squash,no_subtree_check" in config, "default flags not found"
-
-        server.succeed('${nodes.server.system.build.toplevel}/specialisation/withCustomFlags/bin/switch-to-configuration test')
-
-        config = server.execute('cat /etc/exports')[1]
-        assert "rw,sync,root_squash,no_subtree_check" not in config, "default flags found but not expected"
-        assert "rw,sync,no_root_squash,no_subtree_check" in config, "custom flags not found"
-
-      '';
-
   }
 )


### PR DESCRIPTION
Certain systemd units related to network configuration are configured so that they will be stopped by switch-to-configuration before systemd is reloaded, and then started again afterwards. This causes severe problems on machines with NFS mounts, as this can cause the systemd reload to fail when it attempts to stat the NFS mountpoint, which in the worst case can render the machine inoperable until a hard reboot is performed.

This change adds the `stopIfChanged = false` flag to the systemd units for ethernet link configuration and resolver and default gateway configuration to ensure that these units are restarted in-place after systemd has been reloaded during switch-to-configuration. Additionally, there is now an additional test case in the NFS test which reproduces this problem and should detect regressions in the future.

PL-133570

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [x] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Adjust the order of operations of service restarts during configuration switches to improve reliability and robustness.
- [x] Security requirements tested? (EVIDENCE)
  - Additional Hydra test case.
  - Manually verified on test VMs that upgrading to this change will use the restart settings of the new units.