### PR TITLE
[25.05] network: move network-setup resstart to nixpkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -386,11 +386,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1747646436,
-        "narHash": "sha256-8pnopk/vayqB8kDoZauOtd7N34L6RSQTY2mGNttOLYU=",
+        "lastModified": 1747681820,
+        "narHash": "sha256-/1SohxeTNb8Et/Kz1l88z2BvFVfHkCK18oPKLHbCKDU=",
         "owner": "flyingcircusio",
         "repo": "nixpkgs",
-        "rev": "f52938b110815f9fa4d274c0ad3ba4d0480a1e67",
+        "rev": "c8ee6effafd7c850c81b25e76ada738247a996b1",
         "type": "github"
       },
       "original": {

--- a/nixos/platform/network.nix
+++ b/nixos/platform/network.nix
@@ -529,11 +529,6 @@ in
           systemd-sysctl.restartTriggers = lib.mkIf (!isNull fclib.underlay) [
             config.environment.etc."sysctl.d/70-fcio-underlay.conf".source
           ];
-          # Stop+starting the network can break
-          # switch-to-configuration on NFS clients by reloading the
-          # systemd config when the NFS server is unreachable. Do an
-          # in-place restart after systemd has reloaded instead.
-          network-setup.stopIfChanged = fclib.mkOverrideUpstreamModule false;
         }
         //
 

--- a/release/versions.json
+++ b/release/versions.json
@@ -14,10 +14,10 @@
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/"
   },
   "nixpkgs": {
-    "hash": "sha256-8pnopk/vayqB8kDoZauOtd7N34L6RSQTY2mGNttOLYU=",
+    "hash": "sha256-/1SohxeTNb8Et/Kz1l88z2BvFVfHkCK18oPKLHbCKDU=",
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "f52938b110815f9fa4d274c0ad3ba4d0480a1e67"
+    "rev": "c8ee6effafd7c850c81b25e76ada738247a996b1"
   },
   "nixpkgs-21_05": {
     "hash": "sha256-5ufC/t0sUFS/LspiEwU8DW5+uVYM3diZ1IC7KjX9ek4=",


### PR DESCRIPTION
Follow-up for the original solution of PL-133570. The network-setup.service change is better suited in our nixpkgs fork and has been moved there.

@flyingcircusio/release-managers

## Release process

- [ ] Created changelog entry using `./changelog.sh`
  - no, code-reorganisation only

## PR release workflow (internal)

- [ ] PR has internal ticket
- [ ] internal issue ID (PL-…) part of branch name
- [ ] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - [x] keeping semantically cohesive code in the same place improves readybility and understandability
- [x] Security requirements tested? (EVIDENCE)
  - [x] the NFS tests still pass, they contain a test case covering this behaviour change.