### PR TITLE
fc-agent: state_version fixup logic also strips suffix

### DIFF
--- a/changelog.d/20250528_025623_PL-133559-fixup-stateversion_scriv.md
+++ b/changelog.d/20250528_025623_PL-133559-fixup-stateversion_scriv.md
@@ -1,0 +1,21 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+- A bullet item for the Impact category.
+
+
+### NixOS XX.XX platform
+
+- Invalid NixOS `state_version` files are automatically fixed to fit the expected YY.MM format. (PL-133559)

--- a/pkgs/fc/agent/src/fc/manage/manage.py
+++ b/pkgs/fc/agent/src/fc/manage/manage.py
@@ -63,7 +63,10 @@ def check(log, enc, config: ConfigParser) -> CheckResult:
     if STATE_VERSION_FILE.exists():
         state_version = STATE_VERSION_FILE.read_text().strip()
         log.debug("check-state-version", state_version=state_version)
-        if re.match(r"\d\d\.\d\d", state_version):
+        # From NixOS 25.05 on this check becomes superfluous, as a malformed
+        # state version causes an evaluation error in the system build.
+        # Keeping this around for a transitory period.
+        if re.fullmatch(r"\d\d\.\d\d", state_version):
             ok_info.append(f"State version: {state_version}.")
         else:
             warnings.append(

--- a/pkgs/fc/agent/src/fc/util/enc.py
+++ b/pkgs/fc/agent/src/fc/util/enc.py
@@ -3,6 +3,7 @@ import grp
 import hashlib
 import json
 import os
+import re
 import shutil
 import socket
 import tempfile
@@ -100,11 +101,10 @@ def initialize_state_version(
         # the build revision as well. Fix it up when necessary.
         # https://github.com/NixOS/nixpkgs/issues/127654
         state_version = state_version_file.read_text().strip()
-        try:
-            version_parts = state_version.split(".")
-            version_major = version_parts[0]
-            version_minor = version_parts[1]
-        except IndexError:
+        if version_matches := re.match(r"(\d\d)\.(\d\d)", state_version):
+            version_major = version_matches[1]
+            version_minor = version_matches[2]
+        else:
             log.error(
                 "initialize-state-version-format-err",
                 _replace_msg=f"Found state version with unexpected format: `{state_version}`",

--- a/pkgs/fc/agent/src/fc/util/tests/test_enc.py
+++ b/pkgs/fc/agent/src/fc/util/tests/test_enc.py
@@ -91,7 +91,7 @@ def test_initialize_state_version_from_scratch(
     assert state_version_file.read_text().strip() == "24.11"
 
 
-def test_initialize_state_version_fixes_wrong_state_format(
+def test_initialize_state_version_fixes_wrong_state_format_of_2105(
     log, logger, tmp_path, os_release_file, monkeypatch
 ):
     state_version_file = tmp_path / "state_version"
@@ -99,9 +99,23 @@ def test_initialize_state_version_fixes_wrong_state_format(
     monkeypatch.setattr("shutil.chown", unittest.mock.Mock())
 
     initialize_state_version(logger, os_release_file, state_version_file)
-    assert log.has(
-        "initialize-state-version-format-fixup"
-    ), "Fixup logic not called"
+    assert log.has("initialize-state-version-format-fixup"), (
+        "Fixup logic not called"
+    )
+    assert state_version_file.read_text().strip() == "21.05"
+
+
+def test_initialize_state_version_fixes_wrong_state_format_pregit(
+    log, logger, tmp_path, os_release_file, monkeypatch
+):
+    state_version_file = tmp_path / "state_version"
+    state_version_file.write_text("21.05pre-git")
+    monkeypatch.setattr("shutil.chown", unittest.mock.Mock())
+
+    initialize_state_version(logger, os_release_file, state_version_file)
+    assert log.has("initialize-state-version-format-fixup"), (
+        "Fixup logic not called"
+    )
     assert state_version_file.read_text().strip() == "21.05"
 
 
@@ -112,9 +126,9 @@ def test_initialize_state_version_fixup_does_not_crash_on_wrong_format(
     state_version_file.write_text("24Elf")
 
     initialize_state_version(logger, os_release_file, state_version_file)
-    assert log.has(
-        "initialize-state-version-format-err"
-    ), "Format error not discovered"
+    assert log.has("initialize-state-version-format-err"), (
+        "Format error not discovered"
+    )
 
 
 @unittest.mock.patch("fc.util.enc.write_system_state")

--- a/tests/ceph-nautilus.nix
+++ b/tests/ceph-nautilus.nix
@@ -470,6 +470,10 @@ import ./make-test-python.nix (
 
         # Maintenance integration
         with subtest("Check maintenance integration"):
+          # TODO: This is a workaround for PL-133673, fc-agent interactive logs shall **not** go to the
+          # journal of `backdoor.service` only.
+          h.execute("unset JOURNAL_STREAM")
+
           host1.execute("rm /var/log/fc-agent.log")
           host1.execute('fc-maintenance -v request script "test" "ceph -s"')
           result = host1.execute("cat /var/log/fc-agent.log")[1]


### PR DESCRIPTION
Follow-up to 5a816aca002272191b7e11b283f4c0bec24e81c9. It turns out that some hosts still had "21.05pre-git" recorded as a state_version, and the previously introduced fixups and checks did not catch additional suffixes.
Starting from NixOS 25.05, invalid state versions cause evaluation errors in the system build. Hence, state versions need to be fixed before upgrading, and the change will be backported to fc-24.11-dev.

PL-133559

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - [x] fixup needs to be covered by additional test cases to cover the practical cases we overlooked before 
- [ ] Security requirements tested? (EVIDENCE)
  - [x] extended pytest cases
  - [x] pytest suite of agent still passes
  - [x] manually tested the autofix on an affected host
