### PR TITLE
[PL-133746] fix alloy syslog configuration for logs from nginx

### DIFF
--- a/changelog.d/20250603_113446_PL-133746-fix-alloy-nginx-configuration_scriv.md
+++ b/changelog.d/20250603_113446_PL-133746-fix-alloy-nginx-configuration_scriv.md
@@ -1,0 +1,19 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+
+### NixOS XX.XX platform
+
+- Fix a part of the alloy configuration that receives syslog messages from nginx (PL-133746)

--- a/nixos/services/nginx/default.nix
+++ b/nixos/services/nginx/default.nix
@@ -655,6 +655,8 @@ in
           loki.source.syslog "syslog_nginx" {
             listener {
               address = "127.0.0.1:51893"
+              protocol = "udp"
+              syslog_format = "rfc3164"
             }
 
             forward_to = [loki.write.fcio_rg_loki.receiver]


### PR DESCRIPTION
@flyingcircusio/release-managers

PL-133746

Die Standardeinstellungen des Syslog-Receivers von Alloy weichen von denen des Syslog-Senders aufseiten von Nginx ab, weshalb sie angepasst werden müssen um eine Verbindung herzustellen. 

Konfiguration aus https://grafana.com/docs/alloy/v1.8/reference/components/loki/loki.source.syslog/, da 25.11 Alloy Version 1.8.3 mitliefert.

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [ ] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [ ] Security requirements tested? (EVIDENCE)
