### PR TITLE
fix eval for 25.11 - acme, mongodb and open-webui changes

### DIFF
--- a/nixos/platform/acme.nix
+++ b/nixos/platform/acme.nix
@@ -46,34 +46,6 @@ lib.mkMerge [
       }
     ) config.security.acme.certs;
 
-    systemd.services =
-      let
-        # Retry certificate renewal 30s after a failure.
-        serviceConfig = {
-          Restart = "on-failure";
-          RestartSec = fclib.mkPlatformOverride 30;
-        };
-
-        # Allow 3 retries/starts per hour to not hit the rate limit
-        # of 5 per hour so we have two left to try manually.
-        unitConfig = {
-          StartLimitIntervalSec = "1h";
-          StartLimitBurst = 3;
-        };
-      in
-      lib.listToAttrs (
-        map (
-          n:
-          lib.nameValuePair "acme-${n}" {
-            inherit serviceConfig unitConfig;
-            # Upstream added the renewal service to multi-user.target which means that
-            # every fc-manage run triggers a renewal. We want that the renewal is
-            # only triggered by the timer.
-            wantedBy = lib.mkForce [ ];
-          }
-        ) (lib.attrNames config.security.acme.certs)
-      );
-
     # fallback ACME settings
     security.acme.acceptTerms = true;
     security.acme.defaults.email = "admin@flyingcircus.io";

--- a/nixos/platform/kernel.nix
+++ b/nixos/platform/kernel.nix
@@ -166,7 +166,7 @@ in
           name = "9pfs-fixes";
           patch = pkgs.fetchurl {
             url = "https://lore.kernel.org/linux-fsdevel/20250811-iot_iter_folio-v1-0-d9c223adf93c@codewreck.org/t.mbox.gz";
-            hash = "sha256-lgcoaBDd9FkFTb/hi9a+knfC0T7ZAAh410SxUFBIM1k=";
+            hash = "sha256-36ssMPha5R31f0wQ+GsLrB78X8uOLM19T+eHETm5KBY=";
           };
         }
       ];

--- a/nixos/roles/coturn.nix
+++ b/nixos/roles/coturn.nix
@@ -106,9 +106,9 @@ in
       };
     };
 
-    systemd.services.coturn = rec {
-      requires = [ "acme-selfsigned-${hostname}.service" ];
-      after = requires;
+    systemd.services.coturn = {
+      wants = [ "acme-${hostname}.service" ];
+      after = [ "acme-${hostname}.service" ];
       serviceConfig = {
         Restart = lib.mkForce "always";
       }

--- a/nixos/roles/open-webui.nix
+++ b/nixos/roles/open-webui.nix
@@ -61,6 +61,8 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    # The way we use open-webui is allowed by the license.
+    flyingcircus.allowedUnfreePackageNames = [ "open-webui" ];
     services.open-webui = {
       enable = true;
       host = fclib.mkPlatform config.networking.hostName;

--- a/release/important_packages.json
+++ b/release/important_packages.json
@@ -106,7 +106,6 @@
   "mcpp",
   "memcached",
   "mongodb",
-  "mongodb-6_0",
   "monitoring-plugins",
   "mstflint",
   "mstflint",

--- a/release/package-versions.json
+++ b/release/package-versions.json
@@ -524,11 +524,6 @@
     "pname": "mongodb",
     "version": "7.0.22"
   },
-  "mongodb-6_0": {
-    "name": "mongodb-6.0.24",
-    "pname": "mongodb",
-    "version": "6.0.24"
-  },
   "monitoring-plugins": {
     "name": "monitoring-plugins-2.4.0",
     "pname": "monitoring-plugins",

--- a/tests/nginx.nix
+++ b/tests/nginx.nix
@@ -292,7 +292,7 @@ import ./make-test-python.nix (
           server1.succeed("stat /etc/systemd/system/acme-server.service.wants/nginx-config-reload-post-renew.service")
 
         with subtest("acme script should have lego calls with custom key-type and required default settings"):
-          lego_calls = server1.succeed("grep lego $(systemctl cat acme-server | awk -F '=' '/ExecStart=/ {print $2}')")
+          lego_calls = server1.succeed("grep lego $(systemctl cat acme-order-renew-server | awk -F '=' '/ExecStart=/ {print $2}')")
           print("lego calls emitted:")
           print("*" * 20)
           print(lego_calls)


### PR DESCRIPTION
@flyingcircusio/release-managers

This fixes the evaluation errors in our 25.11 branch. Note that this doesn't adapt our `services.nginx` module to the Nixpkgs acme changes, as we will re-use the module from Nixpkgs. 

PL-133850

## Release process

- [ ] Created changelog entry using `./changelog.sh`
  no: internal change, unreleased

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [x] Security requirements tested? (EVIDENCE)
  - Testing Hydra