### PR TITLE
Don't set bridge options on routed networks in FRR config

### DIFF
--- a/nixos/platform/network.nix
+++ b/nixos/platform/network.nix
@@ -454,7 +454,7 @@ in
                   " advertise-svi-ip"
                   "exit-vni"
                 ]
-              ) vxlanInterfaces
+              ) (filter (i: !i.routed) vxlanInterfaces)
             }
            exit-address-family
            !


### PR DESCRIPTION
In the FRR config we set the `advertise-svi-ip` option for virtual networks using VXLAN, to ensure that the corresponding bridge interfaces are made visible in the EVPN control plane if they have IP addresses assigned. However, we were also setting this option for the routed pub network, which is an invalid configuration (layer 2 config applied to layer 3 network), which causes FRR to log an error message and then fail to process routes in the pub VRF properly. This can cause VMs with routed pub interfaces to lose connectivity.

This change ensures that the `advertise-svi-ip` option is only set for non-routed (i.e. bridged/switched) networks.

PL-133325

@flyingcircusio/release-managers

## Release process

- [ ] ~~Created changelog entry using `./changelog.sh`~~

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Configuration correctness affecting network availability.
- [x] Security requirements tested? (EVIDENCE)
  - Verified manually on hosts in dev.