### PR TITLE
nixos/k3s: don't set cluster DNS in hosts resolv.conf

### DIFF
--- a/changelog.d/20251015_152120_HEAD_scriv.md
+++ b/changelog.d/20251015_152120_HEAD_scriv.md
@@ -1,0 +1,26 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+### NixOS XX.XX platform
+
+- nixos/k3s: don't set cluster DNS in hosts resolv.conf (PL-134112)
+
+  The hosts' resolv.conf is passed to the k3s cluster coredns, which leads
+  to coredns trying to _sometimes_ resolve requests to itself.
+  This leads to timeouts and otherwise failing DNS request.
+
+  This change also modifies the behavior of DNS resolving on the host
+  directly. Especially HAProxy now requires to especially set the CoreDNS
+  as resolver. We checked that this won't affect customers currently.

--- a/nixos/roles/k3s/server.nix
+++ b/nixos/roles/k3s/server.nix
@@ -524,8 +524,6 @@ in
           ];
         };
 
-        networking.nameservers = lib.mkOverride 90 (lib.take 3 ([ netCfg.clusterDns ] ++ fcNameservers));
-
         services.k3s =
           let
             k3sFlags = [

--- a/nixos/roles/k3s/single-node.nix
+++ b/nixos/roles/k3s/single-node.nix
@@ -119,8 +119,6 @@ in
       iptables -I nixos-fw 1 -i cni+ -j ACCEPT
     '';
 
-    networking.nameservers = lib.mkOverride 90 (lib.take 3 ([ netCfg.clusterDns ] ++ fcNameservers));
-
     services.k3s =
       let
         k3sFlags = [

--- a/tests/k3s/default.nix
+++ b/tests/k3s/default.nix
@@ -322,9 +322,9 @@ import ../make-test-python.nix (
         with subtest("test user should be able to use kubectl with generated kubeconfig"):
           k3sserver.succeed("KUBECONFIG=/home/test/kubeconfig k3s kubectl cluster-info")
 
-        with subtest("master should be able to use cluster DNS"):
+        with subtest("master should be able to reach cluster DNS"):
           k3sserver.wait_until_succeeds('k3s kubectl -n kube-system get pods | grep coredns | grep -v ContainerCreating | grep Running')
-          k3sserver.wait_until_succeeds('dig redis.default.svc.cluster.local | grep -q 10.43')
+          k3sserver.wait_until_succeeds('dig redis.default.svc.cluster.local @10.43.0.10 | grep NOERROR')
 
         k3snodeB.start()
         time.sleep(5)


### PR DESCRIPTION
The hosts' resolv.conf is passed to the k3s cluster coredns, which leads to coredns trying to _sometimes_ resolve requests to itself. This leads to timeouts and otherwise failing DNS request.

This change also modifies the behavior of DNS resolving on the host directly. Especially HAProxy now requires to especially set the CoreDNS as resolver. We checked that this won't affect customers currently.

PL-134112

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [x] Security requirements tested? (EVIDENCE)
  - tested on host that kubectl tooling still works
  - checked that coredns' resolv.conf is correct