### PR TITLE
devhost: switch to kea as dhcp server

### DIFF
--- a/changelog.d/20250715_095102_PL-133857-devhost-dhcp-issues_scriv.md
+++ b/changelog.d/20250715_095102_PL-133857-devhost-dhcp-issues_scriv.md
@@ -1,0 +1,22 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+
+### NixOS XX.XX platform
+
+- devhost: switch to kea as dhcp server (PL-133857)
+
+  We had seen issues with DHCP packets having an invalid checksum. Kea handles this better and seems to resolve provisioning issues.
+  We continue to monitor the issues.

--- a/nixos/roles/devhost/vm.nix
+++ b/nixos/roles/devhost/vm.nix
@@ -158,14 +158,27 @@ in {
         externalInterface = null;
       };
     };
-    # Maybe switch to kea long-term, but it's not available in 21.05
-    services.dnsmasq = {
+    services.kea.dhcp4 = {
       enable = true;
-      resolveLocalQueries = false;
       settings = {
-        interface = "br-vm-srv";
-        dhcp-range="10.12.250.10,10.12.254.254,255.255.0.0,24h";
-        dhcp-option=[ "option:router,10.12.0.1" "option:dns-server,${lib.concatStringsSep "," config.networking.nameservers}"];
+        interfaces-config = { interfaces = [ "br-vm-srv" ]; };
+        subnet4 = [
+          {
+            id = 1;
+            subnet = "10.12.0.0/16";
+            pools = [{ pool = "10.12.250.10 - 10.12.254.254"; }];
+            option-data = [
+              {
+                name = "routers";
+                data = "10.12.0.1";
+              }
+              {
+                name = "domain-name-servers";
+                data = lib.concatStringsSep "," config.networking.nameservers;
+              }
+            ];
+          }
+        ];
       };
     };
     networking.firewall.interfaces."br-vm-srv".allowedUDPPorts = [ 67 ];


### PR DESCRIPTION
dnsmasq had weird issues where some udp messages had an invalid checksum. kea seems to be better.

PL-133857

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [x] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Kea is a modern replacement for dnsmasq. Also we use kea for our production VMs. So this fulfills our requirements for software
- [x] Security requirements tested? (EVIDENCE)
  - tested on largo00 that it resolves the provisioning issues. We have still seen some provisioning fluctuations, so we will test on our internal devhost before rolling out the change to customers.