### PR TITLE
[PL-133751] tests: integrate interactive SSH debugging into our test suite

### DIFF
--- a/nixos/infrastructure/testing.nix
+++ b/nixos/infrastructure/testing.nix
@@ -14,7 +14,6 @@
       name = "testvm";
     };
     services.haveged.enable = true; # use pseudo-entropy to speed up tests
-    services.openssh.enable = lib.mkOverride 60 false;
     services.telegraf.enable = lib.mkOverride 150 false;
 
     # build-vms.nix from NixOS automatically generates numbered interface

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -17,19 +17,9 @@ let
       // args
     );
 
-  callTest = fn: args: hydraJob (importTest fn args system).test;
+  callTest = fn: args: importTest fn args system;
 
-  callSubTests =
-    fn: args:
-    let
-      discover =
-        attrs:
-        let
-          subTests = filterAttrs (const (hasAttr "test")) attrs;
-        in
-        mapAttrs (const (t: hydraJob t.test)) subTests;
-    in
-    discover (importTest fn args system);
+  callSubTests = callTest;
 
 in
 {

--- a/tests/k3s/default.nix
+++ b/tests/k3s/default.nix
@@ -131,6 +131,7 @@ import ../make-test-python.nix (
                 home_directory = "/home/test";
                 login_shell = "/bin/bash";
                 class = "human";
+                ssh_pubkey = [ ];
               }
             ];
 

--- a/tests/lamp/vm-test.nix
+++ b/tests/lamp/vm-test.nix
@@ -70,6 +70,7 @@ import ../make-test-python.nix (
               home_directory = "/srv/s-test";
               login_shell = "/bin/bash";
               class = "service";
+              ssh_pubkey = [ ];
             }
             {
               id = 1001;
@@ -82,6 +83,7 @@ import ../make-test-python.nix (
               home_directory = "/home/test";
               login_shell = "/bin/bash";
               class = "human";
+              ssh_pubkey = [ ];
             }
           ];
         };

--- a/tests/make-test-python.nix
+++ b/tests/make-test-python.nix
@@ -62,7 +62,19 @@ let
     else
       f;
 
-  makeTestSkipLint = args: makeTest ({ skipLint = true; } // args);
+  makeTestSkipLint =
+    args:
+    runTest {
+      imports = [ args ];
+      skipLint = true;
+      interactive.sshBackdoor.enable = true;
+      defaults =
+        { lib, ... }:
+        {
+          # for interactive debugging
+          services.openssh.settings.PasswordAuthentication = lib.mkForce true;
+        };
+    };
 
 in
 if test ? testCases then


### PR DESCRIPTION
~~__Note:__ a draft because we still need to confirm that Hydra does the right thing (though `nix-eval-jobs` indicates that it should).~~

PL-133751

With that, it's possible to do

    nix-build tests -A redis.driverInteractive

and use the ipython-based repl to step through the test. For tests from fc-nixos, the SSH backdoor is enabled by default, i.e. you get instructions on how to log into the VM.

This also reworks the test setup a bit: I removed the recursive test discovery since this removes `driverInteractive` among other useful attributes.

@flyingcircusio/release-managers

## Release process

- [ ] Created changelog entry using `./changelog.sh` (__Note:__ purely internal, so I skipped that)

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Ability to debug issues with our platform: this change allows to enter test-VMs inside the Nix sandbox via SSH.
- [x] Security requirements tested? (EVIDENCE)
  - COnfirmed on hydra01 that all features behave as expected.
