### PR TITLE
nixos/mysql: Add new option bufferMemoryPercentage to allow adjusting mem usage

### DIFF
--- a/changelog.d/20250801_175336_PL-133850-mysql-memory-percentage_scriv.md
+++ b/changelog.d/20250801_175336_PL-133850-mysql-memory-percentage_scriv.md
@@ -1,0 +1,22 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+
+### NixOS XX.XX platform
+
+- nixos/mysql: Add new option bufferMemoryPercentage to allow adjusting mem usage (PL-133850)
+
+  Currently, the memory percentage is fixed to 70%. This is too much when there is another service on the host.
+  This option allows to customize this

--- a/nixos/roles/mysql.nix
+++ b/nixos/roles/mysql.nix
@@ -54,6 +54,15 @@ in
             defaultText = "the addresses of the networks `lo` and `srv` (IPv4 & IPv6)";
           };
 
+          bufferMemoryPercentage = lib.mkOption {
+            type = lib.types.ints.between 0 100;
+            default = 70;
+            description = ''
+              Percentage of the host's memory used by InnoDB for buffering.
+              This is the primary memory use source of MySQL/Percona.
+            '';
+          };
+
           extraConfig = mkOption {
             type = types.lines;
             default = "";
@@ -290,7 +299,7 @@ in
               }
 
               # * InnoDB
-              innodb_buffer_pool_size         = ${toString (current_memory * 70 / 100)}M
+              innodb_buffer_pool_size         = ${toString (current_memory * cfg.bufferMemoryPercentage / 100)}M
               innodb_log_buffer_size          = 64M
               innodb_file_per_table           = 1
               innodb_read_io_threads          = ${toString (cores * 4)}


### PR DESCRIPTION
Currently, the memory percentage is fixed to 70%. This is too much when there is another service on the host. Especially this is the case for our internal releasetest VMs. This option allows to customize this.

PL-133850

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  None
- [x] Security requirements tested? (EVIDENCE)
  - Tested on releasetest VM
