### PR TITLE
flake: fix versionsJson script after 21.05 removal from versions.json

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -137,18 +137,6 @@
                   owner = "nix-community";
                   repo = "poetry2nix";
                 };
-                nixpkgs-21_05 = with inputs.nixpkgs-21_05; {
-                  inherit rev;
-                  hash = narHash;
-                  owner = "flyingcircusio";
-                  repo = "nixpkgs";
-                };
-                fc-nixos-21_05 = with inputs.fc-nixos-21_05; {
-                  inherit rev;
-                  hash = narHash;
-                  owner = "flyingcircusio";
-                  repo = "fc-nixos";
-                };
               }
             );
           };


### PR DESCRIPTION
PL-134020

(partial forward-port of #1781)

@flyingcircusio/release-managers

## Release process

- [ ] Created changelog entry using `./changelog.sh`
  no: internal

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
 none applicable here, might want future regression test and fix in fc-n-release-tools (see ticket)
- [x] Security requirements tested? (EVIDENCE)
