### PR TITLE
Set socket timeouts in router scripts when connecting to the directory

### DIFF
--- a/pkgs/fc/agent/src/fc/manage/kea.py
+++ b/pkgs/fc/agent/src/fc/manage/kea.py
@@ -2,6 +2,7 @@
 
 import argparse
 import json
+import socket
 import sys
 from pathlib import Path
 
@@ -306,6 +307,9 @@ present, return 2 to signal the output file has been changed.
             file=sys.stderr,
         )
         return
+
+    if not socket.getdefaulttimeout():
+        socket.setdefaulttimeout(60)
 
     kea = Kea(args)
     kea.query_directory()

--- a/pkgs/fc/agent/src/fc/manage/zones.py
+++ b/pkgs/fc/agent/src/fc/manage/zones.py
@@ -2,6 +2,7 @@ import argparse
 import collections
 import os.path as p
 import re
+import socket
 import subprocess
 import sys
 
@@ -457,6 +458,8 @@ def update():
         default="/etc/local/configure-zones.cfg",
         help="path to configuration file (default: %(default)s)",
     )
+    if not socket.getdefaulttimeout():
+        socket.setdefaulttimeout(60)
     args = a.parse_args()
     config = configobj.ConfigObj(args.config)
     zones = Zones(config)


### PR DESCRIPTION
We've ran into a fluke with unfortunate timing where fc-zones has an open connection to the directory and packets start getting silently dropped due, which caused fc-zones to hang indefinitely as it doesn't have any timeouts in order to detect the stuck connection. This change sets socket timeouts in fc-zones and fc-kea (which are both called by the systemd job for the agent) so they will crash with an error instead of silently hanging if this kind of network issue is encountered again.

PL-134012

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh` => none, internal change.

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Defensive programming to gracefully handle network interruptions.
- [x] Security requirements tested? (EVIDENCE)
  - Tested by hand with iptables on a dev router. Logic corresponds to that in fc-monitor.