### PR TITLE
fc.agent: improve test coverage for `release_path`

### DIFF
--- a/pkgs/fc/agent/src/fc/maintenance/activity/update.py
+++ b/pkgs/fc/agent/src/fc/maintenance/activity/update.py
@@ -35,7 +35,10 @@ class UpdateActivity(Activity):
     """
 
     def __init__(
-        self, next_channel_url: str, next_environment: str = None, log=_log
+        self,
+        next_channel_url: str,
+        next_environment: str | None = None,
+        log=_log,
     ):
         super().__init__()
         self.next_environment = next_environment

--- a/pkgs/fc/agent/src/fc/maintenance/tests/test_maintenance.py
+++ b/pkgs/fc/agent/src/fc/maintenance/tests/test_maintenance.py
@@ -1,7 +1,7 @@
-import contextlib
 import json
 import unittest.mock
 from unittest.mock import MagicMock
+from pathlib import Path
 
 import fc.maintenance.maintenance
 from fc.maintenance import Request
@@ -361,9 +361,7 @@ def test_request_update(log, logger, agent_configparser, monkeypatch):
     assert log.has("request-update-prepared")
 
 
-def test_request_update_unchanged(
-    log, logger, agent_configparser, monkeypatch
-):
+def test_request_update_unchanged(log, logger, agent_configparser, monkeypatch):
     from_enc_mock = MagicMock()
     from_enc_mock.return_value = None
     monkeypatch.setattr(
@@ -504,3 +502,34 @@ def test_do_not_request_reboot_when_tempfail_update_present(
         assert not mock.called
 
     assert request is None
+
+
+def test_release_path(tmp_path, logger, log, monkeypatch):
+    import fc.util.nixos
+
+    current_d = Path(tmp_path / "current")
+    next_d = Path(tmp_path / "next")
+    current_os_release = current_d / "etc/os-release"
+    current_os_release.parent.mkdir(parents=True)
+    next_os_release = next_d / "etc/os-release"
+    next_os_release.parent.mkdir(parents=True)
+
+    monkeypatch.setattr("fc.util.nixos.CURRENT_SYSTEM", current_d)
+
+    class PathAwareFakeUpdateActivity(FakeUpdateActivity):
+        def _detect_current_state(self):
+            self.current_system = fc.util.nixos.current_system()
+            # usually acquired through `nixos.build_system`, which returns a str
+            self.next_system = str(next_d)
+
+    activity = PathAwareFakeUpdateActivity(
+        "https://fake/1", "https://fake/2", logger
+    )
+
+    current_os_release.write_text("VERSION_ID=24.11")
+    next_os_release.write_text("VERSION_ID=24.11")
+
+    assert activity.release_path() == ["24.11"]
+
+    next_os_release.write_text("VERSION_ID=25.05")
+    assert activity.release_path() == ["24.11", "25.05"]

--- a/pkgs/fc/agent/src/fc/util/nixos.py
+++ b/pkgs/fc/agent/src/fc/util/nixos.py
@@ -147,7 +147,7 @@ def get_fc_channel_build(channel_url: str, log=_log) -> Optional[str]:
 CURRENT_SYSTEM = Path("/run/current-system")
 
 
-def os_release(system: Path = None):
+def os_release(system: Path | None = None):
     if not system:
         # Not used as default arg due to monkeypatch support.
         system = CURRENT_SYSTEM
@@ -209,11 +209,11 @@ def current_nixos_channel_url(log=_log) -> Optional[str]:
 
 
 def current_system(log=_log):
-    if not p.exists("/run/current-system"):
+    if not p.exists(CURRENT_SYSTEM):
         log.warn("current-system-missing")
-        return
+        return None
 
-    return os.readlink("/run/current-system")
+    return os.path.realpath(CURRENT_SYSTEM)
 
 
 def resolve_url_redirects(url):
@@ -436,7 +436,9 @@ def _increase_soft_fd_limit():
     resource.setrlimit(resource.RLIMIT_NOFILE, (soft_limit, hard_limit))
 
 
-def build_system(channel_url=None, build_options=None, out_link=None, log=_log):
+def build_system(
+    channel_url=None, build_options=None, out_link=None, log=_log
+) -> str:
     """
     Build system with this channel. Works like nixos-rebuild build.
     Does not modify the running system.


### PR DESCRIPTION
Provide test coverage for the code path responsible for PL-133713. Also corrects some type annotations.

The switch from `os.readlink` to `os.path.realpath` was done to simplify testing: `readlink` *requires* the target to be a link, while `realpath` only *allows* it to be. We do not have to enforce system paths to be links though, this is more an implementation decision of NixOS.

PL-133713

@flyingcircusio/release-managers

## Release process

- [ ] Created changelog entry using `./changelog.sh`
  - no, unreleased release, not customer visible

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [ ] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - `release_path` needs test coverage
- [ ] Security requirements tested? (EVIDENCE)
  - [ ] tests still pass
  - [x] htmlcov shows coverage for `release_path`
  - [x] investigated the involved return types of functions