### PR TITLE
Update fc.qemu for routed pub support in cloud-init VM's

### DIFF
--- a/changelog.d/20250416_165849_PL-133325-routed-networks-cloud-init_scriv.md
+++ b/changelog.d/20250416_165849_PL-133325-routed-networks-cloud-init_scriv.md
@@ -1,0 +1,21 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+
+
+### NixOS XX.XX platform
+
+- kvm: support layer 3 routed networks when bootstrapping cloud-init
+  VM's. (PL-133325)

--- a/pkgs/fc/default.nix
+++ b/pkgs/fc/default.nix
@@ -52,8 +52,8 @@ rec {
       repo = "fc.qemu";
       # The release tooling didn't upgrade properly so we had to pick a specific
       # commit instead.
-      rev = "76db32082dbd72676d1d5be343b7496045037ff8";
-      hash = "sha256-1fJPKQtavp4MOLUuhBQJ04yPcfayZYvq0xUIsYDpBdM=";
+      rev = "db7d94c8b29029bb84d5d82dabd9ed8ec3195bb5";
+      hash = "sha256-ZKZl7uoXu3SXRoiEvR3xwtMWauV1vyyDfudxmgb5huo=";
     };
     fc-ceph = ceph;
     qemu_ceph = pkgs.qemu-ceph-nautilus;


### PR DESCRIPTION
See flyingcircusio/fc.qemu#25.

PL-133325

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [x] ensure the merge bot has determined a merge date
- [x] ensure all checks are green
- [x] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Configure guest networking correctly for supported guest/network type combinations.
- [x] Security requirements tested? (EVIDENCE)
  - Hydra tests.