### PR TITLE
fc.qemu: better throttling

### DIFF
--- a/changelog.d/20250715_145230_PL-133868-improve-qemu-throttling_scriv.md
+++ b/changelog.d/20250715_145230_PL-133868-improve-qemu-throttling_scriv.md
@@ -1,0 +1,31 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+
+### NixOS XX.XX platform
+
+- Improve IO throttling on our hypervisors:
+
+  * HDD-class VMs can burst up to 2.500 IOPS for 60 seconds and
+    have an explicit bandwidth limit of 250 MiB/s.
+  * SSD-class VMs can burst up to 20.000 IOPS for 60 seconds
+    and have an explicit bandwidth limit of 500 MiB/s.
+  * Reads and writes are now throttled separately, so all VMs
+    can use their IOPS limit separately for reading and
+    writing at the same time.
+
+- Agent units (fc-agent, fc-collect-garbage, fc-update-channel) now use
+  a more dynamic throttling mechanism (cgroup's `io.weight`) so that
+  the new burst mechanism and generally idle IOPS can be used without
+  hurting application load. Under stress those units can consume at
+  most 20% of all available IOPS.

--- a/nixos/infrastructure/flyingcircus-virtual.nix
+++ b/nixos/infrastructure/flyingcircus-virtual.nix
@@ -155,29 +155,15 @@ mkIf (cfg.infrastructureModule == "flyingcircus") {
         script = "echo \"$(date) -- SERIAL CONSOLE IS LIVE --\" > /dev/ttyS0";
       };
 
-      fc-agent.serviceConfig =
-        let
-          # Must not consume more than 75% of available IOPS.
-          # The systemd setting is split between read and write but
-          # we only have one IOPS limit for the VM so combined we
-          # could get requests that are over the VM limit.
-          vdaIopsMax = "/dev/vda ${toString (maxIops - maxIops / 4)}";
-        in
-        {
-          IOReadIOPSMax = vdaIopsMax;
-          IOWriteIOPSMax = vdaIopsMax;
-        };
-
-      fc-collect-garbage.serviceConfig =
-        let
-          # Must not consume more than 12.5% of available IOPS.
-          # We don't have a problem with this taking really long.
-          vdaIopsMax = "/dev/vda ${toString (maxIops / 8)}";
-        in
-        {
-          IOReadIOPSMax = vdaIopsMax;
-          IOWriteIOPSMax = vdaIopsMax;
-        };
+      fc-agent.serviceConfig = {
+        IODeviceWeight = "/dev/vda 20"; # 1/5th performance compared to a single user service process
+      };
+      fc-collect-garbage.serviceConfig = {
+        IODeviceWeight = "/dev/vda 10"; # 1/10th performance compared to a single user service process
+      };
+      fc-update-channel.serviceConfig = {
+        IODeviceWeight = "/dev/vda 10"; # 1/10th performance compared to a single user service process
+      };
     };
   };
 

--- a/nixos/platform/agent.nix
+++ b/nixos/platform/agent.nix
@@ -384,9 +384,6 @@ in
           Type = "oneshot";
           TimeoutSec = "2h";
           Nice = 18; # 19 is the lowest
-          IOSchedulingClass = "idle";
-          IOSchedulingPriority = 7; # lowest
-          IOWeight = 10; # 1-10000
           LimitMEMLOCK = nixBuildMEMLOCK;
         };
 
@@ -450,9 +447,6 @@ in
           Type = "oneshot";
           TimeoutSec = "2h";
           Nice = 18; # 19 is the lowest
-          IOSchedulingClass = "idle";
-          IOSchedulingPriority = 7; # lowest
-          IOWeight = 10; # 1-10000
           ExecStart =
             let
               verbose = lib.optionalString cfg.agent.verbose "--show-caller-info";

--- a/nixos/platform/collect-garbage.nix
+++ b/nixos/platform/collect-garbage.nix
@@ -57,9 +57,6 @@ in
           # gives way to nearly everything else.
           CPUSchedulingPolicy = "idle";
           CPUWeight = 1;
-          IOSchedulingClass = "idle";
-          IOSchedulingPriority = 7;
-          IOWeight = 1;
           Nice = 19;
           # We expect our script to produce error codes from 0 to 3.
           # Ignore them as they are often temporary and the garbage collection

--- a/nixos/roles/kvm.nix
+++ b/nixos/roles/kvm.nix
@@ -155,8 +155,21 @@ in
         vm-expected-overhead = 512
 
         [qemu-throttle-by-pool]
+        ; compatibility section, can be thrown out once fc.qemu has been updated
         rbd.hdd = 250
         rbd.ssd = 10000
+
+        [block-throttle-rbd.hdd]
+        iops = 250
+        ; 250 mib/s
+        bps = 262144000
+        burst-factor = 10
+
+        [block-throttle-rbd.ssd]
+        iops = 10000
+        ; 500 mib/s
+        bps = 524288000
+        burst-factor = 2
 
         [network]
         tap-ifup-bridge = /etc/kvm/kvm-ifup

--- a/pkgs/fc/default.nix
+++ b/pkgs/fc/default.nix
@@ -53,8 +53,8 @@ rec {
       repo = "fc.qemu";
       # The release tooling didn't upgrade properly so we had to pick a specific
       # commit instead.
-      rev = "44a7dbba681f9c2a0418397ca15aef68cbba7071";
-      hash = "sha256-hUzhaLUrK6Sp+d0o/8a3UZkvv+ZiAr1JS60hd/X6epM=";
+      rev = "5ce500974496a2bbf18295f990ee1a2c7f2a915d";
+      hash = "sha256-6kRGa5PFlWro464EgzFXGMV5CaRDTI1e+9Hmfg6RVLo=";
     };
     fc-ceph = ceph;
     qemu_ceph = pkgs.qemu-ceph-nautilus;


### PR DESCRIPTION
Also, adapt the io limited agent units to make use of more flexible/ dynamic throttling.

Re PL-133868

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

no specific requirements, changes are around 

- [x] Security requirements tested? (EVIDENCE)

unit/functional and manual tests on vms and hardware.