### PR TITLE
gitlab: generate ActiveRecord encryption secrets

### DIFF
--- a/changelog.d/20250515_124630_gitlab-activerecord-secrets-24.11_scriv.md
+++ b/changelog.d/20250515_124630_gitlab-activerecord-secrets-24.11_scriv.md
@@ -1,0 +1,19 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+
+### NixOS XX.XX platform
+
+- gitlab: generate ActiveRecord encryption secrets

--- a/nixos/roles/gitlab.nix
+++ b/nixos/roles/gitlab.nix
@@ -161,6 +161,9 @@ in
           secretFile = "${cfg.secretsDir}/secret";
           otpFile = "${cfg.secretsDir}/otp";
           jwsFile = "${cfg.secretsDir}/jws";
+          activeRecordPrimaryKeyFile = "${cfg.secretsDir}/active_record_primary_key";
+          activeRecordDeterministicKeyFile = "${cfg.secretsDir}/active_record_deterministic_key";
+          activeRecordSaltFile = "${cfg.secretsDir}/active_record_salt";
         };
 
         # less memory usage with jemalloc
@@ -366,6 +369,13 @@ in
           for x in db db_password jws otp root_password secret; do
             if [ ! -e "$x" ]; then
               apg -n1 -m40 > "$x"
+            fi
+          done
+          # Generate keys similar to Rails
+          # https://guides.rubyonrails.org/active_record_encryption.html#basic-usage
+          for x in active_record_primary_key active_record_deterministic_key active_record_salt; do
+            if [ ! -e "$x" ]; then
+              apg -n1 -m32 -MNCL > "$x"
             fi
           done
         '';


### PR DESCRIPTION
@flyingcircusio/release-managers

depends on #1479. This change will be required for 25.05

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [ ] PR has internal ticket: no, upstream nixpkgs change that gets followed here
- [ ] internal issue ID (PL-…) part of branch name
- [ ] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Enough entropy: Follow Rails recommendation
  - Functionality ensured by Hydra test 
- [x] Security requirements tested? (EVIDENCE)
