### PR TITLE
services/mail: do not hardcode postsrsd socket

### DIFF
--- a/nixos/services/mail/default.nix
+++ b/nixos/services/mail/default.nix
@@ -378,12 +378,12 @@ in
                   "permit_sasl_authenticated"
                 ];
                 # --- postsrsd integration ---
-                recipient_canonical_maps = "socketmap:unix:/run/postsrsd/socket:reverse";
+                recipient_canonical_maps = "socketmap:unix:${config.services.postsrsd.socketPath}:reverse";
                 recipient_canonical_classes = [
                   "envelope_recipient"
                   "header_recipient"
                 ];
-                sender_canonical_maps = "socketmap:unix:/run/postsrsd/socket:forward";
+                sender_canonical_maps = "socketmap:unix:${config.services.postsrsd.socketPath}:forward";
                 sender_canonical_classes = "envelope_sender";
                 # ------
                 smtpd_client_restrictions =


### PR DESCRIPTION
Recent NixOS revisions introduced a read-only option containing the socket path of postsrsd. This avoids relying on a hardcoded path extracted fro the module source code.

Part of PL-133559

@flyingcircusio/release-managers

## Release process

- [ ] Created changelog entry using `./changelog.sh`
  - no, never released before

## PR release workflow (internal)

- [x] PR has internal ticket
- [ ] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - availability: avoid stale socket paths and drifting hardcoded values that cause subsystems to loose coupling
- [ ] Security requirements tested? (EVIDENCE)
  - tests still pass
