### PR TITLE
gha: Add backport action

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -1,0 +1,44 @@
+name: Backport
+
+on:
+  pull_request_target:
+    types: [closed, labeled]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  backport:
+    name: Backport Pull Request
+    if: github.event.pull_request.merged == true && (github.event.action != 'labeled' || startsWith(github.event.label.name, 'backport'))
+    runs-on: ubuntu-24.04
+    steps:
+      # Use a GitHub App to create the PR so that CI gets triggered
+      - uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
+        id: app-token
+        with:
+          app-id: ${{ vars.AUTO_MERGE_APP_ID }}
+          private-key: ${{ secrets.AUTO_MERGE_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Create backport PRs
+        id: backport
+        uses: korthout/backport-action@436145e922f9561fc5ea157ff406f21af2d6b363 # v3.2.0
+        with:
+          # Config README: https://github.com/korthout/backport-action#backport-action
+          copy_labels_pattern: '(risk|urgency): \d'
+          github_token: ${{ steps.app-token.outputs.token }}
+          pull_description: |-
+            Bot-based backport to `${target_branch}`, triggered by a label in #${pull_number}. Original body:
+
+            ${pull_description}


### PR DESCRIPTION
@flyingcircusio/release-managers

PL-133725

## Release process

- [ ] Created changelog entry using `./changelog.sh`
  - no: internal change
 
## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Permissions of token: This token has write access to the fc-nixos repo and write on issues+PRs. This is required to create backport PRs
  - Functionality
  - Supply Chain Attacks 
  - NPC identification
- [x] Security requirements tested? (EVIDENCE)
  - Tested in fc-nixos-testing: https://github.com/flyingcircusio/fc-nixos-testing/pull/62, https://github.com/flyingcircusio/fc-nixos-testing/pull/63
  - The action is used widely in various communities and we're following the most conservative appropoach (like NixOS does) of pinning the specific commit to avoid unnoticed updates/injections
  - Changes triggered by the action are not specifically traceable to the action, but shown as the "[platform-pr-manager](https://github.com/apps/platform-pr-manager) (bot)" user.
  - the action receives a temporary token that is only valid while the action is running (when it was legitimately  triggered) and can not use this token later if the token gets extracted.