### PR TITLE
[24.11] Add new networks to RZOB keepalived configuration

### DIFF
--- a/nixos/roles/router/keepalived/rzob.conf
+++ b/nixos/roles/router/keepalived/rzob.conf
@@ -64,9 +64,10 @@ vrrp_instance mgm {
     garp_master_refresh 30
 
     virtual_ipaddress {
-        2a02:248:101:61::1/64
+        2a06:3a80:200:1::1/64
     }
     virtual_ipaddress_excluded {
+        2a02:248:101:61::1/64
         172.22.1.1/24
     }
 }
@@ -80,10 +81,11 @@ vrrp_instance fe {
     garp_master_refresh 30
 
     virtual_ipaddress {
-        2a02:248:101:62::1/64
+        2a06:3a80:200:2::1/64
     }
 
     virtual_ipaddress_excluded {
+        2a02:248:101:62::1/64
         185.105.252.1/24
         185.105.253.1/24
         195.62.125.1/25
@@ -100,10 +102,11 @@ vrrp_instance srv {
     garp_master_refresh 30
 
     virtual_ipaddress {
-        2a02:248:101:63::1/64
+        2a06:3a80:200:3::1/64
     }
 
     virtual_ipaddress_excluded {
+        2a02:248:101:63::1/64
         195.62.125.129/25
         195.62.126.129/25
         172.22.48.1/20


### PR DESCRIPTION
This change adds new networks to the RZOB keepalived configuration. The enclosing subnet is already configured on the BGP sessions.

PL-133260

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh` => none, internal change

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [x] ensure the merge bot has determined a merge date
- [x] ensure all checks are green
- [x] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Adding new addresses to the configuration
- [x] Security requirements tested? (EVIDENCE)
  - Configuration builds and passes a keepalived config test on the relevant routers.