### PR TITLE
PL-133864 feature flag xfs upgrades

### DIFF
--- a/changelog.d/20250714_081049_fc-25.05-dev_scriv.md
+++ b/changelog.d/20250714_081049_fc-25.05-dev_scriv.md
@@ -1,0 +1,25 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+
+
+### NixOS XX.XX platform
+
+- Make XFS upgrades at boot-time optional and disable it by default.  (PL-133864)
+
+  We introduced the XFS upgrade code in the 25.05 cycle to allow long-living
+  filesystems enable features like "bigtime" which makes the filesystem
+  year 2038 compatible. The implementation chose robustness over performance
+  but the tradeoff ended up with boot times of tens of minutes even for
+  small or medium VMs. We're taking this feature back to the drawing board,
+  but provide a knob so it can be used in situations where it's really needed.

--- a/doc/src/upgrade.md
+++ b/doc/src/upgrade.md
@@ -250,16 +250,28 @@ Both `mailserver` and `mailstub` roles are affected by changes in the underlying
 - docker: fix role not working on devhosts (PL-133607)
 
   This change also prepares the role to work on machines without FE interface or PUB interface.
-- Add a mechanism to upgrade XFS flags over time. Initially this will cause
-  `bigtime`, `inobtcount` and `nrext64` flags to be set. With `bigtime` set VMs
-  from this release on will consistently support file times beyond 2038, even if
-  they were bootstrapped on older releases. (PL-133321, PL-130365)
-  :::{warning}
-  With large disks or many files and inodes, this process can take several (tens of) minutes.
-  As this migration step is done during the early boot phase, the machine won't be available for that time at the first boot after upgrading.
 
-  If your machine has an especially large disk of >500GB, contact [support](/platform/index.html#support) and we might be able to speed up that process for you.
+- We added a mechanism to upgrade XFS flags over time. This is disabled by default (see warning).
+
+  At the moment this will cause the `bigtime`, `inobtcount` and `nrext64` flags to be set.
+  With `bigtime` set VMs will consistently support file times beyond 2038, even if
+  they were bootstrapped on older releases. (PL-133321, PL-130365)
+
+  :::{warning}
+
+  With large disks or many files and inodes, this process can take several (tens
+  of) minutes. As this migration step is done during the early boot phase, the
+  machine won't be available for that time at the first boot after upgrading.
+
+  We are working on another implementation that will schedule separate maintenances
+  and predict downtimes more accurately and will speed up the process.
+
+  If you need to upgrades and your machine has an especially large disk of
+  >500GB, please contact [support](/platform/index.html#support) before enabling
+  the `flyingcircus.initrd.enableXFSUpgrades` option.
+
   :::
+
 - Prepare VMs to read ENC data (the config management metadata) seeded from the
   host from the separate `cidata` volume in the future. This allows disabling or
   reconfiguring /tmp to use tmpfs without breaking our configuration management.

--- a/nixos/platform/initrd.nix
+++ b/nixos/platform/initrd.nix
@@ -27,6 +27,10 @@ in
 {
   options = with lib; {
     flyingcircus.initrd = {
+      enableXFSUpgrades = lib.mkEnableOption {
+        description = "Enable XFS upgrades during initrd.";
+        default = false;
+      };
       upgradeXFS = lib.mkOption {
         description = ''
           Call xfs_admin -O with the specified devices and features before mounting.
@@ -61,7 +65,7 @@ in
   };
 
   config = lib.mkMerge [
-    (lib.mkIf (cfg.upgradeXFS != { }) {
+    (lib.mkIf (cfg.enableXFSUpgrades && cfg.upgradeXFS != { }) {
       boot.initrd = {
         extraUtilsCommands = ''
           copy_bin_and_libs ${pkgs.xfsprogs}/bin/xfs_admin

--- a/tests/initrd.nix
+++ b/tests/initrd.nix
@@ -34,6 +34,7 @@ import ./make-test-python.nix (
           };
         };
         flyingcircus.initrd = {
+          enableXFSUpgrades = true;
           upgradeXFS = {
             "/dev/disk/by-label/root" = [ "bigtime=1" ];
           };
@@ -79,9 +80,9 @@ import ./make-test-python.nix (
         machine.succeed('mount /dev/disk/by-label/cidata /cidata')
 
       with subtest("xfs upgrade/format"):
-        assert "bigtime=1" in machine.succeed('xfs_info /dev/disk/by-label/root')
-        assert "bigtime=1" in machine.succeed('xfs_info /dev/disk/by-label/tmp')
-        assert "drwxrwxrwt" in machine.succeed('stat /tmp')
+        assert "bigtime=1" in (r := machine.succeed('xfs_info /dev/disk/by-label/root')), r
+        assert "bigtime=1" in (r := machine.succeed('xfs_info /dev/disk/by-label/tmp')), r
+        assert "drwxrwxrwt" in (r := machine.succeed('stat /tmp')), r
 
       with subtest("/tmp data"):
         machine.succeed('mkdir /tmp/fc-data')


### PR DESCRIPTION
PL-133864

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

availability

- [x] Security requirements tested? (EVIDENCE)

tested by enabling/disabling the toggle on the test.