### PR TITLE
Update Bird route-leaking service for renamed upstream services

### DIFF
--- a/nixos/roles/router/bird2-vrf-bridge.nix
+++ b/nixos/roles/router/bird2-vrf-bridge.nix
@@ -145,13 +145,13 @@ in
   config = lib.mkIf (role.enable && enableVrfBridge) {
     environment.systemPackages = [ package ];
 
-    environment.etc."bird/bird2-vrf.conf".source = pkgs.writeTextFile {
-      name = "bird2-vrf";
+    environment.etc."bird/bird-vrf.conf".source = pkgs.writeTextFile {
+      name = "bird-vrf";
       text = configText;
       derivationArgs.nativeBuildInputs = [ package ];
       checkPhase = ''
-        ln -s $out bird2.conf
-        vrf-bird -d -p -c bird2.conf
+        ln -s $out bird.conf
+        vrf-bird -d -p -c bird.conf
       '';
     };
 
@@ -159,18 +159,18 @@ in
       201 bird-vrf
     '';
 
-    systemd.services.bird2-vrf-bridge = {
+    systemd.services.bird-vrf-bridge = {
       description = "BIRD Internet Routing Daemon (VRF Bridge)";
       wantedBy = [ "multi-user.target" ];
       reloadTriggers = [
-        config.environment.etc."bird/bird2-vrf.conf".source
+        config.environment.etc."bird/bird-vrf.conf".source
       ];
       serviceConfig = {
         Type = "forking";
         Restart = "on-failure";
-        User = "bird2";
-        Group = "bird2";
-        ExecStart = "${lib.getExe' package "vrf-bird"} -c /etc/bird/bird2-vrf.conf";
+        User = "bird";
+        Group = "bird";
+        ExecStart = "${lib.getExe' package "vrf-bird"} -c /etc/bird/bird-vrf.conf";
         ExecReload = "${lib.getExe' package "vrf-birdc"} configure";
         ExecStop = "${lib.getExe' package "vrf-birdc"} down";
         RuntimeDirectory = "bird-vrf";

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -153,14 +153,6 @@ builtins.mapAttrs (_: patchPhps phpLogPermissionPatch) {
     aprutil = self.aprutil.override { libxcrypt = self.libxcrypt-legacy; };
   };
 
-  bird2 = super.bird2.overrideAttrs (old: rec {
-    version = "2.0.10";
-    src = fetchurl {
-      url = "ftp://bird.network.cz/pub/bird/${super.bird2.pname}-${version}.tar.gz";
-      sha256 = "sha256-ftNB3djch/qXNlhrNRVEeoQ2/sRC1l9AIhVaud4f/Vo=";
-    };
-  });
-
   # Sidecar bird for managing VRF routes on routers
   bird2-vrf = self.bird2.overrideAttrs (old: {
     configureFlags = [


### PR DESCRIPTION
Between 24.11 and 25.05, upstream has renamed the `bird2` services and service user to `bird`. Due to this renaming, the secondary Bird instance used by the router role for managing VRF routes failed to start, due to (among other things) the missing service user.

This change renames our local Bird service instance to match the naming now used in upstream. Additionally, the version pin of Bird in the overlay is removed, as this is a remnant of VXLAN migration under 21.05 which wasn't cleaned up afterwards.

PL-133727

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh` => none, internal change.

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [x] ensure the merge bot has determined a merge date
- [x] ensure all checks are green
- [x] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Consistency with upstream refactoring
  - Removing redundant version pins to ensure we receive new software versions
  - High risk rating due to update of critical network software (Bird).
- [x] Security requirements tested? (EVIDENCE)
  - Manually verified on dev hardware. Hydra tests to evaluate basic functionality of the router role.