### PR TITLE
gitlab: fix registry port

### DIFF
--- a/changelog.d/20250507_133919_PL-133568-gitlab-registry-port_scriv.md
+++ b/changelog.d/20250507_133919_PL-133568-gitlab-registry-port_scriv.md
@@ -1,0 +1,20 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+
+
+### NixOS XX.XX platform
+
+- gitlab: fix registry port. (PL-133568)

--- a/nixos/roles/gitlab.nix
+++ b/nixos/roles/gitlab.nix
@@ -337,7 +337,7 @@ in
         "${cfg.dockerHostName}" = {
           forceSSL = true;
           locations."/" = {
-            proxyPass = "http://127.0.0.1:5000";
+            proxyPass = "http://127.0.0.1:${toString config.services.gitlab.registry.port}";
             extraConfig = ''
               client_max_body_size 2000M;
               proxy_read_timeout 900;

--- a/tests/gitlab.nix
+++ b/tests/gitlab.nix
@@ -134,7 +134,7 @@ import ./make-test-python.nix (
               "${pkgs.sudo}/bin/sudo -u gitlab -H gitlab-rake gitlab:check 1>&2"
           )
           gitlab.succeed(
-              "echo \"Authorization: Bearer \$(curl -X POST -H 'Content-Type: application/json' -d @${auth} http://gitlab/oauth/token | ${pkgs.jq}/bin/jq -r '.access_token')\" >/tmp/headers"
+              "echo \"Authorization: Bearer $(curl -X POST -H 'Content-Type: application/json' -d @${auth} http://gitlab/oauth/token | ${pkgs.jq}/bin/jq -r '.access_token')\" >/tmp/headers"
           )
           gitlab.succeed(
               "curl -X POST -H 'Content-Type: application/json' -H @/tmp/headers -d @${createProject} http://gitlab/api/v4/projects"
@@ -150,6 +150,9 @@ import ./make-test-python.nix (
           )
           gitlab.succeed("test -s /tmp/archive.tar.gz")
           gitlab.succeed("test -s /tmp/archive.tar.bz2")
+
+        with subtest("Test docker registry http is available"):
+          gitlab.succeed("curl -sSf http://docker.gitlab")
       '';
   }
 )


### PR DESCRIPTION
PL-133568

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - bug fix 
- [ ] Security requirements tested? (EVIDENCE)
