### PR TITLE
telegraf: enable `nstat` module by default

### DIFF
--- a/changelog.d/20250701_114120_PL-133683-enable-nstat_scriv.md
+++ b/changelog.d/20250701_114120_PL-133683-enable-nstat_scriv.md
@@ -1,0 +1,21 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+
+### NixOS XX.XX platform
+
+- telegraf: enable [`nstat`](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/nstat) input to provide network protocol stats
+
+  In preparation of the [`net`](https://github.com/influxdata/telegraf/blob/2933b85c7dcdd816cc09584c7fca04ca7dfd55b2/plugins/inputs/net/README.md) input deprecating
+  the report of network protocol metrics, this provides a transitory period of both legacy and future metrics being available.  \
+  Deprecated metrics will be disabled in the next major Flying Circus 25.11 platform release.

--- a/nixos/platform/monitoring.nix
+++ b/nixos/platform/monitoring.nix
@@ -65,7 +65,8 @@ let
     kernel = [ { } ];
     mem = [ { } ];
     netstat = [ { } ];
-    net = [ { } ];
+    net = [ { ignore_protocol_stats = false; } ]; # PL-133683
+    nstat = [ { } ]; # PL-133683
     processes = [ { } ];
     system = [ { } ];
     swap = [ { } ];


### PR DESCRIPTION
In preparation of the `net` input module deprecating protocol stats, enable `nstat` to get these metrics from there. This enables a transitory period whre both metrics are available and dashboards can be re-designed.

Also set the switch for generating deprecated metrics, `ignore_protocol_stats` explicitly to not experience implicit changes in more recent versions.

PL-133638

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - better explicit than implicit: explicitly set an option prone to deprecation, to avoid undioscovered implicit changes
  - provide a transitory period for metrics name deprecations
- [x] Security requirements tested? (EVIDENCE)
  - [x] automated tests show no regressions
  - [x] manually inspected the metrics generated on a test VM to contain nstat metrics
    ```
    nstat_Icmp6InEchoReplies{host="test72",location="dev",name="snmp6",platform="nixos",profile="generic",resource_group="test"} 161
    ```