### PR TITLE
Fix typo in the Bird config for RZOB

### DIFF
--- a/nixos/roles/router/bird2/rzob.conf
+++ b/nixos/roles/router/bird2/rzob.conf
@@ -104,7 +104,7 @@ filter kamp_route_export {
   if MIGRATION_STATE = MIGRATION_G1_ONLY then reject;
 
   if public_export = 0 then bgp_community.add((65535, 65281)); # no-export because these are kamp owned
-  else bgp_med = UPLINK_MED;
+  bgp_med = UPLINK_MED;
   accept;
 }
 


### PR DESCRIPTION
The configuration used in RZOB contained a typo which caused some address space to be announced without the MED being set correctly, which led to the standby router receiving inbound traffic which should have been directed to the primary router. This change updates the platform config to match the config currently deployed via a dev checkout.

PL-133260

@flyingcircusio/release-managers

## Release process

- [ ] ~~Created changelog entry using `./changelog.sh`~~

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [x] ensure the merge bot has determined a merge date
- [x] ensure all checks are green
- [x] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Updating our recorded configuration to match reality.
- [x] Security requirements tested? (EVIDENCE)
  - This is a forward port of the currently active production configuration onto the dev branch.
