### PR TITLE
antivirus: fix listen config on devhosts

### DIFF
--- a/changelog.d/20250428_161054_PL-133648-fix-clamav-on-devhost_scriv.md
+++ b/changelog.d/20250428_161054_PL-133648-fix-clamav-on-devhost_scriv.md
@@ -1,0 +1,21 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+- A bullet item for the Impact category.
+
+
+### NixOS XX.XX platform
+
+- antivirus: fix listen statement on devhost setups (PL-133648)

--- a/nixos/infrastructure/dev-vm.nix
+++ b/nixos/infrastructure/dev-vm.nix
@@ -89,7 +89,7 @@ in
       services.postgresql.settings.full_page_writes = "off";
       services.postgresql.settings.synchronous_commit = "off";
 
-      flyingcircus.roles.antivirus.listenAddresses = [ "[::]" ];
+      flyingcircus.roles.antivirus.listenAddresses = [ "::" ];
 
       flyingcircus.roles.coturn.hostName = config.networking.hostName;
       flyingcircus.roles.coturn.config.listening-ips = [ "[::]" ];


### PR DESCRIPTION
Fixes PL-133648

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

n/a

- [x] Security requirements tested? (EVIDENCE)

n/a
