### PR TITLE
[PL-134006] fix the nginx configuration for grafana

### DIFF
--- a/changelog.d/20250901_103510_PL-134006-adjust-grafana-nginx-config_scriv.md
+++ b/changelog.d/20250901_103510_PL-134006-adjust-grafana-nginx-config_scriv.md
@@ -1,0 +1,21 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+-
+
+### NixOS XX.XX platform
+
+- Remove a misconfigured alias in the automatically generated Nginx configuration for the Grafana service that is enabled as part of the statshost role.
+  This lead to plugins not loading for example due to a change in how Grafana routes to them interally. (PL-134006)

--- a/nixos/roles/statshost/default.nix
+++ b/nixos/roles/statshost/default.nix
@@ -585,7 +585,6 @@ in
               proxy_pass http://${prometheusListenAddress};
             '';
             "/grafana/".proxyPass = "http://127.0.0.1:3001/";
-            "/grafana/public/".alias = "${pkgs.grafana}/share/grafana/public/";
           };
         };
       };


### PR DESCRIPTION
The `/grafana/public/` alias here needs to be removed since for example the javascript files for plugins are located elsewhere. Grafana handles the routing to these static files so we can just pass all requests through to it.

PL-134006

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [x] Security requirements tested? (EVIDENCE)

this pr does not introduce changes that affect security
