### PR TITLE
Move VFS cache sysctl to backyserver role behind option

### DIFF
--- a/changelog.d/20250923_130717_PL-133712-backy-vfs-cache-sysctl_scriv.md
+++ b/changelog.d/20250923_130717_PL-133712-backy-vfs-cache-sysctl_scriv.md
@@ -1,0 +1,26 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+
+
+### NixOS XX.XX platform
+
+- hardware: remove settings for aggressive filesystem caching which
+  are no longer appropriate with widespread adoption of SSD-backed
+  storage from the default hardware profile.
+
+  Add a NixOS option `increaseVfsCacheWeight` in the backyserver role
+  to allow enabling the previous behaviour on old HDD-based backup
+  servers which may still benefit from increased caching. (PL-133712)

--- a/nixos/infrastructure/flyingcircus-physical.nix
+++ b/nixos/infrastructure/flyingcircus-physical.nix
@@ -59,8 +59,6 @@ mkIf (cfg.infrastructureModule == "flyingcircus-physical") (
           "net.ipv4.tcp_l3mdev_accept" = fclib.mkPlatform false;
           "net.ipv4.udp_l3mdev_accept" = fclib.mkPlatform false;
           "vm.swappiness" = fclib.mkPlatform 0;
-          # Wanted by backy and Ceph servers
-          "vm.vfs_cache_pressure" = 10;
         };
       };
 

--- a/nixos/roles/backyserver.nix
+++ b/nixos/roles/backyserver.nix
@@ -73,6 +73,19 @@ in
         description = "Codename of the Ceph release series used as external backy tooling.";
       };
 
+      increaseVfsCacheWeight = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = ''
+          Increase the relative weight of the kernel VFS cache to prevent/defer eviction of filesystem
+          objects from working memory.
+
+          Setting this option can improve performance on systems with HDD-backed filesystems where
+          the default cache eviction behaviour is too eager for regular scans of filesystems with
+          a large number of small files.
+        '';
+      };
+
       # this indirection is required by the tests as a config input
       fsOptions = lib.mkOption {
         type = lib.types.attrs;
@@ -128,9 +141,11 @@ in
     ];
 
     boot = {
-      # Extracted to flyingcircus-physical.nix
-      # kernel.sysctl."vm.vfs_cache_pressure" = 10;
       kernelModules = [ "mq_deadline" ];
+      kernel.sysctl = lib.optionalAttrs role.increaseVfsCacheWeight {
+        # default is 100. higher values increase eviction eagerness.
+        "vm.vfs_cache_pressure" = 10;
+      };
     };
 
     environment.etc."backy.global.conf".text = ''


### PR DESCRIPTION
Previously we've been setting `vm.vfs_cache_pressure=10` in the sysctl settings in the general hardware profile configuration as a holdover from Gentoo, to improve performance (and presumably latency) on filesystems with lots of small files backed by hard disks. However, we've recently encountered problems where workloads with high memory requirements (e.g. rclone backups of object storage) have been OOM-killed, because the VFS cache has been configured with such a high weight that the kernel does not evict entries in order to make memory available to the user space processes.

Empirically, setting the VFS cache pressure back to the default value of 100 fixes this problem. Such aggressive caching is no longer appropriate to have deployed everywhere given that the newest generation of backup servers have NVME flash storage (which do not have the performance bottlenecks of hard disks which require cache tuning), and the Ceph clusters have long since been migrated to Bluestore and access disks directly without a filesystem sitting in between.

This change removes this sysctl setting from the hardware infrastructure module. It also introduces a NixOS option in the backy role for backwards compatibility on older servers which still use hard disk backed storage which may still benefit from more eager caching.

PL-133712

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - The kernel cache settings are superfluous on contemporary hardware, and violate the principle of least astonishment when debugging OOMs.
- [x] Security requirements tested? (EVIDENCE)
  - Tested on DEV backup server. As the explicit configuration is removed without replacement, the implicit default will take effect at the next reboot.