### PR TITLE
[PL-133563][PL-133583][FC-41338] redis: monitoring for multiple servers

### DIFF
--- a/changelog.d/20250520_165012_PL-133563-PL-133583-redis-role-rework_scriv.md
+++ b/changelog.d/20250520_165012_PL-133563-PL-133583-redis-role-rework_scriv.md
@@ -1,0 +1,22 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+- The Redis cache of GitLab will be flushed.
+- GitLab will be restarted.
+
+
+### NixOS XX.XX platform
+
+- The GitLab role requires an active Redis role on the same machine.

--- a/changelog.d/20250520_165054_PL-133563-PL-133583-redis-role-rework_scriv.md
+++ b/changelog.d/20250520_165054_PL-133563-PL-133583-redis-role-rework_scriv.md
@@ -1,0 +1,28 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+- Telegraf will be restarted.
+
+### NixOS XX.XX platform
+
+- Additional Redis servers configured with `services.redis.servers` now
+  get Sensu checks and their metrics are scraped by Telegraf.
+
+  This is not possible if a server doesn't have a TCP listener and its UNIX socket isn't
+  readable & writable by its owning group. For each server like that, a warning
+  will be printed.
+
+- The option `services.telegraf.environmentVariablesFromFile` was introduced which allows
+  substituting variables inside the Telegraf config with the content of a file.

--- a/doc/src/redis.md
+++ b/doc/src/redis.md
@@ -123,4 +123,44 @@ service configuration changes and trigger service restarts (if necessary).
 The default monitoring setup checks that the Redis server is running
 and is responding to [PING](https://redis.io/commands/ping).
 
+## Additional servers
+
+By default, a single instance of Redis is started when enabling the role.
+
+It's possible to set up more Redis servers like this:
+
+```nix
+{
+  services.redis.servers = {
+    foo = {
+      enable = true;
+      port = 6380;
+    };
+    bar = {
+      enable = true;
+      port = 6381;
+    };
+  };
+}
+```
+
+Additionally, this has the following impact on a system:
+
+* For each of these instances, another Sensu check doing a `PING` is added
+  and metrics will be scraped using Telegraf.
+
+  If a server is configured with no TCP socket and a UNIX socket that
+  cannot be written to & read from its owning group, this __won't__ be configured
+  and a warning will be printed by the agent.
+
+* By default, Redis gets to use 80% of the RAM available on a machine.
+  With >1 machine being enabled, each machine will get
+  `floor(80 / N)` percent of the machine's RAM with N being the amount
+  of enabled Redis servers.
+
+  This can be changed by setting the option
+  `services.redis.servers.<name>.settings.maxmemory` to a
+  [different value](https://redis.io/docs/latest/develop/reference/eviction/#maxmem).
+  Please keep in mind that this only takes absolute values.
+
 % vim: set spell spelllang=en:

--- a/nixos/roles/gitlab.nix
+++ b/nixos/roles/gitlab.nix
@@ -117,6 +117,15 @@ in
 
     (lib.mkIf cfg.enable {
 
+      assertions = [
+        {
+          assertion = config.flyingcircus.roles.redis.enable;
+          message = ''
+            Please enable the 'Redis' role to enable the GitLab role!
+          '';
+        }
+      ];
+
       environment.systemPackages = with pkgs; [
         (writeScriptBin "gitlab-show-config" ''sudo -u gitlab jq '.' /srv/gitlab/state/config/gitlab.yml'')
       ];
@@ -143,7 +152,6 @@ in
         databaseCreateLocally = fclib.mkPlatform true;
         databasePasswordFile = "${cfg.secretsDir}/db_password";
         initialRootPasswordFile = "${cfg.secretsDir}/root_password";
-        redisUrl = "redis://:${config.services.redis.servers."".requirePass}@localhost:6379/";
         statePath = "/srv/gitlab/state";
         https = true;
         port = 443;

--- a/nixos/services/redis.nix
+++ b/nixos/services/redis.nix
@@ -24,6 +24,118 @@ let
 
   extraConfig = fclib.configFromFile /etc/local/redis/custom.conf "";
 
+  enabledServers = lib.filterAttrs (_: getAttr "enable") config.services.redis.servers;
+
+  redisServiceName = name: if name == "" then "redis" else "redis-${name}";
+
+  # If Redis only has a Unix socket that doesn't have r/w access for its group,
+  # then Telegraf and Sensu can't connect to it. This will give a warning.
+  isGroupRW =
+    mask:
+    let
+      groupPart = lib.mod (div mask 10) 10;
+    in
+    bitAnd groupPart 2 == 2 && bitAnd groupPart 4 == 4;
+
+  serversByConnection = lib.groupBy (
+    serverName:
+    let
+      cfg = enabledServers.${serverName};
+    in
+    if cfg.bind != null && cfg.port > 0 then
+      "tcp"
+    else if cfg.unixSocket != null && isGroupRW cfg.unixSocketPerm then
+      "uds"
+    else
+      "none"
+  ) (attrNames enabledServers);
+
+  bind = bindAddrs: head (lib.splitString " " bindAddrs);
+
+  getRedisPassword =
+    name: fFile:
+    if enabledServers.${name}.requirePass != null then
+      enabledServers.${name}.requirePass
+    else if enabledServers.${name}.requirePassFile != null then
+      fFile enabledServers.${name}.requirePassFile
+    else
+      null;
+
+  mkSensuCheck =
+    name: connArgs:
+    let
+      password = getRedisPassword name (file: ''"$(<${file})"'');
+    in
+    lib.nameValuePair (redisServiceName name) {
+      notification = "Redis" + lib.optionalString (name != "") " (instance ${name})" + " alive";
+      command = ''
+        ${pkgs.sensu-plugins-redis}/bin/check-redis-ping.rb \
+          ${lib.optionalString (password != null) "-P ${password}"} ${connArgs}
+      '';
+    };
+
+  checks = lib.listToAttrs (
+    lib.forEach (serversByConnection.tcp or [ ]) (
+      name:
+      mkSensuCheck name "-h ${bind enabledServers.${name}.bind} -p ${
+        toString enabledServers.${name}.port
+      }"
+    )
+    ++ lib.forEach (serversByConnection.uds or [ ]) (
+      name: mkSensuCheck name "-s ${enabledServers.${name}.unixSocket}"
+    )
+  );
+
+  # Drop string fields. They are converted to labels in Prometheus
+  # which blows up the number of metrics.
+  telegrafFielddrop = [
+    "aof_last_bgrewrite_status"
+    "aof_last_write_status"
+    "maxmemory_policy"
+    "rdb_last_bgsave_status"
+    "used_memory_dataset_perc"
+    "used_memory_peak_perc"
+  ];
+
+  telegrafInputs =
+    let
+      mkPassword = name: getRedisPassword name (lib.const "\${REDIS_PASSWORD_${name}}");
+    in
+    map (
+      name:
+      let
+        password = mkPassword name;
+      in
+      {
+        servers = [
+          "tcp://${lib.optionalString (password != null) ":${password}@"}${
+            bind enabledServers.${name}.bind
+          }:${toString enabledServers.${name}.port}"
+        ];
+        fielddrop = telegrafFielddrop;
+      }
+    ) (serversByConnection.tcp or [ ])
+    ++ map (
+      name:
+      let
+        password = mkPassword name;
+      in
+      {
+        servers = [
+          "unix://${enabledServers.${name}.unixSocket}"
+        ];
+        fielddrop = telegrafFielddrop;
+        inherit password;
+      }
+    ) (serversByConnection.uds or [ ]);
+
+  # Usually, the access to Redis sockets is restricted, e.g. to user & group.
+  # To allow Telegraf and Sensu access to it, their processes need to be
+  # in these groups as well (see `SupplementaryGroups` in `systemd.exec(5)`).
+  supplementaryGroups = map (name: config.services.redis.servers.${name}.group) (
+    serversByConnection.uds or [ ]
+  );
+
 in
 {
   options = with lib; {
@@ -82,7 +194,8 @@ in
 
       memoryPercentage = mkOption {
         type = types.int;
-        default = 80;
+        default = 80 / (length (attrNames enabledServers));
+        defaultText = "80 / len(enabledServers)";
         description = "Amount of memory in percent to use as maximum for redis";
         example = "100";
       };
@@ -91,6 +204,16 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    warnings = lib.optionals (serversByConnection ? none) [
+      ''
+        Cannot configure Telegraf metrics and Sensu checks for the following named redis servers:
+
+        ${lib.concatMapStringsSep "\n" (name: "* ${name}") serversByConnection.none}
+
+        This means that no TCP socket is configured for connection and the Unix socket either doesn't
+        exist or cannot be accessed by its respective group.
+      ''
+    ];
 
     assertions = [
       {
@@ -102,6 +225,20 @@ in
       }
     ];
 
+    # Ensure sensu client can talk to Redis via socket.
+    systemd.services = lib.mkMerge [
+      {
+        sensu-client.serviceConfig.SupplementaryGroups = supplementaryGroups;
+        telegraf.serviceConfig.SupplementaryGroups = supplementaryGroups;
+      }
+      (lib.mapAttrs' (
+        name: _:
+        lib.nameValuePair (redisServiceName name) {
+          serviceConfig.Restart = "always";
+        }
+      ) enabledServers)
+    ];
+
     services.redis = {
       package = cfg.package;
       vmOverCommit = true;
@@ -109,7 +246,7 @@ in
       servers = {
         "" = {
           bind = concatStringsSep " " cfg.listenAddresses;
-          enable = true;
+          enable = lib.mkDefault true;
           requirePass = password;
           settings = lib.mkMerge [
             (lib.mkIf (cfg.maxmemory-policy != null) {
@@ -122,8 +259,6 @@ in
         };
       };
     };
-
-    systemd.services.redis.serviceConfig.Restart = "always";
 
     flyingcircus.activationScripts.redis = lib.stringAfter [ "fc-local-config" ] ''
       if [[ ! -e /etc/local/redis/password ]]; then
@@ -141,31 +276,17 @@ in
     };
 
     flyingcircus.services = {
-      sensu-client.checks.redis = {
-        notification = "Redis alive";
-        command = ''
-          ${pkgs.sensu-plugins-redis}/bin/check-redis-ping.rb \
-            -h localhost -P ${lib.escapeShellArg password}
-        '';
-      };
+      sensu-client = { inherit checks; };
 
-      telegraf.inputs.redis = [
-        {
-          servers = [
-            "tcp://:${password}@localhost:${toString config.services.redis.servers."".port}"
-          ];
-          # Drop string fields. They are converted to labels in Prometheus
-          # which blows up the number of metrics.
-          fielddrop = [
-            "aof_last_bgrewrite_status"
-            "aof_last_write_status"
-            "maxmemory_policy"
-            "rdb_last_bgsave_status"
-            "used_memory_dataset_perc"
-            "used_memory_peak_perc"
-          ];
+      telegraf.environmentVariablesFromFile = lib.concatMapAttrs (
+        name:
+        { requirePassFile, ... }:
+        lib.optionalAttrs (requirePassFile != null) {
+          "REDIS_PASSWORD_${name}" = requirePassFile;
         }
-      ];
+      ) enabledServers;
+
+      telegraf.inputs.redis = telegrafInputs;
     };
 
     boot.kernel.sysctl = {

--- a/nixos/services/telegraf/default.nix
+++ b/nixos/services/telegraf/default.nix
@@ -12,7 +12,8 @@
 with lib;
 
 let
-  cfg = config.services.telegraf;
+  upstreamCfg = config.services.telegraf;
+  cfg = config.flyingcircus.services.telegraf;
   fclib = config.fclib;
 
   telegrafShowConfig = pkgs.writeScriptBin "telegraf-show-config" ''
@@ -24,7 +25,7 @@ let
   '';
 
   settingsFormat = pkgs.formats.toml { };
-  configFile = settingsFormat.generate "config.toml" cfg.extraConfig;
+  configFile = settingsFormat.generate "config.toml" upstreamCfg.extraConfig;
 
 in
 {
@@ -61,11 +62,23 @@ in
           See https://github.com/influxdata/telegraf/blob/master/plugins/inputs/prometheus/README.md#metric-format-configuration
         '';
       };
+      environmentVariablesFromFile = mkOption {
+        default = { };
+        type = types.attrsOf types.str;
+        description = ''
+          Sets environment variables based on the content of given files.
+          These will be interpolated into the config file using envsubst
+          with this syntax: `$ENVIRONMENT` or `''${VARIABLE}`.
+        '';
+        example = {
+          REDIS_PASSWORD = "/etc/local/redis/password";
+        };
+      };
     };
   };
 
   config = mkMerge [
-    (mkIf cfg.enable {
+    (mkIf upstreamCfg.enable {
 
       # merge in our platform configs
       services.telegraf.extraConfig.inputs = config.flyingcircus.services.telegraf.inputs;
@@ -90,10 +103,28 @@ in
 
       systemd.services.telegraf = {
         serviceConfig = {
+          LoadCredential = lib.mapAttrsToList (
+            name: file: "${name}:${file}"
+          ) cfg.environmentVariablesFromFile;
+          ExecStartPre =
+            let
+              envInvocation = builtins.concatStringsSep "\n" (
+                lib.mapAttrsToList (
+                  name: file: "export ${name}=$(<$CREDENTIALS_DIRECTORY/${name})"
+                ) cfg.environmentVariablesFromFile
+              );
+            in
+            [
+              (pkgs.writeShellScript "telegraf-pre-start" ''
+                ${envInvocation}
+                umask 077
+                ${pkgs.envsubst}/bin/envsubst -i "${configFile}" > /var/run/telegraf/config.toml
+              '')
+            ];
           ExecStart = mkOverride 90 (
             concatStringsSep " " (
               lib.flatten [
-                [ "${cfg.package}/bin/telegraf -config \"${configFile}\"" ]
+                [ "${upstreamCfg.package}/bin/telegraf -config '/var/run/telegraf/config.toml'" ]
                 (
                   if builtins.pathExists /etc/local/telegraf then
                     [ "-config-directory ${/etc/local/telegraf}" ]
@@ -108,15 +139,15 @@ in
       };
 
     })
-    (mkIf (config.flyingcircus.services.telegraf.inputs ? prometheus) {
+    (mkIf (cfg.inputs ? prometheus) {
       # only set when that plugin is configured to be used, to not accidentally enable it without use
       services.telegraf.extraConfig.inputs.prometheus = builtins.map (
         attr:
         attr
         // {
-          metric_version = config.flyingcircus.services.telegraf.prometheus-metric_version;
+          metric_version = cfg.prometheus-metric_version;
         }
-      ) config.flyingcircus.services.telegraf.inputs.prometheus;
+      ) cfg.inputs.prometheus;
     })
   ];
 }

--- a/tests/redis.nix
+++ b/tests/redis.nix
@@ -1,16 +1,22 @@
 import ./make-test-python.nix (
-  { ... }:
+  { pkgs, ... }:
   {
     name = "redis";
     nodes = {
       redis =
-        { ... }:
+        { pkgs, lib, ... }:
         {
           imports = [
             ../nixos
             ../nixos/roles
           ];
           flyingcircus.roles.redis.enable = true;
+
+          services.redis.servers.gitlab = {
+            enable = true;
+            unixSocketPerm = 770;
+            requirePassFile = "${pkgs.writeText "password" "hunter2"}";
+          };
 
           flyingcircus.enc.parameters = {
             resource_group = "test";
@@ -24,23 +30,95 @@ import ./make-test-python.nix (
             };
           };
 
+          # Taken from statshost-master test: needed to verify that
+          # telegraf is correctly configured.
+          flyingcircus.roles.statshost-master.enable = true;
+          flyingcircus.roles.statshost = {
+            hostName = "redis";
+            useSSL = false;
+          };
+
+          flyingcircus.encAddresses = [
+            {
+              name = "redis";
+              ip = "192.168.1.1";
+            }
+          ];
+          networking.extraHosts = ''
+            192.168.1.1 redis.fcio.net redis
+          '';
+
+          services.telegraf.enable = true;
+          services.telegraf.extraConfig.agent.interval = "1s";
+
+          users.users.s-test = {
+            isNormalUser = true;
+            extraGroups = [ "service" ];
+          };
+
+          services.prometheus.globalConfig.scrape_interval = "1s";
+
+          # Grafana is being enabled by statshost-master. This isn't needed for this
+          # test-case and spams the logs, so it's disabled here.
+          services.grafana.enable = lib.mkForce false;
         };
     };
 
-    testScript = ''
-      redis.wait_for_unit("redis.service")
-      cli = "redis-cli -a `< /etc/local/redis/password `"
-      redis.wait_until_succeeds(f"{cli} ping | grep PONG")
-      redis.succeed(f"{cli} set msg 'hello world'")
-      redis.succeed(f"{cli} get msg | grep 'hello world'")
+    testScript =
+      { nodes, ... }:
+      let
+        sensuChecks = nodes.redis.flyingcircus.services.sensu-client.checks;
+        api = "http://192.168.1.1:9090/api/v1";
+      in
+      ''
+        import json
 
-      # service user should be able to write the password file
-      redis.succeed('sudo -u redis touch /etc/local/redis/password')
+        redis.wait_for_unit("redis.service")
+        redis.wait_for_unit("redis-gitlab.service")
+        redis.wait_for_unit("prometheus.service")
+        redis.wait_for_unit("telegraf.service")
+        redis.wait_for_file("/run/telegraf/influx.sock")
 
-      # killing the redis process should trigger an automatic restart
-      redis.succeed("kill $(systemctl show redis.service --property MainPID | sed -e 's/MainPID=//')")
-      redis.wait_for_unit("redis.service")
-      redis.wait_until_succeeds(f"{cli} ping | grep PONG")
-    '';
+        cli = "redis-cli -a `< /etc/local/redis/password `"
+        redis.wait_until_succeeds(f"{cli} ping | grep PONG")
+        redis.succeed(f"{cli} set msg 'hello world'")
+        redis.succeed(f"{cli} get msg | grep 'hello world'")
+
+        cli_gitlab = "redis-cli -a hunter2 -s /run/redis-gitlab/redis.sock"
+        redis.wait_until_succeeds(f"{cli_gitlab} ping | grep PONG")
+        redis.wait_until_succeeds(f"{cli_gitlab} set msg 'hello world'")
+        redis.wait_until_succeeds(f"{cli_gitlab} get msg | grep 'hello world'")
+
+        with subtest("service user should be able to write the password file"):
+            redis.succeed('sudo -u redis touch /etc/local/redis/password')
+
+        with subtest("Sensu checks correctly configured"):
+            redis.succeed("${pkgs.writeShellScript "sensu-redis" sensuChecks.redis.command}")
+            redis.succeed("${pkgs.writeShellScript "sensu-redis-gitlab" sensuChecks.redis-gitlab.command}")
+
+        with subtest("Metrics for servers are scraped by telegraf"):
+            redis.wait_until_succeeds("test true = \"$(curl -s ${api}/query?query='redis_uptime' | jq '.data.result|length > 0')\"")
+
+            ret_val = json.loads(redis.succeed("""
+                curl -s ${api}/query?query='redis_uptime'
+            """))
+            print(ret_val)
+
+            assert ret_val['status'] == 'success'
+            data = ret_val['data']['result']
+            assert len(data) == 2
+
+            assert '/run/redis-gitlab/redis.sock' ==  [x['metric']['socket'] for x in data if 'socket' in x['metric']][0]
+            assert '127.0.0.1:6379' ==  [
+                x['metric']['server'] + ":" + x['metric']['port']
+                for x in data if 'server' in x['metric']
+            ][0]
+
+        with subtest("killing the redis process should trigger an automatic restart"):
+            redis.succeed("kill $(systemctl show redis.service --property MainPID | sed -e 's/MainPID=//')")
+            redis.succeed("sleep 5")
+            redis.wait_for_unit("redis.service")
+            redis.wait_until_succeeds(f"{cli} ping | grep PONG")
+      '';
   }
 )


### PR DESCRIPTION
__Note:__ this isn't a complete fix for PL-133563 since we still need to get rid of the IFD-based pwgen hack in Redis for this, but I decided to do this in a second PR and the issue is related nonetheless.

Also related: PL-133583, FC-41338

With this change, Sensu checks and Telegraf metrics are enabled for each Redis server configured with `services.redis.servers`. To achieve this, I picked @leona-ya's patch for using envsubst from #1367[1].

Additionally:

* if a Redis server doesn't have a TCP socket configured and its UNIX socket is not readable/writable by the owning group, no monitoring is configured and a warning will be printed by the agent.
* gitlab uses the `redis-gitlab` instance: for that, the upstream module guarantees correct service ordering and we now get monitoring for it as well.
* with >1 Redis server being enabled, the upper limit of available memory will be divided by the number of enabled servers.

@flyingcircusio/release-managers

[1] while telegraf supports env substitution at runtime, this would mean that we'd have to synthesize an env-file first from the password in its execstartpre and on top, the secrets would be passed to all of Telegraf's children by default. So strictly worse in this case.

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
  - I think not using additional redis servers is enough of a toggle here.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Secure defaults: each Redis server is being monitored.
- [x] Security requirements tested? (EVIDENCE)
  - Extended the Redis VM test to make sure Telegraf & Sensu work for additional servers
  - Activated this commit on a test VM and confirmed this manually.
