### PR TITLE
[25.05] flake: fix versionsJson script after 21.05 removal from versions.json 

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -137,18 +137,6 @@
                   owner = "nix-community";
                   repo = "poetry2nix";
                 };
-                nixpkgs-21_05 = with inputs.nixpkgs-21_05; {
-                  inherit rev;
-                  hash = narHash;
-                  owner = "flyingcircusio";
-                  repo = "nixpkgs";
-                };
-                fc-nixos-21_05 = with inputs.fc-nixos-21_05; {
-                  inherit rev;
-                  hash = narHash;
-                  owner = "flyingcircusio";
-                  repo = "fc-nixos";
-                };
               }
             );
           };

--- a/release/package-versions.json
+++ b/release/package-versions.json
@@ -10,9 +10,9 @@
     "version": "2.4.65"
   },
   "asterisk": {
-    "name": "asterisk-20.15.1",
+    "name": "asterisk-20.15.2",
     "pname": "asterisk",
-    "version": "20.15.1"
+    "version": "20.15.2"
   },
   "auditbeat7-oss": {
     "name": "auditbeat-oss-7.17.27",
@@ -40,9 +40,9 @@
     "version": "5.2p37"
   },
   "bind": {
-    "name": "bind-9.20.11",
+    "name": "bind-9.20.12",
     "pname": "bind",
-    "version": "9.20.11"
+    "version": "9.20.12"
   },
   "binutils": {
     "name": "binutils-wrapper-2.44",
@@ -75,14 +75,14 @@
     "version": "14.2.22"
   },
   "chromedriver": {
-    "name": "chromedriver-unwrapped-139.0.7258.154",
+    "name": "chromedriver-unwrapped-140.0.7339.80",
     "pname": "chromedriver-unwrapped",
-    "version": "139.0.7258.154"
+    "version": "140.0.7339.80"
   },
   "chromium": {
-    "name": "chromium-139.0.7258.154",
+    "name": "chromium-140.0.7339.80",
     "pname": "chromium",
-    "version": "139.0.7258.154"
+    "version": "140.0.7339.80"
   },
   "cifs-utils": {
     "name": "cifs-utils-7.3",
@@ -305,9 +305,9 @@
     "version": "3.1.7"
   },
   "imagemagick": {
-    "name": "imagemagick-7.1.2-2",
+    "name": "imagemagick-7.1.2-3",
     "pname": "imagemagick",
-    "version": "7.1.2-2"
+    "version": "7.1.2-3"
   },
   "imagemagick6": {
     "name": "imagemagick-6.9.13-10",
@@ -340,9 +340,9 @@
     "version": "21.0.6-b895.109"
   },
   "jetty": {
-    "name": "jetty-12.0.21",
+    "name": "jetty-12.1.0",
     "pname": "jetty",
-    "version": "12.0.21"
+    "version": "12.1.0"
   },
   "jicofo": {
     "name": "jicofo-1.0-1128",
@@ -460,14 +460,14 @@
     "version": "0.2.5"
   },
   "linuxKernelStable": {
-    "name": "linux-6.12.44",
+    "name": "linux-6.12.45",
     "pname": "linux",
-    "version": "6.12.44"
+    "version": "6.12.45"
   },
   "linuxKernelVerify": {
-    "name": "linux-6.12.44",
+    "name": "linux-6.12.45",
     "pname": "linux",
-    "version": "6.12.44"
+    "version": "6.12.45"
   },
   "logrotate": {
     "name": "logrotate-3.22.0",
@@ -500,9 +500,9 @@
     "version": "4.3.11"
   },
   "matomo_5": {
-    "name": "matomo-5.3.2",
+    "name": "matomo-5.4.0",
     "pname": "matomo",
-    "version": "5.3.2"
+    "version": "5.4.0"
   },
   "matrix-synapse": {
     "name": "matrix-synapse-wrapped-1.137.0",
@@ -570,9 +570,9 @@
     "version": "1.28.0"
   },
   "nix": {
-    "name": "nix-2.28.4",
+    "name": "nix-2.28.5",
     "pname": "nix",
-    "version": "2.28.4"
+    "version": "2.28.5"
   },
   "nodejs": {
     "name": "nodejs-22.18.0",
@@ -595,9 +595,9 @@
     "version": "4.37"
   },
   "nss_latest": {
-    "name": "nss-3.115",
+    "name": "nss-3.115.1",
     "pname": "nss",
-    "version": "3.115"
+    "version": "3.115.1"
   },
   "nvme-cli": {
     "name": "nvme-cli-2.11",
@@ -745,9 +745,9 @@
     "version": "8.3.25"
   },
   "php84": {
-    "name": "php-with-extensions-8.4.11",
+    "name": "php-with-extensions-8.4.12",
     "pname": "php-with-extensions",
-    "version": "8.4.11"
+    "version": "8.4.12"
   },
   "phpPackages.composer": {
     "name": "composer-2.8.11",
@@ -1155,9 +1155,9 @@
     "version": "9.1.1566"
   },
   "webkitgtk": {
-    "name": "webkitgtk-2.48.5+abi=4.0",
+    "name": "webkitgtk-2.48.6+abi=4.0",
     "pname": "webkitgtk",
-    "version": "2.48.5"
+    "version": "2.48.6"
   },
   "wget": {
     "name": "wget-1.25.0",

--- a/release/versions.json
+++ b/release/versions.json
@@ -8,10 +8,10 @@
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/"
   },
   "nixpkgs": {
-    "hash": "sha256-t8/K9w1qpfzqWe1Bc7WLZRm/ny5x70/N65U8wBl2QiM=",
+    "hash": "sha256-hoxsDXiqK7fjYv1r5nih0/vWeVDIaVk4rSo/ucJQO38=",
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "365e42fe5ee49544b276e0d0b23497bd671b4760"
+    "rev": "04c1f82ad3e98ad1dfbfe19c7f5b2cf8406eebb6"
   },
   "poetry2nix": {
     "hash": "sha256-nzgO/ZCSBzWjbMkYDxG+yl9Z2eGbCgQu06Oku3ir5D4=",


### PR DESCRIPTION
@flyingcircusio/release-managers

PL-134020

## Release process

- [ ] Created changelog entry using `./changelog.sh`
  no: internal fix

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  none applicable here, might want future regression test and fix in fc-n-release-tools (see ticket)
- [x] Security requirements tested? (EVIDENCE)
