### PR TITLE
Remove timer indirection for keepalived service

### DIFF
--- a/nixos/roles/router/default.nix
+++ b/nixos/roles/router/default.nix
@@ -265,14 +265,28 @@ in
 
     flyingcircus.firewall.enableSrvRgFirewall = false;
 
-    systemd.services = listToAttrs (
-      lib.forEach (filter (iface: iface.policy == "vxlan") gatewayInterfaces) (
-        iface:
-        lib.nameValuePair "network-bridge-suppress-flooding-${iface.link}" {
-          enable = fclib.mkPlatform false;
-        }
-      )
-    );
+    systemd.services =
+      (listToAttrs (
+        lib.forEach (filter (iface: iface.policy == "vxlan") gatewayInterfaces) (
+          iface:
+          lib.nameValuePair "network-bridge-suppress-flooding-${iface.link}" {
+            enable = fclib.mkPlatform false;
+          }
+        )
+      ))
+      // {
+        keepalived.wantedBy = [ "multi-user.target" ];
+      };
+
+    # the upstream module does not start keepalived immediately on
+    # boot in order to prevent it from immediately switching into
+    # master state, instead using a timer to defer the start by a few
+    # seconds. this has the problem that if keepalived crashes for
+    # some reason the next switch-to-configuration run will not
+    # attempt to restart it as it is not wanted by
+    # multi-user.target. we drop this layer of indirection to allow a
+    # crashed keepalived to be recovered.
+    systemd.timers.keepalived-boot-delay.enable = fclib.mkPlatform false;
 
     specialisation.primary = {
       configuration = role.primarySpecialisationConfig;


### PR DESCRIPTION
The upstream NixOS module for keepalived uses a timer to defer the start of the keepalived process at system boot to prevent the daemon from immediately entering the master state before the system is fully initialised. However, this means that if keepalived crashes, then it will not be restarted the next time switch-to-configuration is run, as the service is not wanted by multi-user.target. Restarting keepalived at a later time then requires manual intervention.

This change removes this indirection through the timer and starts keepalived directly through multi-user.target, so that a crashed keepalived will be restarted automatically.

PL-133434

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh` => none, internal change

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [x] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Improving robustness of the router role and the ability to recover from transient failures.
- [x] Security requirements tested? (EVIDENCE)
  - Manually verified on the dev routers running 24.11.