### PR TITLE
[PL-133646] roles/webproxy: filter varnish listen addresses by uniqueness

### DIFF
--- a/changelog.d/20250502_115450_PL-133646-varnish-devhost-addrs_scriv.md
+++ b/changelog.d/20250502_115450_PL-133646-varnish-devhost-addrs_scriv.md
@@ -1,0 +1,19 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+
+### NixOS XX.XX platform
+
+- varnish: Listen addresses are filtered by uniqueness. Before that, adding the same listen IP twice would break Varnish on startup.

--- a/nixos/roles/webproxy.nix
+++ b/nixos/roles/webproxy.nix
@@ -108,7 +108,9 @@ in
       flyingcircus.services.varnish = {
         enable = true;
         extraCommandLine = "-s malloc,${toString cacheMemory}M";
-        http_address = lib.concatMapStringsSep " -a " (addr: "${addr}:8008") fccfg.listenAddresses;
+        http_address = lib.concatMapStringsSep " -a " (addr: "${addr}:8008") (
+          lib.unique fccfg.listenAddresses
+        );
         virtualHosts = lib.optionalAttrs (varnishCfg != null) {
           "default-vcl" = {
             condition = "true";


### PR DESCRIPTION
About a year ago, the devhost configuration only added `[::]` to the listen addresses, however this only added an IPv6 listen breaking certain deployments on devhosts if they explicitly talked to Varnish with IPv4[1].

As a band-aid fix I added the `0.0.0.0` http_addr to said deployment in the devhost configuration which worked until I upgraded fc-nixos to a version with the fix.

While this is something to be cleaned up in the deployment, it's also wrong to generate a broken configuration here, so making the list unique still seems reasonable.

[1] 70bc3858ba0365e1b9563c16a3a9c28e2dbef557

cc @flyingcircusio/release-managers 

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  * Availability: this changes protects us from invalid Varnish configuration in any case (devhost was just the one where this got triggered & noticed).
- [x] Security requirements tested? (EVIDENCE)
  * Confirmed by both rsyncing+nixos-rebuilding this checkout on a devhost and by provisioning a new devhost with the Hydra eval from this PR that the change fixes the problem described above.