### PR TITLE
flake: update branch to nixos-25.05

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -395,7 +395,7 @@
       },
       "original": {
         "owner": "flyingcircusio",
-        "ref": "nixos-unstable",
+        "ref": "nixos-25.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,7 @@
   description = "Flying Circus NixOS platform (dev/release tooling)";
 
   inputs = {
-    nixpkgs.url = "github:flyingcircusio/nixpkgs/nixos-unstable";
+    nixpkgs.url = "github:flyingcircusio/nixpkgs/nixos-25.05";
     nixos-mailserver = {
       url = "gitlab:flyingcircus/nixos-mailserver/master?host=gitlab.flyingcircus.io";
       inputs.nixpkgs.follows = "nixpkgs";


### PR DESCRIPTION
@flyingcircusio/release-managers

It's post branch-off, so let's update the flake `nixpkgs` ref 🥳 

I already updated our nixpkgs fork. 
```
λ git fetch fcio
λ git checkout fcio/nixos-unstable
Updating files: 100% (5856/5856), done.
Note: switching to 'fcio/nixos-unstable'.

You are in 'detached HEAD' state.
[ ... snap ...]
HEAD is now at 1bf3c3457250 network: simplify network interface units to make them more reliable

λ git checkout -b nixos-25.05
Switched to a new branch 'nixos-25.05'

λ git push fcio
[ ... snap ...]
To github.com:flyingcircusio/nixpkgs.git
 * [new branch]                nixos-25.05 -> nixos-25.05
```