### PR TITLE
[PL-133672] roles/jitsi: don't enroll coturn secret at eval-time

### DIFF
--- a/changelog.d/20250725_184711_fc-25.05-dev_scriv.md
+++ b/changelog.d/20250725_184711_fc-25.05-dev_scriv.md
@@ -1,0 +1,24 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+- Restart of `coturn.service` & `prosody.service`.
+
+
+### NixOS XX.XX platform
+
+- The secret for the communication between `coturn` & `prosody` is no longer generated at eval-time (PL-133672).
+
+  This fixes issues where the secret's store-path is garbage-collected and a new secret is enrolled
+  on an agent run which lead to a subsequent restart of Jitsi mid-day in rare cases.

--- a/nixos/roles/jitsi/default.nix
+++ b/nixos/roles/jitsi/default.nix
@@ -12,12 +12,7 @@ let
   fclib = config.fclib;
   cfg = config.flyingcircus.roles.jitsi;
 
-  generatedTurnSecret = readFile (
-    pkgs.runCommand "jitsi-turn-secret" { } "${pkgs.apg}/bin/apg -a 1 -M lnc -n 1 -m 32 > $out"
-  );
-  turnSecret = lib.removeSuffix "\n" (
-    fclib.configFromFile /etc/local/jitsi/turn-secret generatedTurnSecret
-  );
+  turnSecretFile = "/etc/local/jitsi/turn-secret";
   turnHostName = if cfg.coturn.enable then cfg.coturn.hostName else cfg.turnHostName;
 
   # Does the same on the backend side but UI buttons can be turned on/off seperately.
@@ -339,6 +334,36 @@ in
         };
       };
 
+      systemd.services.prosody-coturn-setup-secret = {
+        before = [
+          "prosody.service"
+          "jitsi-meet-init-secrets.service"
+        ];
+        wantedBy = [
+          "prosody.service"
+          "jitsi-meet-init-secrets.service"
+        ];
+        path = [ pkgs.apg ];
+        unitConfig.ConditionFileNotEmpty = "!${turnSecretFile}";
+        serviceConfig = {
+          Type = "oneshot";
+          RemainAfterExit = true;
+          UMask = "0077";
+          ProtectSystem = "strict";
+          ReadWritePaths = [ "/etc/local/jitsi" ];
+          WorkingDirectory = "/etc/local/jitsi";
+          ExecStart = "${pkgs.writeShellScript "generate-turn-secret" ''
+            apg -a 1 -M lnc -n 1 -m 32 > turn-secret
+          ''}";
+        };
+      };
+
+      systemd.services.prosody = {
+        serviceConfig = {
+          LoadCredential = [ "turncredentials_secret:${turnSecretFile}" ];
+        };
+      };
+
       services.prosody = {
 
         modules = {
@@ -356,8 +381,12 @@ in
           cross_domain_websocket = true;
           consider_websocket_secure = true;
 
-
-          turncredentials_secret = "${turnSecret}";
+          -- FIXME when prosody is updated to v13, use
+          --   turncredentials_secret = Credential("turncredentials_secret")
+          local credentials_directory = os.getenv("CREDENTIALS_DIRECTORY")
+          local secret = assert(io.open(credentials_directory .. "/turncredentials_secret", "r"))
+          turncredentials_secret = secret:read("*a"):gsub("\n*$", "")
+          secret:close()
           turncredentials = {
             { type = "turn",
               host = "${turnHostName}",
@@ -467,13 +496,22 @@ in
         hostName = cfg.coturn.hostName;
       };
 
+      systemd.services.prosody-coturn-setup-secret = {
+        before = [ "coturn.service" ];
+        wantedBy = [ "coturn.service" ];
+      };
+
+      systemd.services.coturn.serviceConfig.LoadCredential = [
+        "static-auth-secret:${turnSecretFile}"
+      ];
+
       services.coturn = {
         listening-ips = [
           cfg.coturn.listenAddress
           cfg.coturn.listenAddress6
         ];
         no-tcp = false;
-        static-auth-secret = turnSecret;
+        static-auth-secret-file = "/run/credentials/coturn.service/static-auth-secret";
         tls-listening-port = 443;
         extraConfig = ''
           no-stun

--- a/nixos/services/jitsi/jitsi-meet.nix
+++ b/nixos/services/jitsi/jitsi-meet.nix
@@ -254,6 +254,7 @@ in
       ] ++ (optional cfg.prosody.enable "prosody.service");
       serviceConfig = {
         Type = "oneshot";
+        inherit (config.systemd.services.prosody.serviceConfig) LoadCredential;
       };
 
       path = [ config.services.prosody.package ];


### PR DESCRIPTION
PL-133672

Generating the secret for prosody/coturn at eval-time via IFD has the problem that the derivation is not in the system's closure and gets GCed eventually. In rare cases this lead to restarts of Jitsi mid-day because of a GC and a subsequent rebuild of the password.

It's a little hard to test this correctly because Jitsi seems pretty resilient to a broken coturn. However, with the password-file not existing for coturn, the service failed to start up. With the password mismatching I got the following errors in coturn's log on a test video-conference with two devices:

    Jul 25 18:37:17 test42 turnserver[617432]: 17: (617438): ERROR: session 002000000000000002: check_stun_auth: Cannot find credentials of user <1753547825>

This only happens on a secret mismatch.

Prosody's Lua code would also fail hard if it couldn't read the secret:

    out>    Jul 25 19:08:22 test42 prosodyctl[634356]: A problem occurred while reading the config file /etc/prosody/prosody.cfg.lua
    out>    Jul 25 19:08:22 test42 prosodyctl[634356]: Error: /etc/prosody/prosody.cfg.lua:97: /run/credentials/prosody.service/turncredentials_secret2: No such file or directory

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Secrets shouldn't be stored world-readable.
  - Availability: avoid restarts duriung agent runs mid-day.
- [x] Security requirements tested? (EVIDENCE)
  - Activated on a test-VM
  - Checked that conferences work as expected
  - Tested error-cases (i.e. non-existing files or mismatching secrets).
  - Tested migration from a system with an active Jitsi role.