### PR TITLE
s3users: report secret key back to the directory

### DIFF
--- a/changelog.d/20250620_101137_PL-133656-s3-report-secret-key-to-directory_scriv.md
+++ b/changelog.d/20250620_101137_PL-133656-s3-report-secret-key-to-directory_scriv.md
@@ -1,0 +1,20 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+
+### NixOS XX.XX platform
+
+- Improve convergence in internal S3 user management. Secrets are now also being reported back to our configuration
+  management. This reduces error potential in the future in the secret management (PL-133656)

--- a/pkgs/fc/agent/src/fc/manage/s3users.py
+++ b/pkgs/fc/agent/src/fc/manage/s3users.py
@@ -323,7 +323,7 @@ class UserManager:
                     # as explicit values
                     "location": self.location,
                     "storage_resource_group": self.rg,
-                    "secret_key": None,
+                    "secret_key": user.rgw.secret_key,
                 }
                 for user in self.users.values()
                 if user.rgw.exists
@@ -342,7 +342,7 @@ class UserManager:
                 )
                 self.processing_errors = True
 
-        # report all users present with uid, display_name, access_key
+        # report all users present with uid, display_name, access_key, and secret_key
         self.report_local_users_to_directory()
 
 

--- a/pkgs/fc/agent/src/fc/manage/tests/test_s3users.py
+++ b/pkgs/fc/agent/src/fc/manage/tests/test_s3users.py
@@ -664,11 +664,11 @@ def test_user_manager(subprocess_run, caplog):
                     "keys": [
                         {
                             "access_key": "some-old-key",
-                            "secret_key": "...",
+                            "secret_key": "oldkeysecret",
                         },
                         {
                             "access_key": "some-other-old-key",
-                            "secret_key": "...",
+                            "secret_key": "otheroldkeysecret",
                         },
                     ],
                 }
@@ -703,14 +703,14 @@ def test_user_manager(subprocess_run, caplog):
                     "access_key": "dnDlid0jyRs1sK9vEOGV",
                     "location": "test",
                     "storage_resource_group": "services",
-                    "secret_key": None,
+                    "secret_key": "VqBfxCqupucBSjo7ksDcf4K6vhgsIdGKnL0ielLi",
                 },
                 "services:user1": {
                     "display_name": "user 1",
                     "access_key": "some-old-key",
                     "location": "test",
                     "storage_resource_group": "services",
-                    "secret_key": None,
+                    "secret_key": "oldkeysecret",
                 },
             }
         )


### PR DESCRIPTION
PL-133656

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Security ring of S3 secrets: S3 Secret Keys already temporarily are in the directory. The directory also has full control over storage servers (e.g. by adding a ssh key to a user and giving them wheel)
- [x] Security requirements tested? (EVIDENCE)
  - Tested that this works without the directory change on dev-machine