### PR TITLE
kvm: increase monitoring thresholds for tcp connections

### DIFF
--- a/changelog.d/20250413_161959_PL-133150-increate-kvm-netstat-expectations_scriv.md
+++ b/changelog.d/20250413_161959_PL-133150-increate-kvm-netstat-expectations_scriv.md
@@ -1,0 +1,17 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+
+### NixOS XX.XX platform
+
+- Increase monitoring limits for KVM host network connections. (PL-133150)

--- a/nixos/roles/kvm.nix
+++ b/nixos/roles/kvm.nix
@@ -421,11 +421,17 @@ in
         };
       };
       # each qemu process connects directly to multiple OSD's in the
-      # ceph cluster.
-      expectedConnections = {
-        warning = 18000;
-        critical = 25000;
-      };
+      # ceph cluster for at least 3-4 volumes. let's
+      expectedConnections =
+        let
+          vms = 250;
+          disks = 4;
+          conn_per_disk = 50;
+        in
+        {
+          warning = vms * disks * conn_per_disk;
+          critical = 2 * vms * disks * conn_per_disk;
+        };
     };
 
     flyingcircus.agent = {


### PR DESCRIPTION
Re PL-133150

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

reduce noise

- [x] Security requirements tested? (EVIDENCE)

relying on test coverage