### PR TITLE
doc/upgrade: several additions

### DIFF
--- a/doc/src/upgrade.md
+++ b/doc/src/upgrade.md
@@ -115,6 +115,23 @@ Both are LTS releases still receiving bug and security fixes.
 
 `percona83` is only included to allow upgrades towards `percona84`.
 
+#### no password authentication for root user (all role versions)
+
+Access to the database `root` user was changed to authentication via socket.
+Password authentication is disabled for that user, please switch to the unix user `mysql` for database root operations.
+
+The platform used to provide the password for the database root user under `/etc/local/mysql/mysql.passwd`. That
+file does not exist anymore. Instead, invoke your mysql command via `sudo -u mysql`. \
+Example:
+
+```shell
+sudo -u mysql mysql myDb < someCommands.sql
+```
+
+Users of `batou.lib.mysql` can just [pass `USE_SUDO` as the `admin_password` argument](https://github.com/flyingcircusio/batou/commit/7efcb768613f1d68699defa453c0634a279b98be).
+
+#### changed authentication mechanism in percona84
+
 Version 8.4 of percona (role `percona84`) changes the default authentication mechanism from `mysql_native_password` to `caching_sha2_password`. After upgrading the role to 8.4. *all passwords need to be migrated manually* to the new hash format.
 
 Please do the migration during this platform release cycle, our 25.11 platform with Percona 9.x will disable the deprecated hashing algorithm altogether.


### PR DESCRIPTION
@flyingcircusio/release-managers
Some upgrade doc additions that came up during further QA.

PL-133559

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - properly cover breaking changes
- [x] Security requirements tested? (EVIDENCE)
  - inspected rendered docs