### PR TITLE
roles.jitsi: Fix prosodyctl failures by conditionally loading TURN credentials

### DIFF
--- a/changelog.d/20250901_180411_PL-133672-prosodyctl-secrets_scriv.md
+++ b/changelog.d/20250901_180411_PL-133672-prosodyctl-secrets_scriv.md
@@ -1,0 +1,21 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+- prosody.service will be restarted, potentially interrupting Jitsi sessions.
+
+
+### NixOS XX.XX platform
+
+- jitsi: fix interactive invocations of `prosodyctl` management command, it needs no access to the turncredentials_secret. (PL-133672)

--- a/nixos/roles/jitsi/default.nix
+++ b/nixos/roles/jitsi/default.nix
@@ -379,12 +379,19 @@ in
           cross_domain_websocket = true;
           consider_websocket_secure = true;
 
-          -- FIXME when prosody is updated to v13, use
-          --   turncredentials_secret = Credential("turncredentials_secret")
+          -- `prosodyctl` also reads and executes this config file, but has no
+          -- access to systemd credentials when running outside the service
+          -- context. But it does not require that secret anyways.
           local credentials_directory = os.getenv("CREDENTIALS_DIRECTORY")
-          local secret = assert(io.open(credentials_directory .. "/turncredentials_secret", "r"))
-          turncredentials_secret = secret:read("*a"):gsub("\n*$", "")
-          secret:close()
+          if credentials_directory then
+            -- FIXME when prosody is updated to v13, use
+            --   turncredentials_secret = Credential("turncredentials_secret")
+            local secret = assert(io.open(credentials_directory .. "/turncredentials_secret", "r"))
+            turncredentials_secret = secret:read("*a"):gsub("\n*$", "")
+            secret:close()
+          else
+            print("Warning: Running outside of systemd service context, `turncredentials_secret` will not be set")
+          end
           turncredentials = {
             { type = "turn",
               host = "${turnHostName}",


### PR DESCRIPTION
@flyingcircusio/release-managers

Fixed prosodyctl failures when running outside systemd service context by making TURN credential loading conditional on CREDENTIALS_DIRECTORY environment variable availability.

PL-133986

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - the turn secret only needs to be accessible via the systemd unit – principle of least privilege and least access
  - verify `prosodyctl` indeed does not require access to that secret
  - provide information on what is going on.
- [x] Security requirements tested? (EVIDENCE)
  - [x] manually tested a jitsi call on jitsitest VM
  - [x] manually tested various prosodyctl commands
  - [x] inspected log files of prosodyctl.service for proper turncredentials loading
  - unfortunately, we do not have a NixOS test for the jitsi role.