### PR TITLE
[22.05] admin keys: remove ma27

### DIFF
--- a/nixos/platform/static.nix
+++ b/nixos/platform/static.nix
@@ -129,7 +129,7 @@ with lib;
         os = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJemLKFmr09o6zBscLJSD3KcAs/dnIYBjgxYzJ59VvHx os@Olivers-MBP-3";
         molly = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAmJVyCt6/vSslsEp3dATDD/kk56kaxLggm+3ppwZWbj molly@aqueduct.local";
         phil = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILRVZrVfZrUggrw4wNNcX7r9o7NQ0VjLHTkovVnZBmYH phil";
-        ma27 = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICHlbPnJm1jkJ9wmEXpzO+WFInQkNyc2TzpBR0jXGlzV ma27@frickellinux.local";
+        leona = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIs+pYyC4qcsH8BnfIQLi1lZ7CRYTLgG5NmzqSvfqSOh leona";
       };
 
     };


### PR DESCRIPTION
ma27 has departed from the Flying Circus

PL-134010

(cherry picked from commit 8bcaa50e2e0453212afe8fa462748f231fe2fe7b)

@flyingcircusio/release-managers

## Release process

- [ ] Created changelog entry using `./changelog.sh`
  - no, not customer-facing. Customers can see the current list of administrators in the public docs.

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - remove ssh admin key of departed employees in case they took their key material with them
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still pass