### PR TITLE
flake: replace devenv with simple pkgs.mkShell

### DIFF
--- a/dev-setup
+++ b/dev-setup
@@ -5,7 +5,7 @@ if [[ "$(nixos-version)" =~ ^"21" ]]; then
     ./dev-setup-from-21.05
 else
     # ensure PWD is the directory this script resides in (allows calls like ../dev-setup or $HOME/fc-nixos/dev-setup)
-    echo "You can also use 'nix develop --impure' to open the dev shell and run build_channels_dir from there." >&2
+    echo "You can also use 'nix develop' to open the dev shell and run build_channels_dir from there." >&2
     cd "$(dirname "$(readlink -f "$0")")"
-    nix develop --impure "$@" --command dev_setup
+    nix develop "$@" --command dev_setup
 fi

--- a/flake.lock
+++ b/flake.lock
@@ -16,59 +16,6 @@
         "type": "gitlab"
       }
     },
-    "cachix": {
-      "inputs": {
-        "devenv": [
-          "devenv"
-        ],
-        "flake-compat": [
-          "devenv"
-        ],
-        "git-hooks": [
-          "devenv"
-        ],
-        "nixpkgs": "nixpkgs"
-      },
-      "locked": {
-        "lastModified": 1742042642,
-        "narHash": "sha256-D0gP8srrX0qj+wNYNPdtVJsQuFzIng3q43thnHXQ/es=",
-        "owner": "cachix",
-        "repo": "cachix",
-        "rev": "a624d3eaf4b1d225f918de8543ed739f2f574203",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "ref": "latest",
-        "repo": "cachix",
-        "type": "github"
-      }
-    },
-    "devenv": {
-      "inputs": {
-        "cachix": "cachix",
-        "flake-compat": "flake-compat",
-        "git-hooks": "git-hooks",
-        "nix": "nix",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1743292849,
-        "narHash": "sha256-rybjlr2xNmSHrlRVliYvI9bOPRnROecFqz+tO0V2woI=",
-        "owner": "cachix",
-        "repo": "devenv",
-        "rev": "fa5cbf91fb1f1614936997badbb6018a2fdef320",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "repo": "devenv",
-        "rev": "fa5cbf91fb1f1614936997badbb6018a2fdef320",
-        "type": "github"
-      }
-    },
     "fc-nixos-21_05": {
       "flake": false,
       "locked": {
@@ -102,45 +49,7 @@
         "type": "github"
       }
     },
-    "flake-compat_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
     "flake-parts": {
-      "inputs": {
-        "nixpkgs-lib": [
-          "devenv",
-          "nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1741352980,
-        "narHash": "sha256-+u2UunDA4Cl5Fci3m7S643HzKmIDAe+fiXrLqYsR2fs=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "f4330d22f1c5d2ba72d3d22df5597d123fdb60a9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
-      }
-    },
-    "flake-parts_2": {
       "inputs": {
         "nixpkgs-lib": "nixpkgs-lib"
       },
@@ -179,35 +88,10 @@
     "git-hooks": {
       "inputs": {
         "flake-compat": [
-          "devenv"
-        ],
-        "gitignore": "gitignore",
-        "nixpkgs": [
-          "devenv",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1742649964,
-        "narHash": "sha256-DwOTp7nvfi8mRfuL1escHDXabVXFGT1VlPD1JHrtrco=",
-        "owner": "cachix",
-        "repo": "git-hooks.nix",
-        "rev": "dcf5072734cb576d2b0c59b2ac44f5050b5eac82",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "repo": "git-hooks.nix",
-        "type": "github"
-      }
-    },
-    "git-hooks_2": {
-      "inputs": {
-        "flake-compat": [
           "nixos-mailserver",
           "flake-compat"
         ],
-        "gitignore": "gitignore_2",
+        "gitignore": "gitignore",
         "nixpkgs": [
           "nixos-mailserver",
           "nixpkgs"
@@ -230,28 +114,6 @@
     "gitignore": {
       "inputs": {
         "nixpkgs": [
-          "devenv",
-          "git-hooks",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1709087332,
-        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "type": "github"
-      }
-    },
-    "gitignore_2": {
-      "inputs": {
-        "nixpkgs": [
           "nixos-mailserver",
           "git-hooks",
           "nixpkgs"
@@ -268,55 +130,6 @@
       "original": {
         "owner": "hercules-ci",
         "repo": "gitignore.nix",
-        "type": "github"
-      }
-    },
-    "libgit2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1740952128,
-        "narHash": "sha256-lmG/Vg3hxb/dRVPFhkQRB1dp8XT2YJzCvkPjm7yXP/A=",
-        "owner": "libgit2",
-        "repo": "libgit2",
-        "rev": "21a351b0ed207d0871cb23e09c027d1ee42eae98",
-        "type": "github"
-      },
-      "original": {
-        "owner": "libgit2",
-        "repo": "libgit2",
-        "type": "github"
-      }
-    },
-    "nix": {
-      "inputs": {
-        "flake-compat": [
-          "devenv"
-        ],
-        "flake-parts": "flake-parts",
-        "libgit2": "libgit2",
-        "nixpkgs": "nixpkgs_2",
-        "nixpkgs-23-11": [
-          "devenv"
-        ],
-        "nixpkgs-regression": [
-          "devenv"
-        ],
-        "pre-commit-hooks": [
-          "devenv"
-        ]
-      },
-      "locked": {
-        "lastModified": 1741798497,
-        "narHash": "sha256-E3j+3MoY8Y96mG1dUIiLFm2tZmNbRvSiyN7CrSKuAVg=",
-        "owner": "domenkozar",
-        "repo": "nix",
-        "rev": "f3f44b2baaf6c4c6e179de8cbb1cc6db031083cd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "domenkozar",
-        "ref": "devenv-2.24",
-        "repo": "nix",
         "type": "github"
       }
     },
@@ -344,8 +157,8 @@
     "nixos-mailserver": {
       "inputs": {
         "blobs": "blobs",
-        "flake-compat": "flake-compat_2",
-        "git-hooks": "git-hooks_2",
+        "flake-compat": "flake-compat",
+        "git-hooks": "git-hooks",
         "nixpkgs": [
           "nixpkgs"
         ],
@@ -372,16 +185,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1743315132,
-        "narHash": "sha256-6hl6L/tRnwubHcA4pfUUtk542wn2Om+D4UnDhlDW9BE=",
-        "owner": "NixOS",
+        "lastModified": 1751978961,
+        "narHash": "sha256-VzkVz0w49EkUp63Uc5k30/vnv+HW6ydEu3lLB3g5V1A=",
+        "owner": "flyingcircusio",
         "repo": "nixpkgs",
-        "rev": "52faf482a3889b7619003c0daec593a1912fddc1",
+        "rev": "042ebad29d81745717878cbe018420c33f04e65e",
         "type": "github"
       },
       "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
+        "owner": "flyingcircusio",
+        "ref": "nixos-25.11",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -417,38 +230,6 @@
         "type": "github"
       }
     },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1735651292,
-        "narHash": "sha256-YLbzcBtYo1/FEzFsB3AnM16qFc6fWPMIoOuSoDwvg9g=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "0da3c44a9460a26d2025ec3ed2ec60a895eb1114",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "release-24.05",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_3": {
-      "locked": {
-        "lastModified": 1751978961,
-        "narHash": "sha256-VzkVz0w49EkUp63Uc5k30/vnv+HW6ydEu3lLB3g5V1A=",
-        "owner": "flyingcircusio",
-        "repo": "nixpkgs",
-        "rev": "042ebad29d81745717878cbe018420c33f04e65e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "flyingcircusio",
-        "ref": "nixos-25.11",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "poetry2nix": {
       "inputs": {
         "flake-utils": "flake-utils",
@@ -475,11 +256,10 @@
     },
     "root": {
       "inputs": {
-        "devenv": "devenv",
         "fc-nixos-21_05": "fc-nixos-21_05",
-        "flake-parts": "flake-parts_2",
+        "flake-parts": "flake-parts",
         "nixos-mailserver": "nixos-mailserver",
-        "nixpkgs": "nixpkgs_3",
+        "nixpkgs": "nixpkgs",
         "nixpkgs-21_05": "nixpkgs-21_05",
         "poetry2nix": "poetry2nix"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,4 +1,4 @@
-# This flake is meant to be used with `nix develop --impure`
+# This flake is meant to be used with `nix develop`
 # to provide a dev shell for platform developers and release managers.
 
 # Platform dependencies are still read from
@@ -26,10 +26,6 @@
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.nixpkgs-25_05.follows = "nixpkgs";
     };
-    devenv = {
-      url = "github:cachix/devenv/fa5cbf91fb1f1614936997badbb6018a2fdef320";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
     flake-parts.url = "github:hercules-ci/flake-parts";
     poetry2nix = {
       url = "github:nix-community/poetry2nix";
@@ -46,7 +42,6 @@
     inputs@{ flake-parts, ... }:
     flake-parts.lib.mkFlake { inherit inputs; } {
       imports = [
-        inputs.devenv.flakeModule
         ./release/flake-part-linux-only-packages.nix
       ];
       systems = [
@@ -163,7 +158,7 @@
             );
           };
 
-          devenv.shells.default =
+          devShells.default =
             let
               inherit (builtins) getEnv;
               upstreams = { inherit (inputs) nixpkgs nixos-mailserver; };
@@ -172,7 +167,7 @@
               );
               NIX_PATH = "fc=${getEnv "PWD"}:${nixPathUpstreams}:nixos-config=/etc/nixos/configuration.nix";
             in
-            {
+            pkgs.mkShell {
               name = "fc-nixos-dev";
               env = {
                 inherit NIX_PATH;
@@ -184,63 +179,70 @@
                   jq
                   nixfmt-rfc-style
                 ]
-                ++ (with self'.packages; [
-                  fcGetCurrentChannelUrl
-                  upNixPhps
-                ]);
+                ++ (
+                  with self'.packages;
+                  [
+                    fcGetCurrentChannelUrl
+                    upNixPhps
+                  ]
+                  ++ [
+                    (pkgs.writeShellApplication {
+                      name = "build_channels_dir";
+                      text =
+                        ''
+                          set -e
+                          mkdir -p channels
+                          if ! [[ -e channels/fc ]]; then
+                              ln -s .. channels/fc
+                          fi
+                        ''
+                        + (lib.concatStringsSep "\n" (
+                          lib.mapAttrsToList (name: flake: ''
+                            ln -sfT ${flake.outPath} channels/${name}
+                          '') upstreams
+                        ));
+                    })
+                    (pkgs.writeShellApplication {
+                      name = "cat_package_versions_json";
+                      runtimeInputs = [ nix ];
+                      text = ''
+                        jq < "$(nix build .#packageVersions --print-out-paths)"
+                      '';
+                    })
+                    (pkgs.writeShellApplication {
 
-              scripts = {
-                # This only works on Linux but I couldn't find an easy way to
-                # only build this script on Linux. It just produces an error
-                # message on Non-Linux because packageVersions is missing.
-                build_package_versions_json.exec = ''
-                  nix run .#buildPackageVersionsJson
-                '';
+                      name = "dev_setup";
+                      excludeShellChecks = [ "SC2154" ];
+                      bashOptions = [
+                        "errexit"
+                        "pipefail"
+                      ];
+                      text = ''
+                        build_channels_dir
 
-                build_versions_json.exec = ''
-                  nix run .#buildVersionsJson
-                '';
+                        # -s gives us the absolute path without resolving symlinks.
+                        NIX_PATH=$(realpath -s channels)
 
-                build_channels_dir.exec =
-                  ''
-                    set -e
-                    mkdir -p channels
-                    if ! [[ -e channels/fc ]]; then
-                        ln -s .. channels/fc
-                    fi
-                  ''
-                  + (lib.concatStringsSep "\n" (
-                    lib.mapAttrsToList (name: flake: ''
-                      ln -sfT ${flake.outPath} channels/${name}
-                    '') upstreams
-                  ));
+                        # preserve nixos-config
+                        config=$(nix-instantiate --find-file nixos-config 2>/dev/null) || true
 
-                cat_package_versions_json.exec = ''
-                  jq < $(nix build .#packageVersions --print-out-paths)
-                '';
+                        if [[ -n "$config" ]]; then
+                            NIX_PATH="$NIX_PATH:nixos-config=$config"
+                        else
+                            NIX_PATH="$NIX_PATH:nixos-config=$base/nixos"
+                        fi
 
-                dev_setup.exec = ''
-                  build_channels_dir
-
-                  # -s gives us the absolute path without resolving symlinks.
-                  NIX_PATH=`realpath -s channels`
-
-                  # preserve nixos-config
-                  config=$(nix-instantiate --find-file nixos-config 2>/dev/null) || true
-
-                  if [[ -n "$config" ]]; then
-                      NIX_PATH="$NIX_PATH:nixos-config=$config"
-                  else
-                      NIX_PATH="$NIX_PATH:nixos-config=$base/nixos"
-                  fi
-
-                  echo "export NIX_PATH=$NIX_PATH"
-                '';
-
-                nixos_repl.exec = ''
-                  sudo -E nix repl -f nixos/lib/nixos-repl.nix
-                '';
-              };
+                        echo "export NIX_PATH=$NIX_PATH"
+                      '';
+                    })
+                    (pkgs.writeShellApplication {
+                      name = "nixos_repl";
+                      text = ''
+                        sudo -E nix repl -f nixos/lib/nixos-repl.nix
+                      '';
+                    })
+                  ]
+                );
             };
         };
     }; # end mkFlake


### PR DESCRIPTION
This improves development performance quite a lot as no devenv needs to build. We don't really use devenv features, so this saves us time.

Also remove deprecated scripts
* build_package_versions_json
* build_versions_json

PL-133285

@flyingcircusio/release-managers

## Release process

- [ ] Created changelog entry using `./changelog.sh`
  no: internal dev process

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - not interrupt dev process
- [x] Security requirements tested? (EVIDENCE)
  - tested `dev-setup` on linux machine
  - tested `./update-nixpkgs-lock.sh` on linux machine
  - tested `nix develop` on macOS