### PR TITLE
Pl 133666 haproxy cfg vs conf

### DIFF
--- a/changelog.d/20250513_093854_PL-133666-haproxy-cfg-vs-conf_scriv.md
+++ b/changelog.d/20250513_093854_PL-133666-haproxy-cfg-vs-conf_scriv.md
@@ -1,0 +1,20 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+
+### NixOS XX.XX platform
+
+- Small update of documentation strings on which type of configuration files
+  are used for generated haproxy.cfg (PL-133666)

--- a/nixos/services/haproxy/README.md
+++ b/nixos/services/haproxy/README.md
@@ -1,4 +1,4 @@
-The Haproxy service can be configured by adding `/etc/local/haproxy/*.conf`
+The Haproxy service can be configured by adding `/etc/local/haproxy/*.cfg`
 files in the HAproxy format as well as from custom Nix Configuration Options.
 
 The local plain configuration files are enabled by default and can be disabled

--- a/nixos/services/haproxy/default.nix
+++ b/nixos/services/haproxy/default.nix
@@ -135,7 +135,7 @@ let
         (if cfg.enableStructuredConfig then generatedConfig else "")
         + (
           if cfg.enableLocalPlainConfig then
-            "\n# Plain config from /etc/local/haproxy/*.conf starts here\n" + modifiedCfgContent
+            "\n# Plain config from /etc/local/haproxy/*.cfg starts here.\n" + modifiedCfgContent
           else
             ""
         )


### PR DESCRIPTION
@flyingcircusio/release-managers

This MR just updates a few strings used e.g. in HAProxy readme on /etc/local to ensure users are naming there files correctly.

Fixes PL-133666)

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [x] Security requirements tested? (EVIDENCE)
