### PR TITLE
[25.11] Nixpkgs update 2025-10-16

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -168,11 +168,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1760514760,
-        "narHash": "sha256-SIRcuqwJpAxQmgT3djSAK0bZC0sAAMh8IvkxgTDcZlY=",
+        "lastModified": 1760586203,
+        "narHash": "sha256-Mnj3u4Cgjn2g67Mavhw5kFp34kOp9PDVDT99NFy6djM=",
         "owner": "flyingcircusio",
         "repo": "nixpkgs",
-        "rev": "64f36ec137eb7754c8f234ac32e03d72e3418d8d",
+        "rev": "3e367aff5a460e84cf02bdac5fbaddc26062e6f7",
         "type": "github"
       },
       "original": {

--- a/release/important_packages.json
+++ b/release/important_packages.json
@@ -203,7 +203,6 @@
   "roundcube",
   "rsync",
   "ruby",
-  "ruby_3_2",
   "runc",
   "screen",
   "slurm",

--- a/release/package-versions.json
+++ b/release/package-versions.json
@@ -195,9 +195,9 @@
     "version": "7.17.27"
   },
   "firefox": {
-    "name": "firefox-143.0.4",
+    "name": "firefox-144.0",
     "pname": "firefox",
-    "version": "143.0.4"
+    "version": "144.0"
   },
   "gcc": {
     "name": "gcc-wrapper-14.3.0",
@@ -295,9 +295,9 @@
     "version": "3.2.6"
   },
   "imagemagick": {
-    "name": "imagemagick-7.1.2-5",
+    "name": "imagemagick-7.1.2-6",
     "pname": "imagemagick",
-    "version": "7.1.2-5"
+    "version": "7.1.2-6"
   },
   "imagemagick6": {
     "name": "imagemagick-6.9.13-10",
@@ -480,9 +480,9 @@
     "version": "3.3.5"
   },
   "mastodon": {
-    "name": "mastodon-4.4.5",
+    "name": "mastodon-4.4.6",
     "pname": "mastodon",
-    "version": "4.4.5"
+    "version": "4.4.6"
   },
   "matomo_5": {
     "name": "matomo-5.4.0",
@@ -490,9 +490,9 @@
     "version": "5.4.0"
   },
   "matrix-synapse": {
-    "name": "matrix-synapse-wrapped-1.139.2",
+    "name": "matrix-synapse-wrapped-1.140.0",
     "pname": "matrix-synapse-wrapped",
-    "version": "1.139.2"
+    "version": "1.140.0"
   },
   "mcpp": {
     "name": "mcpp-2.7.2.2",
@@ -941,9 +941,9 @@
     "version": "25.4.0"
   },
   "python3Packages.supervisor": {
-    "name": "python3.13-supervisor-4.2.5",
+    "name": "python3.13-supervisor-4.3.0",
     "pname": "supervisor",
-    "version": "4.2.5"
+    "version": "4.3.0"
   },
   "python3Packages.systemd": {
     "name": "python3.13-systemd-235",
@@ -999,11 +999,6 @@
     "name": "ruby-3.3.9",
     "pname": "ruby",
     "version": "3.3.9"
-  },
-  "ruby_3_2": {
-    "name": "ruby-3.2.9",
-    "pname": "ruby",
-    "version": "3.2.9"
   },
   "runc": {
     "name": "runc-1.3.2",
@@ -1086,9 +1081,9 @@
     "version": "9.0.110"
   },
   "unifi": {
-    "name": "unifi-controller-9.4.19",
+    "name": "unifi-controller-9.5.21",
     "pname": "unifi-controller",
-    "version": "9.4.19"
+    "version": "9.5.21"
   },
   "unzip": {
     "name": "unzip-6.0",

--- a/release/versions.json
+++ b/release/versions.json
@@ -8,10 +8,10 @@
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/"
   },
   "nixpkgs": {
-    "hash": "sha256-SIRcuqwJpAxQmgT3djSAK0bZC0sAAMh8IvkxgTDcZlY=",
+    "hash": "sha256-Mnj3u4Cgjn2g67Mavhw5kFp34kOp9PDVDT99NFy6djM=",
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "64f36ec137eb7754c8f234ac32e03d72e3418d8d"
+    "rev": "3e367aff5a460e84cf02bdac5fbaddc26062e6f7"
   },
   "poetry2nix": {
     "hash": "sha256-nzgO/ZCSBzWjbMkYDxG+yl9Z2eGbCgQu06Oku3ir5D4=",


### PR DESCRIPTION
@flyingcircusio/release-managers

View nixpkgs update branch: [nixpkgs-auto-update/fc-25.11-dev/2025-10-16](https://github.com/flyingcircusio/nixpkgs/tree/nixpkgs-auto-update/fc-25.11-dev/2025-10-16)

This update includes a manual change

* remove ruby_3_2 from important-packages, as it has been removed from Nixpkgs