### PR TITLE
Pl 134125 nix connect timeout too twitchy

### DIFF
--- a/changelog.d/20251017_115646_fc-25.05-dev_scriv.md
+++ b/changelog.d/20251017_115646_fc-25.05-dev_scriv.md
@@ -1,0 +1,23 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+- A bullet item for the Impact category.
+
+
+### NixOS XX.XX platform
+
+- Increase timeout for nix network connections from 1s to 5s. We used to run with a very low timeout
+  to assist with automatic failovers for S3 reachability but are noticing that this
+  is too twitchy in real world network scenarios too often and causes noise and alert fatigue.

--- a/nixos/platform/default.nix
+++ b/nixos/platform/default.nix
@@ -347,7 +347,7 @@ in
           "flyingcircus.io-1:Rr9CwiPv8cdVf3EQu633IOTb6iJKnWbVfCC8x8gVz2o="
         ];
 
-        connect-timeout = 1;
+        connect-timeout = 5;
       };
     };
 


### PR DESCRIPTION
@flyingcircusio/release-managers

PL-134125

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

availibility, noise reduction

- [x] Security requirements tested? (EVIDENCE)

relying on existing test suite