### PR TITLE
[PL-133484] nixos/nix-version: upgrade to 2.25

### DIFF
--- a/changelog.d/20250429_115138_PL-133484-nix-2.25_scriv.md
+++ b/changelog.d/20250429_115138_PL-133484-nix-2.25_scriv.md
@@ -1,0 +1,20 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+
+
+### NixOS XX.XX platform
+
+- The default Nix has been upgraded to 2.25.

--- a/nixos/platform/nix.nix
+++ b/nixos/platform/nix.nix
@@ -8,11 +8,7 @@
 let
   production = lib.attrByPath [ "parameters" "production" ] "" config.flyingcircus.enc;
 
-  nixPackage =
-    if config.flyingcircus.nix.useUnstableNix then
-      pkgs.nixVersions.nix_2_25
-    else
-      pkgs.nixVersions.nix_2_18;
+  nixPackage = pkgs.nixVersions.nix_2_25;
 in
 {
   options.flyingcircus = {
@@ -21,8 +17,8 @@ in
       defaultText = lib.literalExpression ''production == false'';
       type = lib.types.bool;
       description = ''
-        Whether to use a known stable Nix (i.e. 2.18) or a
-        newer, potentially unstable version (i.e. 2.25).
+        This option is used to roll out newer Nix versions earlier for gradual testing.
+        Right now, this has no effect.
       '';
     };
 

--- a/tests/nix-version.nix
+++ b/tests/nix-version.nix
@@ -120,25 +120,25 @@ import ./make-test-python.nix (
 
 
       with subtest("rzob production vm"):
-          verify_nix_versions(production, "2.18")
+          verify_nix_versions(production, "2.25")
 
       with subtest("rzob non-prod vm"):
           verify_nix_versions(nonProd, "2.25")
 
       with subtest("rzob prod vm with slurm"):
-          verify_nix_versions(slurmOnProduction, "2.18", expect_slurm=True)
+          verify_nix_versions(slurmOnProduction, "2.25", expect_slurm=True)
 
       with subtest("rzob non-prod vm with slurm"):
           verify_nix_versions(slurmOnNonProd, "2.25", expect_slurm=True)
 
       with subtest("whq vm"):
-          verify_nix_versions(whqVM, "2.18")
+          verify_nix_versions(whqVM, "2.25")
 
       with subtest("whq vm with non-prod flag"):
           verify_nix_versions(whqVMNonProd, "2.25")
 
       with subtest("dev vm prod"):
-          verify_nix_versions(devVM, "2.18")
+          verify_nix_versions(devVM, "2.25")
 
       with subtest("dev vm non-prod"):
           verify_nix_versions(devVMNonProd, "2.25")


### PR DESCRIPTION
So far, we've seen no issues with it.

I decided to leave the code for separate Nix versions in, this may be useful for future Nix upgrades IMHO.

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Do not run software versions that's basically unmaintained.
  - Availability: Nix 2.24 was dangerous and brought small VMs to its limits because Git tarball cache operations were too expensive.
- [x] Security requirements tested? (EVIDENCE)
  - Nix 2.25 ran on all machines with `useUnstableNix = true;` since ~February. I couldn't find any of the old symptoms (such as IO pressure at 100% for half an hour or similiar) on any machines where the issue could be traced back to Nix.
  - I updated the integration test to ensure that machines with `useUnstableNix` and all machines with 2.18 get the intended version, i.e. 2.25.