### PR TITLE
devhost: remove insecure performance improvements options

### DIFF
--- a/changelog.d/20250829_110448_HEAD_scriv.md
+++ b/changelog.d/20250829_110448_HEAD_scriv.md
@@ -1,0 +1,24 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+
+### NixOS XX.XX platform
+
+- devhost: remove insecure performance improvement options for PostgreSQL. (PL-133628)
+
+  We saw multiple PostgreSQL instances not starting correctly after an unclean shutdown of
+  the instance. In performance testing we saw a negligible benefit only.
+
+  Note that this only affected customers on devhosts.

--- a/nixos/infrastructure/dev-vm.nix
+++ b/nixos/infrastructure/dev-vm.nix
@@ -85,9 +85,6 @@ in
 
       systemd.services.postgresql.bindsTo = lib.mkForce [ ];
       services.postgresql.settings.listen_addresses = lib.mkOverride 20 "0.0.0.0,::";
-      services.postgresql.settings.fsync = "off";
-      services.postgresql.settings.full_page_writes = "off";
-      services.postgresql.settings.synchronous_commit = "off";
 
       flyingcircus.roles.antivirus.listenAddresses = [ "::" ];
 


### PR DESCRIPTION
@flyingcircusio/release-managers

We saw that these options lead to outages on customer side on their
devhosts multiple times now. The performance benefit is neglegible
(3m18s vs 3m26s in the directory testsuite)

PL-133628

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - This goes back to the safer set of options
- [x] Security requirements tested? (EVIDENCE)
  - tested performance impact on devhost vm