### PR TITLE
[FC-46599] doc/upgrade: make unsupportedness of multi-version upgrades explicit

### DIFF
--- a/doc/src/upgrade.md
+++ b/doc/src/upgrade.md
@@ -86,10 +86,12 @@ also subscribe to updates.
 
 ### Upgrade to the next platform version
 
-We recommend upgrading platform versions one at a time without skipping
+We strongly advise upgrading platform versions one at a time without skipping
 versions. Here we assume that you are upgrading from the 24.11 platform.
+Please refrain from opening support cases for broken upgrade paths from older
+platform versions. The resolution is to upgrade one version at a time.
 
-Direct upgrades from older versions are possible in principle, but we cannot
+Direct upgrades from older versions are not tested since we cannot
 reliably test all combinations for all roles and custom configuration also
 plays a role here. Usually, problems that occur when skipping versions are
 only temporary, like service failures that go away with the next system


### PR DESCRIPTION
FC-46599

The way this was worded before doesn't really reflect our reality, i.e. that we advise against it and considering that the upgrade path from <24.11 to 25.05 is known to be broken.

@flyingcircusio/release-managers

## Release process

- [ ] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [ ] internal issue ID (PL-…) part of branch name
- [ ] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [ ] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [ ] Security requirements tested? (EVIDENCE)
