### PR TITLE
nixos/nginx: add deprecation warning for `virtualHosts.<...>.emailACME`

### DIFF
--- a/changelog.d/20250923_175331_HEAD_scriv.md
+++ b/changelog.d/20250923_175331_HEAD_scriv.md
@@ -1,0 +1,19 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+
+### NixOS XX.XX platform
+
+- nixos/nginx: add deprecation warning for `virtualHosts.<name>.emailACME` as this option is deprecated and will be removed with fc-nixos 25.11 (PL-131381)

--- a/nixos/services/nginx/default.nix
+++ b/nixos/services/nginx/default.nix
@@ -361,6 +361,12 @@ in
                     Defaults to none.
                   '';
                   default = null;
+                  apply =
+                    x:
+                    lib.warnIf (x != null) ''
+                      flyingcircus.services.nginx.virtualHosts.<vhost>.emailACME is deprecated.
+                      This option will be removed with fc-nixos 25.11. Please use security.acme.certs.<name>.email.
+                    '' x;
                 };
 
                 enableACME = vhost.options.enableACME // {


### PR DESCRIPTION
PL-131381

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - None: This doesn't change the behavior
- [x] Security requirements tested? (EVIDENCE)

