### PR TITLE
php{72,73}: mark as broken

### DIFF
--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -53,9 +53,21 @@ builtins.mapAttrs (_: patchPhps phpLogPermissionPatch) {
   #
 
   # Import old php versions from nix-phps.
+  php72 = phps.php72.overrideAttrs (oA: {
+    # FIXME: PL-133854
+    meta = oA.meta // {
+      broken = true;
+    };
+  });
+  php73 = phps.php73.overrideAttrs (oA: {
+    # FIXME: PL-133854
+    meta = oA.meta // {
+      broken = true;
+    };
+  });
   inherit (phps)
-    php72
-    php73
+    #php72
+    #php73
     php74
     php80
     ;

--- a/release/default.nix
+++ b/release/default.nix
@@ -155,6 +155,11 @@ let
     "elasticsearch6-oss"
     "graylogFrozen"
     "mc"
+    # FIXME: PL-133854, marked as broken
+    "php72"
+    "php73"
+    "lamp_php72"
+    "lamp_php73"
   ];
 
   overlay = import ../pkgs/overlay.nix pkgs pkgs;

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -64,8 +64,9 @@ in
     clientCephRelease = "nautilus";
   };
   lampVm = callTest ./lamp/vm-test.nix { };
-  lampVm72 = callTest ./lamp/vm-test.nix { version = "lamp_php72"; };
-  lampVm73 = callTest ./lamp/vm-test.nix { version = "lamp_php73"; };
+  # FIXME: PL-133854, php72, php73 marked as broken
+  # lampVm72 = callTest ./lamp/vm-test.nix { version = "lamp_php72"; };
+  # lampVm73 = callTest ./lamp/vm-test.nix { version = "lamp_php73"; };
   lampVm74 = callTest ./lamp/vm-test.nix { version = "lamp_php74"; };
   lampVm80 = callTest ./lamp/vm-test.nix { version = "lamp_php80"; };
   lampVm81 = callTest ./lamp/vm-test.nix { version = "lamp_php81"; };


### PR DESCRIPTION
Currently broken because of libxml changes, requiring upstream nix-phps change, https://github.com/fossar/nix-phps/pull/444/ or similar

PL-133850, PL-133854

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`
  no: internal, release process
## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [ ] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  none
- [ ] Security requirements tested? (EVIDENCE)
  none