### PR TITLE
Only enable secondary Bird instance for managing VRF routes in the router role

### DIFF
--- a/changelog.d/20250414_114754_PL-133324-vrf-bird-router-only_scriv.md
+++ b/changelog.d/20250414_114754_PL-133324-vrf-bird-router-only_scriv.md
@@ -1,0 +1,20 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+
+### NixOS XX.XX platform
+
+- Ensure that the integration for providing gateway services on layer
+  3 routed networks is only enabled in the router role. (PL-133324)

--- a/nixos/roles/router/bird2-vrf-bridge.nix
+++ b/nixos/roles/router/bird2-vrf-bridge.nix
@@ -142,7 +142,7 @@ let
 
 in
 {
-  config = lib.mkIf enableVrfBridge {
+  config = lib.mkIf (role.enable && enableVrfBridge) {
     environment.systemPackages = [ package ];
 
     environment.etc."bird/bird2-vrf.conf".source = pkgs.writeTextFile {


### PR DESCRIPTION
In #1392 we introduced support to the router role for providing gateway services to routed VRF networks, which includes a secondary Bird instance for managing routes in VRF routing tables. This change corrects an error in the previous PR to ensure that this integration is only enabled when the router role is enabled.

PL-133324

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [x] ensure the merge bot has determined a merge date
- [x] ensure all checks are green
- [x] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Fixing a correctness error where role components are enabled when the role isn't assigned.
- [x] Security requirements tested? (EVIDENCE)
  - Manually verified in test hosts in dev, including router and non-router hosts.
