### PR TITLE
nixos/kernel: remove unnecessary useNixStoreImage in tests after 9pfs fix has landed in kernel

### DIFF
--- a/tests/k3s/monitoring.nix
+++ b/tests/k3s/monitoring.nix
@@ -55,7 +55,6 @@ import ../make-test-python.nix (
 
           virtualisation.memorySize = 2000;
           virtualisation.diskSize = lib.mkForce 3000;
-          virtualisation.useNixStoreImage = true; # PL-133821 - 6.12 crashes v9fs in some situations
 
           virtualisation.vlans = [
             1

--- a/tests/matomo.nix
+++ b/tests/matomo.nix
@@ -22,7 +22,6 @@ import ./make-test-python.nix (
 
         virtualisation.diskSize = 1024;
         virtualisation.memorySize = 2048;
-        virtualisation.useNixStoreImage = true; # PL-133821 - 6.12 crashes v9fs in some situations
 
         networking.domain = "test";
 

--- a/tests/opensearch_dashboards.nix
+++ b/tests/opensearch_dashboards.nix
@@ -22,7 +22,6 @@ import ./make-test-python.nix (
         networking.domain = "test";
         virtualisation.memorySize = 3072;
         virtualisation.diskSize = lib.mkForce 2000;
-        virtualisation.useNixStoreImage = true; # PL-133821 - 6.12 crashes v9fs in some situations
         virtualisation.qemu.options = [ "-smp 2" ];
         flyingcircus.roles.opensearch.enable = true;
         flyingcircus.roles.opensearch.nodes = [ "machine" ];


### PR DESCRIPTION
@flyingcircusio/release-managers

Supersedes #1726.
partial backport of https://github.com/flyingcircusio/fc-nixos/pull/1705, the patch has [reached kernel 6.12.44](https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.12.44)
in the meantime. (commit 4652d0b6f7e67fee22f1a1e172efb85368acac24 et
al.)


PL-133821

## Release process

- [ ] Created changelog entry using `./changelog.sh` => None, internal only

## PR release workflow (internal)

- [x] PR has internal ticket
- [ ] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - regression in I/O intensive tests should be resolved by the kernel update, tests pass again when using 9pfs
- [ ] Security requirements tested? (EVIDENCE)
  - [x] verified patch inclusion by looking at changelog of kernel 6.12.44
  - [ ] automated tests still pass
