### PR TITLE
[PL-133563] services/redis: get rid of IFD for generating the Redis password

### DIFF
--- a/changelog.d/20250324_095007_PL-133563-redis-remove-ifd_scriv.md
+++ b/changelog.d/20250324_095007_PL-133563-redis-remove-ifd_scriv.md
@@ -1,0 +1,25 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+- If you access `services.redis."".password` in your NixOS config, please change this to
+  `flyingcircus.services.redis.password`.
+
+### NixOS XX.XX platform
+
+- redis: restructure internal password handling
+  The password file /etc/local/redis/password now gets written as systemd ExecStartPre. (PL-133653)
+
+- telegraf: Add new option `environmentVariablesFromFile` that allows users to store
+  passwords in files and using them as substituted environment variable in a telegraf input. (PL-133563)

--- a/changelog.d/20250324_095007_PL-133563-redis-remove-ifd_scriv.md
+++ b/changelog.d/20250324_095007_PL-133563-redis-remove-ifd_scriv.md
@@ -13,13 +13,11 @@ branches.
 
 ### Impact
 
-- If you access `services.redis."".password` in your NixOS config, please change this to
-  `flyingcircus.services.redis.password`.
-
 ### NixOS XX.XX platform
 
 - redis: restructure internal password handling
   The password file /etc/local/redis/password now gets written as systemd ExecStartPre. (PL-133653)
 
-- telegraf: Add new option `environmentVariablesFromFile` that allows users to store
-  passwords in files and using them as substituted environment variable in a telegraf input. (PL-133563)
+  If you set `services.redis."".requirePassFile` in your NixOS config, please use
+  `flyingcircus.services.redis.password` instead. Also, reading the Redis password
+  at evaluation time from `config.flyingcircus.services.redis.password` is not supported anymore.

--- a/nixos/roles/gitlab.nix
+++ b/nixos/roles/gitlab.nix
@@ -116,15 +116,7 @@ in
   config = lib.mkMerge [
 
     (lib.mkIf cfg.enable {
-
-      assertions = [
-        {
-          assertion = config.flyingcircus.roles.redis.enable;
-          message = ''
-            Please enable the 'Redis' role to enable the GitLab role!
-          '';
-        }
-      ];
+      flyingcircus.roles.redis.enable = true;
 
       environment.systemPackages = with pkgs; [
         (writeScriptBin "gitlab-show-config" ''sudo -u gitlab jq '.' /srv/gitlab/state/config/gitlab.yml'')

--- a/nixos/services/redis.nix
+++ b/nixos/services/redis.nix
@@ -11,17 +11,6 @@ let
   cfg = config.flyingcircus.services.redis;
   fclib = config.fclib;
 
-  generatedPassword = lib.removeSuffix "\n" (
-    readFile (pkgs.runCommand "redis.password" { } "${pkgs.apg}/bin/apg -a 1 -M lnc -n 1 -m 32 > $out")
-  );
-
-  password = lib.removeSuffix "\n" (
-    if cfg.password == null then
-      (fclib.configFromFile /etc/local/redis/password generatedPassword)
-    else
-      cfg.password
-  );
-
   extraConfig = fclib.configFromFile /etc/local/redis/custom.conf "";
 
   enabledServers = lib.filterAttrs (_: getAttr "enable") config.services.redis.servers;
@@ -252,6 +241,35 @@ in
           serviceConfig.Restart = "always";
         }
       ) enabledServers)
+      {
+        redis.before = [ "telegraf.service" ];
+        redis.serviceConfig =
+          let
+            preStart = pkgs.writeShellScript "redis-prestart" (
+              ''
+                if [[ ! -e /etc/local/redis/password ]]; then (
+                umask 007;
+              ''
+              + lib.optionalString (cfg.password == null) ''
+                ${pkgs.apg}/bin/apg -a 1 -M lnc -n 1 -m 32 > /etc/local/redis/password
+              ''
+              + lib.optionalString (cfg.password != null) ''
+                echo ${lib.escapeShellArg cfg.password} > /etc/local/redis/password
+              ''
+              + ''
+                ) fi
+                chmod 0660 /etc/local/redis/password
+                chown redis:service /etc/local/redis/password
+              ''
+            );
+          in
+          {
+            ExecStartPre = lib.mkBefore [
+              ("+" + preStart)
+            ];
+            Restart = "always";
+          };
+      }
     ];
 
     services.redis = {
@@ -262,7 +280,7 @@ in
         "" = {
           bind = concatStringsSep " " cfg.listenAddresses;
           enable = lib.mkDefault true;
-          requirePass = password;
+          requirePassFile = "/etc/local/redis/password";
           settings = lib.mkMerge [
             (lib.mkIf (cfg.maxmemory-policy != null) {
               inherit (cfg) maxmemory-policy;
@@ -274,16 +292,6 @@ in
         };
       };
     };
-
-    flyingcircus.activationScripts.redis = lib.stringAfter [ "fc-local-config" ] ''
-      if [[ ! -e /etc/local/redis/password ]]; then
-        ( umask 007;
-          echo ${lib.escapeShellArg password} > /etc/local/redis/password
-          chown redis:service /etc/local/redis/password
-        )
-      fi
-      chmod 0660 /etc/local/redis/password
-    '';
 
     flyingcircus.localConfigDirs.redis = {
       dir = "/etc/local/redis";
@@ -311,8 +319,8 @@ in
     environment.etc."local/redis/README.txt".text = ''
       Redis is running on this machine.
 
-      You can find the password for the redis in the `password`. You can also change
-      the redis password by changing the `password` file.
+      You can find the password for the redis in the `password` file.
+      You can also change the redis password by changing the `password` file.
 
       Changing the config via custom.conf is not supported anymore. Please use a NixOS module
       with the option `services.redis.servers."".settings` instead.

--- a/nixos/services/redis.nix
+++ b/nixos/services/redis.nix
@@ -41,25 +41,25 @@ let
 
   bind = bindAddrs: head (lib.splitString " " bindAddrs);
 
-  getRedisPassword =
-    name: fFile:
-    if enabledServers.${name}.requirePass != null then
-      enabledServers.${name}.requirePass
-    else if enabledServers.${name}.requirePassFile != null then
-      fFile enabledServers.${name}.requirePassFile
-    else
-      null;
-
   mkSensuCheck =
     name: connArgs:
     let
-      password = getRedisPassword name (file: ''"$(<${file})"'');
+      # If a Redis server requires password authentication (i.e. requirePass or requirePassFile
+      # is not `null`), then pass the raw password or the contents of requirePassFile
+      # to the `check-redis-ping` invocation.
+      passwordExpr =
+        if enabledServers.${name}.requirePass != null then
+          enabledServers.${name}.requirePass
+        else if enabledServers.${name}.requirePassFile != null then
+          ''"$(<${enabledServers.${name}.requirePassFile})"''
+        else
+          null;
     in
     lib.nameValuePair (redisServiceName name) {
       notification = "Redis" + lib.optionalString (name != "") " (instance ${name})" + " alive";
       command = ''
         ${pkgs.sensu-plugins-redis}/bin/check-redis-ping.rb \
-          ${lib.optionalString (password != null) "-P ${password}"} ${connArgs}
+          ${lib.optionalString (passwordExpr != null) "-P ${passwordExpr}"} ${connArgs}
       '';
     };
 
@@ -88,16 +88,29 @@ let
 
   telegrafInputs =
     let
-      mkPassword = name: getRedisPassword name (lib.const "\${REDIS_PASSWORD_${escape name}}");
+      # If a Redis server requires password authentication (i.e. requirePass or requirePassFile
+      # is not `null`), then the password must be passed to the telegraf config for gathering metrics.
+      # If requirePass is used, we inject the raw password into the Redis URL inside the config.
+      # If requirePassFile is used, we inject the password by substituting an environment
+      # variable, i.e. we write `${REDIS_PASSWORD_name}` into the telegraf config
+      # which gets replaced by the actual password when the service starts.
+      mkPasswordExpr =
+        name:
+        if enabledServers.${name}.requirePass != null then
+          enabledServers.${name}.requirePass
+        else if enabledServers.${name}.requirePassFile != null then
+          "\${REDIS_PASSWORD_${escape name}}"
+        else
+          null;
     in
     map (
       name:
       let
-        password = mkPassword name;
+        passwordExpr = mkPasswordExpr name;
       in
       {
         servers = [
-          "tcp://${lib.optionalString (password != null) ":${password}@"}${
+          "tcp://${lib.optionalString (passwordExpr != null) ":${passwordExpr}@"}${
             bind enabledServers.${name}.bind
           }:${toString enabledServers.${name}.port}"
         ];
@@ -107,7 +120,7 @@ let
     ++ map (
       name:
       let
-        password = mkPassword name;
+        passwordExpr = mkPasswordExpr name;
       in
       {
         servers = [
@@ -115,8 +128,8 @@ let
         ];
         fielddrop = telegrafFielddrop;
       }
-      // lib.optionalAttrs (password != null) {
-        inherit password;
+      // lib.optionalAttrs (passwordExpr != null) {
+        password = passwordExpr;
       }
     ) (serversByConnection.uds or [ ]);
 

--- a/nixos/services/redis.nix
+++ b/nixos/services/redis.nix
@@ -99,7 +99,7 @@ let
 
   telegrafInputs =
     let
-      mkPassword = name: getRedisPassword name (lib.const "\${REDIS_PASSWORD_${name}}");
+      mkPassword = name: getRedisPassword name (lib.const "\${REDIS_PASSWORD_${escape name}}");
     in
     map (
       name:
@@ -137,6 +137,8 @@ let
   supplementaryGroups = map (name: config.services.redis.servers.${name}.group) (
     serversByConnection.uds or [ ]
   );
+
+  escape = builtins.replaceStrings [ "-" ] [ "__" ];
 
 in
 {
@@ -225,6 +227,17 @@ in
           Please use a NixOS module with the option services.redis.servers."".settings instead
         '';
       }
+      {
+        # This limitation is relevant for telegraf because we generate env
+        # vars from the server names (and `__` is used to escape dashes).
+        assertion = all (name: null != builtins.match "^[A-Za-z0-9_-]*$" name && !lib.hasInfix "__" name) (
+          attrNames enabledServers
+        );
+        message = ''
+          All Redis server names (keys of `services.redis.servers`) can only
+          contain alphanumeric chars, `-` and `_`, but no consecutive underscores.
+        '';
+      }
     ];
 
     # Ensure sensu client can talk to Redis via socket.
@@ -284,7 +297,7 @@ in
         name:
         { requirePassFile, ... }:
         lib.optionalAttrs (requirePassFile != null) {
-          "REDIS_PASSWORD_${name}" = requirePassFile;
+          "REDIS_PASSWORD_${escape name}" = requirePassFile;
         }
       ) enabledServers;
 

--- a/nixos/services/redis.nix
+++ b/nixos/services/redis.nix
@@ -227,6 +227,27 @@ in
           contain alphanumeric chars, `-` and `_`, but no consecutive underscores.
         '';
       }
+      {
+        assertion =
+          config.services.redis.servers."".enable -> config.services.redis.servers."".requirePass == null;
+        message = ''
+          Setting a password for the default Redis server with requirePass
+          is not supported. Please use `flyingcircus.services.redis.password`
+          instead.
+        '';
+      }
+      {
+        # The default set by the platform is /etc/local/redis/password. If this is set
+        # to something else, we read the password from that value.
+        # The `null` case is undefined and thus rejected.
+        assertion =
+          config.services.redis.servers."".enable -> config.services.redis.servers."".requirePassFile != null;
+        message = ''
+          Value of `services.redis.servers."".requirePassFile`
+          (currently `${toString config.services.redis.servers."".requirePassFile}`)
+          must not be null.
+        '';
+      }
     ];
 
     # Ensure sensu client can talk to Redis via socket.
@@ -245,23 +266,29 @@ in
         redis.before = [ "telegraf.service" ];
         redis.serviceConfig =
           let
-            preStart = pkgs.writeShellScript "redis-prestart" (
-              ''
-                if [[ ! -e /etc/local/redis/password ]]; then (
-                umask 007;
-              ''
-              + lib.optionalString (cfg.password == null) ''
-                ${pkgs.apg}/bin/apg -a 1 -M lnc -n 1 -m 32 > /etc/local/redis/password
-              ''
-              + lib.optionalString (cfg.password != null) ''
-                echo ${lib.escapeShellArg cfg.password} > /etc/local/redis/password
-              ''
-              + ''
-                ) fi
-                chmod 0660 /etc/local/redis/password
-                chown redis:service /etc/local/redis/password
-              ''
-            );
+            preStart = pkgs.writeShellScript "redis-prestart" (''
+              (
+                umask 077;
+                ${
+                  if cfg.password != null then
+                    ''
+                      echo ${lib.escapeShellArg cfg.password} > /etc/local/redis/password
+                    ''
+                  else if config.services.redis.servers."".requirePassFile != "/etc/local/redis/password" then
+                    ''
+                      cp ${config.services.redis.servers."".requirePassFile} /etc/local/redis/password
+                    ''
+                  else
+                    ''
+                      if [[ ! -e /etc/local/redis/password ]]; then
+                        ${pkgs.apg}/bin/apg -a 1 -M lnc -n 1 -m 32 > /etc/local/redis/password
+                      fi
+                    ''
+                }
+              )
+              chmod 0660 /etc/local/redis/password
+              chown redis:service /etc/local/redis/password
+            '');
           in
           {
             ExecStartPre = lib.mkBefore [

--- a/tests/gitlab.nix
+++ b/tests/gitlab.nix
@@ -52,7 +52,7 @@ import ./make-test-python.nix (
 
           flyingcircus.roles.postgresql16.enable = true;
 
-          services.redis.servers."".requirePass = lib.mkForce "test";
+          flyingcircus.services.redis.password = lib.mkForce "test";
 
           services.gitlab = lib.mkForce {
             databasePasswordFile = pkgs.writeText "dbPassword" dbPassword;

--- a/tests/redis.nix
+++ b/tests/redis.nix
@@ -23,6 +23,14 @@ import ./make-test-python.nix (
             unixSocketPerm = 770;
           };
 
+          specialisation.specialserver.configuration = {
+            services.redis.servers.foo-bar = {
+              enable = true;
+              requirePass = "aligator3";
+              port = 6380;
+            };
+          };
+
           flyingcircus.enc.parameters = {
             resource_group = "test";
             interfaces.srv = {
@@ -74,9 +82,29 @@ import ./make-test-python.nix (
       let
         sensuChecks = nodes.redis.flyingcircus.services.sensu-client.checks;
         api = "http://192.168.1.1:9090/api/v1";
+        config = nodes.redis.system.build.toplevel;
       in
       ''
         import json
+        import urllib.parse
+
+        def switch_specialisation(name):
+            path = "${config}/bin/switch-to-configuration" \
+                if name is None \
+                else f"${config}/specialisation/{name}/bin/switch-to-configuration"
+            redis.succeed(f"{path} test")
+
+        def query_prom(qry):
+            str_val = urllib.parse.quote_plus(qry)
+            redis.wait_until_succeeds(f"test true = \"$(curl -s ${api}/query?query={str_val} | jq '.data.result|length > 0')\"")
+
+            ret_val = json.loads(redis.succeed(f"""
+                curl -s ${api}/query?query={str_val}
+            """))
+            print(ret_val)
+
+            return ret_val
+
 
         redis.wait_for_unit("redis.service")
         redis.wait_for_unit("redis-gitlab.service")
@@ -107,28 +135,28 @@ import ./make-test-python.nix (
             redis.succeed("${pkgs.writeShellScript "sensu-redis-gitlab" sensuChecks.redis-gitlab.command}")
 
         with subtest("Metrics for servers are scraped by telegraf"):
-            redis.wait_until_succeeds("test true = \"$(curl -s ${api}/query?query='redis_uptime' | jq '.data.result|length > 0')\"")
-
-            ret_val = json.loads(redis.succeed("""
-                curl -s ${api}/query?query='redis_uptime'
-            """))
-            print(ret_val)
-
+            ret_val = query_prom('redis_uptime{port="6379"}')
             assert ret_val['status'] == 'success'
-            data = ret_val['data']['result']
-            assert len(data) == 3
+            assert len(ret_val['data']['result']) == 1
 
-            assert '/run/redis-gitlab/redis.sock' ==  [x['metric']['socket'] for x in data if 'socket' in x['metric']][0]
-            assert '127.0.0.1:6379' ==  [
-                x['metric']['server'] + ":" + x['metric']['port']
-                for x in data if 'server' in x['metric']
-            ][0]
+            ret_val = query_prom('redis_uptime{socket="/run/redis-gitlab/redis.sock"}')
+            assert ret_val['status'] == 'success'
+            assert len(ret_val['data']['result']) == 1
 
         with subtest("killing the redis process should trigger an automatic restart"):
             redis.succeed("kill $(systemctl show redis.service --property MainPID | sed -e 's/MainPID=//')")
             redis.succeed("sleep 5")
             redis.wait_for_unit("redis.service")
             redis.wait_until_succeeds(f"{cli} ping | grep PONG")
+
+        with subtest("Dashes in server names make no problems"):
+            switch_specialisation("specialserver")
+            redis.succeed(f"redis-cli -a aligator3 -p 6380 ping | grep PONG")
+            ret_val = query_prom('redis_uptime{port="6380"}')
+
+            assert ret_val['status'] == 'success'
+            data = ret_val['data']['result']
+            assert len(data) == 1
       '';
   }
 )

--- a/tests/redis.nix
+++ b/tests/redis.nix
@@ -143,12 +143,12 @@ import ./make-test-python.nix (
 
         with subtest("Metrics for servers are scraped by telegraf"):
             ret_val = query_prom('redis_uptime{port="6379"}')
-            assert ret_val['status'] == 'success'
-            assert len(ret_val['data']['result']) == 1
+            t.assertEqual(ret_val['status'], 'success')
+            t.assertEqual(len(ret_val['data']['result']), 1)
 
             ret_val = query_prom('redis_uptime{socket="/run/redis-gitlab/redis.sock"}')
-            assert ret_val['status'] == 'success'
-            assert len(ret_val['data']['result']) == 1
+            t.assertEqual(ret_val['status'], 'success')
+            t.assertEqual(len(ret_val['data']['result']), 1)
 
         with subtest("killing the redis process should trigger an automatic restart"):
             redis.succeed("kill $(systemctl show redis.service --property MainPID | sed -e 's/MainPID=//')")
@@ -161,16 +161,16 @@ import ./make-test-python.nix (
             redis.succeed(f"redis-cli -a aligator3 -p 6380 ping | grep PONG")
             ret_val = query_prom('redis_uptime{port="6380"}')
 
-            assert ret_val['status'] == 'success'
+            t.assertEqual(ret_val['status'], 'success')
             data = ret_val['data']['result']
-            assert len(data) == 1
+            t.assertEqual(len(ret_val['data']['result']), 1)
 
         with subtest("/etc/local/redis/password is kept up-to-date"):
             password = redis.succeed("cat /etc/local/redis/password").strip()
             switch_specialisation("withpw")
             from_pw_string = redis.succeed("cat /etc/local/redis/password").strip()
 
-            assert password != from_pw_string
+            t.assertNotEqual(password, from_pw_string)
             redis.succeed(f"redis-cli -a {from_pw_string} ping | grep PONG")
 
             redis.succeed("${pkgs.writeShellScript "sensu-redis" sensuChecksWithPW.redis.command}")
@@ -183,7 +183,7 @@ import ./make-test-python.nix (
 
             switch_specialisation("withpwfile")
             from_pwfile = redis.succeed("cat /etc/local/redis/password").strip()
-            assert from_pwfile != from_pw_string
+            t.assertNotEqual(from_pwfile, from_pw_string)
             redis.succeed(f"redis-cli -a {from_pwfile} ping | grep PONG")
       '';
   }

--- a/tests/redis.nix
+++ b/tests/redis.nix
@@ -31,6 +31,10 @@ import ./make-test-python.nix (
             };
           };
 
+          specialisation.withpw.configuration.flyingcircus.services.redis.password = "aligator3";
+          specialisation.withpwfile.configuration.services.redis.servers."".requirePassFile =
+            lib.mkForce "${pkgs.writeText "pw" "aligator4"}";
+
           flyingcircus.enc.parameters = {
             resource_group = "test";
             interfaces.srv = {
@@ -83,6 +87,9 @@ import ./make-test-python.nix (
         sensuChecks = nodes.redis.flyingcircus.services.sensu-client.checks;
         api = "http://192.168.1.1:9090/api/v1";
         config = nodes.redis.system.build.toplevel;
+
+        sensuChecksWithPW =
+          nodes.redis.specialisation.withpw.configuration.flyingcircus.services.sensu-client.checks;
       in
       ''
         import json
@@ -157,6 +164,27 @@ import ./make-test-python.nix (
             assert ret_val['status'] == 'success'
             data = ret_val['data']['result']
             assert len(data) == 1
+
+        with subtest("/etc/local/redis/password is kept up-to-date"):
+            password = redis.succeed("cat /etc/local/redis/password").strip()
+            switch_specialisation("withpw")
+            from_pw_string = redis.succeed("cat /etc/local/redis/password").strip()
+
+            assert password != from_pw_string
+            redis.succeed(f"redis-cli -a {from_pw_string} ping | grep PONG")
+
+            redis.succeed("${pkgs.writeShellScript "sensu-redis" sensuChecksWithPW.redis.command}")
+            redis.succeed("${pkgs.writeShellScript "sensu-redis-gitlab" sensuChecksWithPW.redis-gitlab.command}")
+
+            # We don't generate a password if /etc/local/redis/password already
+            # exists, even if there are no other settings.
+            switch_specialisation(None)
+            redis.succeed(f"redis-cli -a {from_pw_string} ping | grep PONG")
+
+            switch_specialisation("withpwfile")
+            from_pwfile = redis.succeed("cat /etc/local/redis/password").strip()
+            assert from_pwfile != from_pw_string
+            redis.succeed(f"redis-cli -a {from_pwfile} ping | grep PONG")
       '';
   }
 )


### PR DESCRIPTION
@flyingcircusio/release-managers

* Restrict Redis server names (i.e. `<name>` in `services.redis.servers.<name>`) to alphanumeric chars, underscores and dashes. Everything else gives an assertion error. This is because the name will be used for the envsubst in Telegraf. Dashes will be escaped to `__`. Using consecutive underscores in server names is also prohibited to avoid ambiguities.

  This would require people to use multiple redis instances (which isn't documented so far in our role), passwords and special chars in the name to run into problems. I'd suggest to backport it anyways @osnyx 

* Apply @leona-ya's patch to no longer use IFD to generate the Redis password: this means that `services.redis.servers."".requirePass` can no longer be used to obtain the Redis password at eval-time, with no alternatives (on purpose, kinda).

* use unittest-style assertions for the newly written testcases to get better diffs in case of errors (its own commit to keep the other parts backportable).

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels: urgency=3 because of the restriction for naming of servers. We may want to split this, though.
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Principle of Least privilege: the Redis password is no longer kept in the world-readable store, so it's not readable by each process anymore.
  - Availability: we don't risk broken configurations by the password derivation being garbage-collected (this happened in other cases with the same pattern already causing a rotated password and service-restart mid-day).
- [x] Security requirements tested? (EVIDENCE)
  - Implemented VM tests making sure redis gets configured as expected with in each case (i.e. no password; password from option; password from file).
