### PR TITLE
nix: pull in patches for GHSA-g948-229j-48j3

### DIFF
--- a/changelog.d/20250626_024537_os-nix-vulnerability-GHSA-g948-229j-48j3_scriv.md
+++ b/changelog.d/20250626_024537_os-nix-vulnerability-GHSA-g948-229j-48j3_scriv.md
@@ -1,0 +1,18 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+
+
+### NixOS XX.XX platform
+
+- nix: fix GHSA-g948-229j-48j3

--- a/flake.lock
+++ b/flake.lock
@@ -481,11 +481,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1750755853,
-        "narHash": "sha256-B95HJwoEySxAVpFpB7YepWcHoF/+4D/LJDPJWetuz9g=",
+        "lastModified": 1750898458,
+        "narHash": "sha256-vQijTMRLY/eqGl3+ZzcV+zsh7gEo6eZH+rKtTFYNW70=",
         "owner": "flyingcircusio",
         "repo": "nixpkgs",
-        "rev": "721519013c3b0b8ec4b5baf82d5bc5c4383db09c",
+        "rev": "7a49d0ead610694a58e716c37ac616f310b1b156",
         "type": "github"
       },
       "original": {

--- a/release/versions.json
+++ b/release/versions.json
@@ -14,10 +14,10 @@
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/"
   },
   "nixpkgs": {
-    "hash": "sha256-B95HJwoEySxAVpFpB7YepWcHoF/+4D/LJDPJWetuz9g=",
+    "hash": "sha256-vQijTMRLY/eqGl3+ZzcV+zsh7gEo6eZH+rKtTFYNW70=",
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "721519013c3b0b8ec4b5baf82d5bc5c4383db09c"
+    "rev": "7a49d0ead610694a58e716c37ac616f310b1b156"
   },
   "nixpkgs-21_05": {
     "hash": "sha256-5ufC/t0sUFS/LspiEwU8DW5+uVYM3diZ1IC7KjX9ek4=",


### PR DESCRIPTION
This pulls in the patches for GHSA-g948-229j-48j3 from https://github.com/NixOS/nixpkgs/pull/419590 already before the regular channel advance.

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [ ] PR has internal ticket
- [ ] internal issue ID (PL-…) part of branch name
- [ ] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - apply urgent security vulnerabilities
  -  cherry pick only relevant commits of the fix  
- [x] Security requirements tested? (EVIDENCE)
  - automated tests stimm pass