### PR TITLE
Remove deprecated gateway addresses from WHQ keepalived config

### DIFF
--- a/nixos/roles/router/keepalived/whq.conf
+++ b/nixos/roles/router/keepalived/whq.conf
@@ -67,7 +67,6 @@ vrrp_instance mgm {
         2a06:3a80:0:1::1/64
     }
     virtual_ipaddress_excluded {
-        2a02:238:f030:101::1/64
         172.16.1.1/24
     }
 }
@@ -84,10 +83,7 @@ vrrp_instance fe {
         2a06:3a80:0:2::1/64
     }
     virtual_ipaddress_excluded {
-        2a02:238:f030:102::1/64
         185.105.255.1/25
-        212.122.41.129/27
-        212.122.41.193/27
     }
 }
 
@@ -103,9 +99,7 @@ vrrp_instance srv {
         2a06:3a80:0:3::1/64
     }
     virtual_ipaddress_excluded {
-        2a02:238:f030:103::1/64
         172.16.48.1/20
-        212.122.41.161/27
     }
 }
 
@@ -121,7 +115,6 @@ vrrp_instance video {
         2a06:3a80:0:23::1/64
     }
     virtual_ipaddress_excluded {
-        2a02:238:f030:117::1/64
         172.17.112.1/20
     }
 }
@@ -159,9 +152,7 @@ vrrp_instance access {
         2a06:3a80:0:41::1/64
     }
     virtual_ipaddress_excluded {
-        2a02:238:f030:129::1/64
         172.18.144.1/20
-        212.122.41.225/27
         185.105.255.193/27
     }
 }


### PR DESCRIPTION
This change removes some deprecated gateway addresses from the keepalived configuration in WHQ.

PL-133308

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh` => none, internal change

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Removing more addresses from the configuration which will no longer be usable after the end of the month.
- [x] Security requirements tested? (EVIDENCE)
  - Manually checked the directory to ensure that there are no remaining tenants in the deprecated subnets which may be using these gateway addresses.
