### PR TITLE
fc.agent: use `boot` to switch between NixOS release upgrades

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -9,6 +9,6 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
-    - uses: pre-commit/action@v2.0.3
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+    - uses: pre-commit/action@v3.0.0

--- a/changelog.d/20250424_190850_PL-133570-24.05-require-boot-activation-for-distro-upgrades_scriv.md
+++ b/changelog.d/20250424_190850_PL-133570-24.05-require-boot-activation-for-distro-upgrades_scriv.md
@@ -1,0 +1,30 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+
+### NixOS XX.XX platform
+
+- Activate configuration changes in an (immediate) boot cycle when upgrading (or downgrading)
+  the NixOS major release. (PL-133570)
+
+  We've experienced too many paper cuts, trying to get pure "online upgrades" working reliably
+  in our fleet. Many edge cases like systemd upgrades, NFS connections, have shown that this
+  isn't possible in the general case.
+
+  As NixOS major releases ship with different kernel versions anyway and thus always scheduled
+  to perform an immediate reboot in maintenance, we no defer the whole config update into
+  that reboot.
+
+  If a config change is applied manually and causes a major version change, the reboot will
+  be applied immediately - after warning the user visually and giving a 10 second countdown
+  in case of the user wanting to abort.

--- a/pkgs/fc/agent/fc/maintenance/activity/tests/test_update.py
+++ b/pkgs/fc/agent/fc/maintenance/activity/tests/test_update.py
@@ -244,6 +244,7 @@ def nixos_mock(monkeypatch):
     )
 
     mocked.format_unit_change_lines = fc.util.nixos.format_unit_change_lines
+    mocked.get_release_version = fc.util.nixos.get_release_version
     mocked.get_fc_channel_build = fake_get_fc_channel_build
     mocked.channel_version = fake_channel_version
     mocked.kernel_version = fake_changed_kernel_version
@@ -368,6 +369,63 @@ def test_update_nfs_reboot_required(
     )
 
 
+def test_update_release_change_reboot_required(
+    log, logger, tmp_path, activity, nixos_mock
+):
+    # I'd rather like to call prepare() here but the overall logic isn't
+    # factored for testability.
+
+    activity.reboot_needed = None
+    activity._register_reboot_for_release_change()
+    assert not activity.reboot_needed
+
+    # The method is ignorant to the state before, so it doesn't change what's
+    # already there.
+    activity.reboot_needed = RebootType.WARM
+    activity._register_reboot_for_release_change()
+    assert activity.reboot_needed == RebootType.WARM
+
+    # We do not require a reboot if the release path contains only
+    # a single (current) version
+    activity.reboot_needed = None
+    activity.current_version = "24.11"
+    activity.next_version = "24.11"
+    assert activity.release_path() == ["24.11"]
+    activity._register_reboot_for_release_change()
+    assert not activity.reboot_needed
+
+    # We do not require a reboot if the release path contains only
+    # a single (current) version
+    activity.reboot_needed = None
+    activity.current_version = "24.11"
+    activity.next_version = "25.05"
+    assert activity.release_path() == ["24.11", "25.05"]
+    activity._register_reboot_for_release_change()
+    assert activity.reboot_needed == RebootType.WARM
+
+    assert activity.summary == textwrap.dedent(
+        """\
+        System update: 24.11 -> 25.05
+
+        Will reboot after the update.
+
+        Start/Stop: postgresql
+        Restart: telegraf
+        Reload: nginx
+
+        Release: 2021_002 -> 2021_003
+        ChangeLog: https://doc.flyingcircus.io/platform/changes/2021/r003.html
+        Environment: fc-21.05-production (unchanged)
+        Build number: 93111 -> 93222
+        Channel URL: https://hydra.flyingcircus.io/build/93222/download/1/nixexprs.tar.xz"""
+    )
+    assert log.has(
+        "distro-release-change-require-reboot",
+        current_release="24.11",
+        next_release="25.05",
+    )
+
+
 def test_update_activity_run(log, nixos_mock, activity, logger):
     activity.run()
 
@@ -382,7 +440,7 @@ def test_update_activity_run(log, nixos_mock, activity, logger):
         NEXT_SYSTEM_PATH, log=activity.log
     )
     nixos_mock.switch_to_system.assert_called_with(
-        NEXT_SYSTEM_PATH, lazy=False, log=activity.log
+        NEXT_SYSTEM_PATH, lazy=False, switch_type="switch", log=activity.log
     )
     assert log.has("update-run-succeeded")
 
@@ -444,6 +502,34 @@ def test_update_activity_switch_to_system_fails(log, nixos_mock, activity):
 
     assert activity.returncode == state.EXIT_TEMPFAIL
     assert log.has("update-run-tempfail", returncode=state.EXIT_TEMPFAIL)
+
+
+def test_update_activity_switch_if_no_release_change(
+    log, nixos_mock, activity
+):
+    activity.current_version = "24.11.1111"
+    activity.next_version = "24.11.9999"
+    activity.run()
+
+    nixos_mock.switch_to_system.assert_called_once_with(
+        NEXT_SYSTEM_PATH,
+        lazy=False,
+        switch_type="switch",
+        log=activity.log,
+    )
+
+
+def test_update_activity_boot_if_release_change(log, nixos_mock, activity):
+    activity.current_version = "24.11.1111"
+    activity.next_version = "25.05.9999"
+    activity.run()
+
+    nixos_mock.switch_to_system.assert_called_once_with(
+        NEXT_SYSTEM_PATH,
+        lazy=False,
+        switch_type="boot",
+        log=activity.log,
+    )
 
 
 def test_update_activity_from_enc(

--- a/pkgs/fc/agent/fc/maintenance/activity/update.py
+++ b/pkgs/fc/agent/fc/maintenance/activity/update.py
@@ -168,6 +168,7 @@ class UpdateActivity(Activity):
             self.next_system, self.log
         )
 
+        self._register_reboot_for_release_change()
         self._register_reboot_for_units()
         self._register_reboot_for_kernel()
 
@@ -292,7 +293,13 @@ class UpdateActivity(Activity):
             # configuration changes, so update it here.
             self.next_system = system_path
             nixos.register_system_profile(system_path, log=self.log)
-            nixos.switch_to_system(system_path, lazy=False, log=self.log)
+
+            switch_type = "switch"
+            if len(self.release_path()) > 1:
+                switch_type = "boot"
+            nixos.switch_to_system(
+                system_path, lazy=False, switch_type=switch_type, log=self.log
+            )
 
         except nixos.ChannelException as e:
             self._handle_channel_exception(e)
@@ -433,6 +440,30 @@ class UpdateActivity(Activity):
         return ActivityMergeResult(
             merged, merged.is_effective, is_significant, changes
         )
+
+    def release_path(self):
+        """Return the path of involved NixOS releases.
+
+        Returns a single element if no upgrade/downgrade happening, e.g. ["24.05"]
+        or more than one if there is a downgrade happening. e.g. ["24.05", "24.11"]
+
+        The order reflects the before -> after progression.
+
+        """
+        result = [nixos.get_release_version(self.current_version)]
+        next_release = nixos.get_release_version(self.next_version)
+        if next_release not in result:
+            result.append(next_release)
+        return result
+
+    def _register_reboot_for_release_change(self):
+        if len(release_path := self.release_path()) > 1:
+            self.log.info(
+                "distro-release-change-require-reboot",
+                current_release=release_path[0],
+                next_release=release_path[1],
+            )
+            self.reboot_needed = RebootType.WARM
 
     def _register_reboot_for_units(self):
         reboot_on_unit_change = {"mnt-nfs-shared.mount"}

--- a/pkgs/fc/agent/fc/manage/manage.py
+++ b/pkgs/fc/agent/fc/manage/manage.py
@@ -215,7 +215,16 @@ def initial_switch_if_needed(log, enc):
         nixos.register_system_profile(system_path, log)
         # New system is registered, delete the temporary result link.
         os.unlink(out_link)
-        nixos.switch_to_system(system_path, lazy=False, log=log)
+        nixos.switch_to_system(
+            system_path,
+            lazy=False,
+            # There is a slight potential that this does cause a distro
+            # change, because the user may have updated the ENC faster than
+            # we booted the first time, but I think this chance is relatively
+            # neglible and hasn't bitten us before.
+            switch_type="switch",
+            log=log,
+        )
     except Exception:
         log.warn(
             "fc-manage-initial-build-failed",

--- a/pkgs/fc/agent/fc/util/channel.py
+++ b/pkgs/fc/agent/fc/util/channel.py
@@ -1,5 +1,8 @@
 import os
 import os.path as p
+import subprocess
+import time
+from pathlib import Path
 
 from fc.util import nixos
 from fc.util.nixos import RE_FC_CHANNEL
@@ -116,7 +119,41 @@ class Channel:
         nixos.register_system_profile(self.system_path, self.log)
         # New system is registered, delete the temporary result link.
         os.unlink(out_link)
-        return nixos.switch_to_system(self.system_path, lazy, self.log)
+
+        current_release = nixos.get_release_version(
+            nixos.running_system_version()
+        )
+        next_release = nixos.get_release_version(
+            (Path(self.system_path) / "nixos-version").read_text()
+        )
+
+        if current_release != next_release:
+            reboot_delay = 10
+            self.log.warn(
+                "release-change-requires-reboot",
+                current_release=current_release,
+                next_release=next_release,
+            )
+            while reboot_delay:
+                self.log.warn(
+                    "reboot-scheduled",
+                    _replace_msg=f"WILL REBOOT IN {reboot_delay} SECONDS. PRESS Ctrl-C TO ABORT.",
+                )
+                time.sleep(1)
+                reboot_delay -= 1
+            if not nixos.switch_to_system(
+                self.system_path, lazy, "boot", self.log
+            ):
+                return False
+            self.log.warn(
+                "reboot-scheduled",
+                _replace_msg="System switched. Triggering reboot NOW.",
+            )
+            subprocess.check_call(["reboot"])
+        else:
+            return nixos.switch_to_system(
+                self.system_path, lazy, "switch", self.log
+            )
 
     def build(self, out_link=None, show_trace=False):
         """

--- a/pkgs/fc/agent/fc/util/nixos.py
+++ b/pkgs/fc/agent/fc/util/nixos.py
@@ -1,4 +1,5 @@
 """Helpers for interaction with the NixOS system"""
+
 import itertools
 import os
 import os.path as p
@@ -83,7 +84,7 @@ def kernel_version(kernel):
     moddir = os.listdir(p.join(p.dirname(bzImage), "lib", "modules"))
     if len(moddir) != 1:
         raise RuntimeError(
-            "modules subdir does not contain exactly " "one item", moddir
+            "modules subdir does not contain exactly one item", moddir
         )
     return moddir[0]
 
@@ -133,6 +134,19 @@ def get_fc_channel_build(channel_url: str, log=_log) -> Optional[str]:
             ),
             channel_url=channel_url,
         )
+
+
+def get_release_version(v):
+    """Extract the "major" release version to detection distro
+    upgrades/downgrades.
+
+    Accept development versions, like 24.11pre-git and release versions
+    like "24.05.12355.adc37d7fe"
+
+    """
+    v = v.replace("pre-git", "")
+    v = v.split(".")[:2]
+    return ".".join(v)
 
 
 def running_system_version(log=_log):
@@ -473,7 +487,7 @@ def build_system(
         system_path = proc.stdout.read().strip()
         try:
             size_bytes = system_closure_size(log, Path(system_path))
-            size_humanized = f"{size_bytes/1024**3:.1f} GiB"
+            size_humanized = f"{size_bytes / 1024**3:.1f} GiB"
         except Exception:
             size_humanized = None
 
@@ -508,7 +522,7 @@ def build_system(
     return system_path
 
 
-def switch_to_system(system_path, lazy, log=_log):
+def switch_to_system(system_path, lazy, switch_type, log=_log):
     if lazy and p.realpath("/run/current-system") == system_path:
         log.info(
             "system-switch-skip",
@@ -523,7 +537,7 @@ def switch_to_system(system_path, lazy, log=_log):
         system=system_path,
     )
 
-    cmd = [f"{system_path}/bin/switch-to-configuration", "switch"]
+    cmd = [f"{system_path}/bin/switch-to-configuration", switch_type]
 
     log.debug("system-switch-command", cmd=" ".join(cmd))
 

--- a/pkgs/fc/agent/fc/util/tests/test_dmi_memory.py
+++ b/pkgs/fc/agent/fc/util/tests/test_dmi_memory.py
@@ -1,8 +1,8 @@
-""" Unit-test for dmidecode parser"""
+"""Unit-test for dmidecode parser"""
 
+import importlib.resources
 from unittest import mock
 
-import pkg_resources
 from fc.util.dmi_memory import calc_mem, get_device, main
 
 
@@ -30,15 +30,19 @@ def test_get_device():
 
 @mock.patch("subprocess.check_output")
 def test_multibank_should_be_calculated_correctly(check_output):
-    check_output().decode.return_value = pkg_resources.resource_string(
-        __name__, "dmidecode_multibank.out"
-    ).decode("us-ascii")
+    check_output().decode.return_value = (
+        importlib.resources.files(__package__)
+        .joinpath("dmidecode_multibank.out")
+        .read_text(encoding="us-ascii")
+    )
     assert 262144 == main()
 
 
 @mock.patch("subprocess.check_output")
 def test_singlebank_should_be_calculated_correctly(check_output):
-    check_output().decode.return_value = pkg_resources.resource_string(
-        __name__, "dmidecode.out"
-    ).decode("us-ascii")
+    check_output().decode.return_value = (
+        importlib.resources.files(__package__)
+        .joinpath("dmidecode.out")
+        .read_text(encoding="us-ascii")
+    )
     assert 8192 == main()

--- a/pkgs/fc/agent/fc/util/tests/test_nixos.py
+++ b/pkgs/fc/agent/fc/util/tests/test_nixos.py
@@ -167,7 +167,9 @@ def test_switch_to_system(log, monkeypatch):
     monkeypatch.setattr("subprocess.Popen", popen_mock)
     monkeypatch.setattr("os.path.realpath", lambda p: "other")
 
-    changed = nixos.switch_to_system(system_path, lazy=True)
+    changed = nixos.switch_to_system(
+        system_path, lazy=True, switch_type="switch"
+    )
     assert changed
 
 
@@ -175,7 +177,9 @@ def test_switch_to_system_lazy_unchanged(log, monkeypatch):
     system_path = "/nix/store/v49jzgwblcn9vkrmpz92kzw5pkbsn0vz-nixos-system-test-21.05.1367.817a5b0"
     monkeypatch.setattr("os.path.realpath", lambda p: system_path)
 
-    changed = nixos.switch_to_system(system_path, lazy=True)
+    changed = nixos.switch_to_system(
+        system_path, lazy=True, switch_type="switch"
+    )
     assert not changed
     assert log.has("system-switch-skip")
 
@@ -483,3 +487,10 @@ def test_multiple_kernel_versions(dirsetup, tmpdir):
     mod.mkdir("4.4.28")
     with pytest.raises(RuntimeError):
         nixos.kernel_version(str(kernel))
+
+
+def test_nixos_release_version():
+    assert nixos.get_release_version("24.05") == "24.05"
+    assert nixos.get_release_version("24.11.5377.8f6c4605") == "24.11"
+    assert nixos.get_release_version("24.05pre-git") == "24.05"
+    assert nixos.get_release_version("25.11pre-git") == "25.11"


### PR DESCRIPTION
Fixes PL-133570

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.

I strongly considered providing a feature toggle. However, due to the nature of the change, a feature toggle complicates this logic even further and IMHO increases the risk.

- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

improve availability/reliability

- [x] Security requirements tested? (EVIDENCE)

manual testing and unit tests