### PR TITLE
nixos/statshost: disable default admin user

### DIFF
--- a/changelog.d/20250925_115648_HEAD_scriv.md
+++ b/changelog.d/20250925_115648_HEAD_scriv.md
@@ -1,0 +1,22 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+
+### NixOS XX.XX platform
+
+- nixos/statshost: Disable default insecure admin user (PL-134036)
+
+  Currently, we have an insecure default admin activated, as this is the grafana default.
+  With this change, this user is disabled on new installations and our AppOps team will disable the user on existing instances.

--- a/nixos/roles/statshost/default.nix
+++ b/nixos/roles/statshost/default.nix
@@ -530,6 +530,7 @@ in
               http_addr = "127.0.0.1";
               root_url = "https://${cfgStats.hostName}/grafana/";
             };
+            security.disable_initial_admin_creation = true;
           }
 
           (lib.mkIf cfgStats.ldap.enable {

--- a/tests/statshost/statshost-global.nix
+++ b/tests/statshost/statshost-global.nix
@@ -203,7 +203,9 @@ import ../make-test-python.nix (
           };
           virtualisation.memorySize = 3000;
           virtualisation.diskSize = 1000;
-
+          environment.systemPackages = [
+            pkgs.sqlite
+          ];
         };
 
       statssource = {
@@ -264,6 +266,13 @@ import ../make-test-python.nix (
         statshost.execute("systemctl stop acme-statshost.fe.loc.fcio.net.service")
         statshost.wait_for_unit("prometheus.service")
         statshost.wait_for_unit("grafana.service")
+        statshost.wait_for_open_port(3001)
+
+        with subtest("Grafana should not have insecure admin user"):
+          statshost.wait_for_file("/var/lib/grafana/data/grafana.db")
+          admin_user_rc, admin_user_q = statshost.execute("sqlite3 /var/lib/grafana/data/grafana.db \"select 1 from user where login='admin'\"")
+          assert admin_user_rc == 0
+          assert admin_user_q.strip() == ""
 
         statssource.wait_for_unit("telegraf.service")
         statssource.wait_for_file("/run/telegraf/influx.sock")


### PR DESCRIPTION
PL-134036

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [x] Security requirements tested? (EVIDENCE)
  - Tested, that this actually disables the user with a regression test