### PR TITLE
Update RZOB router config, add breakglass options for Bind operability

### DIFF
--- a/nixos/roles/router/bind/default.nix
+++ b/nixos/roles/router/bind/default.nix
@@ -65,19 +65,34 @@ let
     	 */
     	dnssec-validation auto;
 
-    	forwarders {
-    		9.9.9.9;
-    		149.112.112.112;
-    		2620:fe::fe;
-    		2620:fe::9;
-    	};
-    	/* We originally used "forward only" but Quad9 sometimes does have issues
-    	   and then we immediately failed. "forward first" allows us to use quad9
-    	   wherever possible and if they return SERVFAIL or similar we go back
-    	   to the root nameservers. I _think_ this does circumvent the security
-    	   blocks which we aren't too happy about anyway.
-    	 */
-    	forward first;
+      /*
+       * Operator's note: control forwarders by setting
+       *
+       *    flyingcircus.roles.router.dnsForwarders = lib.mkForce [ ... ];
+       *
+       * in the NixOS configuration. Leave the list empty to disable
+       * forwarding entirely.
+       */
+
+    ${lib.optionalString (role.dnsForwarders != [ ]) (
+      # align the indentation with the rest of the file
+      let
+        text = ''
+          forwarders {
+            ${lib.concatMapStringsSep "\n  " (a: "${a};") role.dnsForwarders}
+          };
+          /* We originally used "forward only" but Quad9 sometimes does have issues
+             and then we immediately failed. "forward first" allows us to use quad9
+             wherever possible and if they return SERVFAIL or similar we go back
+             to the root nameservers. I _think_ this does circumvent the security
+             blocks which we aren't too happy about anyway.
+           */
+          forward first;
+        '';
+        lines = lib.splitString "\n" text;
+      in
+      lib.concatMapStringsSep "\n" (a: "  ${a}") lines
+    )}
 
     	/* if you have problems and are behind a firewall: */
     	//query-source address * port 53;

--- a/nixos/roles/router/bird2/rzob.conf
+++ b/nixos/roles/router/bird2/rzob.conf
@@ -232,10 +232,10 @@ protocol bgp peer_rzob_kamp_02_6 from peer_rzob_kamp_6 {
 }
 
 protocol bgp peer_rzob_g1priv_01_4 from peer_rzob_g1priv_4 {
-  neighbor 185.84.83.145;
+  neighbor 185.84.83.161;
 }
 protocol bgp peer_rzob_g1priv_02_4 from peer_rzob_g1priv_4 {
-  neighbor 185.84.83.146;
+  neighbor 185.84.83.162;
 }
 protocol bgp peer_rzob_g1priv_01_6 from peer_rzob_g1priv_6 {
   neighbor 2a02:248:ffff:640::1;

--- a/nixos/roles/router/default.nix
+++ b/nixos/roles/router/default.nix
@@ -111,6 +111,17 @@ in
         defaultText = "2001:db8::1";
         description = "IPv6 address to prefer as source address for outgoing connections";
       };
+
+      dnsForwarders = mkOption {
+        type = types.listOf types.str;
+        default = [
+          "9.9.9.9"
+          "149.112.112.112"
+          "2620:fe::fe"
+          "2620:fe::9"
+        ];
+        description = "IP addresses to be used as upstream DNS resolvers (default Quad9)";
+      };
     };
   };
 


### PR DESCRIPTION
This change updates the platform with manually applied changes to the Bird config in RZOB. Additionally, this adds NixOS options to adjust the forwarder configuration in the Bind (i.e. named) config, to improve operability in situations requiring manual intervention.

PL-134025

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh` => internal change, not required.

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Dealing with named.conf at 3am is annoying if we need to take Quad9 out of the rotation temporarily.
- [x] Security requirements tested? (EVIDENCE)
  - Bird config is already in prod.
  - Normal QA workflow for the named.conf.