### PR TITLE
nixos/default-packages: remove atop

### DIFF
--- a/changelog.d/20250429_131920_fc-24.11-dev_scriv.md
+++ b/changelog.d/20250429_131920_fc-24.11-dev_scriv.md
@@ -1,0 +1,21 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+
+### NixOS XX.XX platform
+
+- nixos/default-packages: remove atop (PL-133575)
+  atop has/had security problems and we see not much use.
+  Remove in the default platform as it's still accessible with nix-shell.

--- a/doc/src/base.md
+++ b/doc/src/base.md
@@ -23,7 +23,6 @@ You can look up packages and their descriptions via:
 ## Packages added by our platform
 
 - apacheHttpd
-- atop
 - automake
 - bc
 - cmake

--- a/nixos/platform/packages.nix
+++ b/nixos/platform/packages.nix
@@ -17,7 +17,6 @@
       in
       [
         apacheHttpd
-        atop
         automake
         bc
         cmake


### PR DESCRIPTION
atop has/had security problems and we see not much use. Remove in the default platform as it's still accessible with nix-shell.

PL-133575

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  n/a
- [x] Security requirements tested? (EVIDENCE)
  n/a