### PR TITLE
[25.05] Add agent option to immediately reboot when activating new configuration

### DIFF
--- a/changelog.d/20250610_183716_PL-133308-agent-stc-boot_scriv.md
+++ b/changelog.d/20250610_183716_PL-133308-agent-stc-boot_scriv.md
@@ -1,0 +1,22 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+
+### NixOS XX.XX platform
+
+- agent: the command `fc-manage switch` now has a `-R` option which
+  will activate the new configuration by performing an immediate
+  reboot, similar to the process used for upgrading between major
+  versions. (PL-133308)

--- a/pkgs/fc/agent/src/fc/manage/cli.py
+++ b/pkgs/fc/agent/src/fc/manage/cli.py
@@ -121,6 +121,12 @@ def switch_cmd(
         "-c",
         help="Fetch nixpkgs channel before building the system.",
     ),
+    switch_with_reboot: bool = Option(
+        False,
+        "--activate-reboot",
+        "-R",
+        help="Reboot system immediately in order to activate new configuration.",
+    ),
     lazy: bool = Option(
         False,
         help="Skip the system activation script if system is unchanged.",
@@ -140,6 +146,10 @@ def switch_cmd(
     )
 
     if specialisation_name and to_base_configuration:
+        log.error("invalid-args")
+        raise Exit(1)
+
+    if specialisation_name and switch_with_reboot:
         log.error("invalid-args")
         raise Exit(1)
 
@@ -174,6 +184,7 @@ def switch_cmd(
                     lock_dir=context.lock_dir,
                     lazy=lazy,
                     show_trace=context.show_trace or show_trace,
+                    switch_reboot=switch_with_reboot,
                 )
             else:
                 keep_cmd_output |= fc.manage.manage.switch(
@@ -183,6 +194,7 @@ def switch_cmd(
                     lock_dir=context.lock_dir,
                     lazy=lazy,
                     show_trace=context.show_trace or show_trace,
+                    switch_reboot=switch_with_reboot,
                 )
         except nixos.ChannelException:
             raise Exit(2)
@@ -411,6 +423,7 @@ def fc_manage(
                     lock_dir=lock_dir,
                     lazy=False,
                     show_trace=show_trace,
+                    switch_reboot=False,
                 )
             elif switch:
                 keep_cmd_output |= fc.manage.manage.switch(
@@ -420,6 +433,7 @@ def fc_manage(
                     lock_dir=lock_dir,
                     lazy=False,
                     show_trace=show_trace,
+                    switch_reboot=False,
                 )
         except nixos.ChannelException:
             raise Exit(2)

--- a/pkgs/fc/agent/src/fc/manage/manage.py
+++ b/pkgs/fc/agent/src/fc/manage/manage.py
@@ -281,6 +281,7 @@ def switch(
     lock_dir: Path,
     lazy=False,
     show_trace=False,
+    switch_reboot=False,
 ):
     """Rebuild the system and switch to it.
     For regular operation, the current "nixos" channel is used for building the
@@ -331,7 +332,11 @@ def switch(
 
     if channel_to_build:
         return channel_to_build.switch(
-            specialisation, lock_dir, lazy, show_trace
+            specialisation,
+            lock_dir,
+            lazy,
+            show_trace,
+            switch_reboot,
         )
 
 
@@ -342,6 +347,7 @@ def switch_with_update(
     lock_dir: Path,
     lazy=False,
     show_trace=False,
+    switch_reboot=False,
 ):
     channel_url = enc.get("parameters", {}).get("environment_url")
     environment = enc.get("parameters", {}).get("environment")
@@ -379,7 +385,13 @@ def switch_with_update(
     if not channel:
         return
 
-    return channel.switch(specialisation, lock_dir, lazy, show_trace)
+    return channel.switch(
+        specialisation,
+        lock_dir,
+        lazy,
+        show_trace,
+        switch_reboot,
+    )
 
 
 def switch_to_configuration(

--- a/pkgs/fc/agent/src/fc/manage/tests/test_cli.py
+++ b/pkgs/fc/agent/src/fc/manage/tests/test_cli.py
@@ -79,6 +79,7 @@ def test_invoke_switch(
         "lock_dir": tmpdir,
         "lazy": False,
         "show_trace": False,
+        "switch_reboot": False,
     }
     assert switch.call_args.kwargs == expected
 
@@ -121,6 +122,7 @@ def test_invoke_switch_with_channel_update(
         "lock_dir": tmpdir,
         "lazy": False,
         "show_trace": False,
+        "switch_reboot": False,
     }
     assert switch_with_update.call_args.kwargs == expected
 

--- a/pkgs/fc/agent/src/fc/util/channel.py
+++ b/pkgs/fc/agent/src/fc/util/channel.py
@@ -112,6 +112,7 @@ class Channel:
         lock_dir: Path,
         lazy=True,
         show_trace=False,
+        switch_reboot=False,
     ) -> bool:
         """
         Build system with this channel and switch to it.
@@ -128,7 +129,12 @@ class Channel:
         nixos.register_system_profile(self.system_path, self.log)
         # New system is registered, delete the temporary result link.
         os.unlink(out_link)
-        return self.switch_to_configuration(specialisation, lock_dir, lazy)
+        return self.switch_to_configuration(
+            specialisation,
+            lock_dir,
+            lazy,
+            switch_reboot,
+        )
 
     def build(self, out_link=None, show_trace=False):
         """
@@ -150,7 +156,11 @@ class Channel:
         self.system_path = system_path
 
     def switch_to_configuration(
-        self, specialisation: str | Specialisation, lock_dir: Path, lazy=True
+        self,
+        specialisation: str | Specialisation,
+        lock_dir: Path,
+        lazy=True,
+        switch_reboot=False,
     ) -> bool:
         switch_path = nixos.get_specialisation_path_for_system(
             Path(self.system_path), specialisation, self.log
@@ -159,13 +169,19 @@ class Channel:
         current_release = nixos.os_release()["VERSION_ID"]
         next_release = nixos.os_release(Path(switch_path))["VERSION_ID"]
 
-        if current_release != next_release:
+        if current_release != next_release or switch_reboot:
             reboot_delay = self.REBOOT_DELAY
-            self.log.warn(
-                "release-change-requires-reboot",
-                current_release=current_release,
-                next_release=next_release,
-            )
+            if current_release != next_release:
+                self.log.warn(
+                    "release-change-requires-reboot",
+                    current_release=current_release,
+                    next_release=next_release,
+                )
+            else:
+                self.log.warn(
+                    "activate-with-reboot",
+                    _replace_msg="Activating new system with reboot.",
+                )
             while reboot_delay:
                 self.log.warn(
                     "reboot-scheduled",


### PR DESCRIPTION
Forward port of #1543.

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [x] ensure the merge bot has determined a merge date
- [x] ensure all checks are green
- [x] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [x] Security requirements tested? (EVIDENCE)
