### PR TITLE
fix remaining tests

### DIFF
--- a/nixos/roles/mongodb.nix
+++ b/nixos/roles/mongodb.nix
@@ -75,8 +75,8 @@ let
   enabledRolesCount = length (lib.attrNames enabledRoles);
   majorVersion = head (lib.attrNames enabledRoles);
   checkPkg =
-    if (lib.versionOlder majorVersion "3.6") then
-      getPkg /nix/store/c7i75mvqqg1mjk3w6zz1j9cysvch6328-fc-check-mongodb-1.0
+    if (lib.versionOlder majorVersion "4.0") then
+      pkgs.fc.check-mongodb.override { pymongo = pkgs.python3Packages.pymongo3; }
     else
       pkgs.fc.check-mongodb;
 

--- a/nixos/roles/mongodb.nix
+++ b/nixos/roles/mongodb.nix
@@ -122,6 +122,8 @@ in
 
       environment.systemPackages = [
         pkgs.mongodb-tools
+        # the nixpkgs service has moved towards `mongosh`, but we continue to provide the legacy `mongo` in PATH
+        mcfg.package
       ];
 
       services.mongodb.enable = true;

--- a/pkgs/fc/check-mongodb/default.nix
+++ b/pkgs/fc/check-mongodb/default.nix
@@ -1,10 +1,10 @@
-{ pkgs, python3Packages }:
+{ buildPythonApplication, pymongo }:
 
-python3Packages.buildPythonApplication rec {
+buildPythonApplication rec {
   name = "fc-check-mongodb-${version}";
   version = "1.0";
   src = ./.;
   propagatedBuildInputs = [
-    python3Packages.pymongo
+    pymongo
   ];
 }

--- a/pkgs/fc/default.nix
+++ b/pkgs/fc/default.nix
@@ -29,7 +29,7 @@ rec {
   check-haproxy = callPackage ./check-haproxy { };
   check-journal = callPackage ./check-journal.nix { };
   check-link-redundancy = callPackage ./check-link-redundancy { };
-  check-mongodb = callPackage ./check-mongodb { };
+  check-mongodb = pyPackages.callPackage ./check-mongodb { };
   check-postfix = callPackage ./check-postfix { };
   check-rib-integrity = callPackage ./check-rib-integrity { };
   check-xfs-broken = callPackage ./check-xfs-broken { };

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -128,6 +128,14 @@ builtins.mapAttrs (_: patchPhps phpLogPermissionPatch) {
   pythonPackagesExtensions = super.pythonPackagesExtensions ++ [
     (python-self: python-super: {
       pytest_patterns = python-self.callPackage ./python/pytest-patterns { };
+      pymongo3 = python-super.pymongo.overridePythonAttrs (old: {
+        version = "3.13.0";
+        src = python-self.fetchPypi {
+          inherit (old) pname;
+          version = "3.13.0";
+          hash = "sha256-4i1s9YAs0JtnTDB8yeA4cLjDfFA+vsPSW4byzoxTXcc=";
+        };
+      });
     })
   ];
 

--- a/tests/coturn.nix
+++ b/tests/coturn.nix
@@ -188,6 +188,9 @@ import ./make-test-python.nix (
                 "/run/current-system/specialisation/withPrivilegedBind/bin/switch-to-configuration test",
                 timeout=30,
             )
+            # XXX: for some reason coturn.service is not started at switch-to-configuration *in the test*.
+            # The restart happens in actual VMs though.
+            turnserver.execute("systemctl restart coturn")
             turnserver.wait_for_open_port(443, timeout=30)
       '';
   }

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -48,8 +48,7 @@ in
   backyserver_volumes = callTest ./backy_volumes.nix { };
   channel = callTest ./channel.nix { };
   ceph-nautilus = callTest ./ceph-nautilus.nix { };
-  # FIXME: fix and re-enable
-  #coturn = callTest ./coturn.nix { };
+  coturn = callTest ./coturn.nix { };
   docker = callTest ./docker.nix { };
   fcagent = callTest ./fcagent.nix { };
   fde-tooling = callTest ./fde-tooling.nix { };

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -89,12 +89,11 @@ in
   mailstub = callTest ./mail/stub.nix { };
   matomo = callTest ./matomo.nix { };
   memcached = callTest ./memcached.nix { };
-  # FIXME: fix and re-enable
-  #mongodb32 = callTest ./mongodb.nix { version = "3.2"; };
-  #mongodb34 = callTest ./mongodb.nix { version = "3.4"; };
-  #mongodb36 = callTest ./mongodb.nix { version = "3.6"; };
-  #mongodb40 = callTest ./mongodb.nix { version = "4.0"; };
-  #mongodb42 = callTest ./mongodb.nix { version = "4.2"; };
+  mongodb32 = callTest ./mongodb.nix { version = "3.2"; };
+  mongodb34 = callTest ./mongodb.nix { version = "3.4"; };
+  mongodb36 = callTest ./mongodb.nix { version = "3.6"; };
+  mongodb40 = callTest ./mongodb.nix { version = "4.0"; };
+  mongodb42 = callTest ./mongodb.nix { version = "4.2"; };
   mysql57 = callTest ./mysql.nix { rolename = "mysql57"; };
   network = callSubTests ./network { };
   nfs = callSubTests ./nfs.nix { };


### PR DESCRIPTION
@flyingcircusio/release-managers

Fixes the remaining disabled tests of fc-25.05.

PL-133559

## Release process

- [ ] Created changelog entry using `./changelog.sh`
  - n/a

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - increase test coverage again
- [ ] Security requirements tested? (EVIDENCE)
  - automated tests still pass