### PR TITLE
nixos/kernel: update verification kernel 6.6 -> 6.12

### DIFF
--- a/changelog.d/20250429_132119_PL-133562-verification-kernel-6.12_scriv.md
+++ b/changelog.d/20250429_132119_PL-133562-verification-kernel-6.12_scriv.md
@@ -1,0 +1,21 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+
+### NixOS XX.XX platform
+
+- nixos/kernel: update verification kernel 6.6 -> 6.12 (PL-133562)
+  Kernel verision 6.12 is the new LTS. This change makes that version
+  default on non-production hosts to try it out.

--- a/nixos/platform/kernel.nix
+++ b/nixos/platform/kernel.nix
@@ -21,7 +21,7 @@ in
       type = lib.types.bool;
       description = ''
         Participate in using an evaluation kernel.
-        This currently selects a 6.11 kernel for testing purposes.
+        This currently selects a 6.12 kernel for testing purposes.
         By default, all non-prod VMs in all locations and all VMs in our internal locations
         DEV and WHQ use the evaluation kernel.
       '';

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -274,7 +274,7 @@ builtins.mapAttrs (_: patchPhps phpLogPermissionPatch) {
   # The logic for enabling different kernels on prod and non-prod remains active
   # the whole time. But in the normal case, both kernels point to the same
   # stable kernel packages.
-  linuxKernelVerify = self.linuxKernelStable;
+  linuxKernelVerify = self.linux_6_12;
 
   linuxKernelStable = self.linux_6_6;
 

--- a/tests/kernelversions.nix
+++ b/tests/kernelversions.nix
@@ -222,7 +222,7 @@ import ./make-test-python.nix (
               )
 
       assert "${stableVersion}".startswith("6.6."), "Expecting a 6.6.x kernel as stable kernel"
-      assert "${verifyVersion}".startswith("6.6."), "Expecting a 6.6.x kernel as verify kernel"
+      assert "${verifyVersion}".startswith("6.12."), "Expecting a 6.12.x kernel as verify kernel"
       assertKernelVersion(verifyKernel, "${verifyVersion}")
       assertKernelVersion(prodKernel, "${stableVersion}")
       assertKernelVersion(rzobProdKernel, "${stableVersion}")


### PR DESCRIPTION
PL-133562

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [x] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - basic tests
- [x] Security requirements tested? (EVIDENCE)
  - switched dev machine to 6.12. Works correctly