### PR TITLE
initrd: hide new xfs upgrade mechanism behind feature flag

### DIFF
--- a/nixos/platform/initrd.nix
+++ b/nixos/platform/initrd.nix
@@ -27,6 +27,10 @@ in
 {
   options = with lib; {
     flyingcircus.initrd = {
+      enableXFSUpgrades = lib.mkEnableOption {
+        description = "Enable XFS upgrades during initrd.";
+        default = false;
+      };
       upgradeXFS = lib.mkOption {
         description = "Call xfs_admin -O with the specified devices and features before mounting.";
         type = with lib.types; attrsOf (listOf (strMatching "[^=]+=[01]"));
@@ -55,7 +59,7 @@ in
   };
 
   config = lib.mkMerge [
-    (lib.mkIf (cfg.upgradeXFS != { }) {
+    (lib.mkIf (cfg.enableXFSUpgrades && cfg.upgradeXFS != { }) {
       boot.initrd = {
         extraUtilsCommands = ''
           copy_bin_and_libs ${pkgs.xfsprogs}/bin/xfs_admin

--- a/tests/initrd.nix
+++ b/tests/initrd.nix
@@ -34,6 +34,7 @@ import ./make-test-python.nix (
           };
         };
         flyingcircus.initrd = {
+          enableXFSUpgrades = true;
           upgradeXFS = {
             "/dev/disk/by-label/root" = [ "bigtime=1" ];
           };
@@ -79,9 +80,9 @@ import ./make-test-python.nix (
         machine.succeed('mount /dev/disk/by-label/cidata /cidata')
 
       with subtest("xfs upgrade/format"):
-        assert "bigtime=1" in machine.succeed('xfs_info /dev/disk/by-label/root')
-        assert "bigtime=1" in machine.succeed('xfs_info /dev/disk/by-label/tmp')
-        assert "drwxrwxrwt" in machine.succeed('stat /tmp')
+        assert "bigtime=1" in (r := machine.succeed('xfs_info /dev/disk/by-label/root')), r
+        assert "bigtime=1" in (r := machine.succeed('xfs_info /dev/disk/by-label/tmp')), r
+        assert "drwxrwxrwt" in (r := machine.succeed('stat /tmp')), r
 
       with subtest("/tmp data"):
         machine.succeed('mkdir /tmp/fc-data')


### PR DESCRIPTION
forward port of #1633, with release notes and changelog removed (dev-branch of a non-released platform version)