### PR TITLE
Update FRR to 10.1.4

### DIFF
--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -168,12 +168,12 @@ builtins.mapAttrs (_: patchPhps phpLogPermissionPatch) {
   });
 
   frr = super.frr.overrideAttrs (old: rec {
-    version = "10.1.3";
+    version = "10.1.4";
     src = super.fetchFromGitHub {
       owner = "FRRouting";
       repo = old.pname;
       rev = "${old.pname}-${version}";
-      hash = "sha256-bfCNh/ZjHtZAoij7kimFDZzCcGTHshcFaPM+yq9bBJQ=";
+      hash = "sha256-rH/MuOrCKrWepZH8w/FQBuwx0OkKL9+o6JkhWtzffvo=";
     };
 
     patches = [


### PR DESCRIPTION
This change updates FRR to 10.1.4, the latest patch release in the 10.1 series.

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh` => none, internal change

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Regular update of third party software
- [x] Security requirements tested? (EVIDENCE)
  - Hydra tests pass. Further smoke testing to be achieved by letting this change run in dev and staging in advance of production release.
  - There are newer minor releases of FRR (10.2, 10.3), but I'm staying on 10.1 for now as we have limited capacity for more thorough acceptance testing of newer versions currently.
