### PR TITLE
fc-agent: compare kernel packages instead of versions

### DIFF
--- a/changelog.d/20251003_021028_PL-134082-fix-agent_scriv.md
+++ b/changelog.d/20251003_021028_PL-134082-fix-agent_scriv.md
@@ -1,0 +1,19 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+
+### NixOS XX.XX platform
+
+- fc-maintenance: detect need for reboot based on kernel package, not only version number (PL-134082)
+
+  This makes the parsing of a system's used kernel more robust, and introduces reboots for changed kernels within the same version number.

--- a/pkgs/fc/agent/src/fc/maintenance/activity/tests/test_update.py
+++ b/pkgs/fc/agent/src/fc/maintenance/activity/tests/test_update.py
@@ -1,6 +1,7 @@
 import textwrap
 from io import StringIO
 from unittest.mock import Mock, create_autospec
+from pathlib import Path
 
 import responses
 import yaml
@@ -15,6 +16,7 @@ from fc.util.nixos import (
     ChannelUpdateFailed,
     RegisterFailed,
     SwitchFailed,
+    KernelIdentifier,
 )
 from pytest import fixture
 from rich.console import Console
@@ -38,8 +40,8 @@ NEXT_VERSION_ID = "21.05"
 CURRENT_SYSTEM_PATH = f"/nix/store/zbx8i9v4j8dzlwp83qvrzjgvj7d0qm0d-nixos-system-test-{NEXT_BUILD_ID}"
 NEXT_SYSTEM_PATH = f"/nix/store/v49jzgwblcn9vkrmpz92kzw5pkbsn0vz-nixos-system-test-{NEXT_BUILD_ID}"
 
-CURRENT_KERNEL_VERSION = "5.10.45"
-NEXT_KERNEL_VERSION = "5.10.50"
+CURRENT_KERNEL_VERSION = KernelIdentifier("asdfgh-linux-5.10.45")
+NEXT_KERNEL_VERSION = KernelIdentifier("qwertz-linux-5.10.50")
 
 UNIT_CHANGES = {
     "reload": ["nginx.service"],
@@ -77,7 +79,8 @@ activity: !!python/object:fc.maintenance.activity.update.UpdateActivity
   current_version: 21.05.1233.a9cc58d
   next_channel_url: https://hydra.flyingcircus.io/build/93222/download/1/nixexprs.tar.xz
   next_environment: fc-21.05-production
-  next_kernel: 5.10.50
+  next_kernel: !!python/object:fc.util.nixos.KernelIdentifier
+    store_name: qwertz-linux-5.10.50
   next_system: {NEXT_SYSTEM_PATH}
   next_version: 21.05.1235.bacc11d
   reboot_needed: !!python/object/apply:fc.maintenance.activity.RebootType
@@ -104,7 +107,8 @@ SERIALIZED_ACTIVITY = f"""\
 !!python/object:fc.maintenance.activity.update.UpdateActivity
 next_channel_url: https://hydra.flyingcircus.io/build/93222/download/1/nixexprs.tar.xz
 next_environment: fc-21.05-production
-next_kernel: 5.10.50
+next_kernel: !!python/object:fc.util.nixos.KernelIdentifier
+  store_name: qwertz-linux-5.10.50
 next_system: {NEXT_SYSTEM_PATH}
 next_version: 21.05.1235.bacc11d
 reboot_needed: !!python/object/apply:fc.maintenance.activity.RebootType
@@ -219,10 +223,10 @@ def nixos_mock(monkeypatch):
         elif channel_url == NEXT_CHANNEL_URL:
             return mocked.NEXT_BUILD_ID
 
-    def fake_changed_kernel_version(path):
-        if path == CURRENT_SYSTEM_PATH + "/kernel":
+    def fake_changed_system_kernel(path):
+        if path == Path(CURRENT_SYSTEM_PATH):
             return CURRENT_KERNEL_VERSION
-        elif path == NEXT_SYSTEM_PATH + "/kernel":
+        elif path == Path(NEXT_SYSTEM_PATH):
             return NEXT_KERNEL_VERSION
 
     def fake_os_release(path=None):
@@ -256,7 +260,7 @@ def nixos_mock(monkeypatch):
     mocked.format_unit_change_lines = fc.util.nixos.format_unit_change_lines
     mocked.get_fc_channel_build = fake_get_fc_channel_build
     mocked.channel_version = fake_channel_version
-    mocked.kernel_version = fake_changed_kernel_version
+    mocked.system_kernel = fake_changed_system_kernel
     mocked.resolve_url_redirects = lambda url: url
     mocked.os_release = fake_os_release
     mocked.build_system.return_value = NEXT_SYSTEM_PATH
@@ -609,7 +613,10 @@ def test_current_properties_return_expected_values(nixos_mock, activity):
         "BUILD_ID": "21.05.1233.a9cc58d",
         "VERSION_ID": "21.05",
     }
-    nixos_mock.kernel_version.return_value = "5.10.45"
+    nixos_mock.system_kernel = Mock()
+    nixos_mock.system_kernel.return_value = KernelIdentifier(
+        "yshd-mocktest-5.10.42"
+    )
 
     # Test that properties return the mocked values
     assert (
@@ -618,7 +625,7 @@ def test_current_properties_return_expected_values(nixos_mock, activity):
     )
     assert activity.current_environment == "fc-21.05-production"
     assert activity.current_version == "21.05.1233.a9cc58d"
-    assert activity.current_kernel == "5.10.45"
+    assert str(activity.current_kernel) == "<Kernel: mocktest v5.10.42>"
 
 
 def test_current_properties_not_serialized(activity):

--- a/pkgs/fc/agent/src/fc/maintenance/activity/update.py
+++ b/pkgs/fc/agent/src/fc/maintenance/activity/update.py
@@ -4,6 +4,7 @@ This activity does nothing if the machine already uses the new version.
 """
 
 import os.path as p
+from pathlib import Path
 from typing import Optional
 
 import structlog
@@ -468,7 +469,7 @@ class UpdateActivity(Activity):
             self.reboot_needed = RebootType.WARM
 
     def _register_reboot_for_kernel(self):
-        next_kernel = nixos.kernel_version(p.join(self.next_system, "kernel"))
+        next_kernel = nixos.system_kernel(Path(self.next_system))
 
         if self.current_kernel == next_kernel:
             self.log.debug("update-kernel-unchanged")
@@ -504,8 +505,10 @@ class UpdateActivity(Activity):
         return nixos.os_release()["BUILD_ID"]
 
     @property
-    def current_kernel(self):
-        return nixos.kernel_version(p.join(nixos.current_system(), "kernel"))
+    def current_kernel(self) -> nixos.KernelIdentifier:
+        system = nixos.current_system()
+        assert system, "No current system path"
+        return nixos.system_kernel(Path(system))
 
     def _detect_next_version(self):
         self.next_version = nixos.channel_version(self.next_channel_url)

--- a/pkgs/fc/agent/src/fc/maintenance/maintenance.py
+++ b/pkgs/fc/agent/src/fc/maintenance/maintenance.py
@@ -206,10 +206,10 @@ def request_reboot_for_kernel(
                 "trigger a reboot when it succeeds."
             ),
         )
-        return
+        return None
 
-    booted = fc.util.nixos.kernel_version("/run/booted-system/kernel")
-    current = fc.util.nixos.kernel_version("/run/current-system/kernel")
+    booted = fc.util.nixos.system_kernel(Path("/run/booted-system"))
+    current = fc.util.nixos.system_kernel(Path("/run/current-system"))
     log.debug("check-kernel-reboot", booted=booted, current=current)
     if booted != current:
         log.info(
@@ -224,6 +224,8 @@ def request_reboot_for_kernel(
             RebootActivity("reboot"),
             comment=f"Reboot to activate changed kernel ({booted} to {current})",
         )
+    else:
+        return None
 
 
 def request_update(

--- a/pkgs/fc/agent/src/fc/maintenance/tests/test_maintenance.py
+++ b/pkgs/fc/agent/src/fc/maintenance/tests/test_maintenance.py
@@ -9,6 +9,7 @@ from fc.maintenance.activity import RebootType
 from fc.maintenance.activity.reboot import RebootActivity
 from fc.maintenance.activity.update import UpdateActivity
 from fc.maintenance.activity.vm_change import VMChangeActivity
+from fc.util.nixos import KernelIdentifier
 from pytest import fixture
 
 ENC = {
@@ -304,19 +305,22 @@ def test_do_not_request_for_unchanged_guest_properties(
 
 def test_request_reboot_for_kernel_change(logger):
     def fake_changed_kernel_version(path):
-        if path == "/run/booted-system/kernel":
-            return "5.10.45"
-        elif path == "/run/current-system/kernel":
-            return "5.10.50"
+        if path == Path("/run/booted-system/"):
+            return KernelIdentifier("asdf-linux-5.10.45")
+        elif path == Path("/run/current-system/"):
+            return KernelIdentifier("hjkl-linux-5.10.50")
 
     with unittest.mock.patch(
-        "fc.util.nixos.kernel_version", fake_changed_kernel_version
+        "fc.util.nixos.system_kernel", fake_changed_kernel_version
     ):
         request = fc.maintenance.maintenance.request_reboot_for_kernel(
             logger, []
         )
 
-    assert "kernel (5.10.45 to 5.10.50)" in request.comment
+    assert (
+        "kernel (<Kernel: linux v5.10.45> to <Kernel: linux v5.10.50>)"
+        in request.comment
+    )
     activity = request.activity
     assert isinstance(activity, RebootActivity)
     assert activity.reboot_needed == RebootType.WARM
@@ -324,13 +328,13 @@ def test_request_reboot_for_kernel_change(logger):
 
 def test_do_not_request_reboot_for_unchanged_kernel(logger):
     def fake_changed_kernel_version(path):
-        if path == "/run/booted-system/kernel":
-            return "5.10.50"
-        elif path == "/run/current-system/kernel":
-            return "5.10.50"
+        if path == Path("/run/booted-system"):
+            return KernelIdentifier("hjkl-linux-5.10.50")
+        elif path == Path("/run/current-system"):
+            return KernelIdentifier("hjkl-linux-5.10.50")
 
     with unittest.mock.patch(
-        "fc.util.nixos.kernel_version", fake_changed_kernel_version
+        "fc.util.nixos.system_kernel", fake_changed_kernel_version
     ):
         request = fc.maintenance.maintenance.request_reboot_for_kernel(
             logger, []
@@ -490,7 +494,7 @@ def test_request_update_skip_when_free_disk_low(
 def test_do_not_request_reboot_when_tempfail_update_present(
     logger, log, monkeypatch
 ):
-    with unittest.mock.patch("fc.util.nixos.kernel_version") as mock:
+    with unittest.mock.patch("fc.util.nixos.system_kernel") as mock:
         activity = FakeUpdateActivity("https://fake")
         activity.reboot_needed = RebootType.WARM
         request = Request(activity)

--- a/pkgs/fc/agent/src/fc/util/nixos.py
+++ b/pkgs/fc/agent/src/fc/util/nixos.py
@@ -6,6 +6,7 @@ import os.path as p
 import re
 import resource
 import subprocess
+from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
 from subprocess import PIPE, STDOUT
@@ -79,24 +80,47 @@ class Specialisation(Enum):
     BASE_CONFIG = 2
 
 
-def kernel_version(kernel) -> str:
-    """Guesses kernel version from /run/*-system/kernel.
+@dataclass(eq=True, repr=False)
+class KernelIdentifier:
+    store_name: str
 
-    Theory of operation: A link like `/run/current-system/kernel` points
-    to a bzImage like `/nix/store/abc...-linux-4.4.27/bzImage`. The
-    directory also contains a `lib/modules` dir which should have the
-    kernel version as sole subdir, e.g.
-    `/nix/store/abc...-linux-4.4.27/lib/modules/4.4.27`. This function
-    returns that version number or bails out if the assumptions laid down here
-    do not hold.
+    def __repr__(self):
+        """attempts to print the kernel version, falls back to printing the
+        full name.
+        Equality is always tested against the full name though.
+        """
+        try:
+            name_parts = self.store_name.split("-")
+            package_name = name_parts[-2]
+            package_version = name_parts[-1]
+            return f"<Kernel: {package_name} v{package_version}>"
+        except IndexError:
+            return f"<Kernel: {self.store_name}>"
+
+
+def system_kernel(system_top_level: Path) -> KernelIdentifier:
+    """Return the kernel package name of a given system."""
+    # a system holds a reference to its kernel as a symlink
+    try:
+        kernel_package_path = (system_top_level / "kernel").readlink()
+    except FileNotFoundError:
+        raise RuntimeError(f"{system_top_level} references no kernel.")
+    return kernel_package(kernel_package_path)
+
+
+def kernel_package(kernel_store_path: Path) -> KernelIdentifier:
+    """Return an identifier describing a kernel package.
+    Essentially, this identifier is the name of the nix store path, plus some
+    convenient representation.
+
+    The returned kernel name is **not** the kernel version, but the store path
+    name of the kernel package. When checking the necessity of a reboot, we only
+    care about a *difference* in kernel packages, not exact version number
+    differences. E.g. we still want to reboot when recompiling the same kernel
+    release with different options, resulting in a different store path.
     """
-    bzImage = os.readlink(kernel)
-    moddir = os.listdir(p.join(p.dirname(bzImage), "lib", "modules"))
-    if len(moddir) != 1:
-        raise RuntimeError(
-            "modules subdir does not contain exactly one item", moddir
-        )
-    return moddir[0]
+
+    return KernelIdentifier(kernel_store_path.name)
 
 
 def current_fc_environment_name(log=_log) -> Optional[str]:

--- a/pkgs/fc/agent/src/fc/util/tests/test_nixos.py
+++ b/pkgs/fc/agent/src/fc/util/tests/test_nixos.py
@@ -492,33 +492,46 @@ def test_find_nix_build_error_oneline():
 
 
 @pytest.fixture
-def dirsetup(tmpdir):
-    drv = tmpdir.mkdir("abcdef-linux-4.4.27")
-    current = tmpdir.mkdir("current")
-    bzImage = drv.ensure("bzImage")
-    (current / "kernel").mksymlinkto(bzImage)
-    mod = drv.mkdir("lib").mkdir("modules")
-    return current / "kernel", mod
+def dirsetup(tmp_path):
+    drv = tmp_path / "abcdef-linux-4.4.27"
+    drv.mkdir()
+    current = tmp_path / "current"
+    current.mkdir()
+    (current / "kernel").symlink_to(drv)
+    return current
 
 
 def test_kernel_versions_equal(dirsetup, tmpdir):
-    kernel, mod = dirsetup
-    mod.mkdir("4.4.27")
-    assert "4.4.27" == nixos.kernel_version(str(kernel))
+    system = dirsetup
+    assert nixos.system_kernel(system) == nixos.system_kernel(system)
+    assert not nixos.system_kernel(system) != nixos.system_kernel(system)
+    assert nixos.system_kernel(system) == nixos.kernel_package(
+        Path("/nix/store") / "abcdef-linux-4.4.27"
+    )
+    assert nixos.system_kernel(system) == nixos.KernelIdentifier(
+        "abcdef-linux-4.4.27"
+    )
 
 
 def test_kernel_version_empty(dirsetup, tmpdir):
-    kernel, mod = dirsetup
+    (dirsetup / "kernel").unlink()
     with pytest.raises(RuntimeError):
-        nixos.kernel_version(str(kernel))
+        nixos.system_kernel(dirsetup)
 
 
-def test_multiple_kernel_versions(dirsetup, tmpdir):
-    kernel, mod = dirsetup
-    mod.mkdir("4.4.27")
-    mod.mkdir("4.4.28")
-    with pytest.raises(RuntimeError):
-        nixos.kernel_version(str(kernel))
+def test_KernelIdentifier():
+    id_regular = nixos.KernelIdentifier("abcdef-linux-4.4.27")
+    id_regular_rebuild = nixos.KernelIdentifier("asdfgh-linux-4.4.27")
+    id_patched = nixos.KernelIdentifier("abcdef-linuxPatched-4.4.27")
+    id_bogus = nixos.KernelIdentifier("somebogusString")
+
+    assert id_regular != id_regular_rebuild
+    assert id_regular != id_patched
+    assert str(id_regular) == str(id_regular_rebuild)
+    assert str(id_regular) != str(id_patched)
+    assert str(id_regular) == "<Kernel: linux v4.4.27>"
+    assert str(id_patched) == "<Kernel: linuxPatched v4.4.27>"
+    assert str(id_bogus) == "<Kernel: somebogusString>"
 
 
 def test_os_release_parser(tmp_path):


### PR DESCRIPTION
For checking whether a reboot is required, we compare kernels of current and next system. The previous logic tried to extract the *kernel version* from the store by investigating lib module paths. This was brittle and suffered from multiple issues:
- we encountered a system where the expected subdirectory tree structure was not present -> causing a crash
- kernel changes within the same version, e.g. recompiling with different config, are not detected
- so we actually do not need to compare the kernel *version*, but exact *package*

This introduces a KernelIdentifier denominating the used kernel packages. It deliberately can only be compared for equality, and provides some robust pretty printing of the identifier itself.

fixes PL-134082

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - [x] improve robustness of system kernel parsing and comparison, the existing one turned out to be brittle
  - [x] provide test coverage for new functions
  - [x] adjust existing tests to fit the refactored code
- [ ] Security requirements tested? (EVIDENCE)
  - automated tests pass