### PR TITLE
statshost: OIDC as default, disable local login

### DIFF
--- a/changelog.d/20251007_103630_PL-134048-statshost-oidc-as-default_scriv.md
+++ b/changelog.d/20251007_103630_PL-134048-statshost-oidc-as-default_scriv.md
@@ -1,0 +1,19 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+
+### NixOS XX.XX platform
+
+- statshost/grafana: users now authenticate using OIDC via Keycloak instead of LDAP, resulting in the same permissions as before. Logged-in users will still be shown as using LDAP. Users will be redirected to the FCIO Keycloak server by default when visiting the Grafana frontend. Logging in via OIDC will convert their user accounts automatically. LDAP can still be enabled by local config. When OIDC is enabled, local login is disabled completely. (PL-134048)

--- a/changelog.d/20251024_102859_PL-134142-statshost-oidc-fix-role-mapping_scriv.md
+++ b/changelog.d/20251024_102859_PL-134142-statshost-oidc-fix-role-mapping_scriv.md
@@ -1,0 +1,19 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+
+### NixOS XX.XX platform
+
+- statshost: fix Admin role mapping for OIDC. (PL-134142)

--- a/nixos/roles/statshost/default.nix
+++ b/nixos/roles/statshost/default.nix
@@ -166,10 +166,7 @@ in
       };
 
       ldap = {
-        enable = mkOption {
-          type = types.bool;
-          default = true;
-        };
+        enable = mkEnableOption "Enable LDAP for Grafana";
 
         memberOf = mkOption {
           default = config.flyingcircus.enc.parameters.resource_group;
@@ -191,7 +188,12 @@ in
       };
 
       oidc = {
-        enable = mkEnableOption "Enable OIDC for Grafana";
+        enable = mkOption {
+          type = types.bool;
+          default = true;
+          description = "Enable OIDC for Grafana";
+        };
+
         realm = mkOption {
           type = types.str;
           default = "fcio";

--- a/nixos/roles/statshost/default.nix
+++ b/nixos/roles/statshost/default.nix
@@ -563,7 +563,7 @@ in
                 name_attribute_path = "full_name";
                 auth_url = "${realmUrl}/protocol/openid-connect/auth";
                 token_url = "${realmUrl}/protocol/openid-connect/token";
-                role_attribute_path = "'Admin'";
+                role_attribute_path = "\"'Admin'\"";
               };
           })
         ];

--- a/nixos/roles/statshost/default.nix
+++ b/nixos/roles/statshost/default.nix
@@ -102,33 +102,6 @@ let
     s: s.service == "statshost-collector"
   ) null config.flyingcircus.encServices;
 
-  grafanaLdapConfig = pkgs.writeText "ldap.toml" ''
-    verbose_logging = true
-
-    [[servers]]
-    host = "${cfgStats.ldap.server}"
-    port = 636
-    start_tls = false
-    use_ssl = true
-    bind_dn = "uid=%s,ou=People,dc=gocept,dc=com"
-    search_base_dns = ["ou=People,dc=gocept,dc=com"]
-    search_filter = "(&(&(objectClass=inetOrgPerson)(uid=%s))(memberOf=cn=${cfgStats.ldap.memberOf},ou=GroupOfNames,dc=gocept,dc=com))"
-    group_search_base_dns = ["ou=Group,dc=gocept,dc=com"]
-    group_search_filter = "(&(objectClass=posixGroup)(memberUid=%s))"
-
-    [servers.attributes]
-    name = "cn"
-    surname = "displaname"
-    username = "uid"
-    member_of = "cn"
-    email = "mail"
-
-    [[servers.group_mappings]]
-    group_dn = "${config.flyingcircus.enc.parameters.resource_group}"
-    org_role = "Admin"
-
-  '';
-
   grafanaJsonDashboardPath = "${config.services.grafana.dataDir}/dashboards";
   grafanaProvisioningPath = "${config.services.grafana.dataDir}/provisioning";
 
@@ -516,59 +489,27 @@ in
 
       services.grafana = {
         enable = true;
+        settings = {
+          auth = {
+            login_cookie_name = "grafana9_session";
+          };
 
-        settings = mkMerge [
-          {
-            auth = {
-              login_cookie_name = "grafana9_session";
-            };
+          # We only support LDAP and OIDC, no local login.
+          "auth.basic" = {
+            enabled = false;
+          };
 
-            paths = {
-              provisioning = grafanaProvisioningPath;
-            };
+          paths = {
+            provisioning = grafanaProvisioningPath;
+          };
 
-            server = {
-              http_port = 3001;
-              http_addr = "127.0.0.1";
-              root_url = "https://${cfgStats.hostName}/grafana/";
-            };
-            security.disable_initial_admin_creation = true;
-          }
-
-          (lib.mkIf cfgStats.ldap.enable {
-            "auth.ldap" = {
-              enabled = true;
-              config_file = toString grafanaLdapConfig;
-            };
-          })
-
-          (lib.mkIf cfgStats.oidc.enable {
-
-            auth = {
-              oauth_allow_insecure_email_lookup = true;
-            };
-
-            "auth.generic_oauth" =
-              let
-                realmUrl = "${cfgStats.oidc.server}/realms/${cfgStats.oidc.realm}";
-              in
-              {
-                enabled = true;
-                auto_login = true;
-                name = "FCIO oidc";
-                allow_sign_up = true;
-                client_id = "${config.networking.hostName}_statshost-master";
-                client_secret = fclib.derivePasswordForHost "oidc_statshost-master";
-                scopes = "openid email profile offline_access roles";
-                email_attribute_path = "email";
-                login_attribute_path = "preferred_username";
-                name_attribute_path = "full_name";
-                auth_url = "${realmUrl}/protocol/openid-connect/auth";
-                token_url = "${realmUrl}/protocol/openid-connect/token";
-                role_attribute_path = "\"'Admin'\"";
-              };
-          })
-        ];
+          server = {
+            http_port = 3001;
+            http_addr = "127.0.0.1";
+            root_url = "https://${cfgStats.hostName}/grafana/";
+          };
+          security.disable_initial_admin_creation = true;
+        };
       };
 
       services.nginx = {
@@ -694,6 +635,74 @@ in
 
     })
 
+    # SSO for statshost-master. LDAP and OIDC (default) are supported.
+    # Not affected: statshost-global (uses local SSO config).
+
+    (lib.mkIf (cfgStatsRG.enable && cfgStats.ldap.enable) {
+      services.grafana.settings."auth.ldap" = {
+        enabled = true;
+        config_file = toString (
+          pkgs.writeText "ldap.toml" ''
+            verbose_logging = true
+
+            [[servers]]
+            host = "${cfgStats.ldap.server}"
+            port = 636
+            start_tls = false
+            use_ssl = true
+            bind_dn = "uid=%s,ou=People,dc=gocept,dc=com"
+            search_base_dns = ["ou=People,dc=gocept,dc=com"]
+            search_filter = "(&(&(objectClass=inetOrgPerson)(uid=%s))(memberOf=cn=${cfgStats.ldap.memberOf},ou=GroupOfNames,dc=gocept,dc=com))"
+            group_search_base_dns = ["ou=Group,dc=gocept,dc=com"]
+            group_search_filter = "(&(objectClass=posixGroup)(memberUid=%s))"
+
+            [servers.attributes]
+            name = "cn"
+            surname = "displaname"
+            username = "uid"
+            member_of = "cn"
+            email = "mail"
+
+            [[servers.group_mappings]]
+            group_dn = "${config.flyingcircus.enc.parameters.resource_group}"
+            org_role = "Admin"
+          ''
+        );
+      };
+    })
+
+    (lib.mkIf (cfgStatsRG.enable && cfgStats.oidc.enable) {
+      services.grafana.settings = {
+        auth = {
+          disable_login_form = true;
+          oauth_allow_insecure_email_lookup = true;
+        };
+
+        # We expect that we are talking to our default Keycloak and that a OIDC
+        # client has been set up automatically by the directory when activating
+        # statshost-master role.
+        "auth.generic_oauth" =
+          let
+            realmUrl = "${cfgStats.oidc.server}/realms/${cfgStats.oidc.realm}";
+          in
+          {
+            enabled = true;
+            auto_login = true;
+            name = "FCIO oidc";
+            allow_sign_up = true;
+            client_id = "${config.networking.hostName}_statshost-master";
+            client_secret = fclib.derivePasswordForHost "oidc_statshost-master";
+            scopes = "openid email profile";
+            email_attribute_path = "email";
+            login_attribute_path = "preferred_username";
+            name_attribute_path = "full_name";
+            # Everybody becomes admin, ignoring user roles from OIDC.
+            role_attribute_path = "\"'Admin'\"";
+            auth_url = "${realmUrl}/protocol/openid-connect/auth";
+            token_url = "${realmUrl}/protocol/openid-connect/token";
+          };
+      };
+    })
   ];
 }
 


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [x] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - reduce local login accounts and use OIDC instead
  - when OIDC enabled, local login must not be enabled. Grafana redirects to Keycloak automatically
  - only applies to statshost-master, global statshost has locally managed SSO config
- [x] Security requirements tested? (EVIDENCE)
  - automated tests check that statshost-master and statshost still work
  - checked on a test VM that switching from LDAP to OIDC works, also the other way round and back to OIDC. User accounts are updated properly and show the currently enabled login method after re-login (logged-in users are not logged out automatically, that's ok)