### PR TITLE
graylog: Use headless JDK 8

### DIFF
--- a/changelog.d/20250703_114233_PL-133759-graylog-jdk8_scriv.md
+++ b/changelog.d/20250703_114233_PL-133759-graylog-jdk8_scriv.md
@@ -1,0 +1,21 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+- A bullet item for the Impact category.
+
+
+### NixOS XX.XX platform
+
+- loghost: fix Graylog LDAP login which has been broken since 24.11. Graylog is deprecated, the role is only provided to upgrade existing loghosts (PL-133759).

--- a/pkgs/graylog/default.nix
+++ b/pkgs/graylog/default.nix
@@ -3,7 +3,7 @@
   stdenv,
   fetchurl,
   makeWrapper,
-  openjdk11_headless,
+  openjdk8_headless,
   nixosTests,
 }:
 
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   makeWrapperArgs = [
     "--set-default"
     "JAVA_HOME"
-    "${openjdk11_headless}"
+    "${openjdk8_headless}"
   ];
 
   passthru.tests = { inherit (nixosTests) graylog; };


### PR DESCRIPTION
JDK 11 breaks LDAP in Graylog somehow, JDK 8 works.

PL-133759

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - we just need to make sure that LDAP login works as on older platforms 
- [x] Security requirements tested? (EVIDENCE)
  - verified that login on a test login works 
