### PR TITLE
nixos/nginx: add warning for implicitly enabled `virtualHosts.<...>.enableACME`

### DIFF
--- a/changelog.d/20250923_173244_HEAD_scriv.md
+++ b/changelog.d/20250923_173244_HEAD_scriv.md
@@ -1,0 +1,19 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+
+### NixOS XX.XX platform
+
+- nixos/nginx: Add warning for implicitly enabled `flyingcircus.services.nginx.virtualHosts.<name>.enableACME` as this behavior is deprecated and will be removed with fc-nixos 25.11 (PL-131381)

--- a/nixos/services/nginx/default.nix
+++ b/nixos/services/nginx/default.nix
@@ -325,7 +325,7 @@ in
         in
         types.attrsOf (
           types.submodule (
-            { config, ... }:
+            { name, config, ... }:
             {
               options = vhost.options // {
                 listenAddress = mkOption {
@@ -363,13 +363,23 @@ in
                   default = null;
                 };
 
-                enableACME = vhost.options.enableACME // {
-                  default =
-                    config.onlySSL or false
-                    || config.enableSSL or false
-                    || config.addSSL or false
-                    || config.forceSSL or false;
-                };
+                enableACME =
+                  let
+                    default =
+                      config.onlySSL or false
+                      || config.enableSSL or false
+                      || config.addSSL or false
+                      || config.forceSSL or false;
+                  in
+                  vhost.options.enableACME
+                  // {
+                    # This attribute is only evaluated when no explicit value is set.
+                    # So, when `default = true`, it's set via the above expression.
+                    default = lib.warnIf default ''
+                      flyingcircus.services.nginx.virtualHosts."${name}".enableACME is implicitly set to true.
+                      This behavior is deprecated and will be removed with fc-nixos 25.11. Please set the option explicitly.
+                    '' default;
+                  };
 
                 listenAddresses = vhost.options.listenAddresses // {
                   defaultText = "The default listen addresses configured in `flyingcircus.services.nginx.defaultListenAddresses`";


### PR DESCRIPTION


PL-131381

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - None: This doesn't change the behavior
- [x] Security requirements tested? (EVIDENCE)

