### PR TITLE
Restore systemd agent unit throttling improvements for most VMs

### DIFF
--- a/changelog.d/20250721_103204_PL-133877-partially-restore-age-nt-throttling-improvements_scriv.md
+++ b/changelog.d/20250721_103204_PL-133877-partially-restore-age-nt-throttling-improvements_scriv.md
@@ -1,0 +1,21 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### NixOS XX.XX platform
+
+- On most machines, agent units (fc-agent, fc-collect-garbage, fc-update-channel) now use
+  a more dynamic throttling mechanism (cgroup's `io.weight`) so that
+  the new burst mechanism and generally idle IOPS can be used without
+  hurting application load. Under stress those units can consume at
+  most 20% of all available IOPS.
+  - Database VMs (mongodb, mysql, postgresql) are still using the previous, more strict throttling mechanism due to implementation challenges.

--- a/nixos/infrastructure/flyingcircus-virtual.nix
+++ b/nixos/infrastructure/flyingcircus-virtual.nix
@@ -16,6 +16,10 @@ let
     else
       "bfq";
   maxIops = attrByPath [ "parameters" "iops" ] 250 cfg.enc;
+  agentThrottling = weight: {
+    # device-specific override for the default `IOWeight`
+    IODeviceWeight = "/dev/vda ${toString weight}";
+  };
 
 in
 mkIf (cfg.infrastructureModule == "flyingcircus") {
@@ -163,10 +167,17 @@ mkIf (cfg.infrastructureModule == "flyingcircus") {
           # could get requests that are over the VM limit.
           vdaIopsMax = "/dev/vda ${toString (maxIops - maxIops / 4)}";
         in
-        {
-          IOReadIOPSMax = vdaIopsMax;
-          IOWriteIOPSMax = vdaIopsMax;
-        };
+        # PL-133877
+        if ioScheduler == "none" then
+          {
+            IOReadIOPSMax = vdaIopsMax;
+            IOWriteIOPSMax = vdaIopsMax;
+            IOSchedulingClass = "idle";
+            IOSchedulingPriority = 7; # lowest
+            IOWeight = 10; # 1-10000
+          }
+        else
+          agentThrottling 20; # 1/5th performance compared to a single user service process
 
       fc-collect-garbage.serviceConfig =
         let
@@ -174,10 +185,34 @@ mkIf (cfg.infrastructureModule == "flyingcircus") {
           # We don't have a problem with this taking really long.
           vdaIopsMax = "/dev/vda ${toString (maxIops / 8)}";
         in
-        {
-          IOReadIOPSMax = vdaIopsMax;
-          IOWriteIOPSMax = vdaIopsMax;
-        };
+        # PL-133877
+        if ioScheduler == "none" then
+          {
+            IOReadIOPSMax = vdaIopsMax;
+            IOWriteIOPSMax = vdaIopsMax;
+            IOSchedulingClass = "idle";
+            IOSchedulingPriority = 7; # lowest
+          }
+        else
+          agentThrottling 10; # 1/10th performance compared to a single user service process
+
+      fc-update-channel.serviceConfig =
+        let
+          # Must not consume more than 12.5% of available IOPS.
+          # We don't have a problem with this taking really long.
+          vdaIopsMax = "/dev/vda ${toString (maxIops / 8)}";
+        in
+        # PL-133877
+        if ioScheduler == "none" then
+          {
+            IOReadIOPSMax = vdaIopsMax;
+            IOWriteIOPSMax = vdaIopsMax;
+            IOSchedulingClass = "idle";
+            IOSchedulingPriority = 7; # lowest
+            IOWeight = 10; # 1-10000
+          }
+        else
+          agentThrottling 10; # 1/10th performance compared to a single user service process
     };
   };
 

--- a/nixos/infrastructure/flyingcircus-virtual.nix
+++ b/nixos/infrastructure/flyingcircus-virtual.nix
@@ -172,9 +172,6 @@ mkIf (cfg.infrastructureModule == "flyingcircus") {
           {
             IOReadIOPSMax = vdaIopsMax;
             IOWriteIOPSMax = vdaIopsMax;
-            IOSchedulingClass = "idle";
-            IOSchedulingPriority = 7; # lowest
-            IOWeight = 10; # 1-10000
           }
         else
           agentThrottling 20; # 1/5th performance compared to a single user service process
@@ -190,8 +187,6 @@ mkIf (cfg.infrastructureModule == "flyingcircus") {
           {
             IOReadIOPSMax = vdaIopsMax;
             IOWriteIOPSMax = vdaIopsMax;
-            IOSchedulingClass = "idle";
-            IOSchedulingPriority = 7; # lowest
           }
         else
           agentThrottling 10; # 1/10th performance compared to a single user service process
@@ -207,9 +202,6 @@ mkIf (cfg.infrastructureModule == "flyingcircus") {
           {
             IOReadIOPSMax = vdaIopsMax;
             IOWriteIOPSMax = vdaIopsMax;
-            IOSchedulingClass = "idle";
-            IOSchedulingPriority = 7; # lowest
-            IOWeight = 10; # 1-10000
           }
         else
           agentThrottling 10; # 1/10th performance compared to a single user service process

--- a/nixos/platform/agent.nix
+++ b/nixos/platform/agent.nix
@@ -387,7 +387,7 @@ in
           IOSchedulingClass = "idle";
           IOSchedulingPriority = 7; # lowest
           # default weight, may get disk-specific overrides
-          IOWeight = 10; # 1-10000
+          IOWeight = 20; # 1-10000
           LimitMEMLOCK = nixBuildMEMLOCK;
         };
 

--- a/nixos/platform/agent.nix
+++ b/nixos/platform/agent.nix
@@ -386,6 +386,7 @@ in
           Nice = 18; # 19 is the lowest
           IOSchedulingClass = "idle";
           IOSchedulingPriority = 7; # lowest
+          # default weight, may get disk-specific overrides
           IOWeight = 10; # 1-10000
           LimitMEMLOCK = nixBuildMEMLOCK;
         };
@@ -452,6 +453,7 @@ in
           Nice = 18; # 19 is the lowest
           IOSchedulingClass = "idle";
           IOSchedulingPriority = 7; # lowest
+          # default weight, may get disk-specific overrides
           IOWeight = 10; # 1-10000
           ExecStart =
             let

--- a/nixos/platform/collect-garbage.nix
+++ b/nixos/platform/collect-garbage.nix
@@ -60,7 +60,7 @@ in
           IOSchedulingClass = "idle";
           IOSchedulingPriority = 7;
           # default weight, may get disk-specific overrides
-          IOWeight = 1; # 1-10000
+          IOWeight = 10; # 1-10000
           Nice = 19;
           # We expect our script to produce error codes from 0 to 3.
           # Ignore them as they are often temporary and the garbage collection

--- a/nixos/platform/collect-garbage.nix
+++ b/nixos/platform/collect-garbage.nix
@@ -59,7 +59,8 @@ in
           CPUWeight = 1;
           IOSchedulingClass = "idle";
           IOSchedulingPriority = 7;
-          IOWeight = 1;
+          # default weight, may get disk-specific overrides
+          IOWeight = 1; # 1-10000
           Nice = 19;
           # We expect our script to produce error codes from 0 to 3.
           # Ignore them as they are often temporary and the garbage collection


### PR DESCRIPTION
This brings back the improvements from PL-133868 (#1641) for all but database VMs, as these are using the "none" IO scheduler and suffer from PL-133877.
Those VMs fall back to the previous, more strict throttling.

IO agent unit throttling is disabled altogether for physical machines.

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - bring back throttling improvements wherever possible
- [x] Security requirements tested? (EVIDENCE)
  - [x] automated tests still pass
  - [x] verified unit config in vm without database
  - [x] verified unit config in vm with database role
  - [x] verified unit config on hardware
