### PR TITLE
nixos-mailserver: update and introduce automatic state version update

### DIFF
--- a/doc/src/upgrade.md
+++ b/doc/src/upgrade.md
@@ -114,6 +114,14 @@ Please upgrade to `percona84` before upgrading.
 
 ## Other notable changes
 
+### Mail server
+
+Upstream NixOS mailserver introduced a `stateVersion` construct that requires migrations when updating to 25.11.
+We run these migrations automatically, so you should not be required to take any action.
+A downgrade back to 25.05 is no longer possible.
+Read the [upstream release notes](https://nixos-mailserver.readthedocs.io/en/latest/release-notes.html#nixos-25-11) and
+[migration guide](https://nixos-mailserver.readthedocs.io/en/latest/migrations.html#nixos-25-11) for more informations.
+
 ## Known issues
 
 ## Significant package updates

--- a/flake.lock
+++ b/flake.lock
@@ -36,11 +36,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "lastModified": 1747046372,
+        "narHash": "sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX+fjA8Xf8PUmqCY=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "rev": "9100a0f413b0c601e0533d1d94ffd501ce2e7885",
         "type": "github"
       },
       "original": {
@@ -98,11 +98,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1750684550,
-        "narHash": "sha256-uLtw0iF9mQ94L831NOlQLPX9wm0qzd5yim3rcwACEoM=",
+        "lastModified": 1750779888,
+        "narHash": "sha256-wibppH3g/E2lxU43ZQHC5yA/7kIKLGxVEnsnVK1BtRg=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "fae816c55a75675f30d18c9cbdecc13b970d95d4",
+        "rev": "16ec914f6fb6f599ce988427d9d94efddf25fe6d",
         "type": "github"
       },
       "original": {
@@ -168,17 +168,17 @@
       },
       "locked": {
         "host": "gitlab.flyingcircus.io",
-        "lastModified": 1750693316,
-        "narHash": "sha256-dy2uEaf5Urv9ZgzilOtQxemtufi6Yn5iXlmEt00uNPc=",
+        "lastModified": 1754470053,
+        "narHash": "sha256-TcCthL6TAxWZ15o1E4DCIeXy5cLff5ZOM0Qyo60DPWY=",
         "owner": "flyingcircus",
         "repo": "nixos-mailserver",
-        "rev": "3b1ec3e110e6ce5c1bbf60d32f160b6cfc16d060",
+        "rev": "196691d7b29f104893ac565ffc0117ec497168b7",
         "type": "gitlab"
       },
       "original": {
         "host": "gitlab.flyingcircus.io",
         "owner": "flyingcircus",
-        "ref": "nixos-25.05",
+        "ref": "nixos-25.11",
         "repo": "nixos-mailserver",
         "type": "gitlab"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,7 @@
   inputs = {
     nixpkgs.url = "github:flyingcircusio/nixpkgs/nixos-25.11";
     nixos-mailserver = {
-      url = "gitlab:flyingcircus/nixos-mailserver/nixos-25.05?host=gitlab.flyingcircus.io";
+      url = "gitlab:flyingcircus/nixos-mailserver/nixos-25.11?host=gitlab.flyingcircus.io";
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.nixpkgs-25_05.follows = "nixpkgs";
     };

--- a/nixos/platform/default.nix
+++ b/nixos/platform/default.nix
@@ -20,7 +20,7 @@ let
       )
     else
       [ ];
-  currentPlatform = "24.11";
+  currentPlatform = "25.11";
 
 in
 {

--- a/nixos/services/mail/default.nix
+++ b/nixos/services/mail/default.nix
@@ -56,6 +56,10 @@ in
     flyingcircus.services.mail.enable = lib.mkEnableOption ''
       Mail server (SNM) with Postfix, Dovecot, Rspamd, DKIM & SPF
     '';
+    flyingcircus.services.mail.stateVersionFile = mkOption {
+      type = types.path;
+      default = "/etc/local/nixos/mailserver_state_version";
+    };
   };
 
   config =
@@ -236,6 +240,11 @@ in
           # https://gitlab.com/simple-nixos-mailserver/nixos-mailserver/-/blob/master/default.nix
           mailserver = {
             enable = true;
+            stateVersion =
+              if pathExists svc.stateVersionFile then
+                lib.toInt (lib.fileContents svc.stateVersionFile)
+              else
+                (if lib.versionOlder config.system.stateVersion "25.11" then 1 else 3);
             inherit domains;
             fqdn = role.mailHost;
             loginAccounts = fclib.jsonFromFile "/etc/local/mail/users.json" "{}";
@@ -364,12 +373,10 @@ in
                 "permit_sasl_authenticated"
               ];
               # --- postsrsd integration ---
-              recipient_canonical_maps = "socketmap:unix:${config.services.postsrsd.socketPath}:reverse";
               recipient_canonical_classes = [
                 "envelope_recipient"
                 "header_recipient"
               ];
-              sender_canonical_maps = "socketmap:unix:${config.services.postsrsd.socketPath}:forward";
               sender_canonical_classes = "envelope_sender";
               # ------
               smtpd_client_restrictions = [
@@ -420,7 +427,7 @@ in
 
           services.postsrsd = {
             enable = true;
-            domains = [
+            settings.domains = [
               primaryDomain
             ]
             ++ optionals (domains != [ ]) (
@@ -473,6 +480,27 @@ in
             "f /etc/local/mail/main.cf 0664 postfix service"
           ];
 
+          systemd.services.mailserver-update-stateversion = lib.mkIf (config.mailserver.stateVersion < 3) {
+            before = [ "dovecot2.service" ];
+            requiredBy = [ "dovecot2.service" ];
+            wantedBy = [ "dovecot2.service" ];
+            path = with pkgs; [
+              fc.agent
+              python3
+              sudo
+            ];
+            enableStrictShellChecks = true;
+            script = ''
+              sudo -u vmail python ${./update-mailserver-to-stateversion-3.py} --layout ${
+                if config.mailserver.useFsLayout then "folder" else "default"
+              } ${config.mailserver.mailDirectory}
+              echo 3 > ${svc.stateVersionFile}
+            '';
+            serviceConfig = {
+              Type = "oneshot";
+              RemainAfterExit = true;
+            };
+          };
         }
       ))
 

--- a/nixos/services/mail/update-mailserver-to-stateversion-3.py
+++ b/nixos/services/mail/update-mailserver-to-stateversion-3.py
@@ -1,0 +1,143 @@
+# This is a modified version of https://gitlab.com/simple-nixos-mailserver/nixos-mailserver/-/blob/master/migrations/nixos-mailserver-migration-03.py
+# that is able to run automatically
+
+import argparse
+import os
+import shutil
+import sys
+from enum import Enum
+from pathlib import Path
+from pwd import getpwnam
+
+
+class FolderLayout(Enum):
+    Default = 1
+    Folder = 2
+
+
+def check_user(vmail_root: Path):
+    owner = vmail_root.owner()
+    owner_uid = getpwnam(owner).pw_uid
+
+    if os.geteuid() == owner_uid:
+        return
+
+    try:
+        print(
+            f"Trying to switch effective user id to {owner_uid} ({owner})",
+            file=sys.stderr,
+        )
+        os.seteuid(owner_uid)
+        return
+    except PermissionError:
+        print(
+            f"Failed switching to virtual mail user. Please run this script under it, for example by using `sudo -u {owner}`)",
+            file=sys.stderr,
+        )
+    sys.exit(1)
+
+
+def is_maildir_related(path: Path, layout: FolderLayout) -> bool:
+    if path.name in [
+        "subscriptions",
+        # https://doc.dovecot.org/2.3/admin_manual/mailbox_formats/maildir/#imap-uid-mapping
+        "dovecot-uidlist",
+        # https://doc.dovecot.org/2.3/admin_manual/mailbox_formats/maildir/#imap-keywords
+        "dovecot-keywords",
+    ]:
+        return True
+    if not path.is_dir():
+        return False
+    if path.name in ["cur", "new", "tmp"]:
+        return True
+    if layout is FolderLayout.Default and path.name.startswith("."):
+        return True
+    if layout is FolderLayout.Folder:
+        if path.name in ["mail"]:
+            return False
+        return True
+
+    return False
+
+
+def mkdir(dst: Path, dry_run: bool = True):
+    print(f'mkdir "{dst}"')
+    if not dry_run:
+        # u+rwx, setgid
+        dst.mkdir(mode=0o2700)
+
+
+def move(src: Path, dst: Path, dry_run: bool = True):
+    print(f'mv "{src}" "{dst}"')
+    if not dry_run:
+        src.rename(dst)
+
+
+def delete(dst: Path, dry_run: bool = True):
+    if not dst.exists():
+        return
+
+    if dst.is_dir():
+        print(f'rm --recursive "{dst}"')
+        if not dry_run:
+            shutil.rmtree(dst)
+    else:
+        print(f'rm "{dst}"')
+        if not dry_run:
+            dst.unlink()
+
+
+def main(vmail_root: Path, layout: FolderLayout, dry_run: bool = True):
+    maildirs = {path.parent for path in vmail_root.glob("*/*/cur")}
+    maybe_delete = []
+
+    # The old maildir will be the new home directory
+    for homedir in maildirs:
+        maildir = homedir / "mail"
+        mkdir(maildir, dry_run)
+
+        for path in homedir.iterdir():
+            if is_maildir_related(path, layout):
+                move(path, maildir / path.name, dry_run)
+            else:
+                maybe_delete.append(path)
+
+    # Files that are part of the previous home directory, but now obsolete
+    for path in [
+        vmail_root / ".dovecot.lda-dupes",
+        vmail_root / ".dovecot.lda-dupes.locks",
+    ]:
+        delete(path, dry_run)
+
+    # The remaining files are likely obsolete, but should still be checked with care
+    for path in maybe_delete:
+        print(f"# rm {str(path)}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="""
+        NixOS Mailserver Migration #3: Dovecot mail directory migration
+        (https://nixos-mailserver.readthedocs.io/en/latest/migrations.html#dovecot-mail-directory-migration)
+    """
+    )
+    parser.add_argument(
+        "vmail_root", type=Path, help="Path to the `mailserver.mailDirectory`"
+    )
+    parser.add_argument(
+        "--layout",
+        choices=["default", "folder"],
+        required=True,
+        help="Folder layout: 'default' unless `mailserver.useFsLayout` was enabled, then'folder'",
+    )
+
+    args = parser.parse_args()
+
+    layout = (
+        FolderLayout.Default
+        if args.layout == "default"
+        else FolderLayout.Folder
+    )
+
+    check_user(args.vmail_root)
+    main(args.vmail_root, layout, dry_run=False)

--- a/release/versions.json
+++ b/release/versions.json
@@ -8,9 +8,9 @@
   "nixos-mailserver": {
     "deepClone": false,
     "fetchSubmodules": false,
-    "hash": "sha256-dy2uEaf5Urv9ZgzilOtQxemtufi6Yn5iXlmEt00uNPc=",
+    "hash": "sha256-TcCthL6TAxWZ15o1E4DCIeXy5cLff5ZOM0Qyo60DPWY=",
     "leaveDotGit": false,
-    "rev": "3b1ec3e110e6ce5c1bbf60d32f160b6cfc16d060",
+    "rev": "196691d7b29f104893ac565ffc0117ec497168b7",
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/"
   },
   "nixpkgs": {

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -77,8 +77,7 @@ in
   loghost = callTest ./loghost.nix { };
   login = callTest ./login.nix { };
   logrotate = callTest ./logrotate.nix { };
-  # Known broken, requires update of simple-nixos-mailserver (PL-133851)
-  #mail = callTest ./mail { };
+  mail = callTest ./mail { };
   mailstub = callTest ./mail/stub.nix { };
   matomo = callTest ./matomo.nix { };
   memcached = callTest ./memcached.nix { };

--- a/tests/mail/default.nix
+++ b/tests/mail/default.nix
@@ -247,22 +247,22 @@ import ../make-test-python.nix (
         client.succeed('echo | mail -s testmail6 user1+detail@example.local')
         mail.succeed('echo | mail -s testmail5 root')
         mail.wait_until_succeeds(
-          'test `ls /srv/mail/example.local/user1/new/* | wc -l` == 3')
+          'test `ls /srv/mail/example.local/user1/mail/new/* | wc -l` == 3')
         # check simple delivery
-        mail.succeed('grep testmail1 /srv/mail/example.local/user1/new/*')
+        mail.succeed('grep testmail1 /srv/mail/example.local/user1/mail/new/*')
         # check alias
-        mail.succeed('grep testmail3 /srv/mail/example.local/user1/new/*')
+        mail.succeed('grep testmail3 /srv/mail/example.local/user1/mail/new/*')
         # check address detail
-        mail.succeed('grep testmail6 /srv/mail/example.local/user1/new/*')
-        mail.succeed('fgrep "Delivered-To: user1+detail@" /srv/mail/example.local/user1/new/*')
+        mail.succeed('grep testmail6 /srv/mail/example.local/user1/mail/new/*')
+        mail.succeed('fgrep "Delivered-To: user1+detail@" /srv/mail/example.local/user1/mail/new/*')
         mail.wait_until_succeeds(
-          'test `ls /srv/mail/example.local/user2/new/* | wc -l` == 3')
+          'test `ls /srv/mail/example.local/user2/mail/new/* | wc -l` == 3')
         # check simple delivery
-        mail.succeed('grep testmail2 /srv/mail/example.local/user2/new/*')
+        mail.succeed('grep testmail2 /srv/mail/example.local/user2/mail/new/*')
         # check root alias
-        mail.succeed('grep testmail4 /srv/mail/example.local/user2/new/*')
+        mail.succeed('grep testmail4 /srv/mail/example.local/user2/mail/new/*')
         # check root delivery on mail server
-        mail.succeed('grep testmail5 /srv/mail/example.local/user2/new/*')
+        mail.succeed('grep testmail5 /srv/mail/example.local/user2/mail/new/*')
 
         print("### IMAP ###\n")
         mail.wait_for_open_port(143)


### PR DESCRIPTION
NixOS mailserver introduced a stateVersion construct. We need to update that, and ideally automatic. This introduces a script doing the automatic migration and cleans up options that are no longer necessary.

PL-133851

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`
  - created update notes entry
## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Don't run dovecot2 with old directory structure: assured by `requiredBy` condition on the systemd unit
  - When migration script fails, the migration systemd unit fails and dovecot won't start. Also the stateVersion won't be updated as `set -e` is set.
  - Backups ensure ability to restore
  - Migration step 2 is assured by nixos-mailserver assertion
- [x] Security requirements tested? (EVIDENCE)
  - Tested OS upgrade on test VM