### PR TITLE
nixos/{mail,mailstub}: update to RFC42 pattern for upstream comptability

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -185,11 +185,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1755057548,
-        "narHash": "sha256-rNEGlJPHnkuk6SF8/cRNNsnpp+uwZFTtD7PeN/J0v8g=",
+        "lastModified": 1755157691,
+        "narHash": "sha256-dWx+/dACGvpsqvh2d8InZcbP8dVrfRVm1IZ0rxQCEyM=",
         "owner": "flyingcircusio",
         "repo": "nixpkgs",
-        "rev": "3f7f249ee92986cd5ede37035f4b431f816cc5df",
+        "rev": "4388ac52e37ed1b6ec40546a2e8c98071812b04f",
         "type": "github"
       },
       "original": {

--- a/nixos/services/mail/default.nix
+++ b/nixos/services/mail/default.nix
@@ -159,6 +159,27 @@ in
             }
           ];
 
+          warnings =
+            lib.optionals
+              (config.services.postfix.extraConfig != null && builtins.pathExists "/etc/local/mail/main.cf")
+              [
+                ''
+                  Configuring postfix via /etc/local/mail/main.cf is deprecated.
+                  Please migrate to structured config with services.postfix.settings.main.
+                  This option of configuring will be removed with fc-nixos 26.05.
+                ''
+              ]
+            ++
+              lib.optionals
+                (config.services.postfix.extraConfig != null && (!builtins.pathExists "/etc/local/mail/main.cf"))
+                [
+                  ''
+                    services.postfix.extraConfig is deprecated.
+                    Please migrate to structured config with services.postfix.settings.main.
+                    This option of configuring will be removed with fc-nixos 26.05.
+                  ''
+                ];
+
           environment = {
             etc = {
               "local/mail/dns.zone".text = import ./zone.nix { inherit config lib; };
@@ -365,7 +386,7 @@ in
               "localhost"
             ];
 
-            config = {
+            settings.main = {
               empty_address_recipient = "postmaster";
               enable_long_queue_ids = true;
               local_header_rewrite_clients = [
@@ -409,7 +430,7 @@ in
               }) dynamicMapFiles
             );
 
-            extraConfig = ''
+            extraConfig = lib.mkIf (builtins.pathExists "/etc/local/mail/main.cf") ''
               # included from /etc/local/mail/main.cf
               ${fclib.configFromFile "/etc/local/mail/main.cf" ""}
             '';

--- a/nixos/services/mail/stub.nix
+++ b/nixos/services/mail/stub.nix
@@ -13,15 +13,6 @@ let
 
   interfaces = lib.attrByPath [ "parameters" "interfaces" ] { } config.flyingcircus.enc;
 
-  mainCf =
-    lib.optionals role.explicitSmtpBind [
-      "smtp_bind_address=${role.smtpBind4}"
-      "smtp_bind_address6=${role.smtpBind6}"
-    ]
-    ++ [ (fclib.configFromFile "/etc/local/postfix/main.cf" "") ];
-
-  masterCf = [ (fclib.configFromFile "/etc/local/postfix/master.cf" "") ];
-
   recipientCanonical = toFile "generic.pcre" ''
     /.*@.*\.fcio\.net$/ ${role.rootAlias}
   '';
@@ -58,24 +49,41 @@ in
 
   config = (
     lib.mkIf config.flyingcircus.services.postfix.enable {
+      warnings = lib.optionals (builtins.pathExists "/etc/local/postfix/main.cf") [
+        ''
+          Configuring postfix via /etc/local/postfix/main.cf is deprecated.
+          Please migrate to structured config with services.postfix.settings.main.
+          This option of configuring will be removed with fc-nixos 26.05.
+        ''
+      ];
       services.postfix = {
         enable = true;
         enableSubmission = true;
-        hostname = role.mailHost;
-        extraConfig = lib.concatStringsSep "\n" mainCf;
-        extraMasterConf = lib.concatStringsSep "\n" masterCf;
-        config.recipient_canonical_maps = lib.mkDefault "pcre:${recipientCanonical}";
-        # Trust all networks on the SRV interface.
-        networks = lib.mkDefault (
-          map fclib.quoteIPv6Address (attrNames (lib.attrByPath [ "srv" "networks" ] { } interfaces))
+        extraConfig = lib.mkIf (builtins.pathExists "/etc/local/postfix/main.cf") (
+          fclib.configFromFile "/etc/local/postfix/main.cf" ""
         );
-        destination = lib.mkDefault [
-          "localhost"
-          role.mailHost
-          config.networking.hostName
-          "${config.networking.hostName}.fcio.net"
-          "${config.networking.hostName}.gocept.net"
-        ];
+        extraMasterConf = lib.mkIf (builtins.pathExists "/etc/local/postfix/master.cf") (
+          fclib.configFromFile "/etc/local/postfix/master.cf" ""
+        );
+        settings.main = {
+          hostname = role.mailHost;
+          recipient_canonical_maps = lib.mkDefault "pcre:${recipientCanonical}";
+          # Trust all networks on the SRV interface.
+          mynetworks = lib.mkDefault (
+            map fclib.quoteIPv6Address (attrNames (lib.attrByPath [ "srv" "networks" ] { } interfaces))
+          );
+          mydestination = lib.mkDefault [
+            "localhost"
+            role.mailHost
+            config.networking.hostName
+            "${config.networking.hostName}.fcio.net"
+            "${config.networking.hostName}.gocept.net"
+          ];
+        }
+        // lib.optionalAttrs role.explicitSmtpBind {
+          smtp_bind_address = role.smtpBind4;
+          smtp_bind_address6 = role.smtpBind6;
+        };
         rootAlias = role.rootAlias;
       };
 

--- a/release/versions.json
+++ b/release/versions.json
@@ -14,10 +14,10 @@
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/"
   },
   "nixpkgs": {
-    "hash": "sha256-rNEGlJPHnkuk6SF8/cRNNsnpp+uwZFTtD7PeN/J0v8g=",
+    "hash": "sha256-dWx+/dACGvpsqvh2d8InZcbP8dVrfRVm1IZ0rxQCEyM=",
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "3f7f249ee92986cd5ede37035f4b431f816cc5df"
+    "rev": "4388ac52e37ed1b6ec40546a2e8c98071812b04f"
   },
   "nixpkgs-21_05": {
     "hash": "sha256-5ufC/t0sUFS/LspiEwU8DW5+uVYM3diZ1IC7KjX9ek4=",

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -77,9 +77,8 @@ in
   loghost = callTest ./loghost.nix { };
   login = callTest ./login.nix { };
   logrotate = callTest ./logrotate.nix { };
-  # FIXME: broken with `services.postfix.settings` migration (PL-133946)
-  # mail = callTest ./mail { };
-  # mailstub = callTest ./mail/stub.nix { };
+  mail = callTest ./mail { };
+  mailstub = callTest ./mail/stub.nix { };
   matomo = callTest ./matomo.nix { };
   memcached = callTest ./memcached.nix { };
   mongodb32 = callTest ./mongodb.nix { version = "3.2"; };


### PR DESCRIPTION
PL-133946

@flyingcircusio/release-managers

## Release process

- [ ] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [x] Security requirements tested? (EVIDENCE)
  - functionality ensured by Hydra tests
  - We just use equivalent options here, so breakage is less assumed
