### PR TITLE
[PL-133811] hydra: use our fork for jobset generator, disallow fork PRs

### DIFF
--- a/.hydra/project.json
+++ b/.hydra/project.json
@@ -22,7 +22,7 @@
         },
         "generator": {
             "type": "git",
-            "value": "https://github.com/ctheune/hydra-github-jobsets-generator.git refname-http-urls",
+            "value": "https://github.com/flyingcircusio/hydra-github-jobsets-generator.git main",
             "emailresponsible": false
         },
         "nixpkgs": {
@@ -33,6 +33,11 @@
         "pull_requests": {
             "type": "githubpulls",
             "value": "flyingcircusio fc-nixos",
+            "emailresponsible": false
+        },
+        "ignore_prs_from_forks": {
+            "type": "boolean",
+            "value": "true",
             "emailresponsible": false
         }
     }


### PR DESCRIPTION
__Note:__ this needs a coordinated merge! We'll need to change the Hydra configuration after this gets merged. If the branch gets auto-removed, platform-prs will halt.

The relevant patch is https://github.com/flyingcircusio/hydra-github-jobsets-generator/commit/53d36c1af45f4d66dc0fc55e9b5a5038c8bbea4e

PL-133811

@flyingcircusio/release-managers

## Release process

- [ ] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Don't allow creating jobsets for arbitrary PRs. Restrict to PRs with both base & head branch being in flyingcircusio/fc-nixos.
- [x] Security requirements tested? (EVIDENCE)
  - Hydra uses the configuration from this branch and #1585 didn't get a jobset whereas this PR got one again: https://hydra.flyingcircus.io/jobset/platform-prs/pr-1586