### PR TITLE
doc: update fc-manage invocations to remove deprecated onces

### DIFF
--- a/doc/src/devhost.md
+++ b/doc/src/devhost.md
@@ -62,7 +62,7 @@ using slim VMs on a single powerful, physical machine on our public infrastructu
    i.e. set `*.dev.example.com CNAME mydev00.fe.rzob.fcio.net`.
 
 4) Add the `publicAddress` option to the NixOS configuration on the host,
-   e.g. in {file}`/etc/local/nixos/devhost.nix` and run {command}`fc-manage -b`:
+   e.g. in {file}`/etc/local/nixos/devhost.nix` and run {command}`fc-manage switch`:
 
    ```Nix
    { ... }:

--- a/doc/src/firewall.md
+++ b/doc/src/firewall.md
@@ -24,7 +24,7 @@ that all lines are either:
 - invocations of an iptables command (iptables, ip6tables, ip46tables)
 
 After making changes to the firewall configuration, either wait for the
-agent to apply it or run `sudo fc-manage -b`.
+agent to apply it or run `sudo fc-manage switch`.
 
 :::{note}
 Use IP addresses in firewall rules. Using host names is not reliable and
@@ -113,7 +113,7 @@ ip6tables -L -nv   # show IPv6 firewall rules w/o DNS resolution
 ```
 
 If the intended rules do not show up, check the system journal for possible
-syntax errors in {file}`/etc/local/firewall` and re-run {command}`fc-manage -b`.
+syntax errors in {file}`/etc/local/firewall` and re-run {command}`fc-manage switch`.
 
 ## Fail2ban
 

--- a/doc/src/lamp.md
+++ b/doc/src/lamp.md
@@ -268,7 +268,7 @@ No special interaction is required. Changes to the configuration need to be
 activated as usual using:
 
 ```console
-$ sudo fc-manage -b
+$ sudo fc-manage switch
 ```
 
 ## Network

--- a/doc/src/local.md
+++ b/doc/src/local.md
@@ -15,7 +15,7 @@ automatically upon the next run of our configuration agent (generally every
 10 minutes) but you can also explicitly trigger it by running:
 
 ```console
-$ sudo fc-manage --build
+$ sudo fc-manage switch
 ```
 
 This will update the machine's system configuration, which includes copying the
@@ -37,9 +37,7 @@ calls the underlying NixOS commands.
 The basic call to apply changed configuration is:
 
 ```console
-$ sudo fc-manage --build
-# Short form
-$ sudo fc-manage -b
+$ sudo fc-manage switch
 ```
 
 This will pick up locally changed configuration but will not perform general OS
@@ -51,17 +49,17 @@ The call to perform extensive updates including potential OS updates (the
 directory, "ENC") is:
 
 ```console
-$ sudo fc-manage --directory --channel
+$ sudo fc-manage switch --update-enc --channel
 # Short form:
-$ sudo fc-manage -ec
+$ sudo fc-manage switch -ec
 ```
 
 A mixed form (no OS updates but include changes from the CMDB) is:
 
 ```console
-$ sudo fc-manage --directory --build
+$ sudo fc-manage switch --update-enc
 # Short form:
-$ sudo fc-manage -eb
+$ sudo fc-manage switch -e
 ```
 
 (nixos-custom-modules)=
@@ -78,7 +76,7 @@ Care must be taken to avoid breaking the system.
 Overriding options already set by the platform can be dangerous.
 :::
 
-Run `sudo fc-manage -b` to activate the changes (**may restart services!**).
+Run `sudo fc-manage switch` to activate the changes (**may restart services!**).
 
 For more information about writing NixOS modules, refer to the
 [NixOS manual](https://nixos.org/nixos/manual/index.html#sec-writing-modules)

--- a/doc/src/mongodb.md
+++ b/doc/src/mongodb.md
@@ -52,7 +52,7 @@ db.adminCommand( { setFeatureCompatibilityVersion: "4.2" } )
 To upgrade, disable the current role and enable the role for the next major version.
 MongoDB will be upgraded and restarted on the next management task run.
 This happens automatically after some time. You can trigger a rebuild with
-{code}`sudo fc-manage --build --directory` immediately.
+{code}`sudo fc-manage switch --update-enc` immediately.
 
 The restart will fail if the feature compatibility version is too old ("error 62").
 To fix this, go back to the last working role version, rebuild, and set the version.

--- a/doc/src/monitoring.md
+++ b/doc/src/monitoring.md
@@ -36,7 +36,7 @@ Example:
 }
 ```
 
-To activate the checks, run {command}`sudo fc-manage --build`.
+To activate the checks, run {command}`sudo fc-manage switch`.
 For further information about local configuration, also see {ref}`nixos-local`.
 
 The following packages are available in the sensu check PATH:

--- a/doc/src/mysql.md
+++ b/doc/src/mysql.md
@@ -32,7 +32,7 @@ The root user is authenticated by socket auth with the `mysql` and `root` system
 Custom config files in {file}`/etc/local/mysql` are included in the
 main mysql configuration file on the next system build.
 Add a {file}`local.cnf` (or any other `*.cnf`) file there, and run
-{command}`sudo fc-manage --build` to activate the new configuration.
+{command}`sudo fc-manage switch` to activate the new configuration.
 
 :::{note}
 Changes to \*.cnf files in this directory will restart MySQL

--- a/doc/src/postgresql.md
+++ b/doc/src/postgresql.md
@@ -66,7 +66,7 @@ String values will automatically be enclosed in single quotes.
 Single quotes will be escaped with two single quotes.
 Booleans in Nix (true/false) are converted to on/off in the PostgreSQL config.
 
-Run {command}`sudo fc-manage -b` to activate the changes (**restarts PostgreSQL!**).
+Run {command}`sudo fc-manage switch` to activate the changes (**restarts PostgreSQL!**).
 
 See {ref}`nixos-custom-modules` for general information about writing NixOS
 modules.
@@ -77,7 +77,7 @@ Service users can use {command}`sudo -u postgres -i` to access the
 PostgreSQL superuser account to perform administrative commands like
 {command}`createdb` and {command}`createuser`.
 
-Service users may invoke {command}`sudo fc-manage --build`
+Service users may invoke {command}`sudo fc-manage switch`
 to apply configuration changes and restart the PostgreSQL
 server (if necessary).
 

--- a/doc/src/redis.md
+++ b/doc/src/redis.md
@@ -115,7 +115,7 @@ Overriding the `password` to `foobarpass` looks like this:
 
 ## Interaction
 
-Service users may invoke {command}`sudo fc-manage --build` to apply
+Service users may invoke {command}`sudo fc-manage switch` to apply
 service configuration changes and trigger service restarts (if necessary).
 
 ## Monitoring

--- a/doc/src/webgateway.md
+++ b/doc/src/webgateway.md
@@ -40,13 +40,13 @@ and how you are used to configure, start, stop and maintain these packages.
   Since we use NixOS, files have to be edited in {file}`/etc/local`, followed by a
   NixOS rebuild which copies them into the
   Nix store and activates the new configuration. To do so, run the command
-  {command}`sudo fc-manage -b`
+  {command}`sudo fc-manage switch`
 
 - **service control:**
 
   We use {command}`systemd` to control processes. You can use familiar commands
   like {command}`sudo systemctl restart nginx` to control services.
-  However, remember that invoking {command}`sudo fc-manage -b` is
+  However, remember that invoking {command}`sudo fc-manage switch` is
   necessary to put configuration changes into effect. A simple restart is not
   sufficient. For further information, see {ref}`nixos-local`.
 
@@ -112,7 +112,7 @@ Note that changes to listen directives that are incompatible with the running co
 may require a manual Nginx restart that drops connections.
 Using `reuseport` can avoid such situations (see below).
 
-After building it with {command}`sudo fc-manage -b`, the final nginx config file
+After building it with {command}`sudo fc-manage switch`, the final nginx config file
 can be shown with: {command}`nginx-show-config`
 
 You can check if the config is valid with: {command}`nginx-check-config`.

--- a/doc/src/webproxy.md
+++ b/doc/src/webproxy.md
@@ -14,13 +14,13 @@ and how you are used to configure, start, stop and maintain these packages.
   Since we use NixOS, configuration files have to be edited in
   {file}`/etc/local/nixos`, followed by a NixOS rebuild which copies them into
   the Nix store and activates the new configuration. To do so, run the command
-  {command}`sudo fc-manage --build`.
+  {command}`sudo fc-manage switch`.
 
 - **service control:**
 
   We use {command}`systemd` to control processes. You can use familiar commands
   like {command}`sudo systemctl restart varnish` to control services.
-  However, remember that invoking {command}`sudo fc-manage --build` is
+  However, remember that invoking {command}`sudo fc-manage switch` is
   necessary to put configuration changes into effect. A simple restart is not
   sufficient. For further information, also see {ref}`nixos-local`.
 

--- a/nixos/roles/elasticsearch.nix
+++ b/nixos/roles/elasticsearch.nix
@@ -343,7 +343,7 @@ in
         To see the final rendered config for Elasticsearch, use the
         `elasticsearch-show-config` command as service or sudo-srv user.
 
-        To activate config changes, run `sudo fc-manage --build`.
+        To activate config changes, run `sudo fc-manage switch`.
 
         ### NixOS Options
 

--- a/nixos/roles/mysql.nix
+++ b/nixos/roles/mysql.nix
@@ -344,7 +344,7 @@ in
 
           Config files from this directory (/etc/local/mysql) are included in the
           mysql configuration. To set custom options, add a `local.cnf`
-          (or any other *.cnf) file here, and run `sudo fc-manage --build`.
+          (or any other *.cnf) file here, and run `sudo fc-manage switch`.
 
           ATTENTION: Changes to *.cnf files in this directory will restart MySQL
           to activate the new configuration.

--- a/nixos/services/nginx/README.txt
+++ b/nixos/services/nginx/README.txt
@@ -20,7 +20,7 @@ may require a manual Nginx restart that drops connections.
 Using `reuseport` can avoid such situations (see below).
 
 
-After building it with `sudo fc-manage -b`, the final nginx config file
+After building it with `sudo fc-manage switch`, the final nginx config file
 can be shown with: `nginx-show-config`
 
 You can check if the config is valid with: `nginx-check-config`.

--- a/nixos/services/nginx/example-plain-config.nix
+++ b/nixos/services/nginx/example-plain-config.nix
@@ -16,7 +16,7 @@ in
   # Example nginx configuration for the Flying Circus. Copy this file into
   # 'mydomain.conf' and edit. You'll certainly want to replace www.example.com
   # with something more specific. Please note that configuration files must end
-  # with '.conf' to be active. Reload with `sudo fc-manage --build`.
+  # with '.conf' to be active. Reload with `sudo fc-manage switch`.
 
   upstream @varnish {
       server localhost:8008;

--- a/pkgs/fc/agent/README.rst
+++ b/pkgs/fc/agent/README.rst
@@ -21,14 +21,12 @@ fc-manage usage
 
 The main modes of operation are as follows:
 
-fc-manage --channel (-c)
-    Download the latest FC nixpkgs from our Hydra and update the system. This is
-    what the systemd timer usually does.
+fc-manage switch
+    Rebuild the system, but don't pull channel updates from Hydra.
+    This command has the options `--update-enc` (short `-e`) to update ENC
+    and `--update-channel` (short `-c`) to update the channel before switching the channel.
 
-fc-manage --build (-b)
-    Update the system, but don't pull channel updates from Hydra.
-
-fc-manage --directory (-e)
+fc-manage update-enc
     Updates various ENC dumps in `/etc/nixos` from the directory: environment,
     RAM/disk sizings, users, ...
 


### PR DESCRIPTION
PL-133162

@flyingcircusio/release-managers

## Release process

- [ ] Created changelog entry using `./changelog.sh`
  no: docs only

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  none
- [x] Security requirements tested? (EVIDENCE)