### PR TITLE
services.k3s: reduce priority of default package

### DIFF
--- a/changelog.d/20250728_110523_os-k3s-default-package_scriv.md
+++ b/changelog.d/20250728_110523_os-k3s-default-package_scriv.md
@@ -1,0 +1,17 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+
+### NixOS XX.XX platform
+
+- k3s: Overriding the used package version `services.k3s.package` does not require an `mkForce` anymore.

--- a/nixos/roles/k3s/default.nix
+++ b/nixos/roles/k3s/default.nix
@@ -67,7 +67,7 @@
           }
         ];
 
-        services.k3s.package = pkgs.k3s_1_32;
+        services.k3s.package = config.fclib.mkPlatform pkgs.k3s_1_32;
 
       }
 


### PR DESCRIPTION
As k3s needs to be updated version by version, manually overriding/ pinning the package version is necessary on all installations anyways. `mkPlatform` enables us to do this without requiring an mkForce.

Slightly related to PL-132803

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [ ] PR has internal ticket
- [ ] internal issue ID (PL-…) part of branch name
- [ ] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - streamline updating k3s clusters, where package versions need to be pinned manually
- [ ] Security requirements tested? (EVIDENCE)
  - tests still pass
