### PR TITLE
Update FRR and add extra patch for netlink batch message handling

### DIFF
--- a/pkgs/frr/0001-Don-t-throw-error-when-log-directory-already-exists.patch
+++ b/pkgs/frr/0001-Don-t-throw-error-when-log-directory-already-exists.patch
@@ -1,7 +1,7 @@
-From f90575e52f2acd2f857cfc580bd5063a7a5c6032 Mon Sep 17 00:00:00 2001
+From 845b44566a41cfb81887ffac074d70bbd4ad1181 Mon Sep 17 00:00:00 2001
 From: Molly Miller <mm@flyingcircus.io>
 Date: Wed, 26 Jun 2024 17:08:15 +0200
-Subject: [PATCH] Don't throw error when log directory already exists
+Subject: [PATCH 1/2] Don't throw error when log directory already exists
 
 Co-authored-by: Christian Theune <ct@flyingcircus.io>
 ---
@@ -9,10 +9,10 @@ Co-authored-by: Christian Theune <ct@flyingcircus.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/tools/frr-reload.py b/tools/frr-reload.py
-index 7e5a6d284..91d2a3e81 100755
+index ea0ce6fc9c..37bdff4b59 100755
 --- a/tools/frr-reload.py
 +++ b/tools/frr-reload.py
-@@ -1869,7 +1869,7 @@ if __name__ == "__main__":
+@@ -1998,7 +1998,7 @@ if __name__ == "__main__":
  
      elif args.reload:
          if not os.path.isdir("/var/log/frr/"):
@@ -22,5 +22,5 @@ index 7e5a6d284..91d2a3e81 100755
          logging.basicConfig(
              filename="/var/log/frr/frr-reload.log",
 -- 
-2.39.3 (Apple Git-146)
+2.39.5 (Apple Git-154)
 

--- a/pkgs/frr/0002-zebra-dplane-sleep-after-writing-batches-to-netlink.patch
+++ b/pkgs/frr/0002-zebra-dplane-sleep-after-writing-batches-to-netlink.patch
@@ -1,0 +1,57 @@
+From 4e5a945339b4157cfd236758c30600cc4990241d Mon Sep 17 00:00:00 2001
+From: Molly Miller <mm@flyingcircus.io>
+Date: Tue, 29 Apr 2025 16:12:01 +0200
+Subject: [PATCH 2/2] zebra-dplane: sleep after writing batches to netlink
+
+When synchronising the RIB for an L2-VNI into the kernel (e.g. bgpd is
+learning the initial EVPN RIB from a peer, a new VNI interface has
+been brought up, etc), the batched sending of netlink messages by the
+zebra-dplane thread may result in new macfdb entries being inserted
+into the kernel faster than the kernel can resize the hash table
+backing the bridge macfdb. This can result in the entries which don't
+fit in the hash table at that moment getting dropped, which are then
+missing and can't be recovered.
+
+As a workaround, sleep for 100 microseconds after sending each batch
+of messages to the kernel, to give it a chance to do its housekeeping
+and resize the hashtables in the background.
+---
+ zebra/kernel_netlink.c | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/zebra/kernel_netlink.c b/zebra/kernel_netlink.c
+index 561f16609f..f938193eb4 100644
+--- a/zebra/kernel_netlink.c
++++ b/zebra/kernel_netlink.c
+@@ -5,6 +5,7 @@
+ 
+ #include <zebra.h>
+ #include <fcntl.h>
++#include <time.h>
+ 
+ #ifdef HAVE_NETLINK
+ #include <linux/netlink.h>
+@@ -1482,6 +1483,7 @@ static void nl_batch_init(struct nl_batch *bth,
+ static void nl_batch_send(struct nl_batch *bth)
+ {
+ 	struct zebra_dplane_ctx *ctx;
++	const struct timespec post_delay = { .tv_sec = 0, .tv_nsec = 100000 };
+ 	bool err = false;
+ 
+ 	if (bth->curlen != 0 && bth->zns != NULL) {
+@@ -1516,6 +1518,12 @@ static void nl_batch_send(struct nl_batch *bth)
+ 	}
+ 
+ 	nl_batch_reset(bth);
++
++	/* Sleep for 100 microseconds after pushing a batch into the
++	   kernel. If we send e.g. macfdb entries too fast, then the
++	   kernel might not be able to (asynchronously!) resize the
++	   hash table backing the fdb fast enough. */
++	(void) nanosleep(&post_delay, NULL);
+ }
+ 
+ enum netlink_msg_status netlink_batch_add_msg(
+-- 
+2.39.5 (Apple Git-154)
+

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -212,22 +212,17 @@ builtins.mapAttrs (_: patchPhps phpLogPermissionPatch) {
   });
 
   frr = super.frr.overrideAttrs (old: rec {
-    version = "10.1.2";
+    version = "10.1.3";
     src = super.fetchFromGitHub {
       owner = "FRRouting";
       repo = old.pname;
       rev = "${old.pname}-${version}";
-      hash = "sha256-yenWMFHQ8F3/GJ+BVnoi5t//6qtFqH8i3uNq4X0/qdI==";
+      hash = "sha256-bfCNh/ZjHtZAoij7kimFDZzCcGTHshcFaPM+yq9bBJQ=";
     };
 
     patches = [
       ./frr/0001-Don-t-throw-error-when-log-directory-already-exists.patch
-      # issue with best path selection erroneously deleting local mac
-      # addresses during incoming guest migration.
-      (fetchpatch {
-        url = "https://github.com/FRRouting/frr/commit/c3e264e27ac5b682c4647aeeaf4e61f09d5243f9.patch";
-        hash = "sha256-YUNyE2ZeW3q58E+fpFhmMGpp56eba8HUI7pcLLbQDTE=";
-      })
+      ./frr/0002-zebra-dplane-sleep-after-writing-batches-to-netlink.patch
     ];
   });
 


### PR DESCRIPTION
Update our pinned version of FRR from 10.1.2 to 10.1.3, which among other fixes includes a change we had backported previously.

This change also introduces a different patch to our overlay to address an intermittent problem we've seen in production. The kernel uses hash tables for storing the MAC forwarding database (macfdb) associated with a given bridge interface, and this hash table is dynamically resized as the number of entries in the macfdb changes. The default table size is however rather small (two-digit number of items), and the resizing step happens asynchronously with regard to operations on the hash table (insertions, deletions, lookups). We've seen cases where when FRR starts up at first boot and synchronises the EVPN RIB into the kernel it will insert entries into the macfdb faster than the kernel schedules the task for resizing the hash table, which results in some macfdb entries getting dropped when the table is full. These entries are lost and can't later be restored without restarting FRR entirely. The patch I've introduced here adds a sleep for 100 microseconds after sending each batch, which empirically seems to be enough of a delay to avoid this race condition.

PL-133422

@flyingcircusio/release-managers

## Release process

- [x] ~~Created changelog entry using `./changelog.sh`~~ -> internal change

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [x] ensure the merge bot has determined a merge date
- [x] ensure all checks are green
- [x] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Version update, correctness "fix".
- [x] Security requirements tested? (EVIDENCE)
  - Manually verified in dev, Hydra tests should pick up any obvious problems.