### PR TITLE
upgradeXFS: code notes on time impact

### DIFF
--- a/nixos/infrastructure/flyingcircus-physical.nix
+++ b/nixos/infrastructure/flyingcircus-physical.nix
@@ -104,6 +104,9 @@ mkIf (cfg.infrastructureModule == "flyingcircus-physical") (
 
       # Not formatting tmp for now because I dont want to refer to it by
       # the filesystem label and some machines use lvm and others dont.
+
+      # WARN: do not modify these light-heartedly. Changing xfs parameters can
+      # take several (tens of) minutes at the next boot, depending on the number of inodes.
       flyingcircus.initrd.upgradeXFS = {
         "/dev/disk/by-label/root" = [
           "bigtime=1"

--- a/nixos/platform/initrd.nix
+++ b/nixos/platform/initrd.nix
@@ -28,7 +28,13 @@ in
   options = with lib; {
     flyingcircus.initrd = {
       upgradeXFS = lib.mkOption {
-        description = "Call xfs_admin -O with the specified devices and features before mounting.";
+        description = ''
+          Call xfs_admin -O with the specified devices and features before mounting.
+          :::{.warning}
+          Do not modify these light-heartedly. Changing xfs parameters can
+          take several (tens of) minutes at the next boot, depending on the number of inodes.
+          :::
+        '';
         type = with lib.types; attrsOf (listOf (strMatching "[^=]+=[01]"));
         default = { };
         example = {


### PR DESCRIPTION
@flyingcircusio/release-managers

Partial forward port of #1627 to stay in sync code-wise. Only the upgrade docs were not applicable anymore, due to this being the next release already.