### PR TITLE
fc-luks check: ignore no device match

### DIFF
--- a/nixos/platform/full-disk-encryption.nix
+++ b/nixos/platform/full-disk-encryption.nix
@@ -97,7 +97,7 @@ in
       luksParams = {
         notification = "LUKS Volumes use expected parameters.";
         interval = 3600;
-        command = "test ! -d ${keysMountDir} || sudo ${check_luks_cmd} '*'";
+        command = "sudo ${check_luks_cmd} '*'";
       };
     };
 

--- a/pkgs/fc/ceph/src/fc/ceph/luks/manage.py
+++ b/pkgs/fc/ceph/src/fc/ceph/luks/manage.py
@@ -208,15 +208,9 @@ class LUKSKeyStoreManager(object):
     def check_luks(name_glob: str, header: Optional[str]) -> int:
         devices = LuksDevice.filter_cryptvolumes(name_glob, header=header)
         if not devices:
-            console.print(
-                f"Warning: The glob `{name_glob}` matches no volume.",
-                style="yellow",
-            )
-            # based on the assumption that encrypted devices have to exist on a
-            # host in the normal case. Conditionalising the check to only run
-            # on hosts that are indeed expected to hav such devices needs to
-            # happen in platform code.
-            return 1
+            console.print(f"Note: The glob `{name_glob}` matches no volume.")
+            # Do not fail as hosts may be prepared for encryption without having
+            # any encrypted volume yet.
 
         errors = 0
         for dev in devices:


### PR DESCRIPTION
reduces noise during monitoring reviews

PL-133528

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`
  - internal

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.

n/a

- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

n/a

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

Improve operability, reduce monitoring noise.

- [x] Security requirements tested? (EVIDENCE)

manually tested that it doesn't alert any longer on machines without encrypted volumes