### PR TITLE
[24.11] Disable suppression of hung task warnings in VMs

### DIFF
--- a/nixos/infrastructure/flyingcircus-virtual.nix
+++ b/nixos/infrastructure/flyingcircus-virtual.nix
@@ -36,6 +36,12 @@ mkIf (cfg.infrastructureModule == "flyingcircus") {
       "nosetmode"
     ];
 
+    kernel.sysctl = {
+      # Don't suppress hung task warnings in dmesg, as this hides
+      # useful debugging information.
+      "kernel.hung_task_warnings" = -1;
+    };
+
     loader.grub = {
       device = "/dev/disk/device-by-alias/root";
       fsIdentifier = "provided";


### PR DESCRIPTION
The kernel will automatically suppress log messages in dmesg regarding hung tasks once the number of warnings generated since boot passes a threshold controlled by the `kernel.hung_task_warnings` sysctl.

This change disables this suppression logic, as this is unhelpful for debugging hung tasks on machines where the threshold has already been reached.

PL-133760

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh` => none, internal change

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [x] ensure the merge bot has determined a merge date
- [x] ensure all checks are green
- [x] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Change kernel logging settings.
- [x] Security requirements tested? (EVIDENCE)
  - Configuration builds on a test VM. "Cosmetic" change, no functional testing necessary.