### PR TITLE
loghost/graylog: fix JDK pinning

### DIFF
--- a/changelog.d/20250904_145223_PL-133980-fix-graylog-ldap-pin-jdk_scriv.md
+++ b/changelog.d/20250904_145223_PL-133980-fix-graylog-ldap-pin-jdk_scriv.md
@@ -1,0 +1,21 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+- A bullet item for the Impact category.
+
+
+### NixOS XX.XX platform
+
+- loghost/graylog: Fix LDAP by pinning Java to a known good version. (PL-133980)

--- a/nixos/services/graylog/default.nix
+++ b/nixos/services/graylog/default.nix
@@ -123,6 +123,12 @@ in
         description = "Graylog package to use. Only works with Graylog 3.3";
       };
 
+      javaPackage = mkOption {
+        type = types.either types.path types.package;
+        default = cfg.package.jre;
+        description = "Java package override for JAVA_HOME and PATH. Uses the same JRE as the graylog package by default";
+      };
+
       user = mkOption {
         type = types.str;
         default = "graylog";
@@ -262,13 +268,13 @@ in
 
         in
         {
-          JAVA_HOME = pkgs.jdk8_headless;
+          JAVA_HOME = cfg.javaPackage;
           GRAYLOG_CONF = graylogConfPath;
           JAVA_OPTS = lib.concatStringsSep " " javaOpts;
         };
 
       path = [
-        pkgs.jdk8_headless
+        cfg.javaPackage
         pkgs.which
         pkgs.procps
       ];

--- a/pkgs/graylog/default.nix
+++ b/pkgs/graylog/default.nix
@@ -3,7 +3,7 @@
   stdenv,
   fetchurl,
   makeWrapper,
-  openjdk8_headless,
+  jre,
   nixosTests,
 }:
 
@@ -23,10 +23,13 @@ stdenv.mkDerivation rec {
   makeWrapperArgs = [
     "--set-default"
     "JAVA_HOME"
-    "${openjdk8_headless}"
+    "${jre}"
   ];
 
-  passthru.tests = { inherit (nixosTests) graylog; };
+  passthru = {
+    tests = { inherit (nixosTests) graylog; };
+    inherit jre;
+  };
 
   installPhase = ''
     mkdir -p $out

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -338,7 +338,9 @@ builtins.mapAttrs (_: patchPhps phpLogPermissionPatch) {
 
   graylog = self.graylog-3_3;
 
-  graylog-3_3 = super.callPackage ./graylog { };
+  graylog-3_3 = super.callPackage ./graylog {
+    jre = getClosureFromStore "/nix/store/5i1mf8784vx7dzh030ixggrx93j3fs9j-openjdk-headless-8u322-ga";
+  };
 
   graylogPlugins = lib.recurseIntoAttrs (
     super.callPackage ./graylog/plugins.nix {

--- a/tests/loghost.nix
+++ b/tests/loghost.nix
@@ -70,8 +70,12 @@ import ./make-test-python.nix (
         graylogCheck = testlib.sensuCheckCmd nodes.machine "graylog_ui";
         graylogApi = "${pkgs.fc.agent}/bin/fc-graylog --api http://${host}:9001/api get -l";
         esConfigFile = "/srv/elasticsearch/config/elasticsearch.yml";
+        expectedJava = "/nix/store/5i1mf8784vx7dzh030ixggrx93j3fs9j-openjdk-headless-8u322-ga";
       in
       ''
+        graylog_unit = machine.systemctl("cat graylog.service")[1]
+        assert 'Environment="JAVA_HOME=${expectedJava}"' in graylog_unit, "Expected pinned Java version not found!"
+
         machine.wait_for_unit("elasticsearch.service")
 
         with subtest("elasticsearch config should be set-up for single-node mode"):


### PR DESCRIPTION
Graylog really needs this specific version for LDAP. Login just fails without helpful error messages with platform JDK packages.

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [x] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - we want to upgrade our legacy systems, this is needed to make graylog work on 25.05+ 
- [x] Security requirements tested? (EVIDENCE)
  - NixOS test verifies that required jdk package is used by graylog
  - manually tested on a test VM, LDAP login works