### PR TITLE
[PL-133642] roles/lamp: allow drv references in php.ini again

### DIFF
--- a/changelog.d/20250424_101528_PL-133642-drv-references-in-php.ini_scriv.md
+++ b/changelog.d/20250424_101528_PL-133642-drv-references-in-php.ini_scriv.md
@@ -1,0 +1,20 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+
+
+### NixOS XX.XX platform
+
+- lamp: Fix evaluation error when a `php.ini` references a derivation (PL-133642).

--- a/nixos/roles/lamp.nix
+++ b/nixos/roles/lamp.nix
@@ -25,7 +25,7 @@ let
         ''
           mkdir -p $out/bin
           makeWrapper ${phpPackage}/bin/php $out/bin/php-${name} \
-            --add-flags "-c ${builtins.toFile "php-${name}.ini" phpOptions}"
+            --add-flags "-c ${pkgs.writeText "php-${name}.ini" phpOptions}"
 
           ln -sfv ${phpPackage.packages.composer}/bin/composer $out/bin/composer-${name}
         ''

--- a/tests/lamp/vm-test.nix
+++ b/tests/lamp/vm-test.nix
@@ -52,6 +52,7 @@ import ../make-test-python.nix (
             '';
 
             php_ini = ''
+              ; Make sure references to derivations are allowed: ${pkgs.hello}
               # XXX test-i-a-m-the-custom-php-ini
             '';
 


### PR DESCRIPTION
To quote the Nix manual[1]:

> It is also not possible to reference the result of a derivation.
> If you are using Nixpkgs, the writeTextFile function is able to do that.

Also changed the lamp testcases in a way that they'd fail if we'd regress on this again.

[1] https://nix.dev/manual/nix/2.18/language/builtins#builtins-toFile

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Be able to upgrade to 24.11 of our platform: this regression blocks this for projects using derivation references in php.ini.
- [x] Security requirements tested? (EVIDENCE)
  - Reproduced the problem in a test VM, confirmed that this patch solves the problem.
  - Changed the lamp test in a way that it'd break if we regress on that again.
