### PR TITLE
xfs: enable default features

### DIFF
--- a/changelog.d/20250528_185829_PL-133321-xfs-bigtime_scriv.md
+++ b/changelog.d/20250528_185829_PL-133321-xfs-bigtime_scriv.md
@@ -1,0 +1,27 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+
+### NixOS XX.XX platform
+
+- Add a mechanism to upgrade XFS flags over time. Initially this will cause
+  `bigtime`, `inobtcount` and `nrext64` flags to be set. With `bigtime` set VMs
+  from this release on will consistently support file times beyond 2038, even if
+  they were bootstrapped on older releases. (PL-133321, PL-130365)
+
+- Prepare VMs to read ENC data (the config management metadata) seeded from the
+  host from the separate `cidata` volume in the future. This allows disabling or
+  reconfiguring /tmp to use tmpfs without breaking our configuration management.
+  (PL-133311)

--- a/nixos/infrastructure/flyingcircus-physical.nix
+++ b/nixos/infrastructure/flyingcircus-physical.nix
@@ -102,6 +102,16 @@ mkIf (cfg.infrastructureModule == "flyingcircus-physical") (
         };
       };
 
+      # Not formatting tmp for now because I dont want to refer to it by
+      # the filesystem label and some machines use lvm and others dont.
+      flyingcircus.initrd.upgradeXFS = {
+        "/dev/disk/by-label/root" = [
+          "bigtime=1"
+          "inobtcount=1"
+          "nrext64=1"
+        ];
+      };
+
       networking = {
         domain = "fcio.net";
         hostName = fclib.mkPlatform (attrByPath [ "name" ] "default" cfg.enc);

--- a/nixos/infrastructure/flyingcircus-virtual.nix
+++ b/nixos/infrastructure/flyingcircus-virtual.nix
@@ -83,10 +83,24 @@ mkIf (cfg.infrastructureModule == "flyingcircus") {
       fsType = "xfs";
     };
     "/tmp" = {
-      device = "/dev/disk/by-label/tmp";
+      device = "/dev/disk/by-partlabel/tmp";
       fsType = "xfs";
       noCheck = true;
     };
+  };
+
+  flyingcircus.initrd = {
+    upgradeXFS = {
+      "/dev/disk/by-label/root" = [
+        "bigtime=1"
+        "inobtcount=1"
+        "nrext64=1"
+      ];
+    };
+    formatXFS = {
+      "/dev/disk/by-partlabel/tmp" = "-L tmp -q -K -d su=4m,sw=1";
+    };
+    collectQemuData = true;
   };
 
   networking = {

--- a/nixos/platform/default.nix
+++ b/nixos/platform/default.nix
@@ -37,6 +37,7 @@ in
       ./enc.nix
       ./firewall.nix
       ./full-disk-encryption.nix
+      ./initrd.nix
       ./journalbeat.nix
       ./collect-garbage.nix
       ./ipmi.nix

--- a/nixos/platform/initrd.nix
+++ b/nixos/platform/initrd.nix
@@ -1,0 +1,202 @@
+{
+  config,
+  lib,
+  options,
+  utils,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.flyingcircus.initrd;
+  qemuStateDir = "/var/lib/qemu";
+
+  fsInfo =
+    fs:
+    lib.pipe fs [
+      (lib.mapAttrsToList (
+        k: v: [
+          k
+          v
+        ]
+      ))
+      lib.flatten
+      (lib.concatStringsSep "\n")
+      (pkgs.writeText "fsinfo")
+    ];
+in
+{
+  options = with lib; {
+    flyingcircus.initrd = {
+      upgradeXFS = lib.mkOption {
+        description = "Call xfs_admin -O with the specified devices and features before mounting.";
+        type = with lib.types; attrsOf (listOf (strMatching "[^=]+=[01]"));
+        default = { };
+        example = {
+          "/dev/disk/by-label/root" = [ "bigtime=1" ];
+        };
+      };
+      formatXFS = lib.mkOption {
+        description = ''
+          Format device with mkfs.xfs options before mounting.
+          The resulting filesystem can not be used with fileSystems.<name>.neededForBoot=true
+        '';
+        type = with lib.types; attrsOf str;
+        default = { };
+        example = {
+          "/dev/disk/by-partlabel/tmp" = "-L tmp -q -K -m crc=1 -d su=4m,sw=1";
+        };
+      };
+      collectQemuData = lib.mkOption {
+        description = "Copy the qemu boot time properties into ${qemuStateDir}.";
+        type = with lib.types; bool;
+        default = false;
+      };
+    };
+  };
+
+  config = lib.mkMerge [
+    (lib.mkIf (cfg.upgradeXFS != { }) {
+      boot.initrd = {
+        extraUtilsCommands = ''
+          copy_bin_and_libs ${pkgs.xfsprogs}/bin/xfs_admin
+          copy_bin_and_libs ${pkgs.xfsprogs}/bin/xfs_info
+
+          copy_bin_and_libs ${pkgs.xfsprogs}/bin/xfs_db
+          copy_bin_and_libs ${pkgs.xfsprogs}/bin/xfs_spaceman
+        '';
+
+        extraUtilsCommandsTest = ''
+          # from nixos/modules/tasks/filesystems/xfs.nix
+          sed -i -e 's,^#!.*,#!'$out/bin/sh, $out/bin/xfs_admin $out/bin/xfs_info
+          export PATH=$out/bin:$PATH
+          $out/bin/xfs_admin -V
+          $out/bin/xfs_info -V
+        '';
+
+        postDeviceCommands =
+          let
+            fName = f: lib.head (lib.splitString "=" f);
+            fState = f: lib.last (lib.splitString "=" f);
+            invert = f: "${fName f}=${if fState f == "0" then "1" else "0"}";
+            upgradeXFS = lib.mapAttrs (
+              _: v:
+              (
+                (lib.concatMap (f: [
+                  (invert f)
+                  f
+                ]) v)
+              )
+              ++ [ "" ]
+            ) cfg.upgradeXFS;
+          in
+          ''
+            exec 3< ${fsInfo upgradeXFS}
+            while read -u 3 device; do
+              INFO=$(xfs_info "$device")
+              while read -u 3 oldFeature; do
+                if [ -z "$oldFeature" ]; then
+                  break
+                fi
+                read -u 3 newFeature
+                if echo "$INFO" | grep "$oldFeature"; then
+                  # xfs_admin does not always apply all features if they are specified as a list
+                  xfs_repair -n "$device" && xfs_admin -O "$newFeature" "$device"
+                fi
+              done
+            done
+          '';
+      };
+    })
+
+    (lib.mkIf cfg.collectQemuData {
+      assertions =
+        let
+          ls = fss: lib.concatMapStringsSep ", " (x: x.mountPoint) fss;
+          parentAssertion =
+            path:
+            let
+              parents = lib.filter (
+                fs: lib.hasPrefix fs.mountPoint path && !utils.fsNeededForBoot fs
+              ) config.system.build.fileSystems;
+            in
+            {
+              assertion = lib.length parents == 0;
+              message = "Every parent of ${path} needs neededForBoot=true. Offending entries: ${ls parents}";
+            };
+        in
+        map parentAssertion [
+          qemuStateDir
+          config.flyingcircus.encPath
+        ];
+
+      boot.supportedFilesystems = [
+        "vfat"
+        "xfs"
+      ];
+
+      boot.initrd = {
+        supportedFilesystems = [
+          "vfat"
+          "xfs"
+        ];
+
+        postMountCommands = lib.mkBefore ''
+          QEMU_DIR="/mnt-root${qemuStateDir}"
+          ENC_PATH="/mnt-root${config.flyingcircus.encPath}"
+          mkdir -p $QEMU_DIR
+          mkdir -p $(dirname $ENC_PATH)
+          mkdir -m 0755 -p /cidata
+          for args in "cidata vfat" "tmp xfs"; do
+            set $args
+            if [ ! -e /dev/disk/by-label/$1 ]; then
+              continue
+            fi
+            mount -n -t $2 -o ro /dev/disk/by-label/$1 /cidata
+            if [ ! -d /cidata/fc-data ]; then
+              umount -n /cidata
+              continue
+            fi
+            if [ ! -e "$ENC_PATH" ] && [ -e "/cidata/fc-data/enc.json" ]; then
+              cp /cidata/fc-data/enc.json "$ENC_PATH"
+            fi
+            if [ -e /cidata/fc-data/qemu-guest-properties-booted ]; then
+              cp /cidata/fc-data/qemu-guest-properties-booted "$QEMU_DIR"
+            elif [ -e /cidata/fc-data/qemu-binary-generation-booted ]; then
+              cp /cidata/fc-data/qemu-binary-generation-booted "$QEMU_DIR"
+            fi
+            umount -n /cidata
+            break
+          done
+        '';
+      };
+    })
+
+    (lib.mkIf (cfg.formatXFS != { }) {
+      assertions =
+        let
+          shared = lib.attrNames (lib.intersectAttrs cfg.formatXFS cfg.upgradeXFS);
+        in
+        [
+          {
+            assertion = lib.length shared == 0;
+            message = "Can not format and upgrade at the same time. Offending entries: ${lib.concatStringsSep ", " shared}";
+          }
+        ];
+
+      boot.initrd = {
+        extraUtilsCommands = ''
+          copy_bin_and_libs ${pkgs.xfsprogs}/bin/mkfs.xfs
+        '';
+
+        postMountCommands = ''
+          exec 3< ${fsInfo cfg.formatXFS}
+          while read -u 3 device; do
+            read -u 3 options
+            mkfs.xfs -f $options "$device"
+            udevadm trigger "$device"
+          done
+        '';
+      };
+    })
+  ];
+}

--- a/nixos/roles/kvm.nix
+++ b/nixos/roles/kvm.nix
@@ -41,8 +41,11 @@ in
       supportsContainers = fclib.mkDisableDevhostSupport;
       mkfsXfsFlags = lib.mkOption {
         type = with lib.types; nullOr str;
-        # XXX: set bigtime=1 once 15.09 and 20.09 are gone. See PL-130365.
-        # XXX: remove nrext=0 once all VMs are on kernel 6.6+
+        description = ''
+          Note that this should only enable a minimal set of features and that
+          each VM later enables the features it supports at boot time.
+          (See flyingcircus.initrd.formatXFS/upgradeXFS for more info.)
+        '';
         default = "-q -f -K -m crc=1,finobt=1 -i nrext64=0 -d su=4m,sw=1";
       };
       migrationBandwidth = lib.mkOption {

--- a/pkgs/fc/agent/src/fc/maintenance/maintenance.py
+++ b/pkgs/fc/agent/src/fc/maintenance/maintenance.py
@@ -26,7 +26,6 @@ from fc.maintenance.state import State
 from fc.util import nixos
 
 QEMU_STATE_DIR = "/var/lib/qemu"
-KVM_SEED_DIR = "/tmp/fc-data"
 RUNTIME_DIR = "/run"
 
 
@@ -74,9 +73,6 @@ def request_reboot_for_kvm_environment(log) -> Optional[Request]:
 
     qemu_state_dir = Path(QEMU_STATE_DIR)
 
-    def cold_state_file(stem):
-        return Path(KVM_SEED_DIR) / f"qemu-{stem}-booted"
-
     def warm_state_file(stem):
         return qemu_state_dir / f"qemu-{stem}-booted"
 
@@ -85,21 +81,6 @@ def request_reboot_for_kvm_environment(log) -> Optional[Request]:
 
     if not qemu_state_dir.is_dir():
         qemu_state_dir.mkdir(parents=True)
-
-    # Newer versions of fc.qemu can signal multiple relevant guest
-    # properties in a single file. Older versions will only signal the
-    # boot-time qemu binary generation.
-    if cold_state_file("guest-properties").exists():
-        shutil.move(
-            cold_state_file("guest-properties"),
-            warm_state_file("guest-properties"),
-        )
-        cold_state_file("binary-generation").unlink(missing_ok=True)
-    elif cold_state_file("binary-generation").exists():
-        shutil.move(
-            cold_state_file("binary-generation"),
-            warm_state_file("binary-generation"),
-        )
 
     # Optimistically load combined guest properties files
     try:

--- a/pkgs/fc/agent/src/fc/manage/cli.py
+++ b/pkgs/fc/agent/src/fc/manage/cli.py
@@ -19,7 +19,6 @@ from fc.util.typer_utils import FCTyperApp
 
 class Context(NamedTuple):
     config_file: Path
-    tmpdir: Path
     logdir: Path
     lock_dir: Path
     enc_path: Path
@@ -158,7 +157,7 @@ def switch_cmd(
 
     with locked(log, context.lock_dir):
         if update_enc_data:
-            fc.util.enc.update_enc(log, context.tmpdir, context.enc_path)
+            fc.util.enc.update_enc(log, context.enc_path)
 
         enc = fc.util.enc.load_enc(log, context.enc_path)
 
@@ -261,7 +260,7 @@ def update_enc_cmd():
     )
 
     with locked(log, context.lock_dir):
-        fc.util.enc.update_enc(log, context.tmpdir, context.enc_path)
+        fc.util.enc.update_enc(log, context.enc_path)
 
     log.info("fc-manage-succeeded")
 
@@ -321,13 +320,6 @@ def fc_manage(
         default="/var/log",
         help="Directory for log files, expects a fc-agent subdirectory there.",
     ),
-    tmpdir: Path = Option(
-        exists=True,
-        file_okay=False,
-        writable=True,
-        default="/tmp",
-        help="Directory where temporary files should be placed.",
-    ),
     lock_dir: Path = Option(
         exists=True,
         file_okay=False,
@@ -359,7 +351,6 @@ def fc_manage(
         # no action option given, new style call
         context = Context(
             config_file=config_file,
-            tmpdir=tmpdir,
             logdir=logdir,
             lock_dir=lock_dir,
             enc_path=enc_path,
@@ -399,7 +390,7 @@ def fc_manage(
 
     with locked(log, lock_dir):
         if update_enc_data:
-            fc.util.enc.update_enc(log, tmpdir, enc_path)
+            fc.util.enc.update_enc(log, enc_path)
 
         enc = fc.util.enc.load_enc(log, enc_path)
         keep_cmd_output = False

--- a/pkgs/fc/agent/src/fc/manage/tests/test_cli.py
+++ b/pkgs/fc/agent/src/fc/manage/tests/test_cli.py
@@ -32,8 +32,6 @@ def invoke_app(log, tmpdir, agent_maintenance_config):
         "--show-caller-info",
         "--logdir",
         tmpdir,
-        "--tmpdir",
-        tmpdir,
         "--lock-dir",
         tmpdir,
         "--enc-path",

--- a/pkgs/fc/agent/src/fc/util/enc.py
+++ b/pkgs/fc/agent/src/fc/util/enc.py
@@ -36,45 +36,6 @@ def load_enc(log, enc_path):
     return enc
 
 
-def initialize_enc(log, tmpdir, enc_path):
-    """Initialize ENC data during bootstrapping. Our automation puts an
-    initial ENC file in /tmp which provides the password to allow the agent to
-    talk to the directory and get updated ENC data from there."""
-    if enc_path.exists():
-        log.debug(
-            "initialize-enc-present",
-            _replace_msg=(
-                "ENC file already present at {enc_path}, initialization not "
-                "required."
-            ),
-            enc_path=str(enc_path),
-        )
-        return
-
-    initial_enc_path = tmpdir / "fc-data/enc.json"
-    if initial_enc_path.exists():
-        log.info(
-            "initialize-enc-init",
-            _replace_msg=(
-                "ENC file not found at {enc_path}, using initial data from "
-                "{initial_enc_path}"
-            ),
-            enc_path=str(enc_path),
-            initial_enc_path=str(initial_enc_path),
-        )
-        shutil.move(initial_enc_path, enc_path)
-    else:
-        log.info(
-            "initialize-enc-initial-data-not-found",
-            _replace_msg=(
-                "ENC file not found at {enc_path} and initial data from "
-                "{initial_enc_path} is also missing. Agent won't work!"
-            ),
-            enc_path=str(enc_path),
-            initial_enc_path=str(initial_enc_path),
-        )
-
-
 def initialize_state_version(
     log, os_release_file: Path, state_version_file: Path
 ):
@@ -313,12 +274,11 @@ def update_inventory(log, enc):
     )
 
 
-def update_enc(log, tmpdir, enc_path):
+def update_enc(log, enc_path):
     """
     Gets ENC files from the directory, updates custom NixOS config from it
     and writes the current system state.
     """
-    initialize_enc(log, tmpdir, enc_path)
     initialize_state_version(
         log,
         os_release_file=Path("/etc/os-release"),

--- a/pkgs/fc/agent/src/fc/util/tests/test_enc.py
+++ b/pkgs/fc/agent/src/fc/util/tests/test_enc.py
@@ -1,48 +1,9 @@
 import json
 import textwrap
 import unittest.mock
-from pathlib import Path
 
 import pytest
-from fc.util.enc import initialize_enc, initialize_state_version, update_enc
-
-
-def test_initialize_enc_should_do_nothing_when_enc_present(
-    log, logger, tmp_path
-):
-    enc_path = tmp_path / "enc.json"
-    enc_path.write_text("")
-
-    initialize_enc(logger, tmp_path, enc_path)
-
-    assert log.has("initialize-enc-present", enc_path=str(enc_path))
-
-
-def test_initialize_enc_should_populate_enc_initially(log, logger, tmp_path):
-    fc_data_path = tmp_path / "fc-data"
-    fc_data_path.mkdir()
-    initial_enc_path = fc_data_path / "enc.json"
-    initial_enc_path.write_text("")
-    enc_path = tmp_path / "enc.json"
-
-    initialize_enc(logger, tmp_path, enc_path)
-
-    assert log.has(
-        "initialize-enc-init",
-        enc_path=str(enc_path),
-        initial_enc_path=str(initial_enc_path),
-    )
-    assert enc_path.exists()
-
-
-def test_initialize_enc_should_not_crash_when_initial_data_missing(
-    log, logger, tmp_path
-):
-    enc_path = tmp_path / "enc.json"
-
-    initialize_enc(logger, tmp_path, enc_path)
-
-    assert log.has("initialize-enc-initial-data-not-found")
+from fc.util.enc import initialize_state_version, update_enc
 
 
 @pytest.fixture
@@ -135,7 +96,7 @@ def test_update_enc(
     with open(enc_path, "w") as wf:
         json.dump(enc_data, wf)
 
-    update_enc(logger, tmp_path, enc_path)
+    update_enc(logger, enc_path)
 
     initialize_state_version.assert_called_once()
     update_inventory.assert_called_with(logger, enc_data)

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -60,6 +60,7 @@ in
   collect-garbage = callTest ./collect-garbage.nix { };
   gitlab = callTest ./gitlab.nix { };
   haproxy = callTest ./haproxy.nix { };
+  initrd = callTest ./initrd.nix { };
   ip-forward = callTest ./ip-forward.nix { };
   ipv6-autoconfig = callSubTests ./ipv6-autoconfig.nix { };
   java = callTest ./java.nix { };

--- a/tests/initrd.nix
+++ b/tests/initrd.nix
@@ -1,0 +1,115 @@
+import ./make-test-python.nix (
+  {
+    pkgs,
+    lib,
+    testlib,
+    ...
+  }:
+  {
+    name = "initrd";
+
+    nodes.machine =
+      { config, pkgs, ... }:
+      {
+        imports = [
+          ../nixos
+          ../nixos/roles
+          (testlib.fcConfig { net.fe = false; })
+        ];
+
+        virtualisation.useDefaultFilesystems = false;
+        virtualisation.emptyDiskImages = [
+          5000 # tmp
+          10 # cidata
+        ];
+        virtualisation.fileSystems = {
+          "/" = {
+            device = "/dev/disk/by-label/root";
+            fsType = "xfs";
+          };
+          "/tmp" = {
+            device = "/dev/disk/by-partlabel/tmp";
+            fsType = "xfs";
+            noCheck = true;
+          };
+        };
+        flyingcircus.initrd = {
+          upgradeXFS = {
+            "/dev/disk/by-label/root" = [ "bigtime=1" ];
+          };
+          formatXFS = {
+            "/dev/disk/by-partlabel/tmp" =
+              "-L tmp -q -K -m crc=1,finobt=1,bigtime=1 -i nrext64=0 -d su=4m,sw=1";
+          };
+          collectQemuData = true;
+        };
+
+        boot.kernelParams = [ "printk.devkmsg=on" ];
+
+        boot.initrd.postDeviceCommands = lib.mkBefore ''
+          exec > /dev/kmsg 2>&1
+          FSTYPE=$(blkid -o value -s TYPE /dev/vda || true)
+          if test -z "$FSTYPE"; then
+            # first boot; init disks
+            mkfs.xfs -L root -m bigtime=0 /dev/vda
+
+            ${pkgs.gptfdisk}/bin/sgdisk -o /dev/vdb
+            ${pkgs.gptfdisk}/bin/sgdisk -a 8192 -n 1:8192:0 -c "1:tmp" -t 1:8300 /dev/vdb
+            mkfs.xfs -L tmp -m bigtime=0 /dev/vdb1
+
+            ${pkgs.gptfdisk}/bin/sgdisk -o /dev/vdc
+            ${pkgs.gptfdisk}/bin/sgdisk -n 1:: -c "1:cidata" -t 1:8300 /dev/vdc
+            mkfs.vfat -n "cidata" /dev/vdc1
+            udevadm trigger
+            udevadm settle
+          fi
+        '';
+
+        flyingcircus.services.sensu-client.enable = lib.mkForce false;
+      };
+
+    testScript = ''
+      machine.start()
+
+      def reboot():
+        machine.succeed("sync")
+        machine.crash()
+        machine.start()
+        machine.succeed('mkdir -p /cidata')
+        machine.succeed('mount /dev/disk/by-label/cidata /cidata')
+
+      with subtest("xfs upgrade/format"):
+        assert "bigtime=1" in machine.succeed('xfs_info /dev/disk/by-label/root')
+        assert "bigtime=1" in machine.succeed('xfs_info /dev/disk/by-label/tmp')
+        assert "drwxrwxrwt" in machine.succeed('stat /tmp')
+
+      with subtest("/tmp data"):
+        machine.succeed('mkdir /tmp/fc-data')
+        machine.succeed('echo -n "guest-props" > /tmp/fc-data/qemu-guest-properties-booted')
+        machine.succeed('echo -n "bin-gen" > /tmp/fc-data/qemu-binary-generation-booted')
+        machine.succeed('echo -n "enc" > /tmp/fc-data/enc.json')
+        reboot()
+        assert machine.succeed('cat /var/lib/qemu/qemu-guest-properties-booted') == "guest-props"
+        machine.fail('stat /var/lib/qemu/qemu-binary-generation-booted')
+        assert machine.succeed('cat /etc/nixos/enc.json') == "enc"
+
+      with subtest("prefer /cidata data"):
+        machine.succeed('mkdir /tmp/fc-data')
+        machine.succeed('echo -n "guest-props" > /tmp/fc-data/qemu-guest-properties-booted')
+        machine.succeed('echo -n "bin-gen" > /tmp/fc-data/qemu-binary-generation-booted')
+        machine.succeed('echo -n "enc2" > /tmp/fc-data/enc.json')
+        machine.succeed('mkdir /cidata/fc-data')
+        machine.succeed('echo -n "guest-props2" > /cidata/fc-data/qemu-guest-properties-booted')
+        reboot()
+        assert machine.succeed('cat /var/lib/qemu/qemu-guest-properties-booted') == "guest-props2"
+        assert machine.succeed('cat /etc/nixos/enc.json') == "enc" # OLD
+
+      with subtest("only /cidata data"):
+        machine.succeed('echo -n "guest-props3" > /cidata/fc-data/qemu-guest-properties-booted')
+        machine.succeed('echo -n "enc3" > /cidata/fc-data/enc.json')
+        reboot()
+        assert machine.succeed('cat /var/lib/qemu/qemu-guest-properties-booted') == "guest-props3"
+        assert machine.succeed('cat /etc/nixos/enc.json') == "enc"
+    '';
+  }
+)


### PR DESCRIPTION
This upgrades the root device to support bigtime, inobtcount and nrext64 (bigtime and inobtcount are already the default for new machines. nrext64 is supported since kernel 6.6).
Tmp will be formatted with the default options of mkfs.xfs.
Also copies enc/qemu data from tmp and cidata before formatting.

PL-133321, PL-130365, PL-133311

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [ ] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [ ] Security requirements tested? (EVIDENCE)
