### PR TITLE
[24.11] linuxKernelStable: 6.6 -> 6.12

### DIFF
--- a/changelog.d/20250616_162350_PL-133760-kernel-612_scriv.md
+++ b/changelog.d/20250616_162350_PL-133760-kernel-612_scriv.md
@@ -1,0 +1,23 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+- Machines will reboot to activate the changed kernel.
+
+
+### NixOS XX.XX platform
+
+- linux kernel: use 6.12.x series as stable kernel
+
+  Promote the 6.12.x Linux kernel series as a stable kernel, as we have not encountered any issues in the staging environment. This might also resolve some XFS filesystem issues (PL-133760).

--- a/changelog.d/20250616_162350_PL-133760-kernel-612_scriv.md
+++ b/changelog.d/20250616_162350_PL-133760-kernel-612_scriv.md
@@ -15,9 +15,20 @@ branches.
 
 - Machines will reboot to activate the changed kernel.
 
-
 ### NixOS XX.XX platform
 
-- linux kernel: use 6.12.x series as stable kernel
+- Linux kernel: use 6.12.x LTS series as default stable kernel (PL-133760)
 
-  Promote the 6.12.x Linux kernel series as a stable kernel, as we have not encountered any issues in the staging environment. This might also resolve some XFS filesystem issues (PL-133760).
+  Promote the 6.12.x LTS Linux kernel series as our default stable kernel.
+
+  This seems to help resolve some recent IO latency / stalling issues
+
+- Memory management: switch to smaller, fixed size dirty page buffers (PL-133760)
+
+  This also seems to be a factor in the recent IO latency / stalling issues:
+  The dirty page buffers were based on percentages of the installed RAM so far,
+  but can cause long periods of stalling when the kernel passes the hard
+  threshold to flush it.
+
+  We now provide much smaller and fixed sizes for dirty pages (16 MiB to start
+  flushing in the background and 64 MiB to enforce flushing).

--- a/nixos/platform/default.nix
+++ b/nixos/platform/default.nix
@@ -285,7 +285,11 @@ in
         "systemd.log_target=kmsg"
       ];
 
-      kernel.sysctl."vm.swappiness" = mkDefault 1;
+      kernel.sysctl = {
+        "vm.swappiness" = mkDefault 1;
+        "vm.dirty_background_bytes" = fclib.mkPlatform 16777216; # 16 mib, or hopefully at most 15s of flushing time
+        "vm.dirty_bytes" = fclib.mkPlatform 67108864; # 64 mib
+      };
 
       loader.timeout = 3;
     };

--- a/pkgs/fc/default.nix
+++ b/pkgs/fc/default.nix
@@ -52,8 +52,8 @@ rec {
       repo = "fc.qemu";
       # The release tooling didn't upgrade properly so we had to pick a specific
       # commit instead.
-      rev = "fcb67e4e20b7a53202a61a982ae79a60a20d87d4";
-      hash = "sha256-ah7R0igMOIckZyF3WBLsN8tTajryHnSufqjbfJDgvRE=";
+      rev = "44a7dbba681f9c2a0418397ca15aef68cbba7071";
+      hash = "sha256-hUzhaLUrK6Sp+d0o/8a3UZkvv+ZiAr1JS60hd/X6epM=";
     };
     fc-ceph = ceph;
     qemu_ceph = pkgs.qemu-ceph-nautilus;

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -271,7 +271,7 @@ builtins.mapAttrs (_: patchPhps phpLogPermissionPatch) {
   # stable kernel packages.
   linuxKernelVerify = self.linux_6_12;
 
-  linuxKernelStable = self.linux_6_6;
+  linuxKernelStable = self.linux_6_12;
 
   kubernetes-dashboard = super.callPackage ./kubernetes-dashboard.nix { };
   kubernetes-dashboard-metrics-scraper =

--- a/tests/k3s/monitoring.nix
+++ b/tests/k3s/monitoring.nix
@@ -55,6 +55,8 @@ import ../make-test-python.nix (
 
           virtualisation.memorySize = 2000;
           virtualisation.diskSize = lib.mkForce 3000;
+          virtualisation.useNixStoreImage = true; # PL-133821 - 6.12 crashes v9fs in some situations
+
           virtualisation.vlans = [
             1
             2

--- a/tests/kernelconfig.nix
+++ b/tests/kernelconfig.nix
@@ -87,7 +87,6 @@ import ./make-test-python.nix (
       KVM_AMD m
       KVM_INTEL m
       MD y
-      MD_MULTIPATH m
       MD_RAID0 m
       MD_RAID1 m
       MD_RAID456 m

--- a/tests/kernelversions.nix
+++ b/tests/kernelversions.nix
@@ -221,7 +221,7 @@ import ./make-test-python.nix (
                 f"Expected: {expected}, found: {found}. uname -a: {uname_a}"
               )
 
-      assert "${stableVersion}".startswith("6.6."), "Expecting a 6.6.x kernel as stable kernel"
+      assert "${stableVersion}".startswith("6.12."), "Expecting a 6.12.x kernel as stable kernel"
       assert "${verifyVersion}".startswith("6.12."), "Expecting a 6.12.x kernel as verify kernel"
       assertKernelVersion(verifyKernel, "${verifyVersion}")
       assertKernelVersion(prodKernel, "${stableVersion}")

--- a/tests/matomo.nix
+++ b/tests/matomo.nix
@@ -22,6 +22,7 @@ import ./make-test-python.nix (
 
         virtualisation.diskSize = 1024;
         virtualisation.memorySize = 2048;
+        virtualisation.useNixStoreImage = true; # PL-133821 - 6.12 crashes v9fs in some situations
 
         networking.domain = "test";
 

--- a/tests/opensearch_dashboards.nix
+++ b/tests/opensearch_dashboards.nix
@@ -22,6 +22,7 @@ import ./make-test-python.nix (
         networking.domain = "test";
         virtualisation.memorySize = 3072;
         virtualisation.diskSize = lib.mkForce 2000;
+        virtualisation.useNixStoreImage = true; # PL-133821 - 6.12 crashes v9fs in some situations
         virtualisation.qemu.options = [ "-smp 2" ];
         flyingcircus.roles.opensearch.enable = true;
         flyingcircus.roles.opensearch.nodes = [ "machine" ];


### PR DESCRIPTION
Promote the 6.12.x series as a stable kernel, as we have not encountered any issues with it in our staging environment.
We also hope that this resolves filesystem issues found in PL-133760.

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - [x] integrate current versions of software to ensure presence of bug fixes
  - [x] ensure proper testing of kernel updates in staging environments
- [x] Security requirements tested? (EVIDENCE)
  - [x] NixOS tests still pass
  - [x] kernel has been tested as `linuxKernelVerify` in staging environment for several weeks already