### PR TITLE
nixos/nginx: replace multiline warnings with singleline

### DIFF
--- a/nixos/services/nginx/default.nix
+++ b/nixos/services/nginx/default.nix
@@ -363,10 +363,10 @@ in
                   default = null;
                   apply =
                     x:
-                    lib.warnIf (x != null) ''
-                      flyingcircus.services.nginx.virtualHosts.<vhost>.emailACME is deprecated.
-                      This option will be removed with fc-nixos 25.11. Please use security.acme.certs.<name>.email.
-                    '' x;
+                    lib.warnIf (x != null) (
+                      "flyingcircus.services.nginx.virtualHosts.<vhost>.emailACME is deprecated. "
+                      + "This option will be removed with fc-nixos 25.11. Please use security.acme.certs.<name>.email."
+                    ) x;
                 };
 
                 enableACME =
@@ -381,10 +381,10 @@ in
                   // {
                     # This attribute is only evaluated when no explicit value is set.
                     # So, when `default = true`, it's set via the above expression.
-                    default = lib.warnIf default ''
-                      flyingcircus.services.nginx.virtualHosts."${name}".enableACME is implicitly set to true.
-                      This behavior is deprecated and will be removed with fc-nixos 25.11. Please set the option explicitly.
-                    '' default;
+                    default = lib.warnIf default (
+                      "flyingcircus.services.nginx.virtualHosts.\"${name}\".enableACME is implicitly set to true. "
+                      + "This behavior is deprecated and will be removed with fc-nixos 25.11. Please set the option explicitly."
+                    ) default;
                   };
 
                 listenAddresses = vhost.options.listenAddresses // {


### PR DESCRIPTION
multi-line warnings are not correctly shown in our fc-manage check

@flyingcircusio/release-managers

## Release process

- [ ] Created changelog entry using `./changelog.sh`
  no: followup to existing change, mostly internal

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [x] Security requirements tested? (EVIDENCE)
  tested `fc-manage check` on dev vm 