### PR TITLE
[25.05] Patch FRR to stub out neighbour table management

### DIFF
--- a/pkgs/fc/ping-on-tap/ping-on-tap.py
+++ b/pkgs/fc/ping-on-tap/ping-on-tap.py
@@ -56,7 +56,7 @@ class ArpIcmpMux_am(scapy.AnsweringMachine):
 
 def gratuitous_arp(args):
     return scapy.Ether(src=args.mac, dst="ff:ff:ff:ff:ff:ff") / scapy.ARP(
-        op="who-has", psrc=args.ip, pdst=args.ip
+        op="who-has", hwsrc=args.mac, psrc=args.ip, pdst=args.ip
     )
     pass
 

--- a/pkgs/frr/0001-Don-t-throw-error-when-log-directory-already-exists.patch
+++ b/pkgs/frr/0001-Don-t-throw-error-when-log-directory-already-exists.patch
@@ -1,7 +1,7 @@
 From 845b44566a41cfb81887ffac074d70bbd4ad1181 Mon Sep 17 00:00:00 2001
 From: Molly Miller <mm@flyingcircus.io>
 Date: Wed, 26 Jun 2024 17:08:15 +0200
-Subject: [PATCH 1/2] Don't throw error when log directory already exists
+Subject: [PATCH 1/3] Don't throw error when log directory already exists
 
 Co-authored-by: Christian Theune <ct@flyingcircus.io>
 ---

--- a/pkgs/frr/0002-zebra-dplane-sleep-after-writing-batches-to-netlink.patch
+++ b/pkgs/frr/0002-zebra-dplane-sleep-after-writing-batches-to-netlink.patch
@@ -1,7 +1,7 @@
 From 4e5a945339b4157cfd236758c30600cc4990241d Mon Sep 17 00:00:00 2001
 From: Molly Miller <mm@flyingcircus.io>
 Date: Tue, 29 Apr 2025 16:12:01 +0200
-Subject: [PATCH 2/2] zebra-dplane: sleep after writing batches to netlink
+Subject: [PATCH 2/3] zebra-dplane: sleep after writing batches to netlink
 
 When synchronising the RIB for an L2-VNI into the kernel (e.g. bgpd is
 learning the initial EVPN RIB from a peer, a new VNI interface has

--- a/pkgs/frr/0003-netlink-don-t-manage-kernel-neighbour-table-entries-.patch
+++ b/pkgs/frr/0003-netlink-don-t-manage-kernel-neighbour-table-entries-.patch
@@ -1,0 +1,36 @@
+From f871a5a7aff5d98e7d9fe186fa9bb9a69b6651f0 Mon Sep 17 00:00:00 2001
+From: Molly Miller <mm@flyingcircus.io>
+Date: Tue, 1 Jul 2025 16:11:41 +0200
+Subject: [PATCH 3/3] netlink: don't manage kernel neighbour table entries for
+ evpn
+
+From experience, zebra's tracking of MAC-IP mappings for SVI
+interfaces doesn't always stay in sync with the kernel, which can lead
+to it advertising stuck routes for IP addresses which are no longer
+locally assigned.
+
+To hedge against this on the receiving side, let's stop populating the
+neighbour table with mappings learned from EVPN, and let the kernel
+fall back to dynamic neighbour discovery.
+---
+ zebra/kernel_netlink.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/zebra/kernel_netlink.c b/zebra/kernel_netlink.c
+index f938193eb4..3466a644d1 100644
+--- a/zebra/kernel_netlink.c
++++ b/zebra/kernel_netlink.c
+@@ -1617,6 +1617,10 @@ static enum netlink_msg_status nl_put_msg(struct nl_batch *bth,
+ 	case DPLANE_OP_NEIGH_INSTALL:
+ 	case DPLANE_OP_NEIGH_UPDATE:
+ 	case DPLANE_OP_NEIGH_DELETE:
++		/* no-op: don't attempt to insert kernel neighbour
++		 * table entries for evpn */
++		return FRR_NETLINK_SUCCESS;
++
+ 	case DPLANE_OP_VTEP_ADD:
+ 	case DPLANE_OP_VTEP_DELETE:
+ 	case DPLANE_OP_NEIGH_DISCOVER:
+-- 
+2.39.5 (Apple Git-154)
+

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -179,6 +179,7 @@ builtins.mapAttrs (_: patchPhps phpLogPermissionPatch) {
     patches = [
       ./frr/0001-Don-t-throw-error-when-log-directory-already-exists.patch
       ./frr/0002-zebra-dplane-sleep-after-writing-batches-to-netlink.patch
+      ./frr/0003-netlink-don-t-manage-kernel-neighbour-table-entries-.patch
     ];
   });
 

--- a/tests/frr.nix
+++ b/tests/frr.nix
@@ -551,11 +551,8 @@ import ./make-test-python.nix (
                   host1.wait_until_succeeds(f"bridge fdb show br br0 | grep -F extern_learn | grep -F {guest_mac}", timeout=10)
 
               with subtest("check remote TAP responder is reachable"):
-                  # if ping-on-tap sends its garp before the neighbour entry from the
-                  # remote host is withdrawn, then the remotely learned entry will take
-                  # precedence and a locally learned entry will not be created. we need to
-                  # reprime the local neighbour table to ensure that an entry is learned
-                  # which exported to the remote host.
+                  # ensure that dynamic neighbour learning functions correctly after
+                  # the migration
                   host2.succeed(f"ping -A -c5 {guest_ip}")
                   host1.succeed(f"ping -A -c5 {guest_ip}")
 


### PR DESCRIPTION
We've been having recurring issues on the routers where after a failover the secondary router will continue to announce stuck MAC-IP routes, which will cause other hardware machines to import incorrect MAC/IP mappings into their neighbour tables. This commit introduces a further patch to FRR which disables the neighbour table management functions used in EVPN to avoid the symptoms of this problem as we haven't been able to fix the source.

PL-132588

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh` => none, internal change

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [x] ensure the merge bot has determined a merge date
- [x] ensure all checks are green
- [x] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - This patch changes the intended behaviour of FRR to diverge from what is expected and tested upstream. However, this only disables functionality, which reduces the amount of code which is actually executed.
- [x] Security requirements tested? (EVIDENCE)
  - Tested without noticeable regressions in both dev and on a handful of production hosts which have been hitting the neighbour table corruption issues particularly frequently.
