### PR TITLE
Update the default route for secondary router in whq

### DIFF
--- a/nixos/roles/router/bird2/whq.conf
+++ b/nixos/roles/router/bird2/whq.conf
@@ -3,7 +3,7 @@ protocol static uplink_whq_4 {
     table master4;
   };
 
-  route 0.0.0.0/0 via 212.122.41.129%brfe onlink yes;
+  route 0.0.0.0/0 via 185.105.255.1%brfe onlink yes;
 }
 
 protocol static uplink_whq_6 {


### PR DESCRIPTION
In #1767 we removed deprecated gateway addresses from the keepalived config in WHQ, however one of the FE addresses was still used in the WHQ Bird config in the default router used by the standby router. This resulted in the standby router being unable to correctly forward IPv4 packets to the outside world. DEV was also partially affected, due to ECMP on the uplink between DEV and WHQ causing some IPv4 packets from DEV to be forwarded to the WHQ standby router.

This change corrects the gateway address in the Bird config which is used by the routers when acting as standby.

PL-134015

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh` => none, internal change.

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [x] ensure the merge bot has determined a merge date
- [x] ensure all checks are green
- [x] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - RFC 1925, Sec. 2, Par. 1: "It Has To Work."
- [x] Security requirements tested? (EVIDENCE)
  - Already deployed on the WHQ routers via dev checkout.