### PR TITLE
fc-manage check: display all Nix eval warnings

### DIFF
--- a/changelog.d/20250729_105614_PL-133786-eval-warnings-agent_scriv.md
+++ b/changelog.d/20250729_105614_PL-133786-eval-warnings-agent_scriv.md
@@ -1,0 +1,17 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+
+### NixOS XX.XX platform
+
+- `fc-manage check` now displays all evaluation warnings of the system configuration, including package deprecations. (PL-133786)

--- a/nixos/platform/agent.nix
+++ b/nixos/platform/agent.nix
@@ -471,6 +471,7 @@ in
         "d /root 0711"
         "d /var/log/fc-agent - - - ${toString logDaysKeep}d"
         "d /var/spool/maintenance/archive - - - ${toString logDaysKeep}d"
+        "d /var/lib/fc-agent 0755 - - -"
         # Remove various obsolete files and directories
         # The next 2 entries can be removed when all VMs with versions before 22.05 are gone.
         "r /var/log/fc-agent/fc-maintenance-command-output.log"

--- a/nixos/platform/agent.nix
+++ b/nixos/platform/agent.nix
@@ -268,13 +268,6 @@ in
   };
 
   config = mkMerge [
-    {
-      # Write NixOS warnings to a file, separated by two newlines.
-      # We use that for `fc-manage check` to display (deprecation) warnings.
-      environment.etc."fcio_nixos_warnings".text = lib.optionalString (config.warnings != [ ]) (
-        (lib.concatStringsSep "\n\n" config.warnings) + "\n"
-      );
-    }
 
     (mkIf cfg.agent.install {
       environment.systemPackages = [

--- a/pkgs/fc/agent/src/fc/manage/manage.py
+++ b/pkgs/fc/agent/src/fc/manage/manage.py
@@ -126,7 +126,7 @@ def check(log, enc, config: ConfigParser) -> CheckResult:
     else:
         errors.append("`nixos` channel not set.")
 
-    nixos_warnings_file = Path("/etc/fcio_nixos_warnings")
+    nixos_warnings_file = Path("/etc/fcio_nix_eval_warnings")
 
     if nixos_warnings_file.exists():
         nixos_warnings_content = nixos_warnings_file.read_text()

--- a/pkgs/fc/agent/src/fc/manage/manage.py
+++ b/pkgs/fc/agent/src/fc/manage/manage.py
@@ -12,7 +12,7 @@ from fc.util.channel import Channel
 from fc.util.checks import CheckResult
 from fc.util.enc import STATE_VERSION_FILE
 from fc.util.lock import locked
-from fc.util.nixos import Specialisation
+from fc.util.nixos import NIX_EVAL_WARNINGS_FILE, Specialisation
 
 # Other platform code can also check the presence of this marker file to
 # change behaviour before/during the first agent run.
@@ -43,7 +43,9 @@ class SwitchFailed(Exception):
     pass
 
 
-def check(log, enc, config: ConfigParser) -> CheckResult:
+def check(
+    log, enc, config: ConfigParser, eval_warnings_file=NIX_EVAL_WARNINGS_FILE
+) -> CheckResult:
     errors = []
     warnings = []
     ok_info = []
@@ -126,10 +128,8 @@ def check(log, enc, config: ConfigParser) -> CheckResult:
     else:
         errors.append("`nixos` channel not set.")
 
-    nixos_warnings_file = Path("/etc/fcio_nix_eval_warnings")
-
-    if nixos_warnings_file.exists():
-        nixos_warnings_content = nixos_warnings_file.read_text()
+    if eval_warnings_file.exists():
+        nixos_warnings_content = eval_warnings_file.read_text()
         if nixos_warnings_content:
             nixos_warnings = [
                 warning

--- a/pkgs/fc/agent/src/fc/util/channel.py
+++ b/pkgs/fc/agent/src/fc/util/channel.py
@@ -151,7 +151,10 @@ class Channel:
         if self.is_local:
             self.check_local_channel()
         system_path = nixos.build_system(
-            self.resolved_url, build_options, out_link, self.log
+            channel_url=self.resolved_url,
+            build_options=build_options,
+            out_link=out_link,
+            log=self.log,
         )
         self.system_path = system_path
 

--- a/pkgs/fc/agent/src/fc/util/nixos.py
+++ b/pkgs/fc/agent/src/fc/util/nixos.py
@@ -324,6 +324,32 @@ def update_system_channel(channel_url, log=_log):
         raise ChannelUpdateFailed(stdout=stdout, stderr=stderr)
 
 
+def find_nix_eval_warnings(stderr: str) -> list[str]:
+    """Returns the evaluation warnings raised by either `builtins.warn` or the
+    NixOS module warning system `config.warnings`.
+    Evaluation warnings raised in e.g. package definitions are not accessible via
+    the `config.warnings` module endpoint, hence need to be grabbed from stderr.
+    """
+
+    WARNINGS_MARKER = "evaluation warning: "
+    # As long as lix lacks a `builtins.warn`, the `lib.warn` NixOS code falls
+    # back to traces
+    WARNINGS_MARKER_LEGACY = "trace: evaluation warning: "
+    lines = filter(
+        lambda line: line.startswith(WARNINGS_MARKER)
+        or line.startswith(WARNINGS_MARKER_LEGACY),
+        stderr.splitlines(),
+    )
+    return list(
+        map(
+            lambda line: line.removeprefix(WARNINGS_MARKER).removeprefix(
+                WARNINGS_MARKER_LEGACY
+            ),
+            lines,
+        )
+    )
+
+
 def find_nix_build_error(stderr: str, log=_log):
     """Returns the (hopefully) interesting part of the error message from Nix
     build output or a generic message if nothing is found.
@@ -437,7 +463,11 @@ def _increase_soft_fd_limit():
 
 
 def build_system(
-    channel_url=None, build_options=None, out_link=None, log=_log
+    channel_url=None,
+    build_options=None,
+    out_link=None,
+    log=_log,
+    eval_warnings_file=Path("/etc/fcio_nix_eval_warnings"),
 ) -> str:
     """
     Build system with this channel. Works like nixos-rebuild build.
@@ -492,6 +522,11 @@ def build_system(
 
     if stderr:
         changed = True
+        # Write NixOS and nix eval warnings to a file, separated by two newlines.
+        # We use that for `fc-manage check` to display (deprecation) warnings.
+        eval_warnings = find_nix_eval_warnings(stderr)
+        # TODO: make out path parameterisable
+        eval_warnings_file.write_text("\n\n".join(eval_warnings))
     else:
         stderr = None
         changed = False

--- a/pkgs/fc/agent/src/fc/util/nixos.py
+++ b/pkgs/fc/agent/src/fc/util/nixos.py
@@ -30,6 +30,8 @@ RE_FC_CHANNEL = re.compile(
 )
 RE_NUMERIC_VERSION = re.compile(r"\D*([\d.]+)[^\d.]?.*")
 
+NIX_EVAL_WARNINGS_FILE = Path("/var/lib/fc-agent/fcio_nix_eval_warnings")
+
 
 UnitChanges = dict[str, list[str]]
 
@@ -467,7 +469,7 @@ def build_system(
     build_options=None,
     out_link=None,
     log=_log,
-    eval_warnings_file=Path("/etc/fcio_nix_eval_warnings"),
+    eval_warnings_file=NIX_EVAL_WARNINGS_FILE,
 ) -> str:
     """
     Build system with this channel. Works like nixos-rebuild build.

--- a/pkgs/fc/agent/src/fc/util/tests/test_nixos.py
+++ b/pkgs/fc/agent/src/fc/util/tests/test_nixos.py
@@ -11,7 +11,9 @@ from fc.util.tests import PollingFakePopen
 
 structlog.configure(wrapper_class=structlog.BoundLogger)
 
-FC_CHANNEL = "https://hydra.flyingcircus.io/build/93111/download/1/nixexprs.tar.xz"
+FC_CHANNEL = (
+    "https://hydra.flyingcircus.io/build/93111/download/1/nixexprs.tar.xz"
+)
 
 
 def test_get_fc_channel_build(log):
@@ -26,8 +28,10 @@ def test_get_fc_channel_build_should_warn_for_non_fc_channel(log):
     assert log.has("no-fc-channel-url", channel_url=invalid_channel)
 
 
-def test_build_system_with_changes(log, monkeypatch):
-    channel = "https://hydra.flyingcircus.io/build/93222/download/1/nixexprs.tar.xz"
+def test_build_system_with_changes(log, monkeypatch, tmp_path):
+    channel = (
+        "https://hydra.flyingcircus.io/build/93222/download/1/nixexprs.tar.xz"
+    )
     system_path = "/nix/store/v49jzgwblcn9vkrmpz92kzw5pkbsn0vz-nixos-system-test-21.05.1367.817a5b0"
     build_output = textwrap.dedent(
         """
@@ -49,10 +53,16 @@ def test_build_system_with_changes(log, monkeypatch):
 
     popen_mock = mock.Mock(return_value=nix_build_fake)
     monkeypatch.setattr("subprocess.Popen", popen_mock)
-    monkeypatch.setattr("fc.util.nixos.system_closure_size", lambda *args: 2_000_000)
+    monkeypatch.setattr(
+        "fc.util.nixos.system_closure_size", lambda *args: 2_000_000
+    )
 
+    eval_warnings_file = tmp_path / "fcio_nix_eval_warnings"
     built_system_path = nixos.build_system(
-        channel, build_options=["-v"], out_link="/run/fc-agent-test"
+        channel,
+        build_options=["-v"],
+        out_link="/run/fc-agent-test",
+        eval_warnings_file=eval_warnings_file,
     )
 
     popen_mock.assert_called_once_with(
@@ -68,10 +78,13 @@ def test_build_system_with_changes(log, monkeypatch):
         changed=True,
         build_output=build_output.strip(),
     )
+    assert eval_warnings_file.exists()
 
 
 def test_build_system_unchanged(log, monkeypatch):
-    channel = "https://hydra.flyingcircus.io/build/93222/download/1/nixexprs.tar.xz"
+    channel = (
+        "https://hydra.flyingcircus.io/build/93222/download/1/nixexprs.tar.xz"
+    )
     system_path = "/nix/store/v49jzgwblcn9vkrmpz92kzw5pkbsn0vz-nixos-system-test-21.05.1367.817a5b0"
     build_output = "\n"
 
@@ -85,9 +98,13 @@ def test_build_system_unchanged(log, monkeypatch):
 
     popen_mock = mock.Mock(return_value=nix_build_fake)
     monkeypatch.setattr("subprocess.Popen", popen_mock)
-    monkeypatch.setattr("fc.util.nixos.system_closure_size", lambda *args: 2_000_000)
+    monkeypatch.setattr(
+        "fc.util.nixos.system_closure_size", lambda *args: 2_000_000
+    )
 
-    built_system_path = nixos.build_system(channel)
+    built_system_path = nixos.build_system(
+        channel, eval_warnings_file=Path("/dev/null")
+    )
 
     assert built_system_path == system_path
     popen_mock.assert_called_once_with(
@@ -101,7 +118,9 @@ def test_build_system_unchanged(log, monkeypatch):
 
 
 def test_build_system_fail(log, monkeypatch):
-    channel = "https://hydra.flyingcircus.io/build/93222/download/1/nixexprs.tar.xz"
+    channel = (
+        "https://hydra.flyingcircus.io/build/93222/download/1/nixexprs.tar.xz"
+    )
     system_path = "/nix/store/v49jzgwblcn9vkrmpz92kzw5pkbsn0vz-nixos-system-test-21.05.1367.817a5b0"
     build_output = textwrap.dedent(
         """
@@ -127,7 +146,7 @@ def test_build_system_fail(log, monkeypatch):
     monkeypatch.setattr("subprocess.Popen", popen_mock)
 
     with pytest.raises(nixos.BuildFailed):
-        nixos.build_system(channel)
+        nixos.build_system(channel, eval_warnings_file=Path("/dev/null"))
 
     assert log.has("system-build-failed", stderr=build_output.strip())
 
@@ -161,7 +180,9 @@ def test_switch_to_system(log, monkeypatch):
         lambda p: system_path if p == system_path else "other",
     )
 
-    changed = nixos.switch_to_system(system_path, lazy=True, switch_type="switch")
+    changed = nixos.switch_to_system(
+        system_path, lazy=True, switch_type="switch"
+    )
     assert changed
 
 
@@ -169,7 +190,9 @@ def test_switch_to_system_lazy_unchanged(log, monkeypatch):
     system_path = "/nix/store/v49jzgwblcn9vkrmpz92kzw5pkbsn0vz-nixos-system-test-21.05.1367.817a5b0"
     monkeypatch.setattr("pathlib.Path.resolve", lambda p: system_path)
 
-    changed = nixos.switch_to_system(system_path, lazy=True, switch_type="switch")
+    changed = nixos.switch_to_system(
+        system_path, lazy=True, switch_type="switch"
+    )
     assert not changed
     assert log.has("system-switch-skip")
 
@@ -201,6 +224,25 @@ def test_update_system_channel(log, monkeypatch):
         next_channel,
         "nixos",
     ]
+
+
+def test_find_nix_eval_warnings():
+    stderr = textwrap.dedent("""\
+        trace: Obsolete option `flyingcircus.roles.statshost.enable' is used. It was renamed to `flyingcircus.roles.statshost-global.enable'.
+        trace: evaluation warning: 1 NixOS module system warning
+        evaluation warning: 'imagemagick7' has been renamed to/replaced by 'imagemagick'
+        The option `services.nginx.virtualHosts."test66.fe.rzob.fcio.net".forcSSL' does not exist. Definition values:
+        - In `/etc/local/nixos/dev_vm.nix': true
+        """)
+    warnings = nixos.find_nix_eval_warnings(stderr)
+    assert len(warnings) == 2
+    assert "1 NixOS module system warning" in warnings
+    assert (
+        "'imagemagick7' has been renamed to/replaced by 'imagemagick'"
+        in warnings
+    )
+
+    assert nixos.find_nix_eval_warnings("") == []
 
 
 def test_find_nix_build_error_missing_option():


### PR DESCRIPTION
Nix evaluation warnings via `builtins.warn` or `lib.warn` do not show up in `config.warnings` and are just printed to stderr during evaluation. fc-agent now grabs and persists the warnings from there at system-build time.

As `config.warnings` warnings from the NixOS module system are also rendered with calls to `builtins.warn` (or a fallback to tracing), these are also captured using that mechanism.

PL-133786

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [x] ensure the merge bot has determined a merge date
- [x] ensure all checks are green
- [x] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - provide better visibility for Nix warnings: package (name) deprecations announced via warnings did not show up in the fc-agent check before and consequently were ignored by customers
- [x] Security requirements tested? (EVIDENCE)
  - extend test coverage with warnings parsing
  - automated tests still pass
  - manually tested this on a VM with and without warnings