### PR TITLE
[PL-133945] move nginx's common configuration up in the templated configuration file

### DIFF
--- a/changelog.d/20250813_113819_PL-133945_nginx-append-to-commonhttpconfig_scriv.md
+++ b/changelog.d/20250813_113819_PL-133945_nginx-append-to-commonhttpconfig_scriv.md
@@ -18,4 +18,4 @@ branches.
 
 ### NixOS XX.XX platform
 
-- Adjust the nginx configuration by moving general configuration like log formats up above the server configuration blocks (PL-133945)
+- nginx: platform-defined general configuration directives like log formats have been moved up above the server configuration blocks, allowing their re-use in virtual host config (PL-133945)

--- a/changelog.d/20250813_113819_PL-133945_nginx-append-to-commonhttpconfig_scriv.md
+++ b/changelog.d/20250813_113819_PL-133945_nginx-append-to-commonhttpconfig_scriv.md
@@ -1,0 +1,21 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+- The Nginx worker processes will be restarted while applying this change due to changes to it's configuration. Since nginx can handle this using a hot reload, we expect no effective down-time.
+
+
+### NixOS XX.XX platform
+
+- Adjust the nginx configuration by moving general configuration like log formats up above the server configuration blocks (PL-133945)

--- a/nixos/services/nginx/default.nix
+++ b/nixos/services/nginx/default.nix
@@ -567,7 +567,7 @@ in
           enable = true;
           package = fclib.mkPlatform pkgs.nginxLegacyCrypt;
           appendConfig = mainConfig;
-          appendHttpConfig = ''
+          commonHttpConfig = ''
             ${baseHttpConfig}
 
             # === User-provided config from ${localCfgDir}/*.conf ===

--- a/tests/nginx.nix
+++ b/tests/nginx.nix
@@ -162,6 +162,9 @@ import ./make-test-python.nix (
             ];
             addSSL = true;
             locations."/".return = "200 'TESTOK'";
+            extraConfig = ''
+              access_log /var/log/nginx/perf.log performance;
+            '';
           };
         };
       };


### PR DESCRIPTION
the lines of configuration that contain general configuration like log formats or other configuration that might be important for the server blocks should be templated above them so that for example log formats can be reused in the virtual hosts.

@flyingcircusio/release-managers

PL-133945


## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [x] Security requirements tested? (EVIDENCE)

The configuration itself remains unchanged, just the order of what blocks are templated where is adjusted. 
