### PR TITLE
fc-luks: fix external header backup

### DIFF
--- a/pkgs/fc/ceph/src/fc/ceph/backup.py
+++ b/pkgs/fc/ceph/src/fc/ceph/backup.py
@@ -63,7 +63,7 @@ class BackyVolume:
                         os.remove(ext_header)
                         break
                     case "n" | "":
-                        breakpoint
+                        break
                     case _:
                         console.print("invalid choice, retry.")
 

--- a/pkgs/fc/ceph/src/fc/ceph/luks/checks.py
+++ b/pkgs/fc/ceph/src/fc/ceph/luks/checks.py
@@ -1,11 +1,15 @@
-from typing import Iterator
+import filecmp
+from pathlib import Path
+from typing import Iterator, Optional
+
+from fc.ceph.luks import KEYSTORE
 
 # In case these checks ever break: More recent cryptsetup versions also support
 # JSON-formatted output via `cryptsetup luksDump --dump-json-metadata <dev>`.
 # It most likely makes sense parsing that data instead once available.
 
 
-def check_cipher(lines: str) -> Iterator[str]:
+def check_cipher(lines: list[str], **_) -> Iterator[str]:
     checked = False  # plausibility check: did we get any cipher info?
     for line in lines:
         line = line.strip()
@@ -20,7 +24,7 @@ def check_cipher(lines: str) -> Iterator[str]:
         yield "Unable to check cipher correctness, no `Cipher:` found in dump"
 
 
-def _extract_keyslot_numbers(lines: str):
+def _extract_keyslot_numbers(lines: list[str]):
     known_keyslots: set[int] = set()
     lines_iter = iter(lines)
     for line in lines_iter:
@@ -44,13 +48,13 @@ def _extract_keyslot_numbers(lines: str):
     return known_keyslots
 
 
-def check_key_slots_exactly_1_and_0(lines: str) -> Iterator[str]:
+def check_key_slots_exactly_1_and_0(lines: list[str], **_) -> Iterator[str]:
     keyslots = _extract_keyslot_numbers(lines)
     if set([0, 1]) != keyslots:
         yield f"keyslots: unexpected configuration ({keyslots})"
 
 
-def check_512_bit_keys(lines: str) -> Iterator[str]:
+def check_512_bit_keys(lines: list[str], **_) -> Iterator[str]:
     checked = False
     for line in lines:
         line = line.strip()
@@ -65,7 +69,7 @@ def check_512_bit_keys(lines: str) -> Iterator[str]:
         yield "Unable to check key size correctness, no `Key:` found in dump"
 
 
-def check_pbkdf_is_argon2id(lines: str) -> Iterator[str]:
+def check_pbkdf_is_argon2id(lines: list[str], **_) -> Iterator[str]:
     checked = False
     for line in lines:
         line = line.strip()
@@ -80,10 +84,25 @@ def check_pbkdf_is_argon2id(lines: str) -> Iterator[str]:
         yield "Unable to check PBKDF correctness, no `PBKDF:` found in dump"
 
 
+def check_header_backup_valid(
+    lines: list[str], header: Optional[str]
+) -> Iterator[str]:
+    if header is None:
+        return
+    backup = KEYSTORE.local_key_dir / Path(header).name
+    try:
+        filecmp.clear_cache()
+        if not filecmp.cmp(header, backup, shallow=False):
+            yield "Header backup differs from local header"
+    except IOError:
+        yield "Error checking header backup"
+
+
 # All these checks work on a list of lines output by `cryptsetup luksDump`
 all_checks = [
     check_cipher,
     check_key_slots_exactly_1_and_0,
     check_512_bit_keys,
     check_pbkdf_is_argon2id,
+    check_header_backup_valid,
 ]

--- a/pkgs/fc/ceph/src/fc/ceph/luks/manage.py
+++ b/pkgs/fc/ceph/src/fc/ceph/luks/manage.py
@@ -199,6 +199,9 @@ class LUKSKeyStoreManager(object):
             input=add_input,
         )
 
+        if header:
+            self._KEYSTORE.backup_external_header(Path(header))
+
     @staticmethod
     def check_luks(name_glob: str, header: Optional[str]) -> int:
         devices = LuksDevice.filter_cryptvolumes(name_glob, header=header)
@@ -225,7 +228,7 @@ class LUKSKeyStoreManager(object):
             dump_lines = luks_dump.decode("utf-8").splitlines()
             for check in all_checks:
                 check_ok = True
-                for error in check(dump_lines):
+                for error in check(dump_lines, header=dev.header):
                     errors += 1
                     check_ok = False
                     console.print(f"{check.__name__}: {error}", style="red")
@@ -302,9 +305,6 @@ class LUKSKeyStoreManager(object):
             success = False
 
         return success
-
-        if header:
-            self._KEYSTORE.backup_external_header(Path(header))
 
     def fingerprint(self, verify: bool, confirm: bool) -> int:
         """

--- a/pkgs/fc/ceph/src/fc/ceph/tests/test_luks_dump.py
+++ b/pkgs/fc/ceph/src/fc/ceph/tests/test_luks_dump.py
@@ -2,6 +2,8 @@ import textwrap
 import unittest.mock
 from unittest.mock import MagicMock
 
+from fc.ceph.luks import KEYSTORE
+
 data_correct = """LUKS header information
 Version:       	2
 Epoch:         	8
@@ -205,6 +207,31 @@ def test_check_pbkdf_is_argon2id_error():
     ]
 
 
+def test_check_header_backup_valid(tmp_path, monkeypatch):
+    from fc.ceph.luks.checks import check_header_backup_valid
+
+    keystore_path = tmp_path / "keystore"
+    keystore_path.mkdir()
+    orig_header = tmp_path / "header.luks"
+    backup_header = keystore_path / "header.luks"
+    monkeypatch.setattr(KEYSTORE, "local_key_dir", keystore_path)
+
+    assert list(check_header_backup_valid([], orig_header)) == [
+        "Error checking header backup"
+    ]
+
+    orig_header.write_text("abc")
+    backup_header.write_text("aaa")
+
+    assert list(check_header_backup_valid([], orig_header)) == [
+        "Header backup differs from local header"
+    ]
+
+    backup_header.write_text("abc")
+
+    assert list(check_header_backup_valid([], orig_header)) == []
+
+
 def test_check_integration_ok(monkeypatch, capsys):
     from fc.ceph.luks.manage import LuksDevice, LUKSKeyStoreManager
 
@@ -239,11 +266,13 @@ def test_check_integration_ok(monkeypatch, capsys):
         check_key_slots_exactly_1_and_0: OK
         check_512_bit_keys: OK
         check_pbkdf_is_argon2id: OK
+        check_header_backup_valid: OK
         Checking testdev2:
         check_cipher: OK
         check_key_slots_exactly_1_and_0: OK
         check_512_bit_keys: OK
         check_pbkdf_is_argon2id: OK
+        check_header_backup_valid: OK
         """
     )
     assert captured.err == ""
@@ -258,11 +287,13 @@ def test_check_integration_error(monkeypatch, capsys):
                 base_blockdev="/dev/mapper/foo",
                 name="testdev1",
                 mountpoint="/mnt/foo",
+                header="/mnt/foo.luks",
             ),
             LuksDevice(
                 base_blockdev="/dev/vgbar/holygrail",
                 name="testdev2",
                 mountpoint="/mnt/bar",
+                header="/mnt/bar.luks",
             ),
         ]
     )
@@ -287,6 +318,7 @@ def test_check_integration_error(monkeypatch, capsys):
         check_key_slots_exactly_1_and_0: keyslots: unexpected configuration ({0, 3})
         check_512_bit_keys: keysize: 256 bits does not match expected 512 bits
         check_pbkdf_is_argon2id: pbkdf: SHAKE382 does not match expected argon2id
+        check_header_backup_valid: Error checking header backup
         Checking testdev2:
         check_cipher: Unable to check cipher correctness, no `Cipher:` found in dump
         check_key_slots_exactly_1_and_0: keyslots: unexpected configuration (set())
@@ -295,6 +327,7 @@ def test_check_integration_error(monkeypatch, capsys):
         dump
         check_pbkdf_is_argon2id: Unable to check PBKDF correctness, no `PBKDF:` found in
         dump
+        check_header_backup_valid: Error checking header backup
         """
     )
     assert captured.err == ""


### PR DESCRIPTION
Bug was introduced by 87905aa5cbcf160838658eaf1e72d676a61cf4cb in #1087, which was merged on 2024-08-22. However, all backup server encryptions happened before that and the first rekeying is scheduled for 2025-06-01, so no servers are affected.
All backup servers were also manually checked.
Also adds a check that tests if the header backup is up to date.

PL-133661

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`
  - internal

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - bug fix
- [x] Security requirements tested? (EVIDENCE)
  - tests still pass