### PR TITLE
[24.11] Fix fs-check script by restoring old use of fc-directory cli

### DIFF
--- a/changelog.d/20250526_135359_PL-133676-fix-fs-check_scriv.md
+++ b/changelog.d/20250526_135359_PL-133676-fix-fs-check_scriv.md
@@ -1,0 +1,19 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+
+### NixOS XX.XX platform
+
+- Fix fs-check script by restoring old use of fc-directory cli (PL-133676)

--- a/pkgs/fc/agent/src/fc/util/directory.py
+++ b/pkgs/fc/agent/src/fc/util/directory.py
@@ -3,7 +3,6 @@
 """Unified client access to fc.directory."""
 
 import contextlib
-import functools
 import json
 import re
 import urllib.parse
@@ -117,7 +116,7 @@ def directory_cli():
     import sys
 
     cmd = sys.argv[1]
-    connect(ring="max")
+    d = connect(ring="max")  # noqa: F841 - used in fc-directory cli (fs-check) with the name d
     exec(cmd)
 
 


### PR DESCRIPTION
PL-133676

(cherry picked from commit 8f90c46a1d7922a64bf3ca631b14c30828bb6921), backport of #1505

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [x] ensure the merge bot has determined a merge date
- [x] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
    - Workiness: Tested fs-check on dev KVM
- [x] Security requirements tested? (EVIDENCE)
