### PR TITLE
vendor 21.05 dependencies in a lazy way

### DIFF
--- a/changelog.d/20250902_113702_os-lazy-old-nixpkgs-channels_scriv.md
+++ b/changelog.d/20250902_113702_os-lazy-old-nixpkgs-channels_scriv.md
@@ -1,0 +1,19 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+
+### NixOS XX.XX platform
+
+- Reduce size of fc-nixos release tarballs. Pinned old nixpkgs channels are only pulled in on-demand, not occupying space on most machines.

--- a/flake.lock
+++ b/flake.lock
@@ -16,23 +16,6 @@
         "type": "gitlab"
       }
     },
-    "fc-nixos-21_05": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1738853477,
-        "narHash": "sha256-jXN15QR0e7JpXLpC9I4w6Arw2h0KUjgZMvSjv/aesms=",
-        "owner": "flyingcircusio",
-        "repo": "fc-nixos",
-        "rev": "cb34a33a284401eb8ae87ec5e90d8b9226d4cff2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "flyingcircusio",
-        "ref": "fc-21.05-production",
-        "repo": "fc-nixos",
-        "type": "github"
-      }
-    },
     "flake-compat": {
       "flake": false,
       "locked": {
@@ -199,22 +182,6 @@
         "type": "github"
       }
     },
-    "nixpkgs-21_05": {
-      "locked": {
-        "lastModified": 1722265539,
-        "narHash": "sha256-5ufC/t0sUFS/LspiEwU8DW5+uVYM3diZ1IC7KjX9ek4=",
-        "owner": "flyingcircusio",
-        "repo": "nixpkgs",
-        "rev": "a467063b4abb8bd7636d9bb2475edbd2f0e6c6b6",
-        "type": "github"
-      },
-      "original": {
-        "owner": "flyingcircusio",
-        "ref": "nixos-21.05",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs-lib": {
       "locked": {
         "lastModified": 1740877520,
@@ -256,11 +223,9 @@
     },
     "root": {
       "inputs": {
-        "fc-nixos-21_05": "fc-nixos-21_05",
         "flake-parts": "flake-parts",
         "nixos-mailserver": "nixos-mailserver",
         "nixpkgs": "nixpkgs",
-        "nixpkgs-21_05": "nixpkgs-21_05",
         "poetry2nix": "poetry2nix"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -31,11 +31,6 @@
       url = "github:nix-community/poetry2nix";
       inputs.nixpkgs.follows = "nixpkgs";
     };
-    nixpkgs-21_05.url = "github:flyingcircusio/nixpkgs/nixos-21.05";
-    fc-nixos-21_05 = {
-      url = "github:flyingcircusio/fc-nixos/fc-21.05-production";
-      flake = false;
-    };
   };
 
   outputs =

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -7,8 +7,19 @@ let
   # then use release-set as pkgs
   phps = (import ../nix-phps/pkgs/phps.nix) (../nix-phps) { } super;
 
-  nixpkgs-21_05-src = (import ../versions.nix { pkgs = super; }).nixpkgs-21_05;
-  fc-nixos-21_05-src = (import ../versions.nix { pkgs = super; }).fc-nixos-21_05;
+  nixpkgs-21_05-src = fetchFromGitHub {
+    hash = "sha256-5ufC/t0sUFS/LspiEwU8DW5+uVYM3diZ1IC7KjX9ek4=";
+    owner = "flyingcircusio";
+    repo = "nixpkgs";
+    rev = "a467063b4abb8bd7636d9bb2475edbd2f0e6c6b6";
+  };
+
+  fc-nixos-21_05-src = fetchFromGitHub {
+    hash = "sha256-jXN15QR0e7JpXLpC9I4w6Arw2h0KUjgZMvSjv/aesms=";
+    owner = "flyingcircusio";
+    repo = "fc-nixos";
+    rev = "cb34a33a284401eb8ae87ec5e90d8b9226d4cff2";
+  };
   fc-nixos-21_05 = builtins.trace "using fc-nixos-21.05" (
     import fc-nixos-21_05-src {
       inherit (self) config;

--- a/release/versions.json
+++ b/release/versions.json
@@ -1,10 +1,4 @@
 {
-  "fc-nixos-21_05": {
-    "hash": "sha256-jXN15QR0e7JpXLpC9I4w6Arw2h0KUjgZMvSjv/aesms=",
-    "owner": "flyingcircusio",
-    "repo": "fc-nixos",
-    "rev": "cb34a33a284401eb8ae87ec5e90d8b9226d4cff2"
-  },
   "nixos-mailserver": {
     "deepClone": false,
     "fetchSubmodules": false,
@@ -18,12 +12,6 @@
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
     "rev": "e6dbe6794e06cd2749cafe464c6b2256a748307f"
-  },
-  "nixpkgs-21_05": {
-    "hash": "sha256-5ufC/t0sUFS/LspiEwU8DW5+uVYM3diZ1IC7KjX9ek4=",
-    "owner": "flyingcircusio",
-    "repo": "nixpkgs",
-    "rev": "a467063b4abb8bd7636d9bb2475edbd2f0e6c6b6"
   },
   "poetry2nix": {
     "hash": "sha256-nzgO/ZCSBzWjbMkYDxG+yl9Z2eGbCgQu06Oku3ir5D4=",


### PR DESCRIPTION
Change the way we import the pinned 21.05 revisions of fc-nixos and nixpkgs, such that they are only lazyily pulled in when actually bein used by the current system. This removes them from our VM machines. The previous approach combined all channel sources to a tarball in a single derivation, deploying these inputs to all machines no matter whether they are needed. Splitting this into multiple derivations enables lazyness again.

Downsides:
- removes them from the channel tarball, making that one less self-contained
- convenient re-locking via flake inputs does not work anymore. But as these inputs are legacy repo branches not updated frequently anymore, that is tolerable.

@flyingcircusio/release-managers

This had already been built a while ago for the Ceph upgrade, but I've decided to pick this into fc-25.05 as we've seen higher disk usage on machines after they've been upgraded to fc-25.05.

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [ ] PR has internal ticket
- [ ] internal issue ID (PL-…) part of branch name
- [ ] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [x] ensure the merge bot has determined a merge date
- [x] ensure all checks are green
- [x] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - no regressions
- [x] Security requirements tested? (EVIDENCE)
  - [ ] automated tests still pass
  - [x] built on a VM that does not pull in fc-nixos_21_05
  - [x] built on a physical ceph host that does pull in fc-nixos_21_05