### PR TITLE
[24.11] Remove deprecated networks from configuration from DEV

### DIFF
--- a/nixos/platform/enc.nix
+++ b/nixos/platform/enc.nix
@@ -25,7 +25,7 @@ with lib;
       description = "List of addresses of machines in the neighbourhood.";
       example = [
         {
-          ip = "2a02:238:f030:1c3::104c/64";
+          ip = "2001:db8:0:3::104c/64";
           mac = "02:00:00:03:11:b1";
           name = "test03";
           rg = "test";

--- a/nixos/platform/static.nix
+++ b/nixos/platform/static.nix
@@ -138,7 +138,10 @@ with lib;
         # which is fixed in glibc 2.22 which is included in NixOS 16.03.
         dev = [ "2a02:238:f030:1c3::1" ];
         whq = [ "2a02:238:f030:103::1" ];
-        test = [ "2a02:238:f030:1c2::1" ];
+        test = [
+          "2620:fe::fe"
+          "2001:4860:4860::8888"
+        ];
         rzob = [ "2a02:248:101:63::1" ];
         standalone = [
           "2620:fe::fe"

--- a/nixos/platform/static.nix
+++ b/nixos/platform/static.nix
@@ -136,7 +136,7 @@ with lib;
         #
         # This seems to be https://sourceware.org/bugzilla/show_bug.cgi?id=13028
         # which is fixed in glibc 2.22 which is included in NixOS 16.03.
-        dev = [ "2a02:238:f030:1c3::1" ];
+        dev = [ "2a06:3a80:300:3::1" ];
         whq = [ "2a02:238:f030:103::1" ];
         test = [
           "2620:fe::fe"

--- a/nixos/roles/router/bind/gocept.net.zone.static
+++ b/nixos/roles/router/bind/gocept.net.zone.static
@@ -24,7 +24,7 @@ sensu.dev               CNAME   services12.fe.dev
 portage-bin-x86.dev     CNAME   services03.fe.dev
 portage-bin-amd64.dev   CNAME   lovejoy.fe.dev
 ; dev-router.fe
-ns.dev                  AAAA    2a02:238:f030:1c2::1
+ns.dev                  AAAA    2a06:3a80:300:2::1
 ns2.dev                 CNAME   ns.dev
 
 ; === WHQ ===

--- a/nixos/roles/router/bird2/dev.conf
+++ b/nixos/roles/router/bird2/dev.conf
@@ -12,7 +12,6 @@ protocol static local_dev_6 {
     table master6;
   };
 
-  route 2a02:238:f030:1c0::/58 unreachable;
   route 2a06:3a80:0300::/40 unreachable;
 }
 
@@ -55,7 +54,7 @@ filter net_dev_4 {
 }
 
 filter net_dev_6 {
-  if net ~ [ 2a02:238:f030:1c0::/58+, 2a06:3a80:0300::/40+ ] then {
+  if net ~ [ 2a06:3a80:0300::/40+ ] then {
     bgp_med = UPLINK_MED;
     accept;
   } else reject;

--- a/nixos/roles/router/bird2/test.conf
+++ b/nixos/roles/router/bird2/test.conf
@@ -12,7 +12,7 @@ protocol static local_dev_6 {
     table master6;
   };
 
-  route 2a02:238:f030:1c0::/58 unreachable;
+  route fdfc:c12:c05::/56 unreachable;
 }
 
 protocol device {
@@ -54,7 +54,7 @@ filter net_dev_4 {
 }
 
 filter net_dev_6 {
-  if net ~ [ 2a02:238:f030:1c0::/58+ ] then {
+  if net ~ [ fdfc:c12:c05::/56+ ] then {
     bgp_med = UPLINK_MED;
     accept;
   } else reject;
@@ -101,9 +101,9 @@ protocol bgp peer_upstream2_4 from peer_upstream_4 {
 }
 
 protocol bgp peer_upstream1_6 from peer_upstream_6 {
-  neighbor 2a02:238:f030:1c6::3 as 64513;
+  neighbor fdfc:c12:c05:6::3 as 64513;
 }
 
 protocol bgp peer_upstream2_6 from peer_upstream_6 {
-  neighbor 2a02:238:f030:1c6::a as 64513;
+  neighbor fdfc:c12:c05:6::a as 64513;
 }

--- a/nixos/roles/router/bird2/whq.conf
+++ b/nixos/roles/router/bird2/whq.conf
@@ -30,7 +30,7 @@ filter net_dev_4 {
 }
 
 filter net_dev_6 {
-  if net ~ [ 2a02:238:f030:1c0::/58+, 2a06:3a80:0300::/40+ ] then {
+  if net ~ [ 2a06:3a80:0300::/40+ ] then {
     accept;
   } else reject;
 }

--- a/nixos/roles/router/keepalived/dev.conf
+++ b/nixos/roles/router/keepalived/dev.conf
@@ -68,7 +68,6 @@ vrrp_instance mgm {
     }
 
     virtual_ipaddress_excluded {
-        2a02:238:f030:1c1::1/64 preferred_lft 0
         172.20.1.1/24
     }
 }
@@ -86,7 +85,6 @@ vrrp_instance fe {
     }
 
     virtual_ipaddress_excluded {
-        2a02:238:f030:1c2::1/64
         172.20.2.1/24
     }
 
@@ -105,7 +103,6 @@ vrrp_instance srv {
     }
 
     virtual_ipaddress_excluded {
-        2a02:238:f030:1c3::1/64
         172.20.3.1/24
         172.30.3.1/24
     }

--- a/nixos/roles/router/keepalived/test.conf
+++ b/nixos/roles/router/keepalived/test.conf
@@ -57,7 +57,7 @@ vrrp_instance mgm {
     garp_master_refresh 30
 
     virtual_ipaddress {
-        2a02:238:f030:1c1::1/64 preferred_lft 0
+        fdfc:c12:c05:1::1/64 preferred_lft 0
     }
 
     virtual_ipaddress_excluded {
@@ -74,7 +74,7 @@ vrrp_instance fe {
     garp_master_refresh 30
 
     virtual_ipaddress {
-        2a02:238:f030:1c2::1/64
+        fdfc:c12:c05:2::1/64
     }
 
     virtual_ipaddress_excluded {
@@ -92,7 +92,7 @@ vrrp_instance srv {
     garp_master_refresh 30
 
     virtual_ipaddress {
-        2a02:238:f030:1c3::1/64
+        fdfc:c12:c05:3::1/64
     }
 
     virtual_ipaddress_excluded {

--- a/nixos/roles/router/keepalived/whq.conf
+++ b/nixos/roles/router/keepalived/whq.conf
@@ -6,7 +6,7 @@ vrrp_script check_dev_route_v4 {
 }
 
 vrrp_script check_dev_route_v6 {
-      script "/etc/keepalived/check-default-route-v6 '2a02:238:f030:1c0::/58 via'"
+      script "/etc/keepalived/check-default-route-v6 '2a06:3a80:300::/40 via'"
       interval 1
       fall 2
       rise 2

--- a/nixos/services/haproxy/README.md
+++ b/nixos/services/haproxy/README.md
@@ -130,12 +130,12 @@ defaults
     balance leastconn
 
 listen headless-web-service-http
-    bind [2a02:238:f030:1c2::10b6]:80
+    bind [2001:db8:0:2::10b6]:80
     mode http
     server-template svc 3 headless-web-service.default.svc.cluster.local:80 check resolvers cluster init-addr none
 
 listen lb-web-service-http
-    bind [2a02:238:f030:1c2::10b6]:80
+    bind [2001:db8:0:2::10b6]:80
     mode http
     server-template pod 3 *.lb-web-service.default.svc.cluster.local:80 check resolvers cluster init-addr none
     # fallback
@@ -154,7 +154,7 @@ In nixos:
       "headless-web-service-http" = {
         mode = "http";
         binds = [
-          "[2a02:238:f030:1c2::10b6]:80"
+          "[2001:db8:0:2::10b6]:80"
         ];
         extraConfig = ''
           server-template svc 3 headless-web-service.default.svc.cluster.local:80 check resolvers cluster init-addr none
@@ -162,7 +162,7 @@ In nixos:
       };
       "lb-web-service-http" = {
         binds = [
-          "[2a02:238:f030:1c2::10b6]:80"
+          "[2001:db8:0:2::10b6]:80"
         ];
         mode = "http";
         extraConfig = ''
@@ -201,11 +201,11 @@ defaults
   balance leastconn
 listen headless-web-service-http
   mode http
-  bind [2a02:238:f030:1c2::10b6]:80
+  bind [2001:db8:0:2::10b6]:80
   server-template svc 3 headless-web-service.default.svc.cluster.local:80 check resolvers cluster init-addr none
 listen lb-web-service-http
   mode http
-  bind [2a02:238:f030:1c2::10b6]:80
+  bind [2001:db8:0:2::10b6]:80
   server-template pod 3 *.lb-web-service.default.svc.cluster.local:80 check resolvers cluster init-addr none
   # fallback
   server-template svc 1 lb-web-service.default.svc.cluster.local:80 check resolvers cluster init-addr none backup

--- a/tests/router/default.nix
+++ b/tests/router/default.nix
@@ -173,7 +173,7 @@ import ../make-test-python.nix (
               name = "fe";
               subnet6 = [
                 {
-                  subnet = "2a02:238:f030:1c2::/64";
+                  subnet = "fdfc:c12:c05:2::/64";
                   id = 1;
                 }
               ];
@@ -197,11 +197,11 @@ import ../make-test-python.nix (
             bridged = false;
             networks = {
               "172.20.1.0/24" = [ "172.20.1.1${toString id}" ];
-              "2a02:238:f030:1c1::/64" = [ "2a02:238:f030:1c1::1${toString id}" ];
+              "fdfc:c12:c05:1::/64" = [ "fdfc:c12:c05:1::1${toString id}" ];
             };
             gateways = {
               "172.20.1.0/24" = "172.20.1.1";
-              "2a02:238:f030:1c1::/64" = "2a02:238:f030:1c1::1";
+              "fdfc:c12:c05:1::/64" = "fdfc:c12:c05:1::1";
             };
             nics = [
               {
@@ -215,11 +215,11 @@ import ../make-test-python.nix (
             bridged = false;
             networks = {
               "172.20.2.0/24" = [ "172.20.2.1${toString id}" ];
-              "2a02:238:f030:1c2::/64" = [ "2a02:238:f030:1c2::1${toString id}" ];
+              "fdfc:c12:c05:2::/64" = [ "fdfc:c12:c05:2::1${toString id}" ];
             };
             gateways = {
               "172.20.2.0/24" = "172.20.2.1";
-              "2a02:238:f030:1c2::/64" = "2a02:238:f030:1c2::1";
+              "fdfc:c12:c05:2::/64" = "fdfc:c12:c05:2::1";
             };
             nics = [
               {
@@ -234,11 +234,11 @@ import ../make-test-python.nix (
             networks = {
               "172.20.3.0/24" = [ "172.20.3.1${toString id}" ];
               "172.30.3.0/24" = [ "172.30.3.1${toString id}" ];
-              "2a02:238:f030:1c3::/64" = [ "2a02:238:f030:1c3::1${toString id}" ];
+              "fdfc:c12:c05:3::/64" = [ "fdfc:c12:c05:3::1${toString id}" ];
             };
             gateways = {
               "172.20.3.0/24" = "172.20.3.1";
-              "2a02:238:f030:1c3::/64" = "2a02:238:f030:1c3::1";
+              "fdfc:c12:c05:3::/64" = "fdfc:c12:c05:3::1";
             };
             nics = [
               {
@@ -252,11 +252,11 @@ import ../make-test-python.nix (
             bridged = false;
             networks = {
               "172.20.6.0/24" = [ "172.20.6.1${toString id}" ];
-              "2a02:238:f030:1c6::/124" = [ "2a02:238:f030:1c6::1${toString id}" ];
+              "fdfc:c12:c05:6::/124" = [ "fdfc:c12:c05:6::1${toString id}" ];
             };
             gateways = {
               "172.20.6.0/24" = "172.20.6.1";
-              "2a02:238:f030:1c6::/124" = "2a02:238:f030:1c6::1";
+              "fdfc:c12:c05:6::/124" = "fdfc:c12:c05:6::1";
             };
             nics = [
               {


### PR DESCRIPTION
We are retiring old subnets which are currently in use in DEV. This change removes those networks from the static platform configuration and from the relevant router configurations.

Additionally, as DEV addresses were in use in some tests and documentation, I've updated those to use IPv6 ULA space or documentation space.

In spite of the changes to the static nameserver configuration this shouldn't need to be backported. Only the IPv6 nameserver has changed, which is only consumed in the KVM role and all of the affected KVM servers are on a current platform version.

PL-133308

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh` => none, internal change.

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [x] ensure the merge bot has determined a merge date
- [x] ensure all checks are green
- [x] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Addresses previously baked into static platform configurations are being removed.
- [x] Security requirements tested? (EVIDENCE)
  - Manually tested dev VMs
  - Manually tested dev hardware (KVM, storage, router)
  - bird and keepalived configs for WHQ pass config check on the relevant router