### PR TITLE
fix type error in os_release (PL-133713)

### DIFF
--- a/pkgs/fc/agent/src/fc/util/nixos.py
+++ b/pkgs/fc/agent/src/fc/util/nixos.py
@@ -152,6 +152,12 @@ def os_release(system: Path = None):
         # Not used as default arg due to monkeypatch support.
         system = CURRENT_SYSTEM
     result = {}
+
+    # On some machines, this path is a str when this runs in maintenance.
+    # So convert it to Path.
+    if not isinstance(system, Path):
+        system = Path(system)
+
     for line in (system / "etc/os-release").read_text().splitlines():
         line = line.strip()
         if line.startswith("#"):


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

- [ ] Created changelog entry using `./changelog.sh`
  - no: fix for change that is in changelog

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - defensive fix for problem that occured in dev
  - automated tests will be added later
- [x] Security requirements tested? (EVIDENCE)
