### PR TITLE
fc-maintenance: Fix crash on nullable summary properties

### DIFF
--- a/pkgs/fc/agent/src/fc/maintenance/activity/tests/test_update.py
+++ b/pkgs/fc/agent/src/fc/maintenance/activity/tests/test_update.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock, create_autospec
 
 import responses
 import yaml
+import fc.util.nixos
 from fc.maintenance import Request, state
 from fc.maintenance.activity import Activity, RebootType
 from fc.maintenance.activity.update import UpdateActivity
@@ -577,6 +578,23 @@ def test_update_activity_from_enc(
     )
     activity = UpdateActivity.from_enc(logger, enc)
     assert activity
+
+
+def test_update_activity_with_nullable_nixos_properties(nixos_mock, activity):
+    """Set all potentially nullable mocked properties to None and ensure this does not
+    cause crashes"""
+    nixos_mock.current_fc_environment_name.return_value = None
+    nixos_mock.get_fc_channel_build = (
+        fc.util.nixos.get_fc_channel_build
+    )  # un-mock, this function has no side effects
+    nixos_mock.os_release.return_value = {}
+    nixos_mock.current_nixos_channel_url.return_value = None
+    nixos_mock.current_system.return_value = None
+
+    activity._log_current_state()
+    activity._detect_next_version()
+    activity.summary
+    activity.run()
 
 
 def test_current_properties_return_expected_values(nixos_mock, activity):

--- a/pkgs/fc/agent/src/fc/maintenance/activity/update.py
+++ b/pkgs/fc/agent/src/fc/maintenance/activity/update.py
@@ -321,7 +321,7 @@ class UpdateActivity(Activity):
         self.returncode = 0
 
     @property
-    def summary(self):
+    def summary(self) -> str:
         """
         A human-readable summary of what will be changed by this update.
         Includes possible reboots, significant unit state changes (start, stop,
@@ -350,9 +350,11 @@ class UpdateActivity(Activity):
         elif self.current_environment is not None:
             msg.append(f"Environment: {self.current_environment} (unchanged)")
 
-        current_build = nixos.get_fc_channel_build(
-            self.current_channel_url, self.log
-        )
+        current_build = None
+        if self.current_channel_url:
+            current_build = nixos.get_fc_channel_build(
+                self.current_channel_url, self.log
+            )
         if current_build:
             next_build = nixos.get_fc_channel_build(
                 self.next_channel_url, self.log

--- a/pkgs/fc/agent/src/fc/util/nixos.py
+++ b/pkgs/fc/agent/src/fc/util/nixos.py
@@ -79,7 +79,7 @@ class Specialisation(Enum):
     BASE_CONFIG = 2
 
 
-def kernel_version(kernel):
+def kernel_version(kernel) -> str:
     """Guesses kernel version from /run/*-system/kernel.
 
     Theory of operation: A link like `/run/current-system/kernel` points
@@ -99,7 +99,7 @@ def kernel_version(kernel):
     return moddir[0]
 
 
-def current_fc_environment_name(log=_log):
+def current_fc_environment_name(log=_log) -> Optional[str]:
     env_path = Path(FC_ENV_FILE)
     if env_path.exists():
         environment = env_path.read_text()
@@ -107,9 +107,10 @@ def current_fc_environment_name(log=_log):
         return environment
     else:
         log.debug("fc-environment-env-file-missing", filename=FC_ENV_FILE)
+        return None
 
 
-def channel_version(channel_url, log=_log):
+def channel_version(channel_url, log=_log) -> str:
     try:
         nixpkgs_path = subprocess.run(
             ["nix-instantiate", "-I", channel_url, "--find-file", "."],
@@ -144,6 +145,7 @@ def get_fc_channel_build(channel_url: str, log=_log) -> Optional[str]:
             ),
             channel_url=channel_url,
         )
+        return None
 
 
 CURRENT_SYSTEM = Path("/run/current-system")
@@ -175,7 +177,7 @@ def os_release(system: Path | None = None):
     return result
 
 
-def current_nixos_channel_version():
+def current_nixos_channel_version() -> str:
     is_local = False
     if is_local:
         return "local-checkout"
@@ -194,7 +196,7 @@ def current_nixos_channel_url(log=_log) -> Optional[str]:
             "nix-channel-file-missing",
             _replace_msg="/root/.nix-channels does not exist, doing nothing",
         )
-        return
+        return None
     try:
         with open("/root/.nix-channels") as f:
             for line in f.readlines():
@@ -208,9 +210,10 @@ def current_nixos_channel_url(log=_log) -> Optional[str]:
             "Failed to read .nix-channels. See exception for details.",
             exc_info=True,
         )
+    return None
 
 
-def current_system(log=_log):
+def current_system(log=_log) -> Optional[str]:
     if not p.exists(CURRENT_SYSTEM):
         log.warn("current-system-missing")
         return None
@@ -352,7 +355,7 @@ def find_nix_eval_warnings(stderr: str) -> list[str]:
     )
 
 
-def find_nix_build_error(stderr: str, log=_log):
+def find_nix_build_error(stderr: str, log=_log) -> str:
     """Returns the (hopefully) interesting part of the error message from Nix
     build output or a generic message if nothing is found.
     """
@@ -364,7 +367,7 @@ def find_nix_build_error(stderr: str, log=_log):
     try:
         lines = stderr.splitlines()
         num_lines = len(lines)
-        error_lines = []
+        error_lines: list[str] = []
 
         lines = list(
             itertools.dropwhile(


### PR DESCRIPTION
Fixes a crash in `fc-maintenance list` that happened due to `nixos.current_nixos_channel_url` sometimes being None, but the `nixos.get_fc_channel_build` processing it not allowing nullable inputs.

To avoid similar issues, I explicitly specified some further type hints to make things more obvious and enable Mypy type checking for these functions.

Also added test coverage.

Fixes PL-132502

@flyingcircusio/release-managers

## Release process

- [ ] Created changelog entry using `./changelog.sh`
  - Only fixes an issue introduced with #1808, which was not released yet.

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - fix an existing type incompatibility that become more prominent with #1808
- [x] Security requirements tested? (EVIDENCE)
  - added test coverage for the regression
  - automated tests pass