### PR TITLE
nixos/kernel: add 9pfs patch and remove unnecessary useNixStoreImage

### DIFF
--- a/nixos/platform/kernel.nix
+++ b/nixos/platform/kernel.nix
@@ -153,12 +153,22 @@ in
         ""
     );
 
-    boot.kernelPatches = lib.mkIf (config.flyingcircus.kernelOptions != null) [
-      {
-        name = "fcio-kernel-options";
-        patch = null;
-        extraConfig = config.flyingcircus.kernelOptions;
-      }
-    ];
+    boot.kernelPatches =
+      lib.optionals (config.flyingcircus.kernelOptions != null) [
+        {
+          name = "fcio-kernel-options";
+          patch = null;
+          extraConfig = config.flyingcircus.kernelOptions;
+        }
+      ]
+      ++ [
+        {
+          name = "9pfs-fixes";
+          patch = pkgs.fetchurl {
+            url = "https://lore.kernel.org/linux-fsdevel/20250811-iot_iter_folio-v1-0-d9c223adf93c@codewreck.org/t.mbox.gz";
+            hash = "sha256-lgcoaBDd9FkFTb/hi9a+knfC0T7ZAAh410SxUFBIM1k=";
+          };
+        }
+      ];
   };
 }

--- a/tests/k3s/monitoring.nix
+++ b/tests/k3s/monitoring.nix
@@ -55,7 +55,6 @@ import ../make-test-python.nix (
 
           virtualisation.memorySize = 2000;
           virtualisation.diskSize = lib.mkForce 3000;
-          virtualisation.useNixStoreImage = true; # PL-133821 - 6.12 crashes v9fs in some situations
 
           virtualisation.vlans = [
             1

--- a/tests/matomo.nix
+++ b/tests/matomo.nix
@@ -22,7 +22,6 @@ import ./make-test-python.nix (
 
         virtualisation.diskSize = 1024;
         virtualisation.memorySize = 2048;
-        virtualisation.useNixStoreImage = true; # PL-133821 - 6.12 crashes v9fs in some situations
 
         networking.domain = "test";
 

--- a/tests/opensearch_dashboards.nix
+++ b/tests/opensearch_dashboards.nix
@@ -22,7 +22,6 @@ import ./make-test-python.nix (
         networking.domain = "test";
         virtualisation.memorySize = 3072;
         virtualisation.diskSize = lib.mkForce 2000;
-        virtualisation.useNixStoreImage = true; # PL-133821 - 6.12 crashes v9fs in some situations
         virtualisation.qemu.options = [ "-smp 2" ];
         flyingcircus.roles.opensearch.enable = true;
         flyingcircus.roles.opensearch.nodes = [ "machine" ];


### PR DESCRIPTION
PL-133821

@flyingcircusio/release-managers

## Release process

- [ ] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [x] Security requirements tested? (EVIDENCE)
  - Only affects the NixOS Tests, so ensured by them