### PR TITLE
Add `--disk-size` argument in the fc-devhost for disk sizing

### DIFF
--- a/changelog.d/20251014_234412_FC-48241-disk-size-devhost_scriv.md
+++ b/changelog.d/20251014_234412_FC-48241-disk-size-devhost_scriv.md
@@ -1,0 +1,21 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+- DevHost VMs can now have configurable disk sizes, allowing for larger development environments when needed.
+
+
+### NixOS XX.XX platform
+
+- DevHost: Added support for setting custom disk sizes for VMs via the `--disk-size` parameter and `disk-size` batou configuration option. VMs default to 25G if not specified. The filesystem automatically expands to use the full disk space on boot using existing fc-resize-disk functionality. (FC-48241)

--- a/doc/src/devhost.md
+++ b/doc/src/devhost.md
@@ -92,6 +92,7 @@ host = dev.example.com
 release = https://my.flyingcircus.io/releases/metadata/fc-25.05-staging
 # Older batou versions (<=2.5.0) only support the hydra_eval attribute instead of `release`
 # hydra-eval = 309628
+disk_size = 50G
 
 [host:myvm]
 provision-dynamic-hostname = True
@@ -150,6 +151,10 @@ through access to the UI of your applications and act similar to port forwards
 for port 443 -> 443. You should use self-signed certificates within the
 vms. (`batou_ext.ssl.Certificate` already allows switching between
 custom certificates).
+
+Using `provision-disk-size` allows you to specify the disk size for the VM
+(e.g., `25G`, `50G`, `100G`). If not specified, VMs default to 25G. The VM's
+filesystem will be automatically expanded to use the full disk space on boot.
 
 As the development VMs are not managed by our inventory you need to place relevant
 information about roles in a Nix expression file. You can then use a

--- a/doc/src/devhost.md
+++ b/doc/src/devhost.md
@@ -152,10 +152,6 @@ for port 443 -> 443. You should use self-signed certificates within the
 vms. (`batou_ext.ssl.Certificate` already allows switching between
 custom certificates).
 
-Using `provision-disk-size` allows you to specify the disk size for the VM
-(e.g., `25G`, `50G`, `100G`). If not specified, VMs default to 25G. The VM's
-filesystem will be automatically expanded to use the full disk space on boot.
-
 As the development VMs are not managed by our inventory you need to place relevant
 information about roles in a Nix expression file. You can then use a
 provisioning script {file}`provision.sh` to customize the VMs during

--- a/doc/src/devhost.md
+++ b/doc/src/devhost.md
@@ -148,8 +148,8 @@ become available as `<alias>.<vm>.dev.example.com` and are protected
 with Let's Encrypt certificates automatically. They are intended to pass
 through access to the UI of your applications and act similar to port forwards
 for port 443 -> 443. You should use self-signed certificates within the
-vms. (`batou_ext.ssl.Certifiate` already allows switching between
-custom )
+vms. (`batou_ext.ssl.Certificate` already allows switching between
+custom certificates).
 
 As the development VMs are not managed by our inventory you need to place relevant
 information about roles in a Nix expression file. You can then use a

--- a/nixos/roles/devhost/fc.devhost/src/fc/devhost/__init__.py
+++ b/nixos/roles/devhost/fc.devhost/src/fc/devhost/__init__.py
@@ -20,6 +20,7 @@ def main():
     p.set_defaults(func="ensure")
     p.add_argument("--cpu", type=int, help="number of cores")
     p.add_argument("--memory", type=int, help="amount of memory")
+    p.add_argument("--disk-size", type=str, help="disk size (e.g., 25G, 50G)")
     p.add_argument("--location", help="location the VMs live in")
     p.add_argument("--image-url", type=str, help="url to an image for the vm")
     p.add_argument(

--- a/nixos/roles/devhost/fc.devhost/src/fc/devhost/manager.py
+++ b/nixos/roles/devhost/fc.devhost/src/fc/devhost/manager.py
@@ -457,7 +457,7 @@ class Manager:
                     )
                     break
 
-            if current_size is not None:
+            if current_size is not None and self.cfg.get("disk_size"):
                 new_size_bytes = parse_disk_size(self.cfg["disk_size"])
                 if new_size_bytes < current_size:
                     raise ValueError(

--- a/nixos/roles/devhost/fc.devhost/src/fc/devhost/manager.py
+++ b/nixos/roles/devhost/fc.devhost/src/fc/devhost/manager.py
@@ -426,7 +426,8 @@ class Manager:
             fcntl.flock(self.lockfile, fcntl.LOCK_UN)
             # Wait for the VM to get online
             print("Waiting for VM to become pingable ...")
-            while True:
+            ping_timeout = TimeOut(60)
+            while ping_timeout.tick():
                 response = os.system(f"ping -c 1 {self.cfg['srv-ip']}")
                 if response == 0:
                     break
@@ -435,7 +436,8 @@ class Manager:
 
             # wait for port 22 to accept connections
             print("Waiting for SSH to become available ...")
-            while True:
+            ssh_timeout = TimeOut(60)
+            while ssh_timeout.tick():
                 sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
                 sock.settimeout(5)
                 result = sock.connect_ex((self.cfg["srv-ip"], 22))

--- a/nixos/roles/devhost/fc.devhost/src/fc/devhost/manager.py
+++ b/nixos/roles/devhost/fc.devhost/src/fc/devhost/manager.py
@@ -310,15 +310,6 @@ class Manager:
 
         vm_nix_file_existed = os.path.isfile(self.nix_file)
 
-        # Read old config before writing new one to detect disk size changes
-        old_config = None
-        if os.path.isfile(self.config_file):
-            try:
-                with open(self.config_file, "r") as f:
-                    old_config = json.load(f)
-            except (json.JSONDecodeError, IOError):
-                pass
-
         try:
             with open(self.config_file, mode="w") as f:
                 f.write(json.dumps(self.cfg))
@@ -328,28 +319,6 @@ class Manager:
             self.data_dir.mkdir(parents=True, exist_ok=True)
             VM_BASE_IMAGE_DIR.mkdir(parents=True, exist_ok=True)
             vm_has_image = os.path.isfile(self.image_file)
-
-            # Check if we need to resize an existing image
-            needs_resize = False
-            if vm_has_image and old_config:
-                # For existing VMs, check if disk size has changed
-                old_disk_size = old_config.get("disk_size", "25G")
-                if old_disk_size != self.cfg["disk_size"]:
-                    old_size_bytes = parse_disk_size(old_disk_size)
-                    new_size_bytes = parse_disk_size(self.cfg["disk_size"])
-
-                    if new_size_bytes < old_size_bytes:
-                        raise ValueError(
-                            f"Cannot downsize VM disk from {old_disk_size} to {self.cfg['disk_size']}. "
-                            "XFS filesystem does not support shrinking. "
-                            "Only disk expansion (upsizing) is supported."
-                        )
-                    elif new_size_bytes > old_size_bytes:
-                        print(
-                            f"Disk size changed from {old_disk_size} to {self.cfg['disk_size']}, will resize..."
-                        )
-                        needs_resize = True
-                    # If sizes are equal, no resize needed
 
             if not vm_has_image:
                 image_url_hash = hashlib.sha256(
@@ -451,25 +420,6 @@ class Manager:
                             )
                 os.rename(self.image_file_tmp, self.image_file)
 
-            # Resize disk image if this is a new VM or if disk size has changed
-            # The VM's fc-resize-disk will handle partition/filesystem expansion on boot
-            if not vm_has_image or needs_resize:
-                # For existing VMs that need resizing, check if VM is running and shut it down
-                if needs_resize and self.is_running():
-                    print(
-                        "VM is running and needs disk resize. Shutting down VM..."
-                    )
-                    self.shutdown()
-                    print("VM shutdown completed.")
-
-                print(f"Resizing VM disk image to {self.cfg['disk_size']} ...")
-                run(
-                    "qemu-img",
-                    "resize",
-                    str(self.image_file),
-                    self.cfg["disk_size"],
-                )
-
             # Make sure the VM is now online, even if was previously offline
             run("fc-manage", "switch")
 
@@ -494,6 +444,39 @@ class Manager:
                     break
                 else:
                     time.sleep(0.5)
+
+            # Check if disk resize is needed by querying current disk size via QMP
+            block_info = self.qmp.command("query-block")
+            current_size = None
+            for device in block_info:
+                if device.get("device") == "virtio0":
+                    current_size = (
+                        device.get("inserted", {})
+                        .get("image", {})
+                        .get("virtual-size")
+                    )
+                    break
+
+            if current_size is not None:
+                new_size_bytes = parse_disk_size(self.cfg["disk_size"])
+                if new_size_bytes < current_size:
+                    raise ValueError(
+                        f"Cannot downsize VM disk from {current_size} bytes to {self.cfg['disk_size']}. "
+                        "XFS filesystem does not support shrinking. "
+                        "Only disk expansion (upsizing) is supported."
+                    )
+                elif new_size_bytes > current_size:
+                    print(
+                        f"Disk size changed from {current_size} bytes to {self.cfg['disk_size']}, resizing..."
+                    )
+                    self.qmp.command(
+                        "block_resize", device="virtio0", size=new_size_bytes
+                    )
+                    print("Disk resize completed successfully.")
+                else:
+                    print(
+                        f"Disk size already at {self.cfg['disk_size']}, no resize needed."
+                    )
 
             if vm_has_image:
                 print("Syncing VM enc data into running VM ...")

--- a/nixos/roles/devhost/fc.devhost/src/fc/devhost/manager.py
+++ b/nixos/roles/devhost/fc.devhost/src/fc/devhost/manager.py
@@ -209,10 +209,10 @@ class Manager:
         memory,
         aliases,
         location,
-        disk_size=None,
         hydra_eval=None,
         image_url=None,
         channel_url=None,
+        disk_size=None,
     ):
         print("Assuming devhost lock ...")
         fcntl.flock(self.lockfile, fcntl.LOCK_EX)
@@ -264,9 +264,7 @@ class Manager:
         self.cfg["memory"] = memory
         self.cfg["aliases"] = aliases
         self.cfg["location"] = location
-        self.cfg["disk_size"] = (
-            disk_size or "25G"
-        )  # Default to 25G if not specified
+        self.cfg["disk_size"] = disk_size
         self.cfg["image_url"] = image_url
         self.cfg["channel_url"] = image_url
         self.cfg["last_deploy_date"] = datetime.datetime.now(

--- a/nixos/roles/devhost/fc.devhost/src/fc/devhost/manager.py
+++ b/nixos/roles/devhost/fc.devhost/src/fc/devhost/manager.py
@@ -487,6 +487,10 @@ class Manager:
                     print(
                         f"Disk size already at {self.cfg['disk_size']}, no resize needed."
                     )
+            else:
+                print(
+                    f"No disk size specified or current size unknown: current_size={current_size} self.cfg.get('disk_size')={self.cfg.get('disk_size')}"
+                )
 
             if vm_has_image:
                 print("Syncing VM enc data into running VM ...")

--- a/nixos/roles/devhost/fc.devhost/src/fc/devhost/manager.py
+++ b/nixos/roles/devhost/fc.devhost/src/fc/devhost/manager.py
@@ -445,6 +445,25 @@ class Manager:
                             )
                 os.rename(self.image_file_tmp, self.image_file)
 
+            # Resize disk image if this is a new VM or if disk size has changed
+            # The VM's fc-resize-disk will handle partition/filesystem expansion on boot
+            if not vm_has_image or needs_resize:
+                # For existing VMs that need resizing, check if VM is running and shut it down
+                if needs_resize and self.is_running():
+                    print(
+                        "VM is running and needs disk resize. Shutting down VM..."
+                    )
+                    self.shutdown()
+                    print("VM shutdown completed.")
+
+                print(f"Resizing VM disk image to {self.cfg['disk_size']} ...")
+                run(
+                    "qemu-img",
+                    "resize",
+                    str(self.image_file),
+                    self.cfg["disk_size"],
+                )
+
             # Make sure the VM is now online, even if was previously offline
             run("fc-manage", "switch")
 

--- a/nixos/roles/devhost/fc.devhost/src/fc/devhost/manager.py
+++ b/nixos/roles/devhost/fc.devhost/src/fc/devhost/manager.py
@@ -209,6 +209,7 @@ class Manager:
         memory,
         aliases,
         location,
+        disk_size=None,
         hydra_eval=None,
         image_url=None,
         channel_url=None,
@@ -263,6 +264,9 @@ class Manager:
         self.cfg["memory"] = memory
         self.cfg["aliases"] = aliases
         self.cfg["location"] = location
+        self.cfg["disk_size"] = (
+            disk_size or "25G"
+        )  # Default to 25G if not specified
         self.cfg["image_url"] = image_url
         self.cfg["channel_url"] = image_url
         self.cfg["last_deploy_date"] = datetime.datetime.now(

--- a/nixos/roles/devhost/fc.devhost/src/fc/devhost/manager.py
+++ b/nixos/roles/devhost/fc.devhost/src/fc/devhost/manager.py
@@ -472,6 +472,16 @@ class Manager:
                     self.qmp.command(
                         "block_resize", device="virtio0", size=new_size_bytes
                     )
+                    # now, ssh into the VM and resize the filesystem using sudo fc-resize-disk
+                    run(
+                        "ssh",
+                        "-o",
+                        "StrictHostKeyChecking=no",
+                        "-i",
+                        "/var/lib/devhost/ssh_bootstrap_key",
+                        f"developer@{self.name}",
+                        "sudo fc-resize-disk",
+                    )
                     print("Disk resize completed successfully.")
                 else:
                     print(

--- a/nixos/roles/devhost/fc.devhost/src/fc/devhost/manager.py
+++ b/nixos/roles/devhost/fc.devhost/src/fc/devhost/manager.py
@@ -619,10 +619,9 @@ class Manager:
                 # pid file may contain trailing lines with garbage
                 for line in p:
                     proc = psutil.Process(int(line))
-                    # marker = "{name},process=kvm.{name}".format(name=self.name)
-                    marker = self.name  # i was unable to find the marker above in the cmdline of the qemu process
+                    marker = f" -name {self.name} "
                     # Do not use proc.name() here - it's only 16 bytes ...
-                    if marker not in proc.cmdline():
+                    if marker not in " ".join(proc.cmdline()):
                         break
                     return proc
         except (IOError, OSError, ValueError, psutil.NoSuchProcess):

--- a/nixos/roles/devhost/fc.devhost/src/fc/devhost/manager.py
+++ b/nixos/roles/devhost/fc.devhost/src/fc/devhost/manager.py
@@ -470,7 +470,7 @@ class Manager:
                         f"Disk size changed from {current_size} bytes to {self.cfg['disk_size']}, resizing..."
                     )
                     self.qmp.command(
-                        "block_resize", device="virtio0", size=new_size_bytes
+                        "block_resize", device="root", size=new_size_bytes
                     )
                     # now, ssh into the VM and resize the filesystem using sudo fc-resize-disk
                     run(

--- a/nixos/roles/devhost/fc.devhost/src/fc/devhost/manager.py
+++ b/nixos/roles/devhost/fc.devhost/src/fc/devhost/manager.py
@@ -612,7 +612,8 @@ class Manager:
                 # pid file may contain trailing lines with garbage
                 for line in p:
                     proc = psutil.Process(int(line))
-                    marker = "{name},process=kvm.{name}".format(name=self.name)
+                    # marker = "{name},process=kvm.{name}".format(name=self.name)
+                    marker = self.name  # i was unable to find the marker above in the cmdline of the qemu process
                     # Do not use proc.name() here - it's only 16 bytes ...
                     if marker not in proc.cmdline():
                         break

--- a/nixos/roles/devhost/fc.devhost/src/fc/devhost/manager.py
+++ b/nixos/roles/devhost/fc.devhost/src/fc/devhost/manager.py
@@ -307,6 +307,16 @@ class Manager:
                 raise RuntimeError("Could not find free SRV IP address.")
 
         vm_nix_file_existed = os.path.isfile(self.nix_file)
+
+        # Read old config before writing new one to detect disk size changes
+        old_config = None
+        if os.path.isfile(self.config_file):
+            try:
+                with open(self.config_file, "r") as f:
+                    old_config = json.load(f)
+            except (json.JSONDecodeError, IOError):
+                pass
+
         try:
             with open(self.config_file, mode="w") as f:
                 f.write(json.dumps(self.cfg))
@@ -319,31 +329,25 @@ class Manager:
 
             # Check if we need to resize an existing image
             needs_resize = False
-            if vm_has_image:
-                # For existing VMs, check if disk size has changed by loading the old config
-                try:
-                    with open(self.config_file, "r") as f:
-                        current_file_content = f.read()
-                    old_config = json.loads(current_file_content)
-                    old_disk_size = old_config.get("disk_size", "25G")
-                    if old_disk_size != self.cfg["disk_size"]:
-                        old_size_bytes = parse_disk_size(old_disk_size)
-                        new_size_bytes = parse_disk_size(self.cfg["disk_size"])
+            if vm_has_image and old_config:
+                # For existing VMs, check if disk size has changed
+                old_disk_size = old_config.get("disk_size", "25G")
+                if old_disk_size != self.cfg["disk_size"]:
+                    old_size_bytes = parse_disk_size(old_disk_size)
+                    new_size_bytes = parse_disk_size(self.cfg["disk_size"])
 
-                        if new_size_bytes < old_size_bytes:
-                            raise ValueError(
-                                f"Cannot downsize VM disk from {old_disk_size} to {self.cfg['disk_size']}. "
-                                "XFS filesystem does not support shrinking. "
-                                "Only disk expansion (upsizing) is supported."
-                            )
-                        elif new_size_bytes > old_size_bytes:
-                            print(
-                                f"Disk size changed from {old_disk_size} to {self.cfg['disk_size']}, will resize..."
-                            )
-                            needs_resize = True
-                        # If sizes are equal, no resize needed
-                except (json.JSONDecodeError, FileNotFoundError):
-                    pass
+                    if new_size_bytes < old_size_bytes:
+                        raise ValueError(
+                            f"Cannot downsize VM disk from {old_disk_size} to {self.cfg['disk_size']}. "
+                            "XFS filesystem does not support shrinking. "
+                            "Only disk expansion (upsizing) is supported."
+                        )
+                    elif new_size_bytes > old_size_bytes:
+                        print(
+                            f"Disk size changed from {old_disk_size} to {self.cfg['disk_size']}, will resize..."
+                        )
+                        needs_resize = True
+                    # If sizes are equal, no resize needed
 
             if not vm_has_image:
                 image_url_hash = hashlib.sha256(

--- a/nixos/roles/devhost/fc.devhost/src/fc/devhost/manager.py
+++ b/nixos/roles/devhost/fc.devhost/src/fc/devhost/manager.py
@@ -481,6 +481,18 @@ class Manager:
                 else:
                     time.sleep(0.5)
 
+            # wait for port 22 to accept connections
+            print("Waiting for SSH to become available ...")
+            while True:
+                sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                sock.settimeout(5)
+                result = sock.connect_ex((self.cfg["srv-ip"], 22))
+                sock.close()
+                if result == 0:
+                    break
+                else:
+                    time.sleep(0.5)
+
             if vm_has_image:
                 print("Syncing VM enc data into running VM ...")
                 with tempfile.NamedTemporaryFile(mode="w") as f:

--- a/nixos/roles/devhost/fc.devhost/src/fc/devhost/manager.py
+++ b/nixos/roles/devhost/fc.devhost/src/fc/devhost/manager.py
@@ -433,6 +433,8 @@ class Manager:
                     break
                 else:
                     time.sleep(0.5)
+            else:
+                raise RuntimeError("VM did not become pingable in time.")
 
             # wait for port 22 to accept connections
             print("Waiting for SSH to become available ...")
@@ -446,6 +448,8 @@ class Manager:
                     break
                 else:
                     time.sleep(0.5)
+            else:
+                raise RuntimeError("SSH did not become available in time.")
 
             # Check if disk resize is needed by querying current disk size via QMP
             block_info = self.qmp.command("query-block")

--- a/nixos/roles/devhost/fc.devhost/src/fc/devhost/manager.py
+++ b/nixos/roles/devhost/fc.devhost/src/fc/devhost/manager.py
@@ -29,6 +29,41 @@ LOCKFILE_PATH = "/run/fc-devhost-vm"
 MONTH = 60 * 60 * 24 * 30
 
 
+def parse_disk_size(size_str):
+    """Parse disk size string (e.g., '25G', '1024M') and return size in bytes."""
+    if not size_str:
+        raise ValueError("Disk size cannot be empty")
+
+    size_str = size_str.strip().upper()
+
+    # Handle different size units
+    multipliers = {
+        "B": 1,
+        "K": 1024,
+        "M": 1024**2,
+        "G": 1024**3,
+        "T": 1024**4,
+    }
+
+    # Extract number and unit
+    if size_str[-1] in multipliers:
+        unit = size_str[-1]
+        number_str = size_str[:-1]
+    else:
+        # Assume bytes if no unit specified
+        unit = "B"
+        number_str = size_str
+
+    try:
+        number = float(number_str)
+        if number < 0:
+            raise ValueError(f"Disk size cannot be negative: {size_str}")
+    except ValueError as e:
+        raise ValueError(f"Invalid disk size format: {size_str}") from e
+
+    return int(number * multipliers[unit])
+
+
 def run(*args, **kwargs):
     kwargs["check"] = True
     return subprocess.run(args, **kwargs)
@@ -281,6 +316,35 @@ class Manager:
             self.data_dir.mkdir(parents=True, exist_ok=True)
             VM_BASE_IMAGE_DIR.mkdir(parents=True, exist_ok=True)
             vm_has_image = os.path.isfile(self.image_file)
+
+            # Check if we need to resize an existing image
+            needs_resize = False
+            if vm_has_image:
+                # For existing VMs, check if disk size has changed by loading the old config
+                try:
+                    with open(self.config_file, "r") as f:
+                        current_file_content = f.read()
+                    old_config = json.loads(current_file_content)
+                    old_disk_size = old_config.get("disk_size", "25G")
+                    if old_disk_size != self.cfg["disk_size"]:
+                        old_size_bytes = parse_disk_size(old_disk_size)
+                        new_size_bytes = parse_disk_size(self.cfg["disk_size"])
+
+                        if new_size_bytes < old_size_bytes:
+                            raise ValueError(
+                                f"Cannot downsize VM disk from {old_disk_size} to {self.cfg['disk_size']}. "
+                                "XFS filesystem does not support shrinking. "
+                                "Only disk expansion (upsizing) is supported."
+                            )
+                        elif new_size_bytes > old_size_bytes:
+                            print(
+                                f"Disk size changed from {old_disk_size} to {self.cfg['disk_size']}, will resize..."
+                            )
+                            needs_resize = True
+                        # If sizes are equal, no resize needed
+                except (json.JSONDecodeError, FileNotFoundError):
+                    pass
+
             if not vm_has_image:
                 image_url_hash = hashlib.sha256(
                     image_url.encode("utf-8")

--- a/nixos/roles/devhost/fc.devhost/src/fc/devhost/manager.py
+++ b/nixos/roles/devhost/fc.devhost/src/fc/devhost/manager.py
@@ -691,7 +691,7 @@ class Manager:
         self.qmp.command("system_powerdown")
 
     def shutdown(self, location=None):
-        timeout = TimeOut(5, interval=3)
+        timeout = TimeOut(15, interval=3)
         try:
             self.graceful_shutdown()
         except (socket.error, RuntimeError):

--- a/nixos/roles/devhost/fc.devhost/src/fc/devhost/manager.py
+++ b/nixos/roles/devhost/fc.devhost/src/fc/devhost/manager.py
@@ -703,7 +703,7 @@ class Manager:
         self.qmp.command("system_powerdown")
 
     def shutdown(self, location=None):
-        timeout = TimeOut(15, interval=3)
+        timeout = TimeOut(30, interval=5)
         try:
             self.graceful_shutdown()
         except (socket.error, RuntimeError):

--- a/nixos/roles/devhost/fc.devhost/src/fc/devhost/manager.py
+++ b/nixos/roles/devhost/fc.devhost/src/fc/devhost/manager.py
@@ -449,7 +449,7 @@ class Manager:
             block_info = self.qmp.command("query-block")
             current_size = None
             for device in block_info:
-                if device.get("device") == "virtio0":
+                if device.get("device") == "root":
                     current_size = (
                         device.get("inserted", {})
                         .get("image", {})


### PR DESCRIPTION
@flyingcircusio/release-managers

FC-48241

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [x] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [x] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.

This *is* a feature toggle.

- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

Defensive coding and such. However, there is one specific potential thing we decided to not do (now): we are not giving an upper limit for the size of the disk. This is a development host and even though it has impact on productivity, there is no clear hard upper limit that we could introduce that wouldn't potentially hamper the productivity, too.

We do not expect disastruous failure if a user creates an overly eager devhost VM disk size, just minor cleanups.

- [x] Security requirements tested? (EVIDENCE)

manual testing on largo01 and relying on the existing integration tests
