### PR TITLE
[25.05] Revert systemd agent unit throttling changes

### DIFF
--- a/changelog.d/20250715_145230_PL-133868-improve-qemu-throttling_scriv.md
+++ b/changelog.d/20250715_145230_PL-133868-improve-qemu-throttling_scriv.md
@@ -23,9 +23,3 @@ branches.
   * Reads and writes are now throttled separately, so all VMs
     can use their IOPS limit separately for reading and
     writing at the same time.
-
-- Agent units (fc-agent, fc-collect-garbage, fc-update-channel) now use
-  a more dynamic throttling mechanism (cgroup's `io.weight`) so that
-  the new burst mechanism and generally idle IOPS can be used without
-  hurting application load. Under stress those units can consume at
-  most 20% of all available IOPS.

--- a/nixos/infrastructure/flyingcircus-virtual.nix
+++ b/nixos/infrastructure/flyingcircus-virtual.nix
@@ -155,15 +155,29 @@ mkIf (cfg.infrastructureModule == "flyingcircus") {
         script = "echo \"$(date) -- SERIAL CONSOLE IS LIVE --\" > /dev/ttyS0";
       };
 
-      fc-agent.serviceConfig = {
-        IODeviceWeight = "/dev/vda 20"; # 1/5th performance compared to a single user service process
-      };
-      fc-collect-garbage.serviceConfig = {
-        IODeviceWeight = "/dev/vda 10"; # 1/10th performance compared to a single user service process
-      };
-      fc-update-channel.serviceConfig = {
-        IODeviceWeight = "/dev/vda 10"; # 1/10th performance compared to a single user service process
-      };
+      fc-agent.serviceConfig =
+        let
+          # Must not consume more than 75% of available IOPS.
+          # The systemd setting is split between read and write but
+          # we only have one IOPS limit for the VM so combined we
+          # could get requests that are over the VM limit.
+          vdaIopsMax = "/dev/vda ${toString (maxIops - maxIops / 4)}";
+        in
+        {
+          IOReadIOPSMax = vdaIopsMax;
+          IOWriteIOPSMax = vdaIopsMax;
+        };
+
+      fc-collect-garbage.serviceConfig =
+        let
+          # Must not consume more than 12.5% of available IOPS.
+          # We don't have a problem with this taking really long.
+          vdaIopsMax = "/dev/vda ${toString (maxIops / 8)}";
+        in
+        {
+          IOReadIOPSMax = vdaIopsMax;
+          IOWriteIOPSMax = vdaIopsMax;
+        };
     };
   };
 

--- a/nixos/platform/agent.nix
+++ b/nixos/platform/agent.nix
@@ -384,6 +384,9 @@ in
           Type = "oneshot";
           TimeoutSec = "2h";
           Nice = 18; # 19 is the lowest
+          IOSchedulingClass = "idle";
+          IOSchedulingPriority = 7; # lowest
+          IOWeight = 10; # 1-10000
           LimitMEMLOCK = nixBuildMEMLOCK;
         };
 
@@ -447,6 +450,9 @@ in
           Type = "oneshot";
           TimeoutSec = "2h";
           Nice = 18; # 19 is the lowest
+          IOSchedulingClass = "idle";
+          IOSchedulingPriority = 7; # lowest
+          IOWeight = 10; # 1-10000
           ExecStart =
             let
               verbose = lib.optionalString cfg.agent.verbose "--show-caller-info";

--- a/nixos/platform/collect-garbage.nix
+++ b/nixos/platform/collect-garbage.nix
@@ -57,6 +57,9 @@ in
           # gives way to nearly everything else.
           CPUSchedulingPolicy = "idle";
           CPUWeight = 1;
+          IOSchedulingClass = "idle";
+          IOSchedulingPriority = 7;
+          IOWeight = 1;
           Nice = 19;
           # We expect our script to produce error codes from 0 to 3.
           # Ignore them as they are often temporary and the garbage collection


### PR DESCRIPTION
Partial revert of f34302e7f9a421c877b3feb035560d421087e83c, because we have seen issues with the io weight actually being set on some machines. Example:

Failed to set 'io[.bfq].weight' attribute on '/system.slice/fc-agent.service' to '253:0 20': Operation not supported

The throttling adjustments for the fc.qemu infrastructure side remain in place.

Partial revert of #1641

PL-133877

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [ ] PR has internal ticket
- [ ] internal issue ID (PL-…) part of branch name
- [ ] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - roll back a change found during QA in our staging systems to avoid regressions in production
- [ ] Security requirements tested? (EVIDENCE)
  - automated tests still pass
  - change will be verified during release process on the staging release system where we actually discovered it (@osnyx takes care of this)