### PR TITLE
[25.05] Disable suppression of hung task warnings in VMs

### DIFF
--- a/nixos/infrastructure/flyingcircus-virtual.nix
+++ b/nixos/infrastructure/flyingcircus-virtual.nix
@@ -36,6 +36,12 @@ mkIf (cfg.infrastructureModule == "flyingcircus") {
       "nosetmode"
     ];
 
+    kernel.sysctl = {
+      # Don't suppress hung task warnings in dmesg, as this hides
+      # useful debugging information.
+      "kernel.hung_task_warnings" = -1;
+    };
+
     loader.grub = {
       device = "/dev/disk/device-by-alias/root";
       fsIdentifier = "provided";


### PR DESCRIPTION
Forward port of #1557.

PL-133760

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh` => none, internal change

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [x] ensure the merge bot has determined a merge date
- [x] ensure all checks are green
- [x] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [x] Security requirements tested? (EVIDENCE)
