### PR TITLE
[PL-133160] nixos/platform: don't discard user-defined unfree/insecure packages

### DIFF
--- a/changelog.d/20250620_171028_PL-133160-merge-insecure-unfree-declarations_scriv.md
+++ b/changelog.d/20250620_171028_PL-133160-merge-insecure-unfree-declarations_scriv.md
@@ -1,0 +1,26 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+
+### NixOS XX.XX platform
+
+- Introduced option `flyingcircus.permittedInsecurePackages` to allow additional packages marked as insecure.
+
+- Improved error message when trying to use a package marked as insecure or unfree showing FCIO-specific instructions.
+
+- When importing the platform channel (`import <fc> …`), declarations of `config.allowUnfreePredicate` and
+  `config.permittedInsecurePackages` don't get discarded silently. In case of `allowUnfreePredicate`, at least
+  one of the platform-provided or user-supplied predicate must evaluate to `true` to allow the instantiation of
+  an unfree package.

--- a/default.nix
+++ b/default.nix
@@ -23,14 +23,21 @@ with builtins;
 let
   nixpkgsConfig = import ./nixpkgs-config.nix;
   getName = pkg: pkg.pname or (parseDrvName pkg.name);
+
+  inherit (import (nixpkgs + "/lib")) recursiveUpdate;
+
+  mergedNixpkgsConfig = recursiveUpdate config {
+    allowUnfreePredicate =
+      pkg:
+      elem (getName pkg) nixpkgsConfig.allowedUnfreePackageNames
+      || (config.allowUnfreePredicate or (_: false)) pkg;
+
+    permittedInsecurePackages =
+      nixpkgsConfig.permittedInsecurePackages ++ (config.permittedInsecurePackages or [ ]);
+  };
 in
 import nixpkgs {
   overlays = overlays ++ [ (import ./pkgs/overlay.nix) ];
-  config = config // {
-
-    inherit (nixpkgsConfig) permittedInsecurePackages;
-
-    allowUnfreePredicate = pkg: elem (getName pkg) nixpkgsConfig.allowedUnfreePackageNames;
-  };
+  config = mergedNixpkgsConfig;
 }
 // args

--- a/flake.lock
+++ b/flake.lock
@@ -386,11 +386,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1750651377,
-        "narHash": "sha256-9NwC2gqh08cMIUlw/5XidylsG7rrrZRIzNLzed1M/kg=",
+        "lastModified": 1750754646,
+        "narHash": "sha256-tbMx/721KVK1QoKVTVD2gjOZEAXWv4X0LHOlhhpdni4=",
         "owner": "flyingcircusio",
         "repo": "nixpkgs",
-        "rev": "ce25d664a60123eefef75dd1b90deb98c05cbacb",
+        "rev": "339cd468b060218004688dcd6896f7b138a171ef",
         "type": "github"
       },
       "original": {

--- a/nixos/platform/default.nix
+++ b/nixos/platform/default.nix
@@ -77,6 +77,17 @@ in
       type = types.attrsOf types.unspecified;
     };
 
+    flyingcircus.permittedInsecurePackages = mkOption {
+      type = listOf str;
+      description = ''
+        Allow installing packages that were marked as insecure
+        by the upstream distribution. Please note that these are not prebuilt by
+        a CI system and thus will be built locally.
+        e.g. `python3-3.7.0`.
+      '';
+      default = [ ];
+    };
+
     flyingcircus.allowedUnfreePackageNames = mkOption {
       type = listOf str;
       description = ''
@@ -340,7 +351,8 @@ in
     nixpkgs.config.allowUnfreePredicate =
       pkg: builtins.elem (lib.getName pkg) config.flyingcircus.allowedUnfreePackageNames;
 
-    nixpkgs.config.permittedInsecurePackages = nixpkgsConfig.permittedInsecurePackages;
+    nixpkgs.config.permittedInsecurePackages =
+      nixpkgsConfig.permittedInsecurePackages ++ config.flyingcircus.permittedInsecurePackages;
 
     environment.etc."local/nixos/README.txt".text = ''
       To add custom NixOS config, create *.nix files here.

--- a/release/versions.json
+++ b/release/versions.json
@@ -14,10 +14,10 @@
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/"
   },
   "nixpkgs": {
-    "hash": "sha256-9NwC2gqh08cMIUlw/5XidylsG7rrrZRIzNLzed1M/kg=",
+    "hash": "sha256-tbMx/721KVK1QoKVTVD2gjOZEAXWv4X0LHOlhhpdni4=",
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "ce25d664a60123eefef75dd1b90deb98c05cbacb"
+    "rev": "339cd468b060218004688dcd6896f7b138a171ef"
   },
   "nixpkgs-21_05": {
     "hash": "sha256-5ufC/t0sUFS/LspiEwU8DW5+uVYM3diZ1IC7KjX9ek4=",


### PR DESCRIPTION
PL-133160

* Introduced `flyingcircus.permittedInsecurePackages` which is equivalent to `nixpkgs.config.permittedInsecurePackages`. However, the latter cannot be used since we set it in the platform-code already and the merging below `nixpkgs.config` is broken for years now.

* Merge declarations from `config` arg with our own nixpkgs together in the `default.nix`-entrypoint such that user-defined declarations of `permittedInsecurePackages` and `allowUnfreePredicate` don't get discarded silently, but merged together.

  In case of the predicate, at least one of the user-defined predicate (by default `const false`) or the platform-defined one must evaluate to true.

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Packages marked as insecure/unfree are only allowed when explicitly allow-listed (and user-provided items shouldn't be discarded silently).
- [x] Security requirements tested? (EVIDENCE)
  - Tested correct behavior of the newly introduced option on a test-VM.
