### PR TITLE
fc-slurm: adapt to pyslurm API change

### DIFF
--- a/pkgs/fc/agent/src/fc/util/slurm.py
+++ b/pkgs/fc/agent/src/fc/util/slurm.py
@@ -683,7 +683,7 @@ def check_controller(log, hostname):
         f"Running jobs: {stats['jobs_running']}.",
         f"Pending jobs: {stats['jobs_pending']}.",
         f"Total started jobs: {stats['jobs_started']}.",
-        f"Slurm version: {pyslurm.version()}",
+        f"Slurm version: {pyslurm.version.__version__}",
     ]
 
     return CheckResult(errors, warnings, info)

--- a/pkgs/fc/agent/src/fc/util/tests/test_slurm.py
+++ b/pkgs/fc/agent/src/fc/util/tests/test_slurm.py
@@ -22,7 +22,8 @@ pyslurm.statistics.return_value.get.return_value = {
     "jobs_pending": 2,
     "jobs_started": 3,
 }
-pyslurm.version = lambda: "22.5.0"
+pyslurm.version = type(sys)("pyslurm.version")
+pyslurm.version.__version__ = "24.11.0"
 sys.modules["pyslurm"] = pyslurm
 
 
@@ -168,7 +169,7 @@ def test_check_controller(logger):
         "Running jobs: 1.",
         "Pending jobs: 2.",
         "Total started jobs: 3.",
-        "Slurm version: 22.5.0",
+        "Slurm version: 24.11.0",
     ]
 
 


### PR DESCRIPTION
pyslurm.version() has been removed in favour of directly accessing `pyslurm.version.__version__`

@flyingcircusio/release-managers

## Release process

- [ ] Created changelog entry using `./changelog.sh`
  - n/a

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - follow upstream library API changes
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still pass
  - adjusted unit test mock
