### PR TITLE
Move Nixpkgs to nixos-unstable, initialize development for 25.11

### DIFF
--- a/doc/src/upgrade.md
+++ b/doc/src/upgrade.md
@@ -15,25 +15,6 @@ Contact our [support](/platform/index.html#support) for upgrade assistance.
 
 ## Overview
 
-- New roles:
-  - {ref}`percona84 <nixos-upgrade-percona>`
-- Removed roles: none
-- Roles affected by significant breaking changes:
-  - {ref}`gitlab <nixos-upgrade-gitlab>`
-  - {ref}`k3s-agent k3s-server k3s-single-node <nixos-upgrade-k3s>`
-  - {ref}`mailserver mailstub <nixos-upgrade-mail>`
-  - {ref}`redis <nixos-upgrade-redis>`
-  - {ref}`percona84 <nixos-upgrade-percona>`
-  - {ref}`slurm-controller slurm-node <nixos-upgrade-slurm>`
-- Removed significant packages:
-  - `atop`
-  - `dstat`
-  - `go_1_22`
-  - `k3s_1_29`
-  - `latencytop`
-  - `nodejs_18`
-  - `python39`
-
 
 ## Why upgrade? Security
 
@@ -45,7 +26,7 @@ We do back-ports for critical security issues but this may take longer in some
 cases and less important security fixes will not be back-ported most of the time.
 
 NixOS provides regular security updates for about one month after the release.
-Upstream support for 24.11 ended on **2025-06-31**.
+Upstream support for 25.05 ends on **2025-12-31**.
 
 New platform features are always developed for the current stable platform version
 and only critical bug fixes are back-ported to older versions.
@@ -53,7 +34,7 @@ and only critical bug fixes are back-ported to older versions.
 
 ## How to upgrade?
 
-To upgrade your machines, the *Environment* to one of the `fc-25.05-…`
+To upgrade your machines, the *Environment* to one of the `fc-25.11-…`
 values. \
 This can be done either via our customer portal, or by setting the platform
 version using the API.
@@ -121,195 +102,8 @@ time-window.
 
 ## Significant breaking changes
 
-(nixos-upgrade-percona)=
-### Percona/ MySQL
-
-Two versions of percona are actively supported: `percona80` and `percona84`. \
-Both are LTS releases still receiving bug and security fixes.
-
-`percona83` is only included to allow upgrades towards `percona84`.
-
-#### no password authentication for root user (all role versions)
-
-Access to the database `root` user was changed to authentication via socket.
-Password authentication is disabled for that user, please switch to the unix user `mysql` for database root operations.
-
-The platform used to provide the password for the database root user under `/etc/local/mysql/mysql.passwd`. That
-file does not exist anymore. Instead, invoke your mysql command via `sudo -u mysql`. \
-Example:
-
-```shell
-sudo -u mysql mysql myDb < someCommands.sql
-```
-
-Users of `batou.lib.mysql` can just [pass `USE_SUDO` as the `admin_password` argument](https://github.com/flyingcircusio/batou/commit/7efcb768613f1d68699defa453c0634a279b98be).
-
-#### changed authentication mechanism in percona84
-
-Version 8.4 of percona (role `percona84`) changes the default authentication mechanism from `mysql_native_password` to `caching_sha2_password`. After upgrading the role to 8.4. *all passwords need to be migrated manually* to the new hash format.
-
-Please do the migration during this platform release cycle, our 25.11 platform with Percona 9.x will disable the deprecated hashing algorithm altogether.
-
-See {ref}`nixos-mysql-password-hash-migration` for detailed migration instructions.
-
-(nixos-upgrade-k3s)=
-### K3S
-
-k3s-1.32.x is the default k3s version in this release.
-
-Please verify that existing clusters are upgraded to k3s-1.30.x **before** upgrading to NixOS 25.05.
-
-k3s nodes are only allowed to be updated in steps of one minor version at a time.
-The Kubernetes control plane with the `k3s-server` role needs to be updated before
-the cluster's worker nodes with the `k3s-agent` role are updated.
-
-Contact [support](/platform/index.html#support) if you need help with updating your k3s cluster, or if you still
-need to use another specific k3s version for your cluster.
-
-(nixos-upgrade-slurm)=
-### Slurm
-
-This release contains a major version upgrade of Slurm from 24.05.x.x (NixOS 24.11) to 24.11.x.x. Nodes of a cluster need to be upgraded in a particular order, please consult the [upgrade instructions of the role](#nixos-slurm-upgrade) for details.
-
-Regarding new features or changes in Slurm itself, consult [its release notes](https://github.com/SchedMD/slurm/blob/slurm-24-11-0-1/RELEASE_NOTES).
-
-
-(nixos-upgrade-gitlab)=
-### Gitlab
-
-Gitlab version 18.0 will enable pseudonymised [tracking and reporting of events data](https://about.gitlab.com/blog/2025/03/26/more-granular-product-usage-insights-for-gitlab-self-managed-and-dedicated/). To prevent this, an **opt-out** can already be configured in the current Gitlab version:
-- Visit `<yourgitlabdomain>/admin/application_settings/metrics_and_profiling`
-- uncheck *Event tracking -> Enable event tracking*
-
-Postgresql>=16 is required, please upgrade your postgres role before updating.
-
-*Runner registration tokens* have been deprecated for several releases already and are not supported anymore in Gitlab 18.
-Our [support](/platform/index.html#support) staff will take care of migrating your managed Gitlab instance to the new *runner authentication token scheme* ahead of the update. For advanced use cases like interactions between Gitlab and external runners not part of the Flying Circus platform, please reach out to our support.
-
-(nixos-upgrade-mail)=
-### Mailserver, mailstub
-
-Both `mailserver` and `mailstub` roles are affected by changes in the underlying implementations:
-- DKIM signing and verification is now handled by rspamd instead of OpenDKIM. rspamd only supports `relaxed` canoncalisation.
-- `policyd-spf` was removed, SPF record verification of incoming mails is handled by rspamd.
-  - The `policydSPFExtraSkipAddresses` option has been renamed to `spfSkipAddresses`, reflecting that change.
-  - `mailserver.policydSPFExtraConfig` was removed.
-- `flyingcircus.roles.mailserver.imprintUrl` now requires a full URI starting with the `http://` or `https://` protocol. Protocol-less URIs had been deprecated in the 24.11 platform release.
-
-(nixos-upgrade-redis)=
-### Redis
-
-- redis: restructure internal password handling
-  The password file /etc/local/redis/password now gets written as systemd ExecStartPre. (PL-133653)
-
-  `services.redis.servers."".requirePass` must not be used anymore. There are three options to replace it with:
-    - `services.redis.servcers."".requirePassFile` to retrieve the password from an external file
-    - set `flyingcircus.services.redis.password`
-    - just remove the option, causing the password to be autogenerated and stored at `/etc/local/redis/password`.  \
-      Autogenerated passwords can not be read from the Nix config at evaluation time.
-- reading the Redis password at evaluation time from `config.flyingcircus.services.redis.password` is not supported anymore.
-
-### changes not affecting a specific role
-
-% does not affect our platform MongoDB roles but things set up by AppOps via the nixpkgs service
-- mongodb: The option `services.mongodb.initialRootPassword` was removed in favour of `services.mongodb.initialRootPasswordFile` to securely provide the initial root password.
-- postgresql: `pg_config` has been moved to a separate package `postgresql.pg_config` or `postgresql_<major version>.pg_config`. Packages and environment relying on the presence of that command need to explicitly specify that package as a dependency.
-  - Building other software against postgresql usually also requires libraries and headers as well, so in general the following dependencies need to be specified:
-    * `postgresql.pg_config.out`
-    * `postgresql.out`
-    * `postgresql.lib`
-    * `postgresql.dev`
-  - For deplyoments using a [batou_ext userenv](https://github.com/flyingcircusio/batou_ext/blob/98cba22c8fe4c8cf6273855704673161bf108336/src/batou_ext/nix.py#L110), only `postgresql.pg_config` and `postgresql` are required.
-
 ## Other notable changes
-
-- Nix was upgraded to version 2.28
-- agent: the command `fc-manage switch` now has a `-R` option which
-  will activate the new configuration by performing an immediate
-  reboot, similar to the process used for upgrading between major
-  versions. (PL-133308)
-- improvements in configuring the nixpkgs package set:
-  - Introduced option `flyingcircus.permittedInsecurePackages` to allow additional packages marked as insecure.
-  - Improved error message when trying to use a package marked as insecure or unfree showing FCIO-specific instructions.
-  - When importing the platform channel (`import <fc> …`), declarations of `config.allowUnfreePredicate` and
-  `config.permittedInsecurePackages` don't get discarded silently. In case of `allowUnfreePredicate`, at least
-  one of the platform-provided or user-supplied predicate must evaluate to `true` to allow the instantiation of
-  an unfree package.
-- docker: fix role not working on devhosts (PL-133607)
-
-  This change also prepares the role to work on machines without FE interface or PUB interface.
-- Add a mechanism to upgrade XFS flags over time. Initially this will cause
-  `bigtime`, `inobtcount` and `nrext64` flags to be set. With `bigtime` set VMs
-  from this release on will consistently support file times beyond 2038, even if
-  they were bootstrapped on older releases. (PL-133321, PL-130365)
-- Prepare VMs to read ENC data (the config management metadata) seeded from the
-  host from the separate `cidata` volume in the future. This allows disabling or
-  reconfiguring /tmp to use tmpfs without breaking our configuration management.
-  (PL-133311)
-- Invalid NixOS `state_version` files are automatically fixed to fit the expected YY.MM format. (PL-133559)
-- nginx: new JSON-based log format that is being used to ship access logs to a Loki instance automatically if one is present (PL-133702)
-- dstat: drop as it is unmaintained, replace with `dool`
-  - `dstat` is now an alias for `dool`
-- `less` does not utilise external programs to improve rendering by default (lesspipe). To restore the previous behaviour, set `programs.less.lessopen` to `''|${lib.getExe' pkgs.lesspipe "lesspipe.sh"} %s''`.
-- linux kernel: we now follow the 6.12.x LTS series of linux for production environments. This seems to help resolve some recent IO latency / stalling issues.
-- Kernel memory management: switch to smaller, fixed size dirty page buffers (PL-133760)
-
-  This also seems to be a factor in the recent IO latency / stalling issues:
-  The dirty page buffers were based on percentages of the installed RAM so far,
-  but can cause long periods of stalling when the kernel passes the hard
-  threshold to flush it.
-
-  We now provide much smaller and fixed sizes for dirty pages (16 MiB to start
-  flushing in the background and 64 MiB to enforce flushing).
-- For more details, see the
-  [release notes of NixOS 25.05](https://nixos.org/manual/nixos/stable/release-notes.html#sec-release-25.05).
 
 ## Known issues
 
-- mailserver: Incoming e-mails via IPv4 are treated as local e-mails by rspamd, skipping SPF, DKIM, and DMARC checks
-
 ## Significant package updates
-
-*as of 2025-06-24*
-
-- awscli: 1.34 -> 1.37
-- awscli2: 2.19 -> 2.27
-- binutils: 2.43 -> 2.44
-- calibre: 7.21 -> 8.4
-- containerd: 1.7 -> 2.1
-- coreutils: 9.5 -> 9.7
-- curl: 8.12 -> 8.13
-- discourse: 3.3 -> 3.4
-- docker-compose: 2.30 -> 2.36
-- erlang: 25.3 -> 27.3
-- gcc: 13.3 -> 14.2 (other versions available under alias)
-- git: 2.47 -> 2.49
-- gitlab: 17.11 -> 18.0
-- go: 1.23 -> 1.24 (other versions available under alias)
-- grafana: 11.3 -> 12.0
-- haproxy: 3.0 -> 3.1
-- k3s: 1.30 -> 1.32 (other versions available under alias)
-- kubernetes-helm: 3.16 -> 3.17
-- libwebp: 1.4 -> 1.5
-- linux: 6.6 -> 6.12
-- matomo: 5.2 -> 5.3
-- nginx: 1.26 -> 1.28
-- nodejs: 20 -> 22 (other versions available under alias)
-- opensearch: 2.17 -> 2.19
-- openssh: 9.9 -> 10.0
-- openssl: 3.3 -> 3.4
-- podman: 5.2 -> 5.4
-- poetry: 1.8 -> 2.1
-- postfix: 3.9 -> 3.10
-- prometheus: 2.55 -> 3.1
-- python3Packages.boto3: 1.35 -> 1.36
-- python3Packages.rich: 13.8 -> 14.0
-- rclone: 1.68 -> 1.69
-- re2c: 3.1 -> 4.1
-- slurm: 24.05 -> 24.11
-- systemd: 256 -> 257
-- telegraf: 1.32 -> 1.34
-- util-linux: 2.39 -> 2.41
-- uv: 0.4 -> 0.7
-- varnish: 7.5 -> 7.7
-- xz: 5.6 -> 5.8

--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,7 @@
   description = "Flying Circus NixOS platform (dev/release tooling)";
 
   inputs = {
-    nixpkgs.url = "github:flyingcircusio/nixpkgs/nixos-25.05";
+    nixpkgs.url = "github:flyingcircusio/nixpkgs/nixos-25.11";
     nixos-mailserver = {
       url = "gitlab:flyingcircus/nixos-mailserver/nixos-25.05?host=gitlab.flyingcircus.io";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/nixos/roles/mongodb.nix
+++ b/nixos/roles/mongodb.nix
@@ -76,7 +76,7 @@ let
   majorVersion = head (lib.attrNames enabledRoles);
   checkPkg =
     if (lib.versionOlder majorVersion "4.0") then
-      pkgs.fc.check-mongodb.override { pymongo = pkgs.python3Packages.pymongo3; }
+      pkgs.fc.check-mongodb.override { pymongo = pkgs.fc.check-mongodb.python.pkgs.pymongo3; }
     else
       pkgs.fc.check-mongodb;
 

--- a/pkgs/fc/agent/default.nix
+++ b/pkgs/fc/agent/default.nix
@@ -20,6 +20,10 @@ let
   pytest-structlog = pyPackages.buildPythonPackage rec {
     pname = "pytest-structlog";
     version = "0.6-cb82f00";
+    pyproject = true;
+    build-system = with pyPackages; [
+      setuptools
+    ];
 
     src = fetchFromGitHub {
       owner = "wimglenn";

--- a/pkgs/fc/ceph/default.nix
+++ b/pkgs/fc/ceph/default.nix
@@ -11,6 +11,7 @@
   requests,
   pytest,
   pytest_patterns,
+  setuptools,
 }:
 
 buildPythonApplication rec {
@@ -18,6 +19,10 @@ buildPythonApplication rec {
   version = "2.1";
   src = ./.;
   dontStrip = true;
+
+  pyproject = true;
+  build-system = [ setuptools ];
+
   propagatedBuildInputs = [
     blockdev
     lz4

--- a/pkgs/fc/check-haproxy/default.nix
+++ b/pkgs/fc/check-haproxy/default.nix
@@ -13,6 +13,8 @@ py.buildPythonApplication rec {
   version = "1.0";
   src = ./.;
   dontStrip = true;
+  pyproject = true;
+  build-system = [ py.setuptools ];
   propagatedBuildInputs = [
     py.nagiosplugin
     py.numpy

--- a/pkgs/fc/check-mongodb/default.nix
+++ b/pkgs/fc/check-mongodb/default.nix
@@ -1,10 +1,22 @@
-{ buildPythonApplication, pymongo }:
+{
+  buildPythonApplication,
+  setuptools,
+  pymongo,
+  python,
+}:
 
 buildPythonApplication rec {
   name = "fc-check-mongodb-${version}";
   version = "1.0";
   src = ./.;
+  pyproject = true;
+  build-system = [ setuptools ];
   propagatedBuildInputs = [
     pymongo
   ];
+
+  passthru = {
+    # Later we override pymongo and need the python version this is build with
+    inherit python;
+  };
 }

--- a/pkgs/fc/install/default.nix
+++ b/pkgs/fc/install/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  python3Full,
+  python312Full,
   megacli,
   lvm2,
   makeWrapper,
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   dontBuild = true;
   dontConfigure = true;
 
-  buildInputs = [ python3Full ];
+  buildInputs = [ python312Full ];
 
   installPhase = ''
     mkdir -p $out/bin

--- a/pkgs/fc/megacli/default.nix
+++ b/pkgs/fc/megacli/default.nix
@@ -1,5 +1,6 @@
 {
   pkgs,
+  fetchFromGitHub,
   python3Packages,
   megacli,
 }:
@@ -27,13 +28,23 @@ let
   py_terminaltables = py.buildPythonPackage rec {
     pname = "terminaltables";
     version = "3.1.10";
-    src = py.fetchPypi {
-      inherit pname version;
-      hash = "sha256-um7KXLW6ArukyfT5ha+AxU7D3M+Uz80ZAVQ4YlXkdUM=";
+    src = fetchFromGitHub {
+      owner = "matthewdeanmartin";
+      repo = "terminaltables3";
+      rev = "v${version}";
+      hash = "sha256-bnnOiO26e3Bidrls82P/vc+DNAwKSpXhjClCdfXMoFE=";
     };
+
+    prePatch = ''
+      substituteInPlace pyproject.toml \
+        --replace-fail "poetry>=0.12" "poetry-core" \
+        --replace-fail "build-backend = \"poetry.masonry.api\"" "build-backend = \"poetry.core.masonry.api\""
+    '';
+
     pyproject = true;
-    build-system = [ py.setuptools ];
-    propagatedBuildInputs = [ ];
+
+    build-system = [ py.poetry-core ];
+
     meta = with pkgs.lib; {
       description = "Generate simple tables in terminals from a nested list of strings.";
       homepage = "https://github.com/Robpol86/terminaltables";

--- a/pkgs/fc/megacli/default.nix
+++ b/pkgs/fc/megacli/default.nix
@@ -14,6 +14,8 @@ let
       inherit pname version;
       hash = "sha256-cFHX3UlsplsUqKTFwcmS2q+d93O1gZ8Queatu9L1i0A=";
     };
+    pyproject = true;
+    build-system = [ py.setuptools ];
     propagatedBuildInputs = [ ];
     meta = with pkgs.lib; {
       description = "Python library for MegaCli";
@@ -29,6 +31,8 @@ let
       inherit pname version;
       hash = "sha256-um7KXLW6ArukyfT5ha+AxU7D3M+Uz80ZAVQ4YlXkdUM=";
     };
+    pyproject = true;
+    build-system = [ py.setuptools ];
     propagatedBuildInputs = [ ];
     meta = with pkgs.lib; {
       description = "Generate simple tables in terminals from a nested list of strings.";

--- a/pkgs/fc/qemu/default.nix
+++ b/pkgs/fc/qemu/default.nix
@@ -39,6 +39,8 @@ let
       sha256 = "sha256-dt2hKcCtsGx5mtqyd83eTMhFRKjtqK/CcCGBy6ShNk8=";
     };
     doCheck = false; # tests require a running Consul via Docker
+    pyproject = true;
+    build-system = [ py.setuptools ];
     propagatedBuildInputs = [
       py.requests
     ];
@@ -114,6 +116,8 @@ py.buildPythonPackage rec {
         hash = "sha256-4kEqGSC9uOeQh4OyCz1X6drVkMw5qT6Flv/dSTtAPg4=";
       };
 
+      pyproject = true;
+      build-system = [ py.setuptools ];
       propagatedBuildInputs = [ py.pytest ];
 
       meta = with lib; {

--- a/pkgs/fc/roundcube-chpasswd-py/default.nix
+++ b/pkgs/fc/roundcube-chpasswd-py/default.nix
@@ -4,6 +4,8 @@ python3Packages.buildPythonApplication rec {
   name = "fc-roundcube-chpasswd-${version}";
   version = "1.0";
   src = ./.;
+  pyproject = true;
+  build-system = [ python3Packages.setuptools ];
   propagatedBuildInputs = [
     pkgs.mkpasswd
     pkgs.apacheHttpd # for htpasswd

--- a/pkgs/fc/sensuplugins/default.nix
+++ b/pkgs/fc/sensuplugins/default.nix
@@ -16,6 +16,8 @@ py.buildPythonApplication rec {
   version = "1.0";
   src = ./.;
   dontStrip = true;
+  pyproject = true;
+  build-system = [ py.setuptools ];
   propagatedBuildInputs = [
     libyaml
     iproute2

--- a/pkgs/fc/telegraf-collect-psi/default.nix
+++ b/pkgs/fc/telegraf-collect-psi/default.nix
@@ -13,5 +13,7 @@ py.buildPythonApplication rec {
   name = "fc-telegraf-collect-psi-${version}";
   version = "1.0";
   src = ./.;
+  pyproject = true;
+  build-system = [ py.setuptools ];
   # dontStrip = true;
 }

--- a/pkgs/fc/trafficclient.nix
+++ b/pkgs/fc/trafficclient.nix
@@ -59,13 +59,14 @@ buildPythonApplication rec {
     hash = "sha256-dp91sPzcoq4QF/odkWZ96a3y4ZctQoWQjgcVmaDcw5M=";
   };
 
+  pyproject = true;
+  build-system = [ setuptools ];
   checkInputs = [
     pytest
     pytest-cov
     pytest-timeout
   ];
   nativeBuildInputs = [
-    setuptools
     pip
   ];
   nativeCheckInputs = [

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -415,17 +415,7 @@ builtins.mapAttrs (_: patchPhps phpLogPermissionPatch) {
   };
 
   lkl = super.lkl.overrideAttrs (_: {
-    version = "2023-11-07";
-    src = fetchFromGitHub {
-      rev = "970883c348b61954a11c8c1ab9a2ab3ff0d89f08";
-      owner = "lkl";
-      repo = "linux";
-      hash = "sha256-MpvhYLH3toC5DaxeiQxKlYWjrPoFw+1eWkkX3XIiVQ0=";
-    };
-
     prePatch = ''
-      patchShebangs arch/lkl/scripts
-      patchShebangs scripts
       substituteInPlace tools/lkl/cptofs.c \
         --replace mem=100M mem=500M
     '';

--- a/pkgs/python/cheroot/default.nix
+++ b/pkgs/python/cheroot/default.nix
@@ -15,6 +15,7 @@
   requests-toolbelt,
   requests-unixsocket,
   selectors2,
+  setuptools,
   setuptools-scm,
   setuptools-scm-git-archive,
   six,
@@ -30,6 +31,8 @@ buildPythonPackage rec {
     hash = "sha256-NmrfbnyslVVIbC0b5il5kwIu/2+MRlXBRDJozKPwjiU=";
   };
 
+  pyproject = true;
+  build-system = [ setuptools ];
   nativeBuildInputs = [
     setuptools-scm
     setuptools-scm-git-archive

--- a/pkgs/python/portend/default.nix
+++ b/pkgs/python/portend/default.nix
@@ -3,6 +3,7 @@
   buildPythonPackage,
   fetchPypi,
   pytest,
+  setuptools,
   setuptools_scm,
   tempora,
   lib,
@@ -23,6 +24,8 @@ buildPythonPackage rec {
   postPatch = ''
     substituteInPlace pytest.ini --replace "--flake8 --black" ""
   '';
+  pyproject = true;
+  build-system = [ setuptools ];
 
   nativeBuildInputs = [ setuptools_scm ];
 

--- a/release/important_packages.json
+++ b/release/important_packages.json
@@ -233,7 +233,6 @@
   "uv",
   "varnish",
   "vim",
-  "webkitgtk",
   "wget",
   "wireguard-tools",
   "xfsprogs",

--- a/release/package-versions.json
+++ b/release/package-versions.json
@@ -25,14 +25,14 @@
     "version": "1.16.5"
   },
   "awscli": {
-    "name": "awscli-1.37.21",
+    "name": "awscli-1.40.31",
     "pname": "awscli",
-    "version": "1.37.21"
+    "version": "1.40.31"
   },
   "awscli2": {
-    "name": "awscli2-2.27.2",
+    "name": "awscli2-2.27.31",
     "pname": "awscli2",
-    "version": "2.27.2"
+    "version": "2.27.31"
   },
   "bash": {
     "name": "bash-interactive-5.2p37",
@@ -40,9 +40,9 @@
     "version": "5.2p37"
   },
   "bind": {
-    "name": "bind-9.20.9",
+    "name": "bind-9.20.10",
     "pname": "bind",
-    "version": "9.20.9"
+    "version": "9.20.10"
   },
   "binutils": {
     "name": "binutils-wrapper-2.44",
@@ -55,9 +55,9 @@
     "version": "4.2.1"
   },
   "bundler": {
-    "name": "bundler-2.6.6",
+    "name": "bundler-2.6.9",
     "pname": "bundler",
-    "version": "2.6.6"
+    "version": "2.6.9"
   },
   "cacert": {
     "name": "nss-cacert-3.111",
@@ -85,9 +85,9 @@
     "version": "138.0.7204.92"
   },
   "cifs-utils": {
-    "name": "cifs-utils-7.3",
+    "name": "cifs-utils-7.4",
     "pname": "cifs-utils",
-    "version": "7.3"
+    "version": "7.4"
   },
   "clamav": {
     "name": "clamav-1.4.3",
@@ -95,9 +95,9 @@
     "version": "1.4.3"
   },
   "cmake": {
-    "name": "cmake-3.31.6",
+    "name": "cmake-3.31.7",
     "pname": "cmake",
-    "version": "3.31.6"
+    "version": "3.31.7"
   },
   "consul": {
     "name": "consul-1.9.9",
@@ -115,9 +115,9 @@
     "version": "9.7"
   },
   "coturn": {
-    "name": "coturn-4.6.3",
+    "name": "coturn-4.7.0",
     "pname": "coturn",
-    "version": "4.6.3"
+    "version": "4.7.0"
   },
   "curl": {
     "name": "curl-8.14.1",
@@ -145,14 +145,14 @@
     "version": "2.91"
   },
   "docker": {
-    "name": "docker-27.5.1",
+    "name": "docker-28.2.2",
     "pname": "docker",
-    "version": "27.5.1"
+    "version": "28.2.2"
   },
   "docker-compose": {
-    "name": "docker-compose-2.36.0",
+    "name": "docker-compose-2.38.1",
     "pname": "docker-compose",
-    "version": "2.36.0"
+    "version": "2.38.1"
   },
   "dovecot": {
     "name": "dovecot-2.3.21.1",
@@ -200,9 +200,9 @@
     "version": "140.0.2"
   },
   "gcc": {
-    "name": "gcc-wrapper-14.2.1.20250322",
+    "name": "gcc-wrapper-14.3.0",
     "pname": "gcc-wrapper",
-    "version": "14.2.1.20250322"
+    "version": "14.3.0"
   },
   "gcc12": {
     "name": "gcc-wrapper-12.4.0",
@@ -300,9 +300,9 @@
     "version": "2.12"
   },
   "haproxy": {
-    "name": "haproxy-3.1.7",
+    "name": "haproxy-3.2.1",
     "pname": "haproxy",
-    "version": "3.1.7"
+    "version": "3.2.1"
   },
   "imagemagick": {
     "name": "imagemagick-7.1.1-47",
@@ -340,14 +340,14 @@
     "version": "21.0.6-b895.109"
   },
   "jetty": {
-    "name": "jetty-12.0.21",
+    "name": "jetty-12.0.22",
     "pname": "jetty",
-    "version": "12.0.21"
+    "version": "12.0.22"
   },
   "jicofo": {
-    "name": "jicofo-1.0-1128",
+    "name": "jicofo-1.0-1138",
     "pname": "jicofo",
-    "version": "1.0-1128"
+    "version": "1.0-1138"
   },
   "jitsi-meet": {
     "name": "jitsi-meet-1.0.8043",
@@ -355,14 +355,14 @@
     "version": "1.0.8043"
   },
   "jitsi-videobridge": {
-    "name": "jitsi-videobridge2-2.3-220-g7cda0a66",
+    "name": "jitsi-videobridge2-2.3-236-g95ef6210",
     "pname": "jitsi-videobridge2",
-    "version": "2.3-220-g7cda0a66"
+    "version": "2.3-236-g95ef6210"
   },
   "jq": {
-    "name": "jq-1.7.1",
+    "name": "jq-1.8.0",
     "pname": "jq",
-    "version": "1.7.1"
+    "version": "1.8.0"
   },
   "jre": {
     "name": "openjdk-21.0.7+6",
@@ -370,9 +370,9 @@
     "version": "21.0.7+6"
   },
   "k3s": {
-    "name": "k3s-1.32.5+k3s1",
+    "name": "k3s-1.33.1+k3s1",
     "pname": "k3s",
-    "version": "1.32.5+k3s1"
+    "version": "1.33.1+k3s1"
   },
   "k3s_1_30": {
     "name": "k3s-1.30.13+k3s1",
@@ -400,9 +400,9 @@
     "version": "26.1.4"
   },
   "kubernetes-helm": {
-    "name": "kubernetes-helm-3.17.3",
+    "name": "kubernetes-helm-3.18.3",
     "pname": "kubernetes-helm",
-    "version": "3.17.3"
+    "version": "3.18.3"
   },
   "libffi": {
     "name": "libffi-3.4.8",
@@ -415,9 +415,9 @@
     "version": "1.10.3"
   },
   "libjpeg": {
-    "name": "libjpeg-turbo-3.0.4",
+    "name": "libjpeg-turbo-3.1.0",
     "pname": "libjpeg-turbo",
-    "version": "3.0.4"
+    "version": "3.1.0"
   },
   "libmodsecurity": {
     "name": "libmodsecurity-3.0.14",
@@ -430,9 +430,9 @@
     "version": "3.3.5"
   },
   "libressl": {
-    "name": "libressl-4.0.0",
+    "name": "libressl-4.1.0",
     "pname": "libressl",
-    "version": "4.0.0"
+    "version": "4.1.0"
   },
   "libtiff": {
     "name": "libtiff-4.7.0",
@@ -445,9 +445,9 @@
     "version": "1.5.0"
   },
   "libxml2": {
-    "name": "libxml2-2.13.8",
+    "name": "libxml2-2.14.3",
     "pname": "libxml2",
-    "version": "2.13.8"
+    "version": "2.14.3"
   },
   "libxslt": {
     "name": "libxslt-1.1.43",
@@ -480,9 +480,9 @@
     "version": "1.10.0"
   },
   "mailutils": {
-    "name": "mailutils-3.18",
+    "name": "mailutils-3.19",
     "pname": "mailutils",
-    "version": "3.18"
+    "version": "3.19"
   },
   "mariadb": {
     "name": "mariadb-server-10.11.13",
@@ -510,9 +510,9 @@
     "version": "1.133.0"
   },
   "mcpp": {
-    "name": "mcpp-2.7.2.1",
+    "name": "mcpp-2.7.2.2",
     "pname": "mcpp",
-    "version": "2.7.2.1"
+    "version": "2.7.2.2"
   },
   "memcached": {
     "name": "memcached-1.6.37",
@@ -760,9 +760,9 @@
     "version": "0.29.2"
   },
   "podman": {
-    "name": "podman-5.4.1",
+    "name": "podman-5.5.2",
     "pname": "podman",
-    "version": "5.4.1"
+    "version": "5.5.2"
   },
   "poetry": {
     "name": "poetry-2.1.3",
@@ -880,9 +880,9 @@
     "version": "3.4.2"
   },
   "promtail": {
-    "name": "promtail-3.4.4",
+    "name": "promtail-3.5.1",
     "pname": "promtail",
-    "version": "3.4.4"
+    "version": "3.5.1"
   },
   "prosody": {
     "name": "prosody-0.12.4",
@@ -890,9 +890,9 @@
     "version": "0.12.4"
   },
   "python3": {
-    "name": "python3-3.12.11",
+    "name": "python3-3.13.4",
     "pname": "python3",
-    "version": "3.12.11"
+    "version": "3.13.4"
   },
   "python310": {
     "name": "python3-3.10.18",
@@ -915,79 +915,79 @@
     "version": "3.8.11"
   },
   "python3Packages.boto3": {
-    "name": "python3.12-boto3-1.36.21",
+    "name": "python3.13-boto3-1.38.32",
     "pname": "boto3",
-    "version": "1.36.21"
+    "version": "1.38.32"
   },
   "python3Packages.click": {
-    "name": "python3.12-click-8.1.8",
+    "name": "python3.13-click-8.1.8",
     "pname": "click",
     "version": "8.1.8"
   },
   "python3Packages.lxml": {
-    "name": "python3.12-lxml-5.3.1",
+    "name": "python3.13-lxml-5.4.0",
     "pname": "lxml",
-    "version": "5.3.1"
+    "version": "5.4.0"
   },
   "python3Packages.pillow": {
-    "name": "python3.12-pillow-11.2.1",
+    "name": "python3.13-pillow-11.2.1",
     "pname": "pillow",
     "version": "11.2.1"
   },
   "python3Packages.pip": {
-    "name": "python3.12-pip-25.0.1",
+    "name": "python3.13-pip-25.0.1",
     "pname": "pip",
     "version": "25.0.1"
   },
   "python3Packages.pyslurm": {
-    "name": "python3.12-pyslurm-24.11.0",
+    "name": "python3.13-pyslurm-24.11.0",
     "pname": "pyslurm",
     "version": "24.11.0"
   },
   "python3Packages.pystemd": {
-    "name": "python3.12-pystemd-0.13.2",
+    "name": "python3.13-pystemd-0.13.2",
     "pname": "pystemd",
     "version": "0.13.2"
   },
   "python3Packages.pyyaml": {
-    "name": "python3.12-pyyaml-6.0.2",
+    "name": "python3.13-pyyaml-6.0.2",
     "pname": "pyyaml",
     "version": "6.0.2"
   },
   "python3Packages.requests": {
-    "name": "python3.12-requests-2.32.3",
+    "name": "python3.13-requests-2.32.3",
     "pname": "requests",
     "version": "2.32.3"
   },
   "python3Packages.rich": {
-    "name": "python3.12-rich-14.0.0",
+    "name": "python3.13-rich-14.0.0",
     "pname": "rich",
     "version": "14.0.0"
   },
   "python3Packages.rich-rst": {
-    "name": "python3.12-rich-rst-1.3.1",
+    "name": "python3.13-rich-rst-1.3.1",
     "pname": "rich-rst",
     "version": "1.3.1"
   },
   "python3Packages.structlog": {
-    "name": "python3.12-structlog-25.3.0",
+    "name": "python3.13-structlog-25.4.0",
     "pname": "structlog",
-    "version": "25.3.0"
+    "version": "25.4.0"
   },
   "python3Packages.supervisor": {
-    "name": "python3.12-supervisor-4.2.5",
+    "name": "python3.13-supervisor-4.2.5",
     "pname": "supervisor",
     "version": "4.2.5"
   },
   "python3Packages.systemd": {
-    "name": "python3.12-systemd-235",
+    "name": "python3.13-systemd-235",
     "pname": "systemd",
     "version": "235"
   },
   "python3Packages.urllib3": {
-    "name": "python3.12-urllib3-2.3.0",
+    "name": "python3.13-urllib3-2.4.0",
     "pname": "urllib3",
-    "version": "2.3.0"
+    "version": "2.4.0"
   },
   "qemu-ceph-nautilus": {
     "name": "qemu-6.0.0",
@@ -1000,19 +1000,19 @@
     "version": "4.0.9"
   },
   "rclone": {
-    "name": "rclone-1.69.1",
+    "name": "rclone-1.70.2",
     "pname": "rclone",
-    "version": "1.69.1"
+    "version": "1.70.2"
   },
   "re2c": {
-    "name": "re2c-4.1",
+    "name": "re2c-4.2",
     "pname": "re2c",
-    "version": "4.1"
+    "version": "4.2"
   },
   "redis": {
-    "name": "redis-7.2.9",
+    "name": "redis-8.0.2",
     "pname": "redis",
-    "version": "7.2.9"
+    "version": "8.0.2"
   },
   "rich-cli": {
     "name": "rich-cli-1.8.0",
@@ -1050,9 +1050,9 @@
     "version": "5.0.1"
   },
   "slurm": {
-    "name": "slurm-24.11.5.1",
+    "name": "slurm-25.05.0.1",
     "pname": "slurm",
-    "version": "24.11.5.1"
+    "version": "25.05.0.1"
   },
   "smartmontools": {
     "name": "smartmontools-7.5",
@@ -1100,9 +1100,9 @@
     "version": "4.99.5"
   },
   "telegraf": {
-    "name": "telegraf-1.34.3",
+    "name": "telegraf-1.35.1",
     "pname": "telegraf",
-    "version": "1.34.3"
+    "version": "1.35.1"
   },
   "tmux": {
     "name": "tmux-3.5a",
@@ -1120,9 +1120,9 @@
     "version": "9.0.106"
   },
   "unifi": {
-    "name": "unifi-controller-9.1.120",
+    "name": "unifi-controller-9.2.87",
     "pname": "unifi-controller",
-    "version": "9.1.120"
+    "version": "9.2.87"
   },
   "unzip": {
     "name": "unzip-6.0",
@@ -1150,14 +1150,9 @@
     "version": "7.7.1"
   },
   "vim": {
-    "name": "vim-9.1.1336",
+    "name": "vim-9.1.1401",
     "pname": "vim",
-    "version": "9.1.1336"
-  },
-  "webkitgtk": {
-    "name": "webkitgtk-2.48.3+abi=4.0",
-    "pname": "webkitgtk",
-    "version": "2.48.3"
+    "version": "9.1.1401"
   },
   "wget": {
     "name": "wget-1.25.0",
@@ -1165,14 +1160,14 @@
     "version": "1.25.0"
   },
   "wireguard-tools": {
-    "name": "wireguard-tools-1.0.20210914",
+    "name": "wireguard-tools-1.0.20250521",
     "pname": "wireguard-tools",
-    "version": "1.0.20210914"
+    "version": "1.0.20250521"
   },
   "xfsprogs": {
-    "name": "xfsprogs-6.13.0",
+    "name": "xfsprogs-6.15.0",
     "pname": "xfsprogs",
-    "version": "6.13.0"
+    "version": "6.15.0"
   },
   "xorg.libX11": {
     "name": "libX11-1.8.12",

--- a/release/versions.json
+++ b/release/versions.json
@@ -14,10 +14,10 @@
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/"
   },
   "nixpkgs": {
-    "hash": "sha256-PB94f527pRD4pmmAIT3Rm+8Zfb55aOdDzgkHZykT4E4=",
+    "hash": "sha256-VzkVz0w49EkUp63Uc5k30/vnv+HW6ydEu3lLB3g5V1A=",
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "5456fd668551c2c244499b9e7e91eacc1b9a75ee"
+    "rev": "042ebad29d81745717878cbe018420c33f04e65e"
   },
   "nixpkgs-21_05": {
     "hash": "sha256-5ufC/t0sUFS/LspiEwU8DW5+uVYM3diZ1IC7KjX9ek4=",

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -77,7 +77,8 @@ in
   loghost = callTest ./loghost.nix { };
   login = callTest ./login.nix { };
   logrotate = callTest ./logrotate.nix { };
-  mail = callTest ./mail { };
+  # Known broken, requires update of simple-nixos-mailserver (PL-133851)
+  #mail = callTest ./mail { };
   mailstub = callTest ./mail/stub.nix { };
   matomo = callTest ./matomo.nix { };
   memcached = callTest ./memcached.nix { };


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

- [ ] Created changelog entry using `./changelog.sh`
  no: next release
## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [x] Security requirements tested? (EVIDENCE)
  - ensured by hydra and release process
