### PR TITLE
[25.05] revert the reverts of #1845

### DIFF
--- a/changelog.d/20250917_154638_PL-133993-no-path-serialisation_scriv.md
+++ b/changelog.d/20250917_154638_PL-133993-no-path-serialisation_scriv.md
@@ -1,0 +1,20 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+
+
+### NixOS XX.XX platform
+
+- fc-agent: Fix automatic maintenance updates that referred to already garbage-collected system paths (PL-133993)
+
+  This avoids breakage of updates even when they have been pending for a while and the current system state already changed, e.g. due to modified configuration.

--- a/pkgs/fc/agent/src/fc/maintenance/activity/tests/test_update.py
+++ b/pkgs/fc/agent/src/fc/maintenance/activity/tests/test_update.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock, create_autospec
 
 import responses
 import yaml
+import fc.util.nixos
 from fc.maintenance import Request, state
 from fc.maintenance.activity import Activity, RebootType
 from fc.maintenance.activity.update import UpdateActivity
@@ -577,6 +578,23 @@ def test_update_activity_from_enc(
     )
     activity = UpdateActivity.from_enc(logger, enc)
     assert activity
+
+
+def test_update_activity_with_nullable_nixos_properties(nixos_mock, activity):
+    """Set all potentially nullable mocked properties to None and ensure this does not
+    cause crashes"""
+    nixos_mock.current_fc_environment_name.return_value = None
+    nixos_mock.get_fc_channel_build = (
+        fc.util.nixos.get_fc_channel_build
+    )  # un-mock, this function has no side effects
+    nixos_mock.os_release.return_value = {}
+    nixos_mock.current_nixos_channel_url.return_value = None
+    nixos_mock.current_system.return_value = None
+
+    activity._log_current_state()
+    activity._detect_next_version()
+    activity.summary
+    activity.run()
 
 
 def test_current_properties_return_expected_values(nixos_mock, activity):

--- a/pkgs/fc/agent/src/fc/maintenance/activity/tests/test_update.py
+++ b/pkgs/fc/agent/src/fc/maintenance/activity/tests/test_update.py
@@ -22,9 +22,6 @@ CURRENT_BUILD = 93111
 NEXT_BUILD = 93222
 NEXT_NEXT_BUILD = 93333
 
-CURRENT_RELEASE = "2021_002"
-NEXT_RELEASE = "2021_003"
-
 CHANGELOG_URL = "https://doc.flyingcircus.io/platform/changes/2021/r003.html"
 
 CURRENT_CHANNEL_URL = f"https://hydra.flyingcircus.io/build/{CURRENT_BUILD}/download/1/nixexprs.tar.xz"
@@ -60,8 +57,6 @@ SUMMARY = textwrap.dedent(
     Restart: telegraf
     Reload: nginx
 
-    Release: {CURRENT_RELEASE} -> {NEXT_RELEASE}
-    ChangeLog: {CHANGELOG_URL}
     Environment: {ENVIRONMENT} (unchanged)
     Build number: {CURRENT_BUILD} -> {NEXT_BUILD}
     Channel URL: {NEXT_CHANNEL_URL}"""
@@ -106,20 +101,9 @@ updated_at: null
 
 SERIALIZED_ACTIVITY = f"""\
 !!python/object:fc.maintenance.activity.update.UpdateActivity
-changelog_url: {CHANGELOG_URL}
-current_channel_url: https://hydra.flyingcircus.io/build/93111/download/1/nixexprs.tar.xz
-current_environment: fc-21.05-production
-current_kernel: 5.10.45
-current_os_release:
-  BUILD_ID: 21.05.1233.a9cc58d
-  VERSION_ID: '21.05'
-current_release: '{CURRENT_RELEASE}'
-current_system: {CURRENT_SYSTEM_PATH}
-current_version: 21.05.1233.a9cc58d
 next_channel_url: https://hydra.flyingcircus.io/build/93222/download/1/nixexprs.tar.xz
 next_environment: fc-21.05-production
 next_kernel: 5.10.50
-next_release: '{NEXT_RELEASE}'
 next_system: {NEXT_SYSTEM_PATH}
 next_version: 21.05.1235.bacc11d
 reboot_needed: !!python/object/apply:fc.maintenance.activity.RebootType
@@ -139,16 +123,9 @@ unit_changes:
 @fixture
 def activity(logger, nixos_mock, tmp_path):
     activity = UpdateActivity(next_channel_url=NEXT_CHANNEL_URL, log=logger)
-    activity.current_channel_url = CURRENT_CHANNEL_URL
-    activity.changelog_url = CHANGELOG_URL
-    activity.current_environment = ENVIRONMENT
-    activity.current_release = CURRENT_RELEASE
-    activity.current_version = CURRENT_BUILD_ID
-    activity.current_kernel = CURRENT_KERNEL_VERSION
     activity.next_channel_url = NEXT_CHANNEL_URL
     activity.next_environment = ENVIRONMENT
     activity.next_kernel = NEXT_KERNEL_VERSION
-    activity.next_release = NEXT_RELEASE
     activity.next_system = NEXT_SYSTEM_PATH
     activity.next_version = NEXT_BUILD_ID
     activity.reboot_needed = RebootType.WARM
@@ -313,15 +290,12 @@ def test_update_activity_deserialize(activity, logger):
 
 
 def test_update_activity_loading_outdated_serialization_should_work(
-    logger, tmp_path, agent_configparser
+    logger, tmp_path, agent_configparser, nixos_mock
 ):
     request_path = tmp_path / "request.yaml"
     request_path.write_text(OUTDATED_SERIALIZED_REQUEST)
     request = Request.load(tmp_path, agent_configparser, logger, 1800)
     activity = request.activity
-    assert activity.changelog_url is None
-    assert activity.current_release is None
-    assert activity.next_release is None
     assert activity.summary
     assert activity.__rich__()
 
@@ -389,8 +363,6 @@ def test_update_nfs_reboot_required(
 
         Restart: mnt-nfs-shared.mount
 
-        Release: 2021_002 -> 2021_003
-        ChangeLog: https://doc.flyingcircus.io/platform/changes/2021/r003.html
         Environment: fc-21.05-production (unchanged)
         Build number: 93111 -> 93222
         Channel URL: https://hydra.flyingcircus.io/build/93222/download/1/nixexprs.tar.xz"""
@@ -419,7 +391,7 @@ def test_update_release_change_reboot_required(
     activity.reboot_needed = None
     nixos_mock.CURRENT_VERSION_ID = "24.11"
     nixos_mock.NEXT_VERSION_ID = "24.11"
-    activity._detect_current_state()
+    activity._log_current_state()
     activity._detect_next_version()
     assert activity.release_path() == ["24.11"]
     activity._register_reboot_for_release_change()
@@ -432,7 +404,7 @@ def test_update_release_change_reboot_required(
     nixos_mock.NEXT_VERSION_ID = "25.05"
     nixos_mock.CURRENT_BUILD_ID = "24.11.abcde.12345"
     nixos_mock.NEXT_BUILD_ID = "25.05.edcba.54321"
-    activity._detect_current_state()
+    activity._log_current_state()
     activity._detect_next_version()
     assert activity.release_path() == ["24.11", "25.05"]
     activity._register_reboot_for_release_change()
@@ -448,8 +420,6 @@ def test_update_release_change_reboot_required(
         Restart: telegraf
         Reload: nginx
         
-        Release: 2021_002 -> 2021_003
-        ChangeLog: https://doc.flyingcircus.io/platform/changes/2021/r003.html
         Environment: fc-21.05-production (unchanged)
         Build number: 93111 -> 93222
         Channel URL: https://hydra.flyingcircus.io/build/93222/download/1/nixexprs.tar.xz"""
@@ -481,7 +451,8 @@ def test_update_activity_run(log, nixos_mock, activity, logger):
 
 
 def test_update_activity_run_unchanged(log, nixos_mock, activity):
-    activity.current_system = activity.next_system
+    # Mock nixos.current_system() to return the same as next_system
+    nixos_mock.current_system.return_value = activity.next_system
 
     activity.run()
 
@@ -540,7 +511,10 @@ def test_update_activity_switch_to_system_fails(log, nixos_mock, activity):
 
 
 def test_update_activity_switch_if_no_release_change(log, nixos_mock, activity):
-    activity.current_version = "24.11.1111"
+    nixos_mock.os_release.return_value = {
+        "BUILD_ID": "24.11.1111",
+        "VERSION_ID": "24.11",
+    }
     activity.next_version = "24.11.9999"
     activity.run()
 
@@ -558,7 +532,7 @@ def test_update_activity_boot_if_release_change(log, nixos_mock, activity):
     nixos_mock.CURRENT_BUILD_ID = "24.11.abcde.12345"
     nixos_mock.NEXT_BUILD_ID = "25.05.edcba.54321"
 
-    activity._detect_current_state()
+    activity._log_current_state()
     activity._detect_next_version()
     activity.run()
 
@@ -603,6 +577,43 @@ def test_update_activity_from_enc(
     )
     activity = UpdateActivity.from_enc(logger, enc)
     assert activity
+
+
+def test_current_properties_return_expected_values(nixos_mock, activity):
+    """Test that current_* properties return values from nixos functions."""
+
+    # Mock the nixos functions to return specific values
+    nixos_mock.current_nixos_channel_url.return_value = (
+        "https://hydra.flyingcircus.io/build/93111/download/1/nixexprs.tar.xz"
+    )
+    nixos_mock.current_fc_environment_name.return_value = "fc-21.05-production"
+    nixos_mock.os_release.return_value = {
+        "BUILD_ID": "21.05.1233.a9cc58d",
+        "VERSION_ID": "21.05",
+    }
+    nixos_mock.kernel_version.return_value = "5.10.45"
+
+    # Test that properties return the mocked values
+    assert (
+        activity.current_channel_url
+        == "https://hydra.flyingcircus.io/build/93111/download/1/nixexprs.tar.xz"
+    )
+    assert activity.current_environment == "fc-21.05-production"
+    assert activity.current_version == "21.05.1233.a9cc58d"
+    assert activity.current_kernel == "5.10.45"
+
+
+def test_current_properties_not_serialized(activity):
+    """Test that current_* properties are not included in serialized state."""
+    state = activity.__getstate__()
+
+    # None of the current_* properties should be in the serialized state,
+    # they're supposed to be read from the live system
+    assert "current_channel_url" not in state
+    assert "current_environment" not in state
+    assert "current_version" not in state
+    assert "current_kernel" not in state
+    assert "current_os_release" not in state
 
 
 def test_update_from_enc_no_enc(log, logger):

--- a/pkgs/fc/agent/src/fc/maintenance/activity/update.py
+++ b/pkgs/fc/agent/src/fc/maintenance/activity/update.py
@@ -43,21 +43,13 @@ class UpdateActivity(Activity):
         super().__init__()
         self.next_environment = next_environment
         self.next_channel_url = next_channel_url
-        self.changelog_url = None
-        self.current_system = None
         self.next_system = None
-        self.current_channel_url = None
-        self.current_release = None
-        self.next_release = None
-        self.current_version = None
         self.next_version = None
-        self.current_environment = None
         self.unit_changes: UnitChanges = {}
-        self.current_kernel = None
         self.next_kernel = None
         self.reboot_needed = None
         self.set_up_logging(log)
-        self._detect_current_state()
+        self._log_current_state()
         self._detect_next_version()
         self.log.debug(
             "update-init",
@@ -123,19 +115,15 @@ class UpdateActivity(Activity):
         """
         if self.next_channel_url == self.current_channel_url:
             return False
-        if self.current_system == self.next_system:
+        if nixos.current_system() == self.next_system:
             return False
         return True
 
     def load(self):
         # Add attributes after deserialization if needed to stay compatible
         # with older persisted instances of UpdateActivity.
-        if not hasattr(self, "current_release"):
-            self.current_release = None
-        if not hasattr(self, "next_release"):
-            self.next_release = None
-        if not hasattr(self, "changelog_url"):
-            self.changelog_url = None
+        pass
+        # there are currently no old pieces of activity data we need to stay compatible with
 
     def prepare(self, dry_run=False):
         self.log.debug(
@@ -169,6 +157,7 @@ class UpdateActivity(Activity):
             )
             raise
 
+        # Note: These information might be stale in case the current_system has changed in the background between time of *prepare* and actual execution.
         self.unit_changes = nixos.dry_activate_system(
             self.next_system, self.log
         )
@@ -208,7 +197,7 @@ class UpdateActivity(Activity):
 
     @property
     def identical_to_current_system(self) -> bool:
-        if self.current_system == self.next_system:
+        if nixos.current_system() == self.next_system:
             self.log.info(
                 "update-identical-system",
                 version=self.next_version,
@@ -266,13 +255,12 @@ class UpdateActivity(Activity):
             returncode=self.returncode,
             current_version=self.current_version,
             current_channel_url=self.current_channel_url,
-            current_system=self.current_system,
+            current_system=nixos.current_system(),
             current_environment=self.current_environment,
             next_channel=self.next_channel_url,
             next_system=self.next_system,
             next_version=self.next_version,
             next_environment=self.next_environment,
-            next_release=self.next_release,
         )
 
     def resume(self):
@@ -354,13 +342,6 @@ class UpdateActivity(Activity):
         if unit_change_lines:
             msg.extend(unit_change_lines)
             msg.append("")
-
-        if self.next_release:
-            msg.append(
-                f"Release: {self.current_release} -> {self.next_release}"
-            )
-        if self.changelog_url:
-            msg.append(f"ChangeLog: {self.changelog_url}")
 
         if self.current_environment != self.next_environment:
             msg.append(
@@ -458,7 +439,7 @@ class UpdateActivity(Activity):
         or more than one if there is a downgrade happening. e.g. ["24.05", "24.11"]
         The order reflects the before -> after progression.
         """
-        result = [nixos.os_release(self.current_system)["VERSION_ID"]]
+        result = [nixos.os_release(nixos.current_system())["VERSION_ID"]]
         next_release = nixos.os_release(self.next_system)["VERSION_ID"]
         if next_release not in result:
             result.append(next_release)
@@ -485,37 +466,44 @@ class UpdateActivity(Activity):
             self.reboot_needed = RebootType.WARM
 
     def _register_reboot_for_kernel(self):
-        current_kernel = nixos.kernel_version(
-            p.join(self.current_system, "kernel")
-        )
         next_kernel = nixos.kernel_version(p.join(self.next_system, "kernel"))
 
-        if current_kernel == next_kernel:
+        if self.current_kernel == next_kernel:
             self.log.debug("update-kernel-unchanged")
         else:
             self.log.info(
                 "update-kernel-changed",
-                current_kernel=current_kernel,
+                current_kernel=self.current_kernel,
                 next_kernel=next_kernel,
             )
             self.reboot_needed = RebootType.WARM
 
-        self.current_kernel = current_kernel
         self.next_kernel = next_kernel
 
-    def _detect_current_state(self):
-        self.current_os_release = nixos.os_release()
-        self.current_version = self.current_os_release["BUILD_ID"]
-        self.current_channel_url = nixos.current_nixos_channel_url()
-        self.current_environment = nixos.current_fc_environment_name()
-        self.current_system = nixos.current_system()
+    def _log_current_state(self):
         self.log.debug(
             "update-activity-current-state",
-            current_version=self.current_version,
-            current_channel_url=self.current_channel_url,
-            current_environment=self.current_environment,
-            current_system=self.current_system,
+            current_version=nixos.os_release()["BUILD_ID"],
+            current_channel_url=nixos.current_nixos_channel_url(),
+            current_environment=nixos.current_fc_environment_name(),
+            current_system=nixos.current_system(),
         )
+
+    @property
+    def current_channel_url(self):
+        return nixos.current_nixos_channel_url()
+
+    @property
+    def current_environment(self):
+        return nixos.current_fc_environment_name()
+
+    @property
+    def current_version(self):
+        return nixos.os_release()["BUILD_ID"]
+
+    @property
+    def current_kernel(self):
+        return nixos.kernel_version(p.join(nixos.current_system(), "kernel"))
 
     def _detect_next_version(self):
         self.next_version = nixos.channel_version(self.next_channel_url)

--- a/pkgs/fc/agent/src/fc/maintenance/activity/update.py
+++ b/pkgs/fc/agent/src/fc/maintenance/activity/update.py
@@ -321,7 +321,7 @@ class UpdateActivity(Activity):
         self.returncode = 0
 
     @property
-    def summary(self):
+    def summary(self) -> str:
         """
         A human-readable summary of what will be changed by this update.
         Includes possible reboots, significant unit state changes (start, stop,
@@ -350,9 +350,11 @@ class UpdateActivity(Activity):
         elif self.current_environment is not None:
             msg.append(f"Environment: {self.current_environment} (unchanged)")
 
-        current_build = nixos.get_fc_channel_build(
-            self.current_channel_url, self.log
-        )
+        current_build = None
+        if self.current_channel_url:
+            current_build = nixos.get_fc_channel_build(
+                self.current_channel_url, self.log
+            )
         if current_build:
             next_build = nixos.get_fc_channel_build(
                 self.next_channel_url, self.log

--- a/pkgs/fc/agent/src/fc/maintenance/tests/test_maintenance.py
+++ b/pkgs/fc/agent/src/fc/maintenance/tests/test_maintenance.py
@@ -402,7 +402,7 @@ def test_request_update_unchanged_system_and_no_other_requests_skips_request(
 
 
 class FakeUpdateActivity(UpdateActivity):
-    def _detect_current_state(self):
+    def _log_current_state(self):
         pass
 
     def _detect_next_version(self):
@@ -517,8 +517,7 @@ def test_release_path(tmp_path, logger, log, monkeypatch):
     monkeypatch.setattr("fc.util.nixos.CURRENT_SYSTEM", current_d)
 
     class PathAwareFakeUpdateActivity(FakeUpdateActivity):
-        def _detect_current_state(self):
-            self.current_system = fc.util.nixos.current_system()
+        def _log_current_state(self):
             # usually acquired through `nixos.build_system`, which returns a str
             self.next_system = str(next_d)
 

--- a/pkgs/fc/agent/src/fc/util/nixos.py
+++ b/pkgs/fc/agent/src/fc/util/nixos.py
@@ -79,7 +79,7 @@ class Specialisation(Enum):
     BASE_CONFIG = 2
 
 
-def kernel_version(kernel):
+def kernel_version(kernel) -> str:
     """Guesses kernel version from /run/*-system/kernel.
 
     Theory of operation: A link like `/run/current-system/kernel` points
@@ -99,7 +99,7 @@ def kernel_version(kernel):
     return moddir[0]
 
 
-def current_fc_environment_name(log=_log):
+def current_fc_environment_name(log=_log) -> Optional[str]:
     env_path = Path(FC_ENV_FILE)
     if env_path.exists():
         environment = env_path.read_text()
@@ -107,9 +107,10 @@ def current_fc_environment_name(log=_log):
         return environment
     else:
         log.debug("fc-environment-env-file-missing", filename=FC_ENV_FILE)
+        return None
 
 
-def channel_version(channel_url, log=_log):
+def channel_version(channel_url, log=_log) -> str:
     try:
         nixpkgs_path = subprocess.run(
             ["nix-instantiate", "-I", channel_url, "--find-file", "."],
@@ -144,6 +145,7 @@ def get_fc_channel_build(channel_url: str, log=_log) -> Optional[str]:
             ),
             channel_url=channel_url,
         )
+        return None
 
 
 CURRENT_SYSTEM = Path("/run/current-system")
@@ -175,7 +177,7 @@ def os_release(system: Path | None = None):
     return result
 
 
-def current_nixos_channel_version():
+def current_nixos_channel_version() -> str:
     is_local = False
     if is_local:
         return "local-checkout"
@@ -194,7 +196,7 @@ def current_nixos_channel_url(log=_log) -> Optional[str]:
             "nix-channel-file-missing",
             _replace_msg="/root/.nix-channels does not exist, doing nothing",
         )
-        return
+        return None
     try:
         with open("/root/.nix-channels") as f:
             for line in f.readlines():
@@ -208,9 +210,10 @@ def current_nixos_channel_url(log=_log) -> Optional[str]:
             "Failed to read .nix-channels. See exception for details.",
             exc_info=True,
         )
+    return None
 
 
-def current_system(log=_log):
+def current_system(log=_log) -> Optional[str]:
     if not p.exists(CURRENT_SYSTEM):
         log.warn("current-system-missing")
         return None
@@ -352,7 +355,7 @@ def find_nix_eval_warnings(stderr: str) -> list[str]:
     )
 
 
-def find_nix_build_error(stderr: str, log=_log):
+def find_nix_build_error(stderr: str, log=_log) -> str:
     """Returns the (hopefully) interesting part of the error message from Nix
     build output or a generic message if nothing is found.
     """
@@ -364,7 +367,7 @@ def find_nix_build_error(stderr: str, log=_log):
     try:
         lines = stderr.splitlines()
         num_lines = len(lines)
-        error_lines = []
+        error_lines: list[str] = []
 
         lines = list(
             itertools.dropwhile(


### PR DESCRIPTION
@flyingcircusio/release-managers

Reverts the reverts made in #1845, because they do more harm than they do good:
- the reverts break processing of newly serialised activities that are now lacking formerly serialised current attributes
- The reason for reverting it in the first place was not valid: The bug uncovered in PL-134082 was not related to the changes.
  - The code path does not include the current system properties, but only the `next_system`, which was and is still serialised the same way: `        next_kernel = nixos.kernel_version(p.join(self.next_system, "kernel"))`
  - somehow, the layout of the used kernel directory changed, triggering the original issue. Still worth fixing, but unrelated to the commits I am re-introducing again here.

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - revert of a revert: we have already seen all the code affected here in -dev and -staging
  - emergency hotfix merge to fix accumulating stuck maintenances in -dev 
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still pass