### PR TITLE
nginx: enable buffering by default, but not to disk.

### DIFF
--- a/changelog.d/20250814_134717_fc-25.05-dev_scriv.md
+++ b/changelog.d/20250814_134717_fc-25.05-dev_scriv.md
@@ -1,0 +1,17 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+
+### NixOS XX.XX platform
+
+- nginx: re-enable proxy buffering, but only in memory. (FC-47149)

--- a/nixos/services/nginx/default.nix
+++ b/nixos/services/nginx/default.nix
@@ -186,6 +186,11 @@ let
       '}';
 
       access_log syslog:server=127.0.0.1:51893 json_analytics;
+
+      ## Proxy defaults: buffer, but only to RAM.
+      proxy_buffering                 on;
+      proxy_request_buffering         on;
+      proxy_max_temp_file_size        0;
     ''}
 
     # === Buffers and timeouts ===


### PR DESCRIPTION
We generally disabled buffering because it creates noise on the (network-based) disks.

However, we do want in-memory buffering.

Re FC-47149

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [ ] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [ ] Security requirements tested? (EVIDENCE)
