### PR TITLE
varnish: default.vcl is not going to be deprecated.

### DIFF
--- a/changelog.d/20250818_082047_PL-133914-remove-vcl-deprecation-warning_scriv.md
+++ b/changelog.d/20250818_082047_PL-133914-remove-vcl-deprecation-warning_scriv.md
@@ -1,0 +1,17 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+
+### NixOS XX.XX platform
+
+- Remove warning that file-based VCL configuration for varnish would be deprecated. (PL-133914)

--- a/doc/src/webproxy.md
+++ b/doc/src/webproxy.md
@@ -35,8 +35,6 @@ As with all NixOS modules, put your configuration into an appropriately named fi
 in the {file}`/etc/local/nixos` directory, e.g. {file}`/etc/local/nixos/varnish.nix`.
 
 You can also put your verbatim Varnish configuration into {file}`/etc/local/varnish/default.vcl`.
-Please note that this way of configuring Varnish is deprecated and will likely
-be removed in the future.
 
 The role passes a handful of command line arguments to Varnish to
 ensure reasonable default behaviour. If you wish to pass extra command


### PR DESCRIPTION
Re PL-133914

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

n/a

- [x] Security requirements tested? (EVIDENCE)

n/a