### PR TITLE
[24.11] services/redis: fix case with no password and Unix socket

### DIFF
--- a/nixos/services/redis.nix
+++ b/nixos/services/redis.nix
@@ -125,6 +125,8 @@ let
           "unix://${enabledServers.${name}.unixSocket}"
         ];
         fielddrop = telegrafFielddrop;
+      }
+      // lib.optionalAttrs (password != null) {
         inherit password;
       }
     ) (serversByConnection.uds or [ ]);

--- a/tests/redis.nix
+++ b/tests/redis.nix
@@ -18,6 +18,11 @@ import ./make-test-python.nix (
             requirePassFile = "${pkgs.writeText "password" "hunter2"}";
           };
 
+          services.redis.servers.socket_no_pw = {
+            enable = true;
+            unixSocketPerm = 770;
+          };
+
           flyingcircus.enc.parameters = {
             resource_group = "test";
             interfaces.srv = {
@@ -89,6 +94,11 @@ import ./make-test-python.nix (
         redis.wait_until_succeeds(f"{cli_gitlab} set msg 'hello world'")
         redis.wait_until_succeeds(f"{cli_gitlab} get msg | grep 'hello world'")
 
+        cli_socket_no_pw = "redis-cli -s /run/redis-socket_no_pw/redis.sock"
+        redis.wait_until_succeeds(f"{cli_socket_no_pw} ping | grep PONG")
+        redis.wait_until_succeeds(f"{cli_socket_no_pw} set msg 'hello world'")
+        redis.wait_until_succeeds(f"{cli_socket_no_pw} get msg | grep 'hello world'")
+
         with subtest("service user should be able to write the password file"):
             redis.succeed('sudo -u redis touch /etc/local/redis/password')
 
@@ -106,7 +116,7 @@ import ./make-test-python.nix (
 
             assert ret_val['status'] == 'success'
             data = ret_val['data']['result']
-            assert len(data) == 2
+            assert len(data) == 3
 
             assert '/run/redis-gitlab/redis.sock' ==  [x['metric']['socket'] for x in data if 'socket' in x['metric']][0]
             assert '127.0.0.1:6379' ==  [


### PR DESCRIPTION
backport of #1515 

@flyingcircusio/release-managers

## Release process

- [ ] Created changelog entry using `./changelog.sh`

## Release process

- [ ] Created changelog entry using `./changelog.sh`: fixup for #1492 which is also not released yet.

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Upgradability of existing configurations.
- [x] Security requirements tested? (EVIDENCE)
  - Reproduced the evaluation failure in a VM-test and then solved the problem in the module.
  - verified the fix on an affected system