### PR TITLE
[24.11] devhost: simplify upgrade to platform 25.05

### DIFF
--- a/nixos/roles/devhost/default.nix
+++ b/nixos/roles/devhost/default.nix
@@ -25,8 +25,7 @@ in
           "vm"
           "container"
         ];
-        # FIXME: Why is this still the default?
-        default = "container";
+        default = "vm";
       };
 
       publicAddress = lib.mkOption {


### PR DESCRIPTION
type="vm" is the only supported value here anyways for this release, but having the option default on "container" requires a manual override on the machine to "vm".
Having removed this option altogether in 25.05, this creates the need for a config that does not build on both releases and requires a manual config change at upgrade.

Changing this default here allows removing the local config override and simplifies the update process.

@flyingcircusio/release-managers

## Release process

- [ ] Created changelog entry using `./changelog.sh`
  - no, customers don't operate dev*hosts*

## PR release workflow (internal)

- [ ] PR has internal ticket
- [ ] internal issue ID (PL-…) part of branch name
- [ ] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - config compatibility simplifies upgrades
  - at devhosts, a working config is also relevant for provisioning
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still pass