### PR TITLE
docker: fix when fe interface does not exist

### DIFF
--- a/changelog.d/20250610_110653_PL-133607-fix-docker-role-with-partial-interfaces_scriv.md
+++ b/changelog.d/20250610_110653_PL-133607-fix-docker-role-with-partial-interfaces_scriv.md
@@ -1,0 +1,21 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+
+### NixOS XX.XX platform
+
+- docker: fix role not working on devhosts (PL-133607)
+
+  This change also prepares the role to work on machines without FE interface or PUB interface.

--- a/nixos/roles/docker.nix
+++ b/nixos/roles/docker.nix
@@ -34,24 +34,34 @@ in
         "net.ipv4.conf.default.forwarding" = lib.mkOverride 71 true;
       };
 
-      networking.firewall.extraCommands = lib.mkOrder 1200 ''
-        # FC docker rules (1200)
-        # allow access to host from docker networks, we consider this identical
-        # to access from locally running processes.
-        # We grant the full RFC1918 172.16.0.0/12 range.
-        iptables -w -A nixos-fw -i br-+ -s 172.16.0.0/12 -j nixos-fw-accept
-        iptables -w -A nixos-fw -i docker+ -s 172.16.0.0/12 -j nixos-fw-accept
+      networking.firewall.extraCommands = lib.mkOrder 1200 (
+        ''
+          # FC docker rules (1200)
+          # allow access to host from docker networks, we consider this identical
+          # to access from locally running processes.
+          # We grant the full RFC1918 172.16.0.0/12 range.
+          iptables -w -A nixos-fw -i br-+ -s 172.16.0.0/12 -j nixos-fw-accept
+          iptables -w -A nixos-fw -i docker+ -s 172.16.0.0/12 -j nixos-fw-accept
 
-        ip46tables -N fc-docker 2>/dev/null || true
-        ip46tables -A fc-docker -m conntrack --ctstate RELATED,ESTABLISHED -j nixos-fw-accept
-        ip46tables -A fc-docker -i ${fclib.network.srv.interface} -j fc-resource-group
-        ip46tables -A fc-docker -i ${fclib.network.srv.interface} -j nixos-fw-refuse
-        ip46tables -A fc-docker -i ${fclib.network.fe.interface} -j nixos-fw-refuse
-
-        ip46tables -N DOCKER-USER 2>/dev/null || true
-        ip46tables -I DOCKER-USER 1 ! -i docker+ -o docker+ -j fc-docker
-        # End FC docker rules (1200)
-      '';
+          ip46tables -N fc-docker 2>/dev/null || true
+          ip46tables -A fc-docker -m conntrack --ctstate RELATED,ESTABLISHED -j nixos-fw-accept
+        ''
+        + (lib.optionalString (fclib.network ? srv)) ''
+          ip46tables -A fc-docker -i ${fclib.network.srv.interface} -j fc-resource-group
+          ip46tables -A fc-docker -i ${fclib.network.srv.interface} -j nixos-fw-refuse
+        ''
+        + (lib.optionalString (fclib.network ? fe)) ''
+          ip46tables -A fc-docker -i ${fclib.network.fe.interface} -j nixos-fw-refuse
+        ''
+        + (lib.optionalString (fclib.network ? pub)) ''
+          ip46tables -A fc-docker -i ${fclib.network.pub.interface} -j nixos-fw-refuse
+        ''
+        + ''
+          ip46tables -N DOCKER-USER 2>/dev/null || true
+          ip46tables -I DOCKER-USER 1 ! -i docker+ -o docker+ -j fc-docker
+          # End FC docker rules (1200)
+        ''
+      );
 
       networking.firewall.extraStopCommands = lib.mkOrder 1100 ''
         # FC docker rules (1100)


### PR DESCRIPTION
Add firewall rules dynamically depending on which interfaces exist.
Also add firewall rule for pub interface.
PL-133607

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Functionality: Tested on devhost and NixOS test
  - Network security: pub is the new fe, so expected to work the same here
- [x] Security requirements tested? (EVIDENCE)
