### PR TITLE
[25.05] roles/percona84: init role

### DIFF
--- a/doc/src/mysql.md
+++ b/doc/src/mysql.md
@@ -25,12 +25,7 @@ existing machines to this platform version.
 
 MySQL works out-of-the box without configuration.
 
-You can change the password for the mysql *root* user in {file}`/etc/local/mysql/mysql.passwd`.
-The MySQL service must be restarted to pick up the new password:
-
-```
-sudo systemctl restart mysql
-```
+The root user is authenticated by socket auth with the `mysql` and `root` system users.
 
 Custom config files in {file}`/etc/local/mysql` are included in the
 main mysql configuration file on the next system build.
@@ -44,9 +39,6 @@ to activate the new configuration.
 
 ## Interaction
 
-You can find the password for the MySQL *root* user in {file}`/etc/local/mysql.passwd`.
-Service users can read the password file.
-
 Service users can use {command}`sudo -iu mysql` to access the
 MySQL *root* account to perform administrative commands
 and log files in {file}`/var/log/mysql`.
@@ -56,7 +48,7 @@ To connect to the local MySQL server, run {command}`mysql` as *mysql* user:
 sudo -u mysql mysql
 ```
 
-The MySQL server can be accessed from other machines in the same project on the
+The MySQL server can be accessed from other machines in the same resource group on the
 default port 3306.
 
 ## Slow Log

--- a/doc/src/mysql.md
+++ b/doc/src/mysql.md
@@ -16,10 +16,12 @@ There's a role for each supported version, currently:
 - mysql57: Percona 5.7.x (End-of-life)
 - percona80: Percona 8.0.x (*LTS* release)
 - percona83: Percona 8.3.x (End-of-life)
+- percona84: Percona 8.4.x
 
-We recommend the use of `percona80`, as this is the only role version that receives
-security updates. All other versions are only included to allow the upgrade of
-existing machines to this platform version.
+We recommend the use of `percona84`, as this is the most up to date LTS release.
+You might also use `percona80` if you are unable to use 8.4.
+All other versions don't receive security updates and are only included to allow
+the upgrade of existing machines to this platform version.
 
 ## Configuration
 
@@ -85,3 +87,15 @@ Enabling a Percona role first and only setting an initial script later won't hav
 any effect anymore.
 % hidden note as of 20240711: It is possible to re-trigger db initialisation by `touch /run/mysql_init`, but we have decided not to expose this as an official stable API.
 :::
+
+## Migrate user password hash algorithm
+
+Before Percona (and generally MySQL) 8.4, `mysql_native_password` was the default authentication and password hash algorithm.
+This algorithm will be removed in our platform with NixOS 25.11.
+With 8.4 `caching_sha2_password` is the new default algorithm to use.
+Users need to  be manually migrated to the new algorithm with the following SQL statement (insert `username`, `host`, `password`):
+```
+ALTER USER 'username'@'host' IDENTIFIED WITH 'caching_sha2_password' by 'password';
+```
+This migration needs to be done before using Percona 9.0.
+Please check your MySQL client library support for `caching_sha2_password` before migrating the user.

--- a/nixos/roles/mysql.nix
+++ b/nixos/roles/mysql.nix
@@ -15,6 +15,7 @@ let
   supportedPerconaVersions = [
     "8.0"
     "8.3"
+    "8.4"
   ];
   removeDot = builtins.replaceStrings [ "." ] [ "" ];
   lokiServer = fclib.findOneService "loki-collector";
@@ -263,15 +264,22 @@ in
               thread_cache_size          = 8
 
               ${
-                # For 8.0 we still use native password because there are
+                # For 8.4 we need to enable this manually. Will be removed in 9.0
+                lib.optionalString (lib.versionAtLeast package.version "8.4") ''
+                  mysql_native_password = ON
+                ''
+              }
+
+              ${
+                # For 8.0 and 8.3 we still use native password because there are
                 # too many non 8.0 client libs out there, which cannot
                 # connect otherwise.
-                # FIXME: disable from 8.4 on
-                # TODO: migration strategy for existing users?
-                lib.optionalString (lib.versionAtLeast package.version "8.0") ''
-                  default_authentication_plugin = mysql_native_password
-                  log_error_suppression_list = MY-013360
-                ''
+                lib.optionalString
+                  (lib.versionAtLeast package.version "8.0" && lib.versionOlder package.version "8.4")
+                  ''
+                    default_authentication_plugin = mysql_native_password
+                    log_error_suppression_list = MY-013360
+                  ''
               }
 
               ${

--- a/nixos/roles/mysql.nix
+++ b/nixos/roles/mysql.nix
@@ -114,8 +114,6 @@ in
 
       localConfigPath = /etc/local/mysql;
 
-      rootPasswordFile = "${toString localConfigPath}/mysql.passwd";
-
       isCnf = path: t: lib.hasSuffix ".cnf" path;
 
       localConfig =
@@ -172,6 +170,9 @@ in
         systemd.tmpfiles.rules = [
           "d /var/log/mysql 0755 mysql service 90d"
           "f /var/log/mysql/mysql.slow 0640 mysql service -"
+          # Cleanup files that are not required anymore and confusing
+          "r /root/.my.cnf"
+          "r ${toString localConfigPath}/mysql.passwd"
         ];
 
         # Note that this does not use platform defaults, by using priority 100.
@@ -185,7 +186,7 @@ in
             compress = true;
             create = "0640 mysql service";
             postrotate = ''
-              ${package}/bin/mysql --defaults-extra-file=/root/.my.cnf -e \
+              ${package}/bin/mysql -e \
                     'select @@global.long_query_time into @lqt_save; set global long_query_time=2000; select sleep(2); FLUSH LOGS; select sleep(2); set global long_query_time=@lqt_save;'
             '';
             missingok = true;
@@ -194,7 +195,7 @@ in
 
         services.percona = {
           enable = true;
-          inherit package rootPasswordFile;
+          inherit package;
           dataDir = "/srv/mysql";
           extraOptions =
             let
@@ -265,6 +266,8 @@ in
                 # For 8.0 we still use native password because there are
                 # too many non 8.0 client libs out there, which cannot
                 # connect otherwise.
+                # FIXME: disable from 8.4 on
+                # TODO: migration strategy for existing users?
                 lib.optionalString (lib.versionAtLeast package.version "8.0") ''
                   default_authentication_plugin = mysql_native_password
                   log_error_suppression_list = MY-013360
@@ -327,8 +330,9 @@ in
         environment.etc."local/mysql/README.txt".text = ''
           MySQL / Percona (${package.name}) is running on this machine.
 
-          You can find the password for the MySQL root user in the file `mysql.passwd`.
-          Service users can read the password file.
+          The root user is authenticated by socket auth with the `mysql` and `root` system users.
+          If you want to add a password to this user, you can do this manually with interactive
+          SQL commands.
 
           Config files from this directory (/etc/local/mysql) are included in the
           mysql configuration. To set custom options, add a `local.cnf`
@@ -336,10 +340,6 @@ in
 
           ATTENTION: Changes to *.cnf files in this directory will restart MySQL
           to activate the new configuration.
-
-          You can change the password for the mysql root user in the file `mysql.passwd`.
-          The MySQL service must be restarted to pick up the new password:
-          `sudo systemctl restart mysql`
 
           For more information, see our documentation at
           ${fclib.roleDocUrl "mysql"}
@@ -372,7 +372,7 @@ in
                     CREATE DATABASE IF NOT EXISTS ${dbUser};
                     GRANT SELECT ON ${dbUser}.* TO ${dbUser}@localhost IDENTIFIED WITH auth_socket AS '${systemUser}';
                   '';
-              mysqlCmd = sql: ''mysql --defaults-extra-file=/root/.my.cnf -e "${sql}"'';
+              mysqlCmd = sql: ''mysql -e "${sql}"'';
             in
             ''
               # Wait until the MySQL server is available for use

--- a/nixos/roles/slurm/default.nix
+++ b/nixos/roles/slurm/default.nix
@@ -545,12 +545,7 @@ in
               CREATE DATABASE IF NOT EXISTS slurm_acct_db;
               GRANT ALL ON slurm_acct_db.* TO slurm@localhost;
             '';
-            mysqlCmd =
-              sql:
-              "${config.services.percona.package}/bin/mysql"
-              + " --defaults-extra-file=/root/.my.cnf"
-              + " -v"
-              + " -e '${sql}'";
+            mysqlCmd = sql: "${config.services.percona.package}/bin/mysql" + " -v" + " -e '${sql}'";
           in
           "${mysqlCmd ensureUserAndDatabase}";
       };

--- a/nixos/services/percona.nix
+++ b/nixos/services/percona.nix
@@ -42,7 +42,7 @@ let
     chmod 0755 /run/mysqld
     chown -R ${cfg.user} /run/mysqld
 
-    cat > /srv/mysql/.my.cnf <<__EOT__
+    cat > ${config.users.users."${cfg.user}".home}/.my.cnf <<__EOT__
     # Do not modify this file, it will be overwritten when MySQL starts!
     # The following options will be passed to all MySQL clients
     [client]

--- a/nixos/services/percona.nix
+++ b/nixos/services/percona.nix
@@ -13,7 +13,9 @@ let
 
   mysql = cfg.package;
 
-  initFile = "/run/mysqld/init_set_root_password.sql";
+  initFile = pkgs.writeText "mysql_set_root_socket" ''
+    ALTER USER 'root'@'localhost' IDENTIFIED WITH auth_socket AS 'mysql';
+  '';
 
   pidFile = "${cfg.pidDir}/mysqld.pid";
 
@@ -31,17 +33,7 @@ let
     ${cfg.extraOptions}
   '';
 
-  mysqlInit =
-    if versionAtLeast mysql.mysqlVersion "5.7" then
-      "${mysql}/bin/mysqld --initialize-insecure ${mysqldOptions}"
-    else
-      "${pkgs.perl}/bin/perl ${mysql}/bin/mysql_install_db ${mysqldOptions}";
-
-  setPasswordSql =
-    if (lib.versionAtLeast mysql.mysqlVersion "5.7") then
-      "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY \'$pw\';"
-    else
-      "SET PASSWORD FOR 'root'@'localhost' = PASSWORD(\'$pw\');";
+  mysqlInit = "${mysql}/bin/mysqld --initialize-insecure ${mysqldOptions}";
 
   mysqlPreStart = ''
     umask 0066
@@ -50,33 +42,14 @@ let
     chmod 0755 /run/mysqld
     chown -R ${cfg.user} /run/mysqld
 
-    # Generate mysql root password file if it's not present.
-    if [[ ! -f ${cfg.rootPasswordFile} ]]; then
-      pw=`${pkgs.apg}/bin/apg -a 1 -M lnc -n 1 -m 12`
-      echo -n "''${pw}" > ${cfg.rootPasswordFile}
-    fi
-    chown root:service ${cfg.rootPasswordFile}
-    chmod 660 ${cfg.rootPasswordFile}
-
-    pw=$(<${cfg.rootPasswordFile})
-    cat > /root/.my.cnf <<__EOT__
+    cat > /srv/mysql/.my.cnf <<__EOT__
     # Do not modify this file, it will be overwritten when MySQL starts!
     # The following options will be passed to all MySQL clients
     [client]
-    password = ''${pw}
     user = root
     __EOT__
-    chmod 440 /root/.my.cnf
-    # allow convenient logins as db `root` user for unix users `mysql` and `root
-    cp -p /root/.my.cnf /srv/mysql/.my.cnf
+    chmod 440 /srv/mysql/.my.cnf
     chown mysql:mysql /srv/mysql/.my.cnf
-
-    # write init file for mysqld to set the root password
-    cat > ${initFile} <<__EOT__
-    ${setPasswordSql}
-    __EOT__
-    chmod 440 ${initFile}
-    chown ${cfg.user} ${initFile}
 
     if ! test -e ${cfg.dataDir}/mysql; then
         mkdir -m 0700 -p ${cfg.dataDir}
@@ -127,10 +100,6 @@ in
       dataDir = mkOption {
         default = "/srv/mysql";
         description = "Location where MySQL stores its table files";
-      };
-
-      rootPasswordFile = mkOption {
-        description = "Location of the root password file";
       };
 
       pidDir = mkOption {
@@ -302,7 +271,7 @@ in
 
             ${optionalString (cfg.initialScript != null) ''
               # Execute initial script
-              cat ${cfg.initialScript} | ${mysql}/bin/mysql --defaults-extra-file=/root/.my.cnf -u root -N
+              cat ${cfg.initialScript} | ${mysql}/bin/mysql -u root -N
             ''}
 
           rm /run/mysql_init

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -597,6 +597,7 @@ builtins.mapAttrs (_: patchPhps phpLogPermissionPatch) {
     # newer versions cause linking failures against `libabsl_spinlock_wait`
     protobuf = self.protobuf_21;
   };
+  percona84 = self.percona-server_8_4;
 
   percona-xtrabackup_2_4 = super.callPackage ./percona-xtrabackup/2_4/2_4.nix {
     boost = self.boost159;

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -115,6 +115,7 @@ in
   openvpn = callTest ./openvpn.nix { };
   percona80 = callTest ./mysql.nix { rolename = "percona80"; };
   percona83 = callTest ./mysql.nix { rolename = "percona83"; };
+  percona84 = callTest ./mysql.nix { rolename = "percona84"; };
   physical-installer = callTest ./physical-installer.nix { inherit nixpkgs; };
   postgresql13 = callTest ./postgresql { version = "13"; };
   postgresql14 = callTest ./postgresql { version = "14"; };

--- a/tests/mysql.nix
+++ b/tests/mysql.nix
@@ -75,8 +75,9 @@ import ./make-test-python.nix (
 
         master.sleep(5)
 
-        with subtest("can login with root password"):
-            master.succeed("mysql mysql -u root -p$(< /etc/local/mysql/mysql.passwd) -e 'select 1'")
+        with subtest("can connect as root"):
+            master.succeed("sudo -u mysql mysql -e 'select 1'")
+            master.succeed("mysql -e 'select 1'")
 
         with subtest("mysql only opens expected ports"):
             # check for expected ports
@@ -108,17 +109,6 @@ import ./make-test-python.nix (
         with subtest("status check should be red after shutting down mysql"):
             master.succeed('systemctl stop mysql')
             master.fail("""${mysqlCheck}""")
-
-        with subtest("secret files should have correct permissions"):
-            master.succeed("stat /etc/local/mysql/mysql.passwd -c %a:%U:%G | grep '660:root:service'")
-            master.succeed("stat /root/.my.cnf -c %a:%U:%G | grep '440:root:root'")
-            master.succeed("stat /run/mysqld/init_set_root_password.sql -c %a:%U:%G | grep '440:mysql:root'")
-
-        with subtest("root should be able to connect after changing the password"):
-            master.succeed("echo tt > /etc/local/mysql/mysql.passwd")
-            master.succeed("systemctl restart mysql")
-            master.wait_until_succeeds("mysql mysql -u root -ptt -e 'select 1'")
-
         with subtest("xtrabackup works"): # sensuclient has service group
             master.succeed("sudo -u sensuclient sudo xtrabackup --backup -S /run/mysqld/mysqld.sock")
             master.succeed("grep uuid /tmp/xtrabackup_backupfiles/xtrabackup_info")

--- a/tests/mysql.nix
+++ b/tests/mysql.nix
@@ -102,6 +102,14 @@ import ./make-test-python.nix (
             master.wait_for_unit("mysql")
             master.wait_until_succeeds("mysqladmin ping")
 
+        with subtest("creating user and connecting on port works"):
+            master.succeed("mysql -e \"create user test@127.0.0.1 identified by 'foobar' \"")
+            master.succeed("mysql -h 127.0.0.1 -u test -pfoobar -e 'select 1'")
+
+        with subtest("xtrabackup works"): # sensuclient has service group
+            master.succeed("sudo -u sensuclient sudo xtrabackup --backup -S /run/mysqld/mysqld.sock")
+            master.succeed("grep uuid /tmp/xtrabackup_backupfiles/xtrabackup_info")
+
         with subtest("all sensu checks should be green"):
             master.wait_for_unit("fc-mysql-post-init.service")
             master.succeed("""${mysqlCheck}""")
@@ -109,9 +117,6 @@ import ./make-test-python.nix (
         with subtest("status check should be red after shutting down mysql"):
             master.succeed('systemctl stop mysql')
             master.fail("""${mysqlCheck}""")
-        with subtest("xtrabackup works"): # sensuclient has service group
-            master.succeed("sudo -u sensuclient sudo xtrabackup --backup -S /run/mysqld/mysqld.sock")
-            master.succeed("grep uuid /tmp/xtrabackup_backupfiles/xtrabackup_info")
       '';
 
   }


### PR DESCRIPTION
@flyingcircusio/release-managers

PL-133082

## Release process

- [ ] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Functionality
  - Security
  - Continuity 
- [x] Security requirements tested? (EVIDENCE)
  - Tested on test VM that connections via socket and port works
  - Adapted automated tests
  - Activated mysql_native_auth on percona 8.4 to provide migration option
