### PR TITLE
ceph-load-vm-images: only lock image if there is no lock yet

### DIFF
--- a/changelog.d/20250625_160625_fc-25.05-dev_scriv.md
+++ b/changelog.d/20250625_160625_fc-25.05-dev_scriv.md
@@ -1,0 +1,19 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+
+### NixOS XX.XX platform
+
+- Improve our internal image update script to not fail on temporary DNS errors (PL-133726)

--- a/pkgs/fc/ceph/src/fc/ceph/maintenance/images_nautilus.py
+++ b/pkgs/fc/ceph/src/fc/ceph/maintenance/images_nautilus.py
@@ -2,7 +2,6 @@
 
 import base64
 import contextlib
-import fnmatch
 import hashlib
 import logging
 import os
@@ -13,10 +12,7 @@ import stat
 import subprocess
 import sys
 import tempfile
-import time
-import traceback
-import xmlrpc.client
-from typing import Iterable, Optional
+from typing import Iterable
 
 import requests
 from fc.ceph.util import directory, run
@@ -24,7 +20,7 @@ from fc.ceph.util import directory, run
 CEPH_CONF = "/etc/ceph/ceph.conf"
 CEPH_CLIENT = socket.gethostname()
 CEPH_POOL = "rbd.hdd"
-LOCK_COOKIE = "{}.{}".format(CEPH_CLIENT, os.getpid())
+LOCK_COOKIE = f"{CEPH_CLIENT}.updateimages"
 
 logger = logging.getLogger(__name__)
 
@@ -154,6 +150,20 @@ class BaseImage:
         # terminated
         signal.signal(signal.SIGTERM, self._handle_interrupt)
         logger.debug(f"Locking image {self.volume}")
+
+        # Check whether this image is still locked from a previous run.
+        # This is fine as concurrency is prevented by systemd.
+        # If it's not yet locked, lock it now.
+        try:
+            self._determine_image_locker()
+            if self.locker:
+                logger.debug(
+                    f"Image {self.volume} is already locked from a previous run by {self.locker}. Skipping locking."
+                )
+                return self
+        except KeyError:
+            pass
+
         try:
             run.rbd("lock", "add", self.volume, LOCK_COOKIE)
             self._determine_image_locker()
@@ -182,7 +192,7 @@ class BaseImage:
                 f"{CEPH_POOL}/{self.envname}", LOCK_COOKIE, self.locker,
             )  # fmt: skip
         except Exception:
-            logger.exception()
+            logger.exception(f"Removing image lock {self.volume} failed")
 
     def _handle_interrupt(self, _signum, _stack_frame):
         """Workaround for ensuring image unlocking when the process is terminated


### PR DESCRIPTION
We've seen multiple times that locking an image works but unlocking doesn't due to DNS issues. This lead to a locking failure in the next run.

To fix this, use a general lock cookie for the update images script and only lock when there is no lock on the image yet.
Concurrency protection is handled by systemd.

PL-133726

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Concurrency protection
- [x] Security requirements tested? (EVIDENCE)
  - General functionality and also locking issue tested in dev
  - Concurrency protection: Exists as systemd only allows one run per service. In addition the hostname is part of the lock cookie which protects against concurrency with multiple hosts 