### PR TITLE
varnish: provide an option to define a fallback configuration and mix nix/non-nix configuration

### DIFF
--- a/changelog.d/20251008_113413_FC-41407_merged-varnish-config_scriv.md
+++ b/changelog.d/20251008_113413_FC-41407_merged-varnish-config_scriv.md
@@ -1,0 +1,21 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+
+### NixOS XX.XX platform
+
+- Added an option to provide a fallback configuration for the Varnish service that defaults to the contents of `/etc/local/varnish/default.vcl`.
+  The configuration provided via this option will be applied if none of the virtual hosts' conditions defined via the NixOS configuration option
+  `flyingcircus.services.varnish.virtualHosts.<name>` are matched or if none are defined. (FC-41407)

--- a/nixos/roles/webproxy.nix
+++ b/nixos/roles/webproxy.nix
@@ -46,17 +46,6 @@ in
 
   config = lib.mkMerge [
     (lib.mkIf fccfg.enable {
-      assertions = [
-        {
-          assertion =
-            builtins.length (builtins.attrNames config.flyingcircus.services.varnish.virtualHosts) <= 1
-            || builtins.isNull varnishCfg;
-          message = ''
-            Please remove the file `/etc/local/varnish/default.vcl` if you want to specify your Varnish configuration in Nix code.
-          '';
-        }
-      ];
-
       environment.etc = {
         "local/varnish/README.txt".text = ''
           Varnish is enabled on this machine.
@@ -111,12 +100,7 @@ in
         http_address = lib.concatMapStringsSep " -a " (addr: "${addr}:8008") (
           lib.unique fccfg.listenAddresses
         );
-        virtualHosts = lib.optionalAttrs (varnishCfg != null) {
-          "default-vcl" = {
-            condition = "true";
-            config = varnishCfg;
-          };
-        };
+        fallbackConfig = lib.mkIf (varnishCfg != null) varnishCfg;
       };
 
       systemd.services = {

--- a/nixos/services/varnish/default.nix
+++ b/nixos/services/varnish/default.nix
@@ -5,6 +5,7 @@
   ...
 }:
 let
+  inherit (config) fclib;
   cfg = config.flyingcircus.services.varnish;
   vcfg = config.services.varnish;
   vadm = "${vcfg.package}/bin/varnishadm";
@@ -68,8 +69,17 @@ let
     }
   '';
 
-  vhosts = map mkHostSelection (builtins.attrValues cfg.virtualHosts);
-  virtualHostSelection = lib.concatStringsSep "else" (builtins.catAttrs "config" vhosts);
+  vhosts = map mkHostSelection (
+    (builtins.attrValues cfg.virtualHosts)
+    ++ (lib.optionals (cfg.fallbackConfig != "") [
+      {
+        config = cfg.fallbackConfig;
+        host = "localhost";
+        condition = "true";
+      }
+    ])
+  );
+  virtualHostSelection = (lib.concatStringsSep "else" (builtins.catAttrs "config" vhosts));
 
   startupscript =
     let
@@ -128,6 +138,25 @@ in
     extraCommandLine = mkOption {
       type = types.separatedString " ";
       default = "";
+    };
+    # cfg.fallbackConfig is defined seperately to ensure proper ordering when assembling the final configuration.
+    # Unlike lists dictionaries do not have a defined ordering, which is why the fallback config is defined seperately.
+    # This ensures that it comes last in the finished varnish configuration - just as the name implies
+    fallbackConfig = mkOption {
+      type = types.lines;
+      default = ''
+        vcl 4.0;
+        import std;
+
+        backend default {
+          .host = "0.0.0.0";
+          .port = "80";
+        }
+
+        sub vcl_recv {
+          return (synth(503, "Internal Error"));
+        }
+      '';
     };
     http_address = mkOption {
       type = types.str;

--- a/tests/webproxy.nix
+++ b/tests/webproxy.nix
@@ -15,6 +15,46 @@ import ./make-test-python.nix (
   {
     name = "webproxy";
     nodes = {
+      webproxy_mixed_config =
+        { lib, ... }:
+        let
+          serverport = 8080;
+        in
+        {
+          imports = [ (testlib.fcConfig { id = 3; }) ];
+
+          flyingcircus.roles.webproxy.enable = true;
+
+          environment.etc."local/varnish/default.vcl".text = ''
+            vcl 4.0;
+
+            backend test {
+              .host = "127.0.0.1";
+              .port = "${builtins.toString serverport}";
+            }
+          '';
+
+          flyingcircus.services.varnish.virtualHosts.foo = {
+            condition = "req.http.Host == \"Test\"";
+            config = ''
+              vcl 4.0;
+
+              backend test {
+                .host = "127.0.0.1";
+                .port = "666";
+              }
+            '';
+          };
+
+          systemd.services.helloserver = {
+            wantedBy = [ "multi-user.target" ];
+            script = ''
+              echo 'Hello World!' > hello.txt
+              ${pkgs.python3.interpreter} -m http.server ${builtins.toString serverport} >&2
+            '';
+          };
+        };
+
       webproxy_old_varnish =
         { lib, ... }:
         let
@@ -115,6 +155,8 @@ import ./make-test-python.nix (
     };
 
     testScript = ''
+      start_all()
+
       webproxy.wait_for_unit("varnish.service")
       webproxy.wait_for_unit("varnishncsa.service")
       webproxy.wait_for_unit("helloserver.service")
@@ -168,6 +210,17 @@ import ./make-test-python.nix (
         webproxy.start()
         webproxy.wait_for_unit("varnish.service")
         webproxy.fail("/run/current-system/specialisation/varnish-broken-config-test/bin/switch-to-configuration switch")
+
+      with subtest("fallback configuration for varnish works if the other conditions don't match"):
+        # verify that requests with the "Test" host header are being handled by the explicitly defined varnish backend
+        # while others are handled by the fallback backend
+        # the fallback configuration points at a working http server that serves a hello.txt while the other
+        # (explicitly configured) backend which is selected when adding the "Test" host header doesn't serve anything
+        webproxy_mixed_config.wait_for_unit("varnish.service")
+        webproxy_mixed_config.succeed("varnishadm vcl.list | grep \"localhost\"")
+        webproxy_mixed_config.succeed("varnishadm vcl.show")
+        webproxy_mixed_config.fail(f"curl --fail -H 'Host: Test' 127.0.0.1:8008/hello.txt")
+        webproxy_mixed_config.succeed(f"curl --fail 127.0.0.1:8008/hello.txt")
     '';
   }
 )


### PR DESCRIPTION
[FC-41407](https://yt.flyingcircus.io/issue/FC-41407)

Add a new "fallback configuration" option to the Varnish service that serves as a fallback when none of the conditions for the defined virtualHosts are matched. With the default value (set via the webproxy role) being the contents of the file `/etc/local/varnish/default.vcl`, this serves as a means of defining the entire configuration there without the additional functionality of the NixOS module system. This was was possible before but limited to cases where no virtualHosts was defined in the NixOS configuration. If any virtualHost was defined and the above file present with the webproxy role enabled, the entire configuration would fail to evaluate.

With this PR, the above file - or rather it's contents - now also serve as a fallback VCL without having to assign the "default" virtualHost a condition which always evaluates to true and a name that happens to be always end up after the other virtualHosts alphabetically sorted and thereby relying on the fact that Nix sorts dictionary key alphabetically which just happens to be an implementation detail since according to the reference manual dictionaries have no defined ordering (https://nix.dev/manual/nix/2.18/language/values.html#attribute-set).

For cases where the above file is not present, the previous behavior of returning a 503 is retained if none of the defined virtualHost's conditions match or none are defined.

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

- changed behavior regarding the inclusion of the file `/etc/local/varnish/default.vcl` as part of the varnish configuration 

- [x] Security requirements tested? (EVIDENCE)

- The file was also included previously and in cases where it was left behind after a migration to a nix based configuration the system would fail to evaluate.  