### PR TITLE
[PL-133637] nixos/slurm: return nodes to service after unexpected reboot

### DIFF
--- a/changelog.d/20250508_154517_PL-133637-slurm-returntoservice_scriv.md
+++ b/changelog.d/20250508_154517_PL-133637-slurm-returntoservice_scriv.md
@@ -1,0 +1,20 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+- Slurm services will be restarted.
+
+### NixOS XX.XX platform
+
+- Slurm nodes will be returned to service after an unexpected reboot.

--- a/nixos/roles/slurm/default.nix
+++ b/nixos/roles/slurm/default.nix
@@ -351,7 +351,7 @@ in
             # Upon registration with a valid configuration only if it was set
             # DOWN due to being non-responsive.
 
-            ReturnToService = 1
+            ReturnToService = 2
 
             SlurmctldDebug = info
             SlurmdDebug = info


### PR DESCRIPTION
Right now, slurm nodes are kept DOWN after an unexpected reboot until being marked as ready with e.g. `fc-slurm ready`.

This configuration change also returns nodes to service on unexpected reboots matching the behavior of any other service we're running.

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Availability: on our scale we don't want to activate all slurms nodes in a cluster by hand after e.g. a Ceph outage.
- [x] Security requirements tested? (EVIDENCE)
  - Ensured that there's no state change of slurmtest11 after an unuexpected reboot
  - Ensured that slurmtest11 gets into state `DOWN*` after powering it off, but gets back into `IDLE` after starting it up.
