### PR TITLE
fc-maintenance: fix reboot required detection based on kernel package

### DIFF
--- a/changelog.d/20251016_120750_HEAD_scriv.md
+++ b/changelog.d/20251016_120750_HEAD_scriv.md
@@ -1,0 +1,19 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+
+### NixOS XX.XX platform
+
+- fc-maintenance: fix detection whether a reboot is needed based on the kernel package (PL-134119)

--- a/pkgs/fc/agent/src/fc/util/nixos.py
+++ b/pkgs/fc/agent/src/fc/util/nixos.py
@@ -113,6 +113,9 @@ def kernel_package(kernel_store_path: Path) -> KernelIdentifier:
     Essentially, this identifier is the name of the nix store path, plus some
     convenient representation.
 
+    The kernel store path is /nix/store/xyz-linux-6.12.51/bzImage on a live system.
+    We want xyz-linux-6.12.51, which is the parent of bzImage.
+
     The returned kernel name is **not** the kernel version, but the store path
     name of the kernel package. When checking the necessity of a reboot, we only
     care about a *difference* in kernel packages, not exact version number
@@ -120,7 +123,7 @@ def kernel_package(kernel_store_path: Path) -> KernelIdentifier:
     release with different options, resulting in a different store path.
     """
 
-    return KernelIdentifier(kernel_store_path.name)
+    return KernelIdentifier(kernel_store_path.parent.name)
 
 
 def current_fc_environment_name(log=_log) -> Optional[str]:

--- a/pkgs/fc/agent/src/fc/util/tests/test_nixos.py
+++ b/pkgs/fc/agent/src/fc/util/tests/test_nixos.py
@@ -495,9 +495,11 @@ def test_find_nix_build_error_oneline():
 def dirsetup(tmp_path):
     drv = tmp_path / "abcdef-linux-4.4.27"
     drv.mkdir()
+    bzImage = (drv / "bzImage")
+    bzImage.touch()
     current = tmp_path / "current"
     current.mkdir()
-    (current / "kernel").symlink_to(drv)
+    (current / "kernel").symlink_to(bzImage)
     return current
 
 
@@ -506,7 +508,7 @@ def test_kernel_versions_equal(dirsetup, tmpdir):
     assert nixos.system_kernel(system) == nixos.system_kernel(system)
     assert not nixos.system_kernel(system) != nixos.system_kernel(system)
     assert nixos.system_kernel(system) == nixos.kernel_package(
-        Path("/nix/store") / "abcdef-linux-4.4.27"
+        Path("/nix/store") / "abcdef-linux-4.4.27" / "bzImage"
     )
     assert nixos.system_kernel(system) == nixos.KernelIdentifier(
         "abcdef-linux-4.4.27"


### PR DESCRIPTION
The previous change (PL-134082) had a wrong assumption about how the path /run/{booted,current}-system/kernel looks like:
- PL-134082: /nix/store/xyz-linux-6.12.51
- reality, this change: /nix/store/xyz-linux-6.12.51/bzImage

This change adapts this to reality

PL-134119

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`
,
## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Automated testing: Improve test
- [x] Security requirements tested? (EVIDENCE)
  - tested on dev VM that the reboot actually happens