### PR TITLE
[24.11] Add static definitions and router configs for router lab location

### DIFF
--- a/nixos/platform/static.nix
+++ b/nixos/platform/static.nix
@@ -34,6 +34,10 @@ with lib;
           id = 4;
           site = "SaltLabs / ISP";
         };
+        "dev2" = {
+          id = 5;
+          site = "Halle";
+        };
       };
 
       ceph = {
@@ -121,6 +125,7 @@ with lib;
           "9.9.9.9"
           "8.8.8.8"
         ];
+        dev2 = [ "172.21.83.1" ];
       };
 
       nameservers6 = {
@@ -139,6 +144,7 @@ with lib;
           "2620:fe::fe"
           "2001:4860:4860::8888"
         ];
+        dev2 = [ "2a06:3a80:300:103::2" ];
       };
 
       directory = {
@@ -179,6 +185,7 @@ with lib;
         dev = [ "dev-router" ];
         whq = [ "whq-router" ];
         rzob = [ "rzob-router" ];
+        dev2 = [ "dev2-router" ];
       };
 
       minimumPortSpeeds = {
@@ -196,11 +203,13 @@ with lib;
           "tr-kamp-b"
         ];
         test = [ "tr" ];
+        dev2 = [ "tr2" ];
       };
 
       # VLANs on which we provide connectivity to the outside world to others
       routerDownlinkNetworks = {
         whq = [ "tr" ];
+        dev = [ "tr2" ];
       };
 
       # Derivation of router IDs for BGP.
@@ -211,6 +220,7 @@ with lib;
           dev = "tr";
           whq = "tr";
           test = "tr";
+          dev2 = "tr2";
         };
         # Or a per-host override
         host = {
@@ -244,6 +254,11 @@ with lib;
           "srv"
           "fe"
           "tr-kamp-dhp"
+        ];
+        dev2 = [
+          "mgm"
+          "srv"
+          "fe"
         ];
       };
 

--- a/nixos/roles/router/bird2/dev.conf
+++ b/nixos/roles/router/bird2/dev.conf
@@ -22,7 +22,7 @@ protocol device {
 
 protocol bfd {
   strict bind on;
-  interface "ethtr";
+  interface "ethtr", "ethtr2";
 }
 
 protocol kernel kernel_4 {
@@ -60,6 +60,19 @@ filter net_dev_6 {
     accept;
   } else reject;
 }
+
+filter net_routerlab_4 {
+  if net ~ [ 172.21.82.0/24, 172.21.83.0/24 ] then {
+    accept;
+  } else reject;
+}
+
+filter net_routerlab_6 {
+  if net ~ [ 2a06:3a80:0300:100::/56+ ] then {
+    accept;
+  } else reject;
+}
+
 
 filter default_route_4 {
   if net = 0.0.0.0/0 then accept; else reject;
@@ -107,4 +120,47 @@ protocol bgp peer_whq_kenny11_6 from peer_whq_6 {
 
 protocol bgp peer_whq_kenny01_6 from peer_whq_6 {
   neighbor 2a06:3a80:0:ff::5 as 64513;
+}
+
+template bgp peer_routerlab {
+  local as 64512;
+  neighbor as 64514;
+
+  passive;
+
+  bfd;
+  connect retry time 15;
+  error wait time 5,10;
+}
+
+template bgp peer_routerlab_4 from peer_routerlab {
+  ipv4 {
+    table master4;
+    import filter net_routerlab_4;
+    export filter default_route_4;
+  };
+}
+
+template bgp peer_routerlab_6 from peer_routerlab {
+  ipv6 {
+    table master6;
+    import filter net_routerlab_6;
+    export filter default_route_6;
+  };
+}
+
+protocol bgp peer_routerlab_kyle08_4 from peer_routerlab_4 {
+  neighbor 172.21.85.36;
+}
+
+protocol bgp peer_routerlab_kyle08_6 from peer_routerlab_6 {
+  neighbor 2a06:3a80:300:10e::4;
+}
+
+protocol bgp peer_routerlab_kyle18_4 from peer_routerlab_4 {
+  neighbor 172.21.85.37;
+}
+
+protocol bgp peer_routerlab_kyle18_6 from peer_routerlab_6 {
+  neighbor 2a06:3a80:300:10e::5;
 }

--- a/nixos/roles/router/bird2/dev2.conf
+++ b/nixos/roles/router/bird2/dev2.conf
@@ -1,0 +1,108 @@
+protocol static local_routerlab_4 {
+  ipv4 {
+    table master4;
+  };
+
+  route 172.21.82.0/24 unreachable;
+  route 172.21.83.0/24 unreachable;
+}
+
+protocol static local_routerlab_6 {
+  ipv6 {
+    table master6;
+  };
+
+  route 2a06:3a80:300:100::/56 unreachable;
+}
+
+protocol device {
+  scan time 60;
+}
+
+protocol bfd {
+  strict bind on;
+  interface "ethtr2";
+}
+
+protocol kernel kernel_4 {
+  ipv4 {
+    table master4;
+    export all;
+    import none;
+  };
+
+  metric 500;
+  merge paths on;
+}
+
+protocol kernel kernel_6 {
+  ipv6 {
+    table master6;
+    export all;
+    import none;
+  };
+
+  metric 500;
+  merge paths on;
+}
+
+filter net_routerlab_4 {
+  if net ~ [ 172.21.82.0/24, 172.21.83.0/24 ] then {
+    accept;
+  } else reject;
+}
+
+filter net_routerlab_6 {
+  if net ~ [ 2a06:3a80:0300:100::/56+ ] then {
+    accept;
+  } else reject;
+}
+
+filter default_route_4 {
+  if net = 0.0.0.0/0 then accept; else reject;
+}
+
+filter default_route_6 {
+  if net = ::/0 then accept; else reject;
+}
+
+template bgp peer_dev {
+  local as 64514;
+  neighbor as 64512;
+
+  bfd;
+  connect retry time 15;
+  error wait time 5,10;
+}
+
+template bgp peer_dev_4 from peer_dev {
+  ipv4 {
+    table master4;
+    import filter default_route_4;
+    export filter net_routerlab_4;
+  };
+}
+
+template bgp peer_dev_6 from peer_dev {
+  ipv6 {
+    table master6;
+    import filter default_route_6;
+    export filter net_routerlab_6;
+  };
+}
+
+protocol bgp peer_dev_kenny04_4 from peer_dev_4 {
+  neighbor 172.21.85.34;
+}
+
+protocol bgp peer_dev_kenny04_6 from peer_dev_6 {
+  neighbor 2a06:3a80:300:10e::2;
+}
+
+protocol bgp peer_dev_kenny10_4 from peer_dev_4 {
+  neighbor 172.21.85.35;
+}
+
+protocol bgp peer_dev_kenny10_6 from peer_dev_6 {
+  neighbor 2a06:3a80:300:10e::3;
+}

--- a/nixos/roles/router/default.nix
+++ b/nixos/roles/router/default.nix
@@ -213,8 +213,10 @@ in
           ip6tables -A fc-router-forward -o ${fclib.network.mgm.interface} -p icmpv6 -j ACCEPT
           # allow prometheus
           ip46tables -A fc-router-forward -o ${fclib.network.mgm.interface} -p tcp --dport 9126 -j ACCEPT
-          # allow SSH from the sensu server in order to remotely monitor switches
-          iptables -A fc-router-forward -i ${fclib.network.fe.interface} -o ${fclib.network.mgm.interface} -s ${sensuSourceAddress} -p tcp --dport 22 -j ACCEPT
+          ${lib.optionalString (locationSensuServer != null) ''
+            # allow SSH from the sensu server in order to remotely monitor switches
+            iptables -A fc-router-forward -i ${fclib.network.fe.interface} -o ${fclib.network.mgm.interface} -s ${sensuSourceAddress} -p tcp --dport 22 -j ACCEPT
+          ''}
           ip46tables -A fc-router-forward -o ${fclib.network.mgm.interface} -j REJECT
 
           #############

--- a/nixos/roles/router/keepalived/dev2.conf
+++ b/nixos/roles/router/keepalived/dev2.conf
@@ -1,0 +1,104 @@
+vrrp_script check_default_route_v4 {
+      script "/etc/keepalived/check-default-route-v4"
+      interval 1
+      fall 2
+      rise 2
+}
+
+vrrp_script check_default_route_v6 {
+      script "/etc/keepalived/check-default-route-v6"
+      interval 1
+      fall 2
+      rise 2
+}
+
+vrrp_script check_zebra_liveness {
+      script "/etc/keepalived/check-zebra-liveness"
+      interval 1
+      fall 2
+      rise 2
+}
+
+track_file check_stop_file {
+  # Allow admins to locally send keepalive into FAIL state by adding
+  # a non "0" entry
+  file /etc/keepalived/stop
+  # 0 as default causes FAIL if anything != 0 is in the file
+  weight 0
+  init_file 0
+}
+
+track_file check_maint_file {
+  # Used by fc-keepalived enter-maintenance
+  file /etc/keepalived/fcio_maintenance
+  weight -20
+  init_file 0
+}
+
+vrrp_sync_group router {
+    group { mgm srv fe }
+
+    notify_master "/etc/keepalived/fc-keepalived notify master"
+    notify_backup "/etc/keepalived/fc-keepalived notify backup"
+    notify_fault "/etc/keepalived/fc-keepalived notify fault"
+    notify_stop "/etc/keepalived/fc-keepalived notify stop"
+
+    track_script {
+        check_default_route_v4 weight 10
+        check_default_route_v6 weight 5
+        check_zebra_liveness
+    }
+
+    track_file {
+      check_stop_file
+      check_maint_file
+    }
+}
+
+vrrp_instance mgm {
+    interface ethmgm
+    state BACKUP
+    virtual_router_id 51
+    priority 100
+    advert_int 1
+    garp_master_refresh 30
+
+    virtual_ipaddress {
+        172.21.85.1/27
+    }
+}
+
+vrrp_instance fe {
+    interface brfe
+    state BACKUP
+    virtual_router_id 51
+    priority 100
+    advert_int 1
+    garp_master_refresh 30
+
+    virtual_ipaddress {
+        2a06:3a80:300:102::1/64
+    }
+
+    virtual_ipaddress_excluded {
+        172.21.82.1/24
+    }
+
+}
+
+vrrp_instance srv {
+    interface brsrv
+    state BACKUP
+    virtual_router_id 51
+    priority 100
+    advert_int 1
+    garp_master_refresh 30
+
+    virtual_ipaddress {
+        2a06:3a80:300:103::1/64
+    }
+
+    virtual_ipaddress_excluded {
+        172.21.83.1/24
+    }
+}


### PR DESCRIPTION
This change adds static definitions and router configs for the dev2 secondary lab location in RZHAL.

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh` => none, internal change

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [x] ensure the merge bot has determined a merge date
- [x] ensure all checks are green
- [x] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Extra static definitions for running a secondary lab environment.
- [x] Security requirements tested? (EVIDENCE)
  - Manually verified on the routers for both dev and dev2.