### PR TITLE
[24.11] update pinned nixpkgs to include sudo-1.9.17p1

### DIFF
--- a/changelog.d/20250702_143646_PL-133836-sudo_scriv.md
+++ b/changelog.d/20250702_143646_PL-133836-sudo_scriv.md
@@ -1,0 +1,21 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+- A bullet item for the Impact category.
+
+
+### NixOS XX.XX platform
+
+- sudo: 1.9.17 -> 1.9.17p1 (CVE-2025-32462, CVE-2025-32463)

--- a/flake.lock
+++ b/flake.lock
@@ -481,11 +481,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1751370495,
-        "narHash": "sha256-zD/ID19Y67W5t03Y58sSGzHz0JdhqyiVKI1OdejSnwQ=",
+        "lastModified": 1751459541,
+        "narHash": "sha256-DHQYcWM2bDPoyYB3VYdjTFz6BX4LrKJgf7/jdSTY4IM=",
         "owner": "flyingcircusio",
         "repo": "nixpkgs",
-        "rev": "0eb690f59549758b0acefbaccbf63bfe9623613d",
+        "rev": "999b4004c4db402f811a26e180363696fd4ffe18",
         "type": "github"
       },
       "original": {

--- a/release/versions.json
+++ b/release/versions.json
@@ -14,10 +14,10 @@
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/"
   },
   "nixpkgs": {
-    "hash": "sha256-zD/ID19Y67W5t03Y58sSGzHz0JdhqyiVKI1OdejSnwQ=",
+    "hash": "sha256-DHQYcWM2bDPoyYB3VYdjTFz6BX4LrKJgf7/jdSTY4IM=",
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "0eb690f59549758b0acefbaccbf63bfe9623613d"
+    "rev": "999b4004c4db402f811a26e180363696fd4ffe18"
   },
   "nixpkgs-21_05": {
     "hash": "sha256-5ufC/t0sUFS/LspiEwU8DW5+uVYM3diZ1IC7KjX9ek4=",


### PR DESCRIPTION
Fixes CVE-2025-32462 and CVE-2025-32463.

PL-133836

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - critical vulnerability fixes might still be backported after the end of NixOS upstream channel advances
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still pass
