### PR TITLE
mailserver: update simple-nixos-mailserver

### DIFF
--- a/doc/src/mailserver.md
+++ b/doc/src/mailserver.md
@@ -19,9 +19,8 @@ The main ingredients of this role are [Postfix] for mail delivery, [Dovecot] as
 IMAP access server, and [Roundcube] as web frontend.
 {ref}`nixos-postgresql-server` is used as a database to store Roundcube settings.
 
-We rely mainly on [Rspamd] for spam protection. To get outgoing mails
-delivered, they are signed with[OpenDKIM] and a basic [SPF] and [SRS] setup
-is included.
+We rely mainly on [Rspamd] for spam protection and DKIM signing.
+A basic [SPF] and [SRS] setup is included as well.
 
 Additionally, a Thunderbird-compatible client [autoconfiguration] XML file is
 provided which helps many clients to configure themselves properly.
@@ -432,7 +431,6 @@ Monitoring checks/metrics created by this role:
 
 [autoconfiguration]: https://wiki.mozilla.org/Thunderbird:Autoconfiguration
 [dovecot]: https://dovecot.org/
-[opendkim]: http://www.opendkim.org/
 [postfix]: http://www.postfix.org/
 [relay_domains]: http://www.postfix.org/postconf.5.html#relay_domains
 [roundcube]: https://roundcube.net/

--- a/flake.lock
+++ b/flake.lock
@@ -201,10 +201,58 @@
         "type": "github"
       }
     },
+    "git-hooks_2": {
+      "inputs": {
+        "flake-compat": [
+          "nixos-mailserver",
+          "flake-compat"
+        ],
+        "gitignore": "gitignore_2",
+        "nixpkgs": [
+          "nixos-mailserver",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1750684550,
+        "narHash": "sha256-uLtw0iF9mQ94L831NOlQLPX9wm0qzd5yim3rcwACEoM=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "fae816c55a75675f30d18c9cbdecc13b970d95d4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
     "gitignore": {
       "inputs": {
         "nixpkgs": [
           "devenv",
+          "git-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "gitignore_2": {
+      "inputs": {
+        "nixpkgs": [
+          "nixos-mailserver",
           "git-hooks",
           "nixpkgs"
         ]
@@ -297,26 +345,27 @@
       "inputs": {
         "blobs": "blobs",
         "flake-compat": "flake-compat_2",
+        "git-hooks": "git-hooks_2",
         "nixpkgs": [
           "nixpkgs"
         ],
-        "nixpkgs-24_11": [
+        "nixpkgs-25_05": [
           "nixpkgs"
         ]
       },
       "locked": {
         "host": "gitlab.flyingcircus.io",
-        "lastModified": 1742898683,
-        "narHash": "sha256-zXLDkbXXD4S86H9s1FAtuXskdVXglS5F1DNSaOMLpzk=",
+        "lastModified": 1750693316,
+        "narHash": "sha256-dy2uEaf5Urv9ZgzilOtQxemtufi6Yn5iXlmEt00uNPc=",
         "owner": "flyingcircus",
         "repo": "nixos-mailserver",
-        "rev": "70dbce740c4d87627bb9b03b6551b69ca33d5b31",
+        "rev": "3b1ec3e110e6ce5c1bbf60d32f160b6cfc16d060",
         "type": "gitlab"
       },
       "original": {
         "host": "gitlab.flyingcircus.io",
         "owner": "flyingcircus",
-        "ref": "master",
+        "ref": "nixos-25.05",
         "repo": "nixos-mailserver",
         "type": "gitlab"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -22,9 +22,9 @@
   inputs = {
     nixpkgs.url = "github:flyingcircusio/nixpkgs/nixos-25.05";
     nixos-mailserver = {
-      url = "gitlab:flyingcircus/nixos-mailserver/master?host=gitlab.flyingcircus.io";
+      url = "gitlab:flyingcircus/nixos-mailserver/nixos-25.05?host=gitlab.flyingcircus.io";
       inputs.nixpkgs.follows = "nixpkgs";
-      inputs.nixpkgs-24_11.follows = "nixpkgs";
+      inputs.nixpkgs-25_05.follows = "nixpkgs";
     };
     devenv = {
       url = "github:cachix/devenv/fa5cbf91fb1f1614936997badbb6018a2fdef320";

--- a/nixos/roles/mailserver.nix
+++ b/nixos/roles/mailserver.nix
@@ -45,12 +45,12 @@ let
       example = "mail.example.com";
     };
 
-    policydSPFExtraSkipAddresses = mkOption {
+    spfSkipAddresses = mkOption {
       type = with types; listOf str;
       description = ''
-        Extra addresses policyd should skip in SPF checks.
+        Extra addresses rspamd should skip in SPF checks.
         Local addresses are always skipped.
-        This extends the `skip_addresses` setting in policyd-spf.conf.
+        Format: IP address with optional CIDR notation (rspamd radix map)
       '';
       default =
         if hasFE then
@@ -118,9 +118,29 @@ let
 
 in
 {
-  imports = [
-    ../services/mail
-  ];
+  imports =
+    [
+      ../services/mail
+    ]
+    ++ builtins.map
+      (
+        rolePrefix:
+        (lib.mkRenamedOptionModule (rolePrefix ++ [ "policydSPFExtraSkipAddresses" ]) (
+          rolePrefix ++ [ "spfSkipAddresses" ]
+        ))
+      )
+      [
+        [
+          "flyingcircus"
+          "roles"
+          "mailserver"
+        ]
+        [
+          "flyingcircus"
+          "roles"
+          "mailstub"
+        ]
+      ];
 
   options = {
 

--- a/nixos/services/mail/default.nix
+++ b/nixos/services/mail/default.nix
@@ -291,7 +291,6 @@ in
           # See https://gitlab.com/simple-nixos-mailserver/nixos-mailserver/-/issues/289
           systemd.services.postfix.restartTriggers = [ config.mailserver.localDnsResolver ];
           systemd.services.rspamd.restartTriggers = [ config.mailserver.localDnsResolver ];
-          systemd.services.opendkim.restartTriggers = [ config.mailserver.localDnsResolver ];
 
           services.dovecot2.extraConfig = ''
             passdb {

--- a/nixos/services/mail/default.nix
+++ b/nixos/services/mail/default.nix
@@ -399,10 +399,6 @@ in
                   "permit_sasl_authenticated"
                   "reject_unknown_helo_hostname"
                 ];
-                smtpd_tls_mandatory_protocols = lib.mkForce ">=TLSv1.2";
-                smtpd_tls_protocols = lib.mkForce ">=TLSv1.2";
-                smtp_tls_mandatory_protocols = lib.mkForce ">=TLSv1.2";
-                smtp_tls_protocols = lib.mkForce ">=TLSv1.2";
               }
               // (lib.optionalAttrs role.explicitSmtpBind {
                 smtp_bind_address = role.smtpBind4;

--- a/nixos/services/mail/default.nix
+++ b/nixos/services/mail/default.nix
@@ -270,18 +270,6 @@ in
                 specialUse = "Archive";
               };
             };
-            policydSPFExtraConfig =
-              let
-                skipped = [
-                  "127.0.0.0/8"
-                  "::ffff:127.0.0.0/104"
-                  "::/64"
-                ] ++ role.policydSPFExtraSkipAddresses;
-              in
-              ''
-                skip_addresses = ${concatStringsSep "," skipped}
-                HELO_Whitelist = ${fqdn},${role.mailHost}
-              '';
             vmailGroupName = "vmail";
             vmailUserName = "vmail";
           };

--- a/nixos/services/mail/rspamd.nix
+++ b/nixos/services/mail/rspamd.nix
@@ -80,6 +80,10 @@ in
         dynamic_conf = "/var/lib/rspamd/rspamd_dynamic";
         static_dir = "${pkgs.rspamd}/share/rspamd/www";
       '';
+
+      "spf.conf".text = ''
+        whitelist = [${concatStringsSep ", " (map (n: "\"${n}\"") role.spfSkipAddresses)}];
+      '';
     };
   };
 }

--- a/release/versions.json
+++ b/release/versions.json
@@ -8,9 +8,9 @@
   "nixos-mailserver": {
     "deepClone": false,
     "fetchSubmodules": false,
-    "hash": "sha256-zXLDkbXXD4S86H9s1FAtuXskdVXglS5F1DNSaOMLpzk=",
+    "hash": "sha256-dy2uEaf5Urv9ZgzilOtQxemtufi6Yn5iXlmEt00uNPc=",
     "leaveDotGit": false,
-    "rev": "70dbce740c4d87627bb9b03b6551b69ca33d5b31",
+    "rev": "3b1ec3e110e6ce5c1bbf60d32f160b6cfc16d060",
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/"
   },
   "nixpkgs": {


### PR DESCRIPTION
@flyingcircusio/release-managers

Part of PL-133559, PL-133807

## Release process

- [ ] Created changelog entry using `./changelog.sh`
  - no, but breaking changes will be noted separately in the upgrade notes of #1537

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - [x] follow changes of upstream project
- [x] Security requirements tested? (EVIDENCE)
  - [x] skimmed simple-nixos-mailserver changelog
  - [x] reviewed [release notes](https://nixos-mailserver.readthedocs.io/en/nixos-25.05/release-notes.html#nixos-25-05)
  - [x] updated docs
  - [x] reviewed on test mailserver machine that dkim key is still picked up by rspamd
  - [x] automated tests still pass
