### PR TITLE
Fix check script for broken XFS

### DIFF
--- a/changelog.d/20250910_092833_PL-133973-fix-xfs-check-script_scriv.md
+++ b/changelog.d/20250910_092833_PL-133973-fix-xfs-check-script_scriv.md
@@ -1,0 +1,20 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+
+### NixOS XX.XX platform
+
+- Fix sensu check which reads the kernel message buffer to detect
+  potentially broken XFS filesystems. (PL-133973)

--- a/nixos/services/sensu/client.nix
+++ b/nixos/services/sensu/client.nix
@@ -341,6 +341,11 @@ in
           package = pkgs.fc.sensuplugins;
           groups = [ "sensuclient" ];
         }
+        {
+          commands = [ "bin/check-xfs-broken" ];
+          package = pkgs.fc.check-xfs-broken;
+          groups = [ "sensuclient" ];
+        }
       ];
 
       flyingcircus.passwordlessSudoRules = [
@@ -560,7 +565,7 @@ in
             notification = ''
               XFS filesystem has entered a broken state
             '';
-            command = "${fc.check-xfs-broken}";
+            command = "${sudo} ${fc.check-xfs-broken}/bin/check-xfs-broken";
             interval = 300;
           };
         }

--- a/pkgs/fc/check-xfs-broken/default.nix
+++ b/pkgs/fc/check-xfs-broken/default.nix
@@ -1,8 +1,8 @@
 {
-  pkgs ? import <nixpkgs> { },
+  pkgs,
   ...
 }:
-pkgs.writeScript "check-xfs-broken.sh" ''
+pkgs.writeShellScriptBin "check-xfs-broken" ''
   # script to check if xfs is broken
   # does so by checking if '"echo 0 > /proc/sys/kernel/hung_task_timeout_secs" disables this message.'
   # is in `dmesg`


### PR DESCRIPTION
The check script used for detecting a particular XFS bug was broken due to a change in kernel configuration at some point which requires root privileges to read the kernel message buffer using dmesg. This meant the script would search through empty dmesg output and not be able to detect kernel messages which might be indicative of a problem.

This change wraps the check script in sudo to ensure that the kernel message buffer can be read properly.

PL-133973

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Giving more root permissions to sensu-client limited by sudo rules to only the check script.
- [x] Security requirements tested? (EVIDENCE)
  - Positive testing on a dev VM – when run by the sensuclient user the script now runs without printing error messages with dmesg.
