### PR TITLE
KVM: provide DNS resolver services to routed guest interfaces over IPv6 using virtual router IP address

### DIFF
--- a/changelog.d/20250423_101702_PL-133325-cidns-v6-dnat_scriv.md
+++ b/changelog.d/20250423_101702_PL-133325-cidns-v6-dnat_scriv.md
@@ -1,0 +1,21 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+
+
+### NixOS XX.XX platform
+
+- kvm: provide resolver services to layer 3 routed guest interfaces
+  also on the subnet virtual router IPv6 address. (PL-133325)

--- a/nixos/roles/kvm.nix
+++ b/nixos/roles/kvm.nix
@@ -21,7 +21,10 @@ let
   virtualGatewayV6 = "fe80::1";
 
   vrfInterfaces = lib.filterAttrs (n: v: v.routed or false) fclib.network;
-  locationNameserver = head config.flyingcircus.static.nameservers."${location}";
+  locationNameserverV4 = head config.flyingcircus.static.nameservers."${location}";
+  locationNameserverV6 = head config.flyingcircus.static.nameservers6."${location}";
+
+  vrfV6Resolvers = iface: map (net: "${net.network}1") iface.v6.networkAttrs;
 
 in
 {
@@ -574,9 +577,20 @@ in
       # to the location-wide resolver
       ${lib.concatStringsSep "\n" (
         lib.mapAttrsToList (name: _: ''
-          iptables -t nat -A nixos-nat-pre -i t${name}+ -d ${virtualGatewayV4} -p udp --dport 53 -j DNAT --to-destination ${locationNameserver}
-          iptables -t nat -A nixos-nat-pre -i t${name}+ -d ${virtualGatewayV4} -p tcp --dport 53 -j DNAT --to-destination ${locationNameserver}
+          iptables -t nat -A nixos-nat-pre -i t${name}+ -d ${virtualGatewayV4} -p udp --dport 53 -j DNAT --to-destination ${locationNameserverV4}
+          iptables -t nat -A nixos-nat-pre -i t${name}+ -d ${virtualGatewayV4} -p tcp --dport 53 -j DNAT --to-destination ${locationNameserverV4}
         '') vrfInterfaces
+      )}
+      ${lib.concatStringsSep "\n" (
+        lib.mapAttrsToList (
+          name: iface:
+          lib.concatStringsSep "\n" (
+            map (gw: ''
+              ip6tables -t nat -A nixos-nat-pre -i t${name}+ -d ${gw} -p udp --dport 53 -j DNAT --to-destination ${locationNameserverV6}
+              ip6tables -t nat -A nixos-nat-pre -i t${name}+ -d ${gw} -p tcp --dport 53 -j DNAT --to-destination ${locationNameserverV6}
+            '') (vrfV6Resolvers iface)
+          )
+        ) vrfInterfaces
       )}
     '';
 


### PR DESCRIPTION
This change adds additional configuration to ensure that VM's with routed layer 3 interfaces also have DNS resolver services available over IPv6 (in case of v6-only VM's, etc).

For IPv4, we use DNAT on DNS requests sent to the virtual gateway address in order to forward these to the location resolver without configuring this resolver address directly in VM's. However, we can't use the IPv6 virtual gateway address as the resolver address in VM's, as this is a link-local address – when guests send packets to this address, they will use a link-local source address, which means that responses to DNS requests cannot be routed back over the routed overlay to the VM which sent them.

Instead, for IPv6, let's use the first address from every subnet assigned on the network as the virtual resolver address. This is a globally routable address (which means that VM's will use their own global addresses as the source address), and is also reserved by the directory and will never be automatically assigned.

PL-133325

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [x] ensure the merge bot has determined a merge date
- [x] ensure all checks are green
- [x] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Provide DNS resolver services to IPv6 only cloud-init VM's. The virtual address which is used for translation is one which is reserved by default in the directory.
- [x] Security requirements tested? (EVIDENCE)
  - Manually verified in dev with a v6-only Ubuntu VM – sending requests to the virtual router address results in the request and response being routed correctly.