### PR TITLE
[PL-133663] build fcsearch inputs on hydra

### DIFF
--- a/changelog.d/20250603_100901_FC-43799_build-fcsearch-input-on-hydra_scriv.md
+++ b/changelog.d/20250603_100901_FC-43799_build-fcsearch-input-on-hydra_scriv.md
@@ -1,0 +1,20 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+
+
+### NixOS XX.XX platform
+
+- Automatically build a list of all options and packages for consumption by the option/package search (PL-133663)

--- a/nixos/roles/ceph/osd.nix
+++ b/nixos/roles/ceph/osd.nix
@@ -178,6 +178,7 @@ in
       network = lib.mkOption {
         type = with lib.types; attrs; # an attrset from fclib.network.<xy>
         default = fclib.network.stb;
+        defaultText = "The `stb` network";
         description = ''
           The Ceph cluster (replication) network.
         '';

--- a/nixos/roles/consul/default.nix
+++ b/nixos/roles/consul/default.nix
@@ -24,6 +24,7 @@ in
       publicAddress = lib.mkOption {
         type = lib.types.str;
         default = head fclib.network.fe.v6.addressesQuoted;
+        defaultText = "The public v6 address";
       };
     };
   };

--- a/nixos/roles/graylog.nix
+++ b/nixos/roles/graylog.nix
@@ -91,6 +91,7 @@ in
         hostName = mkOption {
           type = types.nullOr types.str;
           default = "graylog.${config.flyingcircus.enc.parameters.resource_group}.fcio.net";
+          defaultText = "graylog.<resource-group-name>.fcio.net";
           description = "HTTP host name for the GL frontend.";
           example = "graylog.example.com";
         };

--- a/nixos/roles/kvm.nix
+++ b/nixos/roles/kvm.nix
@@ -68,6 +68,7 @@ in
       network = lib.mkOption {
         type = with lib.types; attrs; # an attrset from fclib.network.<xy>
         default = fclib.network.sto;
+        defaultText = "The `sto` network";
         description = "Network to use for migration";
       };
 

--- a/nixos/roles/statshost/default.nix
+++ b/nixos/roles/statshost/default.nix
@@ -161,6 +161,7 @@ in
 
       ldapMemberOf = mkOption {
         default = config.flyingcircus.enc.parameters.resource_group;
+        defaultText = "The VM's resource group";
         type = types.str;
         description = ''
           LDAP group to use for the "memberOf" attribute.

--- a/nixos/services/ceph/client.nix
+++ b/nixos/services/ceph/client.nix
@@ -208,6 +208,7 @@ in
               "${head (lib.splitString "." mon.address)}.${cfg.client.network.vlan}.${location}.ipv4.gocept.net"
             ) (fclib.findServices "ceph_mon-mon")
           );
+          defaultText = "The list of hostnames that are mons in this cluster";
           description = ''
             List of hostnames that are mons in this cluster.
           '';
@@ -216,6 +217,7 @@ in
         fsId = lib.mkOption {
           type = lib.types.str;
           default = static.fsids.${location}.${resource_group};
+          defaultText = "This resource group and location's static fsid";
           description = ''
             The Ceph fsid for this cluster.
           '';
@@ -224,6 +226,7 @@ in
         network = lib.mkOption {
           type = with lib.types; attrs; # an attrset from fclib.network.<xy>
           default = fclib.network.sto;
+          defaultText = "The `sto` network";
           description = ''
             The Ceph client network.
           '';

--- a/nixos/services/consul/default.nix
+++ b/nixos/services/consul/default.nix
@@ -31,16 +31,19 @@ in
       bindAddr = lib.mkOption {
         type = with lib.types; str;
         default = head fclib.network.srv.v6.addresses;
+        defaultText = "The `srv` network's first ipv6 address";
       };
 
       advertiseAddr = lib.mkOption {
         type = with lib.types; str;
         default = head fclib.network.srv.v6.addresses;
+        defaultText = "The `srv` network's first ipv6 address";
       };
 
       dc = lib.mkOption {
         type = lib.types.str;
         default = enc.parameters.resource_group;
+        defaultText = "The VM's resource group";
       };
     };
   };

--- a/nixos/services/ferretdb.nix
+++ b/nixos/services/ferretdb.nix
@@ -30,6 +30,7 @@ in
         mkOption {
           type = types.str;
           default = "-h ${cfg.address} -p ${toString cfg.port}";
+          defaultText = "-h <address> -p <port>";
           example = "-h example00.fe.rzob.fcio.net -p 27017 -t";
           description = "Extra arguments to be passed to the check_mongodb script";
         };

--- a/nixos/services/nginx/default.nix
+++ b/nixos/services/nginx/default.nix
@@ -322,6 +322,7 @@ in
                 };
 
                 listenAddresses = vhost.options.listenAddresses // {
+                  defaultText = "The default listen addresses configured in `flyingcircus.services.nginx.defaultListenAddresses`";
                   default =
                     if (config.listenAddress != null || config.listenAddress6 != null) then
                       filter (x: x != null) [

--- a/release/default.nix
+++ b/release/default.nix
@@ -200,6 +200,95 @@ let
 
   doc = {
     roles = platformRoleDoc;
+
+    options =
+      let
+        imgArgs = {
+          nixpkgs = nixpkgs_;
+          version = "${version}${versionSuffix}";
+          channelSources = combinedSources;
+          configFile = ../nixos/etc_nixos_local.nix;
+          contents = initialVMContents;
+        };
+
+        fc_eval = import "${nixpkgs_}/nixos/lib/eval-config.nix" {
+          inherit system;
+          modules = [
+            "${nixpkgs_}/nixos/modules/virtualisation/qemu-vm.nix"
+
+            (import ./vm-image.nix imgArgs)
+            ../nixos
+            ../nixos/roles
+
+            {
+              networking.hostName = "options";
+              mailserver.fqdn = "test.fcio.net";
+            }
+          ];
+        };
+      in
+      lib.hydraJob (
+        (pkgs.nixosOptionsDoc {
+          inherit (fc_eval) options;
+          warningsAreErrors = false;
+        }).optionsJSON
+      );
+
+    packages =
+      let
+        isValid =
+          d:
+          let
+            r = builtins.tryEval (
+              lib.isDerivation d
+              && !(lib.attrByPath [ "meta" "broken" ] false d)
+              && builtins.seq d.name true
+              && d ? outputs
+            );
+          in
+          r.success && r.value;
+        validPkgs = lib.filterAttrs (_: v: isValid v);
+
+        readPackages =
+          system: drvs:
+          lib.mapAttrs (
+            attribute_name: drv:
+            (
+              {
+                entry_type = "package";
+                attribute_name = attribute_name;
+                system = system;
+                name = drv.name;
+                # TODO consider using `builtins.parseDrvName`
+                version = drv.version or "";
+                outputs = drv.outputs;
+                # paths = builtins.listToAttrs ( map (output: {name = output; value = drv.${output};}) drv.outputs );
+                default_output = drv.outputName;
+              }
+              // lib.optionalAttrs (drv ? meta.homepage) {
+                inherit (drv.meta) homepage;
+              }
+              // lib.optionalAttrs (drv ? meta.description) {
+                inherit (drv.meta) description;
+              }
+              // lib.optionalAttrs (drv ? meta.longDescription) {
+                inherit (drv.meta) longDescription;
+              }
+              // lib.optionalAttrs (drv ? meta.license) {
+                inherit (drv.meta) license;
+              }
+            )
+          ) (validPkgs drvs);
+        packages_json = builtins.toFile "fc-search-packages.json" (
+          builtins.toJSON (readPackages system pkgs)
+        );
+      in
+      lib.hydraJob (
+        pkgs.runCommand "fc-search-packages" { buildInputs = [ pkgs.jq ]; } ''
+          mkdir -p $out
+          cat ${packages_json} | jq > $out/packages.json
+        ''
+      );
   };
 
   jobs = {


### PR DESCRIPTION
@flyingcircusio/release-managers

[PL-133663](https://yt.flyingcircus.io/issue/PL-133663)

The constructed test is very minimal, would appreciate specific feedback on that regarding missing module imports / incorrectly set options.
I would almost prefer generating the options from one of the release images instead.

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- adds two new hydra jobs, does not impact security
- [x] Security requirements tested? (EVIDENCE)
- 
