### PR TITLE
initrd: fix eval for enableXFSUpgrades option

### DIFF
--- a/nixos/platform/initrd.nix
+++ b/nixos/platform/initrd.nix
@@ -27,10 +27,7 @@ in
 {
   options = with lib; {
     flyingcircus.initrd = {
-      enableXFSUpgrades = lib.mkEnableOption {
-        description = "Enable XFS upgrades during initrd.";
-        default = false;
-      };
+      enableXFSUpgrades = lib.mkEnableOption "XFS upgrades during initrd";
       upgradeXFS = lib.mkOption {
         description = ''
           Call xfs_admin -O with the specified devices and features before mounting.


### PR DESCRIPTION
@flyingcircusio/release-managers

PL-133864

fix for https://github.com/flyingcircusio/fc-nixos/pull/1633#issuecomment-3069641011

## Release process

- [ ] Created changelog entry using `./changelog.sh`
  no: follow-up only
## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [x] Security requirements tested? (EVIDENCE)
  tested by hydra