### PR TITLE
[25.05] nixos/roles/mysql57: add deprecation warning when mysql57 role is enabled

### DIFF
--- a/changelog.d/20251014_132550_HEAD_scriv.md
+++ b/changelog.d/20251014_132550_HEAD_scriv.md
@@ -1,0 +1,19 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+
+### NixOS XX.XX platform
+
+- nixos/mysql57: add deprecation warning if `mysql57` role is activated, as MySQL 5.7 is end-of-life for 2 years (PL-134105)

--- a/nixos/roles/mysql.nix
+++ b/nixos/roles/mysql.nix
@@ -137,6 +137,9 @@ in
             message = "MySQL / Percona roles are mutually exclusive. Only one may be enabled.";
           }
         ];
+        warnings = lib.optionals (config.flyingcircus.roles.mysql57.enable) [
+          "The mysql57 role is deprecated and will be removed with fc-nixos 25.11, as MySQL 5.7 is end-of-life."
+        ];
 
         users.users.mysql = {
           shell = "/run/current-system/sw/bin/bash";


### PR DESCRIPTION
PL-134105

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [x] Security requirements tested? (EVIDENCE)
  tested that warning shows only when mysql57 is enabled