### PR TITLE
ceph: switch monitor connection config to IP addresses.

### DIFF
--- a/changelog.d/20250812_164131_PL-133752-avoid-ceph-mon-dns_scriv.md
+++ b/changelog.d/20250812_164131_PL-133752-avoid-ceph-mon-dns_scriv.md
@@ -1,0 +1,23 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+
+### NixOS XX.XX platform
+
+- Switch Ceph monitor connection config to IP addresses. (PL-133752)
+
+  After a refactoring of our Ceph client library bindings, switching from
+  C-based bindings to CLI calls we are now more prone to any DNS issues
+  causing problems when instrumenting live migrations. We now connect to
+  mons directly using their IP addresses which takes DNS out of the loop
+  as a potential failure point.

--- a/nixos/services/ceph/client.nix
+++ b/nixos/services/ceph/client.nix
@@ -203,10 +203,7 @@ in
         mons = lib.mkOption {
           type = with lib.types; listOf str;
           default = (
-            map (
-              mon:
-              "${head (lib.splitString "." mon.address)}.${cfg.client.network.vlan}.${location}.ipv4.gocept.net"
-            ) (fclib.findServices "ceph_mon-mon")
+            map (mon: toString (head (filter fclib.isIp4 mon.ips))) (fclib.findServices "ceph_mon-mon")
           );
           defaultText = "The list of hostnames that are mons in this cluster";
           description = ''


### PR DESCRIPTION
After a refactoring of our Ceph client library bindings, switching from C-based bindings to CLI calls we are now more prone to any DNS issues causing problems when instrumenting live migrations. We now connect to mons directly using their IP addresses which takes DNS out of the loop as a potential failure point.

Fixes PL-133752

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

Generally: availability.

- [x] Security requirements tested? (EVIDENCE)

No specific requirements to test. Tried manually on cartman06 and tests still work and show the changed config file in their output.