### PR TITLE
[25.05] Update addresses for WHQ in static platform configuration

### DIFF
--- a/nixos/platform/static.nix
+++ b/nixos/platform/static.nix
@@ -137,7 +137,7 @@ with lib;
         # This seems to be https://sourceware.org/bugzilla/show_bug.cgi?id=13028
         # which is fixed in glibc 2.22 which is included in NixOS 16.03.
         dev = [ "2a02:238:f030:1c3::1" ];
-        whq = [ "2a02:238:f030:103::1" ];
+        whq = [ "2a06:3a80:0:3::1" ];
         test = [ "2a02:238:f030:1c2::1" ];
         rzob = [ "2a02:248:101:63::1" ];
         standalone = [
@@ -166,8 +166,13 @@ with lib;
           "2a02:248:101:62::1187"
           "2a02:248:101:63::118f"
 
-          # vpn-whq.services.fcio.net
+          # vpn-whq.services.fcio.net (new addresses)
           "172.16.48.35"
+          "185.105.255.31"
+          "2a06:3a80:0:2::26"
+          "2a06:3a80:0:3::2f"
+
+          # vpn-whq.services.fcio.net (legacy addresses)
           "212.122.41.150"
           "2a02:238:f030:102::1043"
           "2a02:238:f030:103::1073"


### PR DESCRIPTION
This change updates IP addresses in the static platform configuration for WHQ to support the ongoing renumbering and retirement of old subnets. This includes new addresses for the site VPN gateway to allow parallel operation of both old and new addresses while the rest of the site is being renumbered.

PL-133308

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh` => none, internal change

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [x] ensure the merge bot has determined a merge date
- [x] ensure all checks are green
- [x] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Update of static configuration
- [x] Security requirements tested? (EVIDENCE)
  - Hydra tests