### PR TITLE
adapt release-tools GHA to uv usage

### DIFF
--- a/.github/workflows/auto-merge-check-pr.yaml
+++ b/.github/workflows/auto-merge-check-pr.yaml
@@ -20,11 +20,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: flyingcircusio/fc-nixos-release-tools
-      - uses: cachix/install-nix-action@v30
-      - name: build release tooling
-        run: |
-          nix build .#
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
       - run: |
-          ./result/bin/auto-merge check-pr ${{ github.event.pull_request.number }}
+          uv run --frozen auto-merge check-pr ${{ github.event.pull_request.number }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-nixpkgs-cleanup.yaml
+++ b/.github/workflows/update-nixpkgs-cleanup.yaml
@@ -19,10 +19,8 @@ jobs:
         with:
           repository: flyingcircusio/fc-nixos-release-tools
           path: 'release-tools'
-      - uses: cachix/install-nix-action@v21
-        with:
-          # Nix 2.24 breaks flake update
-          install_url: https://releases.nixos.org/nix/nix-2.18.9/install
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
       - uses: actions/create-github-app-token@v1
         id: app-token
         with:
@@ -39,11 +37,8 @@ jobs:
       - run: |
           git config --global user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
           git config --global user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com>'
-      - name: build release tooling
-        run: |
-          nix build ./release-tools#
       - run: |
-          ./result/bin/update-nixpkgs cleanup \
+          uv --project release-tools run --frozen update-nixpkgs cleanup \
             --merged-pr-id ${{ github.event.number }} \
             --fc-nixos-dir fc-nixos \
             --nixpkgs-dir nixpkgs \


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`
  no: internal

## PR release workflow (internal)

- [ ] PR has internal ticket
- [ ] internal issue ID (PL-…) part of branch name
- [ ] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - should work
- [x] Security requirements tested? (EVIDENCE)
  - similar GHAs work successfully in fc-nixos-release-tools