### PR TITLE
open-webui: init role

### DIFF
--- a/changelog.d/20250826_121357_PL-133951-openwebui_scriv.md
+++ b/changelog.d/20250826_121357_PL-133951-openwebui_scriv.md
@@ -1,0 +1,20 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+
+
+### NixOS XX.XX platform
+
+- open-webui: add as new role that automatically integrates with the Flying Circus AI services.

--- a/doc/src/index.md
+++ b/doc/src/index.md
@@ -48,6 +48,7 @@ mongodb
 mysql
 nfs
 opensearch
+open-webui
 postgresql
 rabbitmq
 redis

--- a/doc/src/open-webui.md
+++ b/doc/src/open-webui.md
@@ -10,9 +10,9 @@ Managed instance of the [Open WebUI](https://openwebui.com/) LLM interface. It a
 
 % TODO: link to subscription, verify subscription naming
 
-A *Flying Circus AI Services* subscription is required for this role.
+A *Flying Circus AI Services* subscription is required for this role. An access token must be created in the customer portal to allow the Open WebUI instance to access our central AI gateway.
 
-Enabling the `open-webui` role automatically sets up Open WebUI available under `https://ai-chat.<resource group name>.fcio.net`. As the first account accessing the application after installation automatically gains administrator privileges, we recommend that a designated admininstrator logs in immediately after setting up the role.
+Enabling the `open-webui` role automatically sets up Open WebUI available under `https://ai-chat.<resource group>.fcio.net`. The access token from the customer portal must then be copied into the file `/etc/local/open-webui/secret` on the VM with the role assigned. As the first account accessing the application after installation automatically gains administrator privileges, we recommend that a designated administrator logs in immediately after the role is assigned and configured.
 
 ## User Management
 

--- a/doc/src/open-webui.md
+++ b/doc/src/open-webui.md
@@ -1,0 +1,26 @@
+(nixos-role-open-webui)=
+
+# Open WebUI
+
+Managed instance of the [Open WebUI](https://openwebui.com/) LLM interface. It automatically integrates with the *Flying Circus AI services*.
+% TODO: link to more general FC AI docs/ overview
+
+## Initial Setup
+
+
+% TODO: link to subscription, verify subscription naming
+
+A *Flying Circus AI Services* subscription is required for this role.
+
+Enabling the `open-webui` role automatically sets up Open WebUI available under `https://ai-chat.<resource group name>.fcio.net`. As the first account accessing the application after installation automatically gains administrator privileges, we recommend that a designated admininstrator logs in immediately after setting up the role.
+
+## User Management
+
+User access is centrally managed via [Flying Circus users](/platform/reference/users/index.html). By default, all members of the resource group are able to log in to the service.  \
+To require the approval of an Open WebUI administrator, set `flyingcircus.roles.open-webui.usersNeedApproval = true;` via NixOS config. New users may then be approved by clicking their *pending* role badge in the administrator interface.
+
+User roles and groups have to be manually managed in the Open WebUI administrator settings. The first user successfully logging in after the initial setup of the role receives administrator privileges. Additional administrators can be authorised by that user in the Open WebUI administrator interface.
+
+## Available AI Models
+
+All models available through our *Flying Circus AI services* are automatically discovered by Open WebUI, but are only available to administrators by default. Under *Administration -> Settings -> Models*, each model can be either set public or be made accessible to certain groups.

--- a/nixos/roles/default.nix
+++ b/nixos/roles/default.nix
@@ -37,6 +37,7 @@ in
     ./nginx.nix
     ./opensearch.nix
     ./opensearch_dashboards.nix
+    ./open-webui.nix
     ./postgresql.nix
     ./rabbitmq.nix
     ./redis.nix

--- a/nixos/roles/open-webui.nix
+++ b/nixos/roles/open-webui.nix
@@ -10,7 +10,14 @@ let
   scfg = config.services.open-webui;
   fclib = config.fclib;
   inherit (builtins) head;
-  inherit (lib) mkOption mkEnableOption types;
+  inherit (lib)
+    mkOption
+    mkEnableOption
+    mkOverride
+    types
+    optional
+    optionalString
+    ;
 in
 {
   options.flyingcircus.roles.open-webui = {
@@ -35,6 +42,13 @@ in
     };
     # expose through role config for better visibility
     environmentFile = options.services.open-webui.environmentFile;
+    llmApiSecretFile = mkOption {
+      example = "/etc/local/open-webui/secret";
+      default = null;
+      type = types.nullOr types.str;
+      description = "A file containing the authentication secret for the Flying
+      Circus AI Provider.";
+    };
   };
 
   # TODO: role shall also configure an nginx with TLS (or webgateway?)
@@ -66,10 +80,29 @@ in
       environmentFile = cfg.environmentFile;
     };
 
+    systemd.services.open-webui.serviceConfig = {
+      LoadCredential = optional (cfg.llmApiSecretFile != null) "OPENAI_API_KEYS:${cfg.llmApiSecretFile}";
+      ExecStart =
+        let
+          execStart = pkgs.writeShellScriptBin "open-webui-start" ''
+            ${optionalString (
+              cfg.llmApiSecretFile != null
+            ) "export OPENAI_API_KEYS=$(<$CREDENTIALS_DIRECTORY/OPENAI_API_KEYS)"}
+            exec ${lib.getExe scfg.package} serve --host "${scfg.host}" --port ${toString scfg.port}
+          '';
+        in
+        mkOverride 90 "${execStart}/bin/open-webui-start";
+    };
+
+    flyingcircus.localConfigDirs.open-webui = {
+      dir = "/etc/local/open-webui";
+    };
+
     networking.firewall.allowedTCPPorts = [
       80
       443
     ];
+
     services.nginx = {
       enable = true;
       recommendedGzipSettings = true;
@@ -98,7 +131,6 @@ in
         };
       };
     };
-
   };
 
 }

--- a/nixos/roles/open-webui.nix
+++ b/nixos/roles/open-webui.nix
@@ -86,6 +86,9 @@ in
         # We do *not* want that and assume convergent configuration behaviour, so
         # let's disable this.
         ENABLE_PERSISTENT_CONFIG = "False";
+
+        ENABLE_VERSION_UPDATE_CHECK = "False";
+        CORS_ALLOW_ORIGIN = "https://${cfg.hostName}";
       };
       # Having a dedicated file only containing that secret would be neat though.
       environmentFile = cfg.environmentFile;

--- a/nixos/roles/open-webui.nix
+++ b/nixos/roles/open-webui.nix
@@ -70,7 +70,7 @@ in
         ENABLE_OAUTH_SIGNUP = "true";
         OAUTH_CLIENT_ID = "${config.networking.hostName}_open-webui";
         OPENID_PROVIDER_URL = "https://auth.flyingcircus.io/realms/fcio/.well-known/openid-configuration";
-        OAUTH_PROVIDER_NAME = "FCIO";
+        OAUTH_PROVIDER_NAME = "Flying Circus";
         OAUTH_MERGE_ACCOUNTS_BY_EMAIL = "true";
         # manage admin approval of new users from OIDC
         DEFAULT_USER_ROLE = if cfg.usersNeedApproval then "pending" else "user";

--- a/nixos/roles/open-webui.nix
+++ b/nixos/roles/open-webui.nix
@@ -23,7 +23,8 @@ in
   options.flyingcircus.roles.open-webui = {
     enable = mkEnableOption "Enable the Flying Circus Open WebUI role";
     hostName = mkOption {
-      default = fclib.fqdn { vlan = "fe"; };
+      default = "ai-chat.${config.flyingcircus.enc.parameters.resource_group}.fcio.net";
+      defaultText = "ai-chat.<resource group>.fcio.net";
       type = types.str;
       description = ''
         Host name for the Open WebUI frontend.
@@ -57,13 +58,17 @@ in
       enable = true;
       host = head fclib.network.srv.v4.addresses;
       environment = {
-        #ENABLE_SIGNUP = "false";
-        #ENABLE_LOGIN_FORM = "false";
-        #ENABLE_OAUTH_SIGNUP = "true";
-        #OAUTH_CLIENT_ID = "fc-ai-chat-FIXME";
-        #OPENID_PROVIDER_URL = "https://auth.flyingcircus.io/realms/fcio/.well-known/openid-configuration";
-        #OAUTH_PROVIDER_NAME = "FCIO";
-        #OAUTH_MERGE_ACCOUNTS_BY_EMAIL = "true";
+        ENABLE_SIGNUP = "false";
+        ENABLE_LOGIN_FORM = "false";
+        ENABLE_OAUTH_SIGNUP = "true";
+        OAUTH_CLIENT_ID = "${config.networking.hostName}_open-webui";
+        OPENID_PROVIDER_URL = "https://auth.flyingcircus.io/realms/fcio/.well-known/openid-configuration";
+        OAUTH_PROVIDER_NAME = "FCIO";
+        OAUTH_MERGE_ACCOUNTS_BY_EMAIL = "true";
+        # do not require admin approval of new users from OIDC
+        DEFAULT_USER_ROLE = "user";
+        # XXX this gets written into the nix store – acceptable?
+        OAUTH_CLIENT_SECRET = fclib.derivePasswordForHost "oidc_open-webui";
 
         OPENAI_API_BASE_URLS = cfg.llmApiUrl;
 
@@ -74,10 +79,11 @@ in
         ENABLE_PERSISTENT_CONFIG = "False";
       };
       # FIXME: populate OAUTH secrets automatically
-      # XXX: We assume for now that the API key is written into the secrets file
-      # as an `OPENAI_API_KEY`.
       # Having a dedicated file only containing that secret would be neat though.
       environmentFile = cfg.environmentFile;
+    };
+    flyingcircus.localConfigDirs.open-webui = {
+      dir = "/etc/local/open-webui";
     };
 
     systemd.services.open-webui.serviceConfig = {

--- a/nixos/roles/open-webui.nix
+++ b/nixos/roles/open-webui.nix
@@ -41,6 +41,14 @@ in
         In most cases, this should NOT contain a trailing /.
       '';
     };
+    usersNeedApproval = mkOption {
+      default = false;
+      type = types.boolean;
+      description = ''
+        Configure whether new users require admin approval after
+        their initial successful login. This approval can be given in the
+        admin settings.'';
+    };
     # expose through role config for better visibility
     environmentFile = options.services.open-webui.environmentFile;
     llmApiSecretFile = mkOption {
@@ -52,7 +60,6 @@ in
     };
   };
 
-  # TODO: role shall also configure an nginx with TLS (or webgateway?)
   config = lib.mkIf cfg.enable {
     services.open-webui = {
       enable = true;
@@ -65,8 +72,8 @@ in
         OPENID_PROVIDER_URL = "https://auth.flyingcircus.io/realms/fcio/.well-known/openid-configuration";
         OAUTH_PROVIDER_NAME = "FCIO";
         OAUTH_MERGE_ACCOUNTS_BY_EMAIL = "true";
-        # do not require admin approval of new users from OIDC
-        DEFAULT_USER_ROLE = "user";
+        # manage admin approval of new users from OIDC
+        DEFAULT_USER_ROLE = if cfg.usersNeedApproval then "pending" else "user";
         # XXX this gets written into the nix store – acceptable?
         OAUTH_CLIENT_SECRET = fclib.derivePasswordForHost "oidc_open-webui";
 
@@ -78,7 +85,6 @@ in
         # let's disable this.
         ENABLE_PERSISTENT_CONFIG = "False";
       };
-      # FIXME: populate OAUTH secrets automatically
       # Having a dedicated file only containing that secret would be neat though.
       environmentFile = cfg.environmentFile;
     };

--- a/nixos/roles/open-webui.nix
+++ b/nixos/roles/open-webui.nix
@@ -87,6 +87,7 @@ in
 
         ENABLE_VERSION_UPDATE_CHECK = "False";
         CORS_ALLOW_ORIGIN = "https://${cfg.hostName}";
+        ENABLE_EVALUATION_ARENA_MODELS = "False";
       };
     };
 

--- a/nixos/roles/open-webui.nix
+++ b/nixos/roles/open-webui.nix
@@ -34,7 +34,7 @@ in
       example = "chat.example.com";
     };
     upstreamUrl = mkOption {
-      default = "https://ai.${location}.fcio.net";
+      default = "https://ai.${location}.fcio.net/openai/v1";
       type = types.str;
       description = ''
         Endpoint of the (OpenAI-style) LLM API used as main upstream AI provider.

--- a/nixos/roles/open-webui.nix
+++ b/nixos/roles/open-webui.nix
@@ -82,9 +82,6 @@ in
       # Having a dedicated file only containing that secret would be neat though.
       environmentFile = cfg.environmentFile;
     };
-    flyingcircus.localConfigDirs.open-webui = {
-      dir = "/etc/local/open-webui";
-    };
 
     systemd.services.open-webui.serviceConfig = {
       LoadCredential = optional (cfg.llmApiSecretFile != null) "OPENAI_API_KEYS:${cfg.llmApiSecretFile}";

--- a/nixos/roles/open-webui.nix
+++ b/nixos/roles/open-webui.nix
@@ -1,0 +1,104 @@
+{
+  config,
+  options,
+  pkgs,
+  lib,
+  ...
+}:
+let
+  cfg = config.flyingcircus.roles.open-webui;
+  scfg = config.services.open-webui;
+  fclib = config.fclib;
+  inherit (builtins) head;
+  inherit (lib) mkOption mkEnableOption types;
+in
+{
+  options.flyingcircus.roles.open-webui = {
+    enable = mkEnableOption "Enable the Flying Circus Open WebUI role";
+    hostName = mkOption {
+      default = fclib.fqdn { vlan = "fe"; };
+      type = types.str;
+      description = ''
+        Host name for the Open WebUI frontend.
+        A Letsencrypt certificate is generated for it.
+        Defaults to the FE FQDN.
+      '';
+      example = "chat.example.com";
+    };
+    llmApiUrl = mkOption {
+      default = "https://api.ai.flyingcircus.io";
+      type = types.str;
+      description = ''
+        Endpoint of the (OpenAI-style) LLM API used as main upstream AI provider.
+        In most cases, this should NOT contain a trailing /.
+      '';
+    };
+    # expose through role config for better visibility
+    environmentFile = options.services.open-webui.environmentFile;
+  };
+
+  # TODO: role shall also configure an nginx with TLS (or webgateway?)
+  config = lib.mkIf cfg.enable {
+    services.open-webui = {
+      enable = true;
+      host = head fclib.network.srv.v4.addresses;
+      environment = {
+        #ENABLE_SIGNUP = "false";
+        #ENABLE_LOGIN_FORM = "false";
+        #ENABLE_OAUTH_SIGNUP = "true";
+        #OAUTH_CLIENT_ID = "fc-ai-chat-FIXME";
+        #OPENID_PROVIDER_URL = "https://auth.flyingcircus.io/realms/fcio/.well-known/openid-configuration";
+        #OAUTH_PROVIDER_NAME = "FCIO";
+        #OAUTH_MERGE_ACCOUNTS_BY_EMAIL = "true";
+
+        OPENAI_API_BASE_URLS = cfg.llmApiUrl;
+
+        # Normally, openwebui would persist certain credentials, like OPENAI_API_KEY,
+        # into the database, never updating it again on changes.
+        # We do *not* want that and assume convergent configuration behaviour, so
+        # let's disable this.
+        ENABLE_PERSISTENT_CONFIG = "False";
+      };
+      # FIXME: populate OAUTH secrets automatically
+      # XXX: We assume for now that the API key is written into the secrets file
+      # as an `OPENAI_API_KEY`.
+      # Having a dedicated file only containing that secret would be neat though.
+      environmentFile = cfg.environmentFile;
+    };
+
+    networking.firewall.allowedTCPPorts = [
+      80
+      443
+    ];
+    services.nginx = {
+      enable = true;
+      recommendedGzipSettings = true;
+      recommendedOptimisation = true;
+      recommendedProxySettings = true;
+      recommendedTlsSettings = true;
+      virtualHosts.${cfg.hostName} = {
+        enableACME = true;
+        forceSSL = true;
+        locations = {
+          "/" = {
+            proxyPass = "http://${scfg.host}:${toString scfg.port}";
+            extraConfig = ''
+              proxy_read_timeout 1200s;
+              proxy_buffering off;
+            '';
+          };
+          "/ws/" = {
+            proxyPass = "http://${scfg.host}:${toString scfg.port}";
+            extraConfig = ''
+              proxy_http_version 1.1;
+              proxy_set_header Upgrade $http_upgrade;
+              proxy_set_header Connection "upgrade";
+            '';
+          };
+        };
+      };
+    };
+
+  };
+
+}

--- a/nixos/roles/open-webui.nix
+++ b/nixos/roles/open-webui.nix
@@ -9,14 +9,14 @@ let
   cfg = config.flyingcircus.roles.open-webui;
   scfg = config.services.open-webui;
   fclib = config.fclib;
+  inherit (config.flyingcircus) location;
   inherit (builtins) head;
   inherit (lib)
     mkOption
     mkEnableOption
     mkOverride
     types
-    optional
-    optionalString
+    optionalAttrs
     ;
 in
 {
@@ -33,8 +33,8 @@ in
       '';
       example = "chat.example.com";
     };
-    llmApiUrl = mkOption {
-      default = "https://api.ai.flyingcircus.io";
+    upstreamUrl = mkOption {
+      default = "https://ai.${location}.fcio.net";
       type = types.str;
       description = ''
         Endpoint of the (OpenAI-style) LLM API used as main upstream AI provider.
@@ -49,9 +49,7 @@ in
         their initial successful login. This approval can be given in the
         admin settings.'';
     };
-    # expose through role config for better visibility
-    environmentFile = options.services.open-webui.environmentFile;
-    llmApiSecretFile = mkOption {
+    secretFile = mkOption {
       example = "/etc/local/open-webui/secret";
       default = null;
       type = types.nullOr types.str;
@@ -65,7 +63,7 @@ in
   config = lib.mkIf cfg.enable {
     services.open-webui = {
       enable = true;
-      host = head fclib.network.srv.v4.addresses;
+      host = fclib.mkPlatform config.networking.hostName;
       environment = {
         ENABLE_SIGNUP = "false";
         ENABLE_LOGIN_FORM = "false";
@@ -76,10 +74,10 @@ in
         OAUTH_MERGE_ACCOUNTS_BY_EMAIL = "true";
         # manage admin approval of new users from OIDC
         DEFAULT_USER_ROLE = if cfg.usersNeedApproval then "pending" else "user";
-        # XXX this gets written into the nix store – acceptable?
+        # XXX this gets written into the nix store
         OAUTH_CLIENT_SECRET = fclib.derivePasswordForHost "oidc_open-webui";
 
-        OPENAI_API_BASE_URLS = cfg.llmApiUrl;
+        OPENAI_API_BASE_URLS = cfg.upstreamUrl;
 
         # Normally, openwebui would persist certain credentials, like OPENAI_API_KEY,
         # into the database, never updating it again on changes.
@@ -90,18 +88,14 @@ in
         ENABLE_VERSION_UPDATE_CHECK = "False";
         CORS_ALLOW_ORIGIN = "https://${cfg.hostName}";
       };
-      # Having a dedicated file only containing that secret would be neat though.
-      environmentFile = cfg.environmentFile;
     };
 
-    systemd.services.open-webui.serviceConfig = {
-      LoadCredential = optional (cfg.llmApiSecretFile != null) "OPENAI_API_KEYS:${cfg.llmApiSecretFile}";
+    systemd.services.open-webui.serviceConfig = optionalAttrs (cfg.secretFile != null) {
+      LoadCredential = "OPENAI_API_KEYS:${cfg.secretFile}";
       ExecStart =
         let
           execStart = pkgs.writeShellScriptBin "open-webui-start" ''
-            ${optionalString (
-              cfg.llmApiSecretFile != null
-            ) "export OPENAI_API_KEYS=$(<$CREDENTIALS_DIRECTORY/OPENAI_API_KEYS)"}
+            export OPENAI_API_KEYS=$(<$CREDENTIALS_DIRECTORY/OPENAI_API_KEYS)
             exec ${lib.getExe scfg.package} serve --host "${scfg.host}" --port ${toString scfg.port}
           '';
         in

--- a/nixos/roles/open-webui.nix
+++ b/nixos/roles/open-webui.nix
@@ -43,7 +43,7 @@ in
     };
     usersNeedApproval = mkOption {
       default = false;
-      type = types.boolean;
+      type = types.bool;
       description = ''
         Configure whether new users require admin approval after
         their initial successful login. This approval can be given in the
@@ -55,8 +55,10 @@ in
       example = "/etc/local/open-webui/secret";
       default = null;
       type = types.nullOr types.str;
-      description = "A file containing the authentication secret for the Flying
-      Circus AI Provider.";
+      description = ''
+        A file containing the authentication secret for the Flying
+        Circus AI Provider.
+      '';
     };
   };
 
@@ -100,7 +102,7 @@ in
             exec ${lib.getExe scfg.package} serve --host "${scfg.host}" --port ${toString scfg.port}
           '';
         in
-        mkOverride 90 "${execStart}/bin/open-webui-start";
+        mkOverride 90 (lib.getExe execStart);
     };
 
     flyingcircus.localConfigDirs.open-webui = {

--- a/nixos/roles/open-webui.nix
+++ b/nixos/roles/open-webui.nix
@@ -109,34 +109,18 @@ in
       dir = "/etc/local/open-webui";
     };
 
-    networking.firewall.allowedTCPPorts = [
-      80
-      443
-    ];
-
-    services.nginx = {
+    flyingcircus.services.nginx = {
       enable = true;
-      recommendedGzipSettings = true;
-      recommendedOptimisation = true;
-      recommendedProxySettings = true;
-      recommendedTlsSettings = true;
       virtualHosts.${cfg.hostName} = {
         enableACME = true;
         forceSSL = true;
         locations = {
           "/" = {
             proxyPass = "http://${scfg.host}:${toString scfg.port}";
+            proxyWebsockets = true;
             extraConfig = ''
               proxy_read_timeout 1200s;
               proxy_buffering off;
-            '';
-          };
-          "/ws/" = {
-            proxyPass = "http://${scfg.host}:${toString scfg.port}";
-            extraConfig = ''
-              proxy_http_version 1.1;
-              proxy_set_header Upgrade $http_upgrade;
-              proxy_set_header Connection "upgrade";
             '';
           };
         };

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -95,6 +95,7 @@ in
   opensearch = callTest ./opensearch.nix { };
   opensearch_dashboards = callTest ./opensearch_dashboards.nix { };
   openvpn = callTest ./openvpn.nix { };
+  open-webui = callTest ./open-webui { };
   percona80 = callTest ./mysql.nix { rolename = "percona80"; };
   percona83 = callTest ./mysql.nix { rolename = "percona83"; };
   percona84 = callTest ./mysql.nix { rolename = "percona84"; };

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -95,7 +95,7 @@ in
   opensearch = callTest ./opensearch.nix { };
   opensearch_dashboards = callTest ./opensearch_dashboards.nix { };
   openvpn = callTest ./openvpn.nix { };
-  open-webui = callTest ./open-webui { };
+  open-webui = callTest ./open-webui.nix { };
   percona80 = callTest ./mysql.nix { rolename = "percona80"; };
   percona83 = callTest ./mysql.nix { rolename = "percona83"; };
   percona84 = callTest ./mysql.nix { rolename = "percona84"; };

--- a/tests/open-webui.nix
+++ b/tests/open-webui.nix
@@ -1,0 +1,31 @@
+import ./make-test-python.nix (
+  { pkgs, testlib, ... }:
+  let
+  in
+  {
+    name = "open-webui";
+    nodes.machine =
+      {
+        pkgs,
+        lib,
+        config,
+        ...
+      }:
+      {
+        imports = [ (testlib.fcConfig { id = 1; }) ];
+
+        flyingcircus.roles.open-webui.enable = true;
+
+        # cannot download sentence transformers model without network
+        # connection.
+        services.open-webui.environment.RAG_EMBEDDING_MODEL = "";
+      };
+    testScript = ''
+      machine.wait_for_unit("multi-user.target")
+
+      # open webui is slow to boot, but should eventually respond
+      # with http status 200
+      machine.wait_until_succeeds("curl http://192.168.3.1:8080", timeout=30)
+    '';
+  }
+)

--- a/tests/open-webui.nix
+++ b/tests/open-webui.nix
@@ -13,6 +13,11 @@ import ./make-test-python.nix (
       }:
       {
         imports = [ (testlib.fcConfig { id = 1; }) ];
+        networking.domain = "fcio.net";
+        networking.extraHosts = ''
+          ${builtins.head config.fclib.network.srv.v4.addresses} machine
+          ${builtins.head config.fclib.network.srv.v6.addresses} machine
+        '';
 
         flyingcircus.roles.open-webui.enable = true;
 


### PR DESCRIPTION
@flyingcircusio/release-managers

PL-133951

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - integrate authentication system with Flying Circus directory
  - ensure compatibility of role and NixOS upstream module
  - permission model needs to be known by the users
- [x] Security requirements tested? (EVIDENCE)
  - NixOS smoke test for role, ensuring that the NixOS code evaluates and the ExecStart remains compatible
  - manually tested OIDC auth integration with a dev deployment of the directory
  - permission model is documented