### PR TITLE
fc-devhost: provide meta.mainProgram

### DIFF
--- a/nixos/roles/devhost/fc.devhost/default.nix
+++ b/nixos/roles/devhost/fc.devhost/default.nix
@@ -1,4 +1,5 @@
 {
+  lib,
   python3,
   qemu,
   xfsprogs,
@@ -21,4 +22,8 @@ python3.pkgs.buildPythonApplication {
     qemu
     xfsprogs
   ];
+  meta = {
+    mainProgram = "fc-devhost";
+    license = lib.licenses.mit;
+  };
 }


### PR DESCRIPTION
resolves a warning issued by using `lib.getExe` on it.

license just makes the implicit MIT licensing inherited from the whole repo explicit.

@flyingcircusio/release-managers

## Release process

- [ ] Created changelog entry using `./changelog.sh`
  - internal only

## PR release workflow (internal)

- [ ] PR has internal ticket
- [ ] internal issue ID (PL-…) part of branch name
- [ ] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - cut down on warning noise were possible
- [ ] Security requirements tested? (EVIDENCE)
  - automated tests still pass
