### PR TITLE
s3users: error when unknown error occurs

### DIFF
--- a/changelog.d/20250430_103535_PL-133656-s3users-exit-when-unknown-error-occurs_scriv.md
+++ b/changelog.d/20250430_103535_PL-133656-s3users-exit-when-unknown-error-occurs_scriv.md
@@ -1,0 +1,21 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+
+### NixOS XX.XX platform
+
+- s3users: error when unknown error occurs (PL-133656)
+  This is a safeguard against unexpected errors happen in the rgw user list
+  / user info calls leading to a re-creation of the user with a new secret key.

--- a/pkgs/fc/agent/fc/manage/s3users.py
+++ b/pkgs/fc/agent/fc/manage/s3users.py
@@ -9,6 +9,7 @@ import argparse
 import datetime
 import json
 import logging
+import subprocess
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -65,6 +66,12 @@ class RGWState:
         self.uid = uid
 
     def update(self, previously_deleted=False):
+        def check_user_doesnt_exist(code, stdout, stderr):
+            return (
+                code == 22
+                and b"could not fetch user info: no user info saved" in stderr
+            )
+
         try:
             state = run.json.radosgw_admin(
                 "user",
@@ -72,20 +79,22 @@ class RGWState:
                 "--uid",
                 self.uid,
                 # silence error when the user was previously deleted
-                silent_errors=(
-                    lambda code, stdout, stderr: previously_deleted
-                    and code == 22
-                    and b"could not fetch user info: no user info saved"
-                    in stderr
-                ),
+                silent_errors=lambda code, stdout, stderr: previously_deleted
+                and check_user_doesnt_exist(code, stdout, stderr),
             )
 
-        except Exception:
-            self.exists = False
-            self.display_name = None
-            self.key_count = 0
-            self.access_key = None
-            self.secret_key = None
+        except subprocess.CalledProcessError as e:
+            if check_user_doesnt_exist(e.returncode, e.stdout, e.stderr):
+                self.exists = False
+                self.display_name = None
+                self.key_count = 0
+                self.access_key = None
+                self.secret_key = None
+            else:
+                # We have an inconsistent state now.
+                # We could still handle other users, but we have no consistent state to report to the directory,
+                # so raise the error and break loud.
+                raise
         else:
             self.exists = True
             self.display_name = state["display_name"]

--- a/pkgs/fc/agent/fc/manage/tests/test_s3users.py
+++ b/pkgs/fc/agent/fc/manage/tests/test_s3users.py
@@ -1,5 +1,7 @@
 import json
 import logging
+import subprocess
+from subprocess import CalledProcessError
 from unittest.mock import Mock, call
 
 import pytest
@@ -585,7 +587,7 @@ def test_ensure_hard_state_deletes_users(subprocess_run):
 
     subprocess_run.side_effect = [
         Mock(stdout=""),
-        Mock(stdout=""),
+        subprocess.CalledProcessError(cmd="", returncode=22, output=b"", stderr=b"could not fetch user info: no user info saved")
     ]
 
     user.ensure()
@@ -757,3 +759,82 @@ def test_usermanager_blocks_users_from_foreign_location_or_resource_group():
         e.value.args[0]
         == "Encountered user from unexpected storage resource group: wrong-resource-group"
     )
+
+def test_rgw_user_unknown_error_info_doesnt_create_user_again(subprocess_run, caplog):
+    caplog.set_level(logging.INFO)
+
+    directory = Mock()
+    directory.list_s3_users.return_value = {
+        "services:sometest": {
+            "location": "test",
+            "storage_resource_group": "services",
+            "display_name": "test test",
+            "access_key": "dnDlid0jyRs1sK9vEOGV",
+            "secret_key": "",
+            "deletion": {"deadline": "", "stages": []},
+        }
+    }
+
+    subprocess_run.side_effect = [
+        Mock(stdout=json.dumps(["services:sometest"])),
+        CalledProcessError(returncode=1, cmd="", output=b"", stderr=b"uh, i'm a weird error")
+    ]
+
+    with pytest.raises(CalledProcessError):
+        UserManager(directory, "test", "services")
+
+    assert subprocess_run.call_args_list == [
+        call(
+            [
+                "radosgw-admin", "--format", "json",
+                "user", "list",
+            ],
+            check=True, stdout=-1, stderr=-1,
+        ),
+        call(
+            [
+                "radosgw-admin", "--format", "json",
+                "user", "info", "--uid", "services:sometest",
+            ],
+            check=True, stdout=-1, stderr=-1,
+        ),
+    ]
+
+    assert directory.list_s3_users.call_args_list == [call()]
+    assert directory.update_s3_users.call_args_list == []
+
+
+def test_rgw_user_unknown_error_list_doesnt_create_user_again(subprocess_run, caplog):
+    caplog.set_level(logging.INFO)
+
+    directory = Mock()
+    directory.list_s3_users.return_value = {
+        "services:sometest": {
+            "location": "test",
+            "storage_resource_group": "services",
+            "display_name": "test test",
+            "access_key": "dnDlid0jyRs1sK9vEOGV",
+            "secret_key": "",
+            "deletion": {"deadline": "", "stages": []},
+        }
+    }
+
+    subprocess_run.side_effect = [
+        CalledProcessError(returncode=1, cmd="", output=b"", stderr=b"uh, i'm a weird list error")
+    ]
+
+    with pytest.raises(CalledProcessError):
+        UserManager(directory, "test", "services")
+
+    assert subprocess_run.call_args_list == [
+        call(
+            [
+                "radosgw-admin", "--format", "json",
+                "user", "list",
+            ],
+            check=True, stdout=-1, stderr=-1,
+        ),
+    ]
+
+    assert directory.list_s3_users.call_args_list == [call()]
+    assert directory.update_s3_users.call_args_list == []


### PR DESCRIPTION
This is a safeguard against unexpected errors happen in the rgw user list / user info calls leading to a re-creation of the user with a new secret key.

PL-133656

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Availability: This decreases availability as it stops handling new users when an unknown error occurs. This is intended to ensure a clean state. We have a stamp file for this, so a failure gets noticed.
  - Consistency: Fail stop behavior
- [x] Security requirements tested? (EVIDENCE)
  - see above
  - tested user creation and key rotation in dev
  - unit tests 