### PR TITLE
Allow coturn to bind to privileged ports

### DIFF
--- a/changelog.d/20250417_153006_PL-133419-coturn-private-users_scriv.md
+++ b/changelog.d/20250417_153006_PL-133419-coturn-private-users_scriv.md
@@ -1,0 +1,20 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+
+### NixOS XX.XX platform
+
+- coturn: ensure that the coturn process can bind to port 443 when
+  enabled by the Jitsi role. (PL-133419)

--- a/nixos/roles/coturn.nix
+++ b/nixos/roles/coturn.nix
@@ -110,9 +110,24 @@ in
     systemd.services.coturn = rec {
       requires = [ "acme-selfsigned-${hostname}.service" ];
       after = requires;
-      serviceConfig = {
-        Restart = lib.mkForce "always";
-      };
+      serviceConfig =
+        {
+          Restart = lib.mkForce "always";
+        }
+        //
+        # Disable sandboxing which prevents binding on privileged ports
+        # when these are explicitly requested in the configuration
+        (lib.optionalAttrs
+          (any (p: p < 1024) [
+            serviceCfg.listening-port
+            serviceCfg.tls-listening-port
+            serviceCfg.alt-listening-port
+            serviceCfg.alt-tls-listening-port
+          ])
+          {
+            PrivateUsers = lib.mkForce false;
+          }
+        );
     };
 
     security.acme.certs."${hostname}" = {

--- a/tests/coturn.nix
+++ b/tests/coturn.nix
@@ -115,6 +115,30 @@ import ./make-test-python.nix (
           systemd.services.coturn.serviceConfig.ExecStartPre = [
             "+${pkgs.acl}/bin/setfacl -Rm u:turnserver:rX /var/lib/acme/${turnserverFe}"
           ];
+
+          # The Jitsi role configures coturn to listen on port 443. However the
+          # stock systemd unit configuration puts coturn into a separate user
+          # namespace, and the additional process capabilities
+          # (e.g. CAP_NET_BIND_SERVICE) are only set within this separate
+          # namespace and not the host namespace. This prevents coturn from
+          # binding to port 443 properly, so this sandboxing measure needs to be
+          # disabled if coturn has a privileged listen port.
+          specialisation = {
+            withPrivilegedBind = {
+              configuration = {
+                services.coturn.tls-listening-port = 443;
+
+                # The ACME services get stuck when running
+                # switch-to-configuration inside the test VM. The self-signed
+                # certs have already been created by the primary system which we
+                # booted into, so we can turn those services off when switching
+                # to the specialisation.
+                systemd.services.coturn.requires = lib.mkForce [ ];
+                services.nginx.enable = lib.mkForce false;
+                security.acme.certs = lib.mkForce { };
+              };
+            };
+          };
         };
     };
 
@@ -159,6 +183,12 @@ import ./make-test-python.nix (
         with subtest("coturn opens no unexpected ports"):
             turnserver.fail("netstat -tlpn | grep turnserver | egrep -qv ':3478 |:3479 |:5349 |:5350 '")
 
+        with subtest("coturn is able to bind to privileged ports"):
+            turnserver.succeed(
+                "/run/current-system/specialisation/withPrivilegedBind/bin/switch-to-configuration test",
+                timeout=30,
+            )
+            turnserver.wait_for_open_port(443, timeout=30)
       '';
   }
 )


### PR DESCRIPTION
On machines with the Jitsi role enabled we've observed that coturn is unable to bind to its configured listening port of 443, in spite of the systemd unit file setting the CAP_NET_BIND_SERVICE capability to allow it to bind to privileged ports as a non-root user. However, the systemd configuration for coturn also sets `PrivateUsers=true`, which puts the coturn process into a separate user namespace and applies capability settings to that separate namespace instead of the host namespace. This results in coturn lacking the privileges to bind to port 443.

This change selectively disables this sandboxing when coturn is explicitly configured to bind to a privileged port (such as through the Jitsi role).

PL-133419

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Sandboxing features should be configured to permit an appropriate level of protection while still allowing services to function correctly.
- [x] Security requirements tested? (EVIDENCE)
  - The Hydra test has been extended to check coturn can bind to privileged ports.
  - Manually verified that the `PrivateUsers` option was the source of the problem on a test VM.