### PR TITLE
devhost: reattach guest tap interfaces when the bridge interface is restarted

### DIFF
--- a/changelog.d/20250902_155915_PL-133436-devhost-tap-reattachment_scriv.md
+++ b/changelog.d/20250902_155915_PL-133436-devhost-tap-reattachment_scriv.md
@@ -1,0 +1,21 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+
+### NixOS XX.XX platform
+
+- devhost: guest VM interfaces will now be correctly reattached to the
+  bridge on the host if the host bridge interface is restarted.
+  (PL-133436)

--- a/nixos/roles/devhost/vm.nix
+++ b/nixos/roles/devhost/vm.nix
@@ -219,6 +219,25 @@ in
     }
     // lib.mapAttrs' mkService cfg.virtualMachines
     // {
+      "fc-devhost-reattach-taps" = {
+        description = "Reattach all VM taps if needed";
+        wantedBy = [ "multi-user.target" ];
+        bindsTo = [ "br-vm-srv-netdev.service" ];
+        after = [ "br-vm-srv-netdev.service" ];
+
+        path = [ pkgs.jq pkgs.iproute2 ];
+        script = ''
+          for interface in $(ip -j link show | jq '.[] | .ifname' -r | egrep '^vm-srv-'); do
+            echo "Ensuring attachment of $interface"
+            ip link set $interface master br-vm-srv || true
+          done
+        '';
+
+        serviceConfig = {
+          Type = "oneshot";
+          RemainAfterExit = true;
+        };
+      };
       "fc-devhost-vm-cleanup" = {
         inherit (config.systemd.services.fc-agent) path;
         # duplicated from fc-agent.service


### PR DESCRIPTION
The devhost role provides network connectivity to guest VMs via a bridge interface on the host, to which the guest VMs each have a tap interface attached at boot time. However, if the host bridge interface is restarted (e.g. due to a large system channel update) then the guest interfaces are not reattached automatically, which leads to the guests becoming unreachable.

This change introduces an auxiliary systemd unit similar to the ones already used in the KVM role to ensure that when the host bridge interface is brought up then all existing guest tap interfaces are automatically (re)attached.

PL-133436

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [x] ensure the merge bot has determined a merge date
- [x] ensure all checks are green
- [x] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Host network configuration should be robust in order to ensure service availability.
- [x] Security requirements tested? (EVIDENCE)
  - Manually verified on the development devhost.
