### PR TITLE
tests.gitlab: disable

### DIFF
--- a/tests/default.nix
+++ b/tests/default.nix
@@ -44,7 +44,7 @@ in {
   ffmpeg = callTest ./ffmpeg.nix {};
   filebeat = callTest ./filebeat.nix {};
   collect-garbage = callTest ./collect-garbage.nix {};
-  gitlab = callTest ./gitlab.nix {};
+  #gitlab = callTest ./gitlab.nix {};
   haproxy = callTest ./haproxy.nix {};
   java = callTest ./java.nix {};
   journal = callTest ./journal.nix {};


### PR DESCRIPTION
The test takes very long and blocks release progress. But we have no gitlabs on 24.05 anymore, hence it is not worth the wait.

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`
  - no, internal only 

## PR release workflow (internal)

- [x] PR has internal ticket
- [ ] internal issue ID (PL-…) part of branch name
- [ ] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [x] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - superfluous test can be disabled, we do not have gitlab hosts on 24.05 anymore
- [ ] Security requirements tested? (EVIDENCE)
