### PR TITLE
nixos/open-webui: set secret file path as default

### DIFF
--- a/nixos/roles/open-webui.nix
+++ b/nixos/roles/open-webui.nix
@@ -50,12 +50,12 @@ in
         admin settings.'';
     };
     secretFile = mkOption {
-      example = "/etc/local/open-webui/secret";
-      default = null;
+      default = "/etc/local/open-webui/secret";
       type = types.nullOr types.str;
       description = ''
         A file containing the authentication secret for the Flying
         Circus AI Provider.
+        Can be null if no secret is required.
       '';
     };
   };

--- a/tests/open-webui.nix
+++ b/tests/open-webui.nix
@@ -21,6 +21,8 @@ import ./make-test-python.nix (
 
         flyingcircus.roles.open-webui.enable = true;
 
+        environment.etc."local/open-webui/secret".text = "imasecret";
+
         # cannot download sentence transformers model without network
         # connection.
         services.open-webui.environment.RAG_EMBEDDING_MODEL = "";


### PR DESCRIPTION
PL-133951

@flyingcircusio/release-managers

## Release process

- [ ] Created changelog entry using `./changelog.sh`
  no: not customer facing yet

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [x] Security requirements tested? (EVIDENCE)
  - Automated test still works
  - Verified that the documentation is accurate