### PR TITLE
doc/upgrade/slurm: add link to upstream release notes

### DIFF
--- a/doc/default.nix
+++ b/doc/default.nix
@@ -6,7 +6,7 @@
 
 {
   pkgs ?
-    import (fetchTarball "https://hydra.flyingcircus.io/build/4347582/download/1/nixexprs.tar.xz")
+    import (fetchTarball "https://hydra.flyingcircus.io/build/5919876/download/1/nixexprs.tar.xz")
       { },
   branch ? "25.05",
   updated ? "1970-01-01 01:00",

--- a/doc/src/upgrade.md
+++ b/doc/src/upgrade.md
@@ -157,6 +157,8 @@ need to use another specific k3s version for your cluster.
 
 This release contains a major version upgrade of Slurm from 24.05.x.x (NixOS 24.11) to 24.11.x.x. Nodes of a cluster need to be upgraded in a particular order, please consult the [upgrade instructions of the role](#nixos-slurm-upgrade) for details.
 
+Regarding new features or changes in Slurm itself, consult [its release notes](https://github.com/SchedMD/slurm/blob/slurm-24-11-0-1/RELEASE_NOTES).
+
 
 (nixos-upgrade-gitlab)=
 ### Gitlab


### PR DESCRIPTION
No breaking changes in there, but slight changes in available config or commands that might be interesting for end users.

PL-133795

@flyingcircusio/release-managers

## Release process

- [ ] Created changelog entry using `./changelog.sh`
  - not necessary

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - None
- [x] Security requirements tested? (EVIDENCE)
