### PR TITLE
tests/{open-webui,k3s_monitoring): reduce flakyness

### DIFF
--- a/tests/k3s/monitoring.nix
+++ b/tests/k3s/monitoring.nix
@@ -74,8 +74,12 @@ import ../make-test-python.nix (
         k3sserver.wait_for_unit("k3s.service")
         k3sserver.wait_until_succeeds('k3s kubectl cluster-info | grep -q https://127.0.0.1:6443')
 
+        # telegraf.service fails to start when the token file doesn't exist. Explicitly restart after k3s created it
+        k3sserver.wait_for_file("/var/lib/k3s/tokens/telegraf")
+        k3sserver.systemctl("start telegraf")
+
         with subtest("sensu should be able to access the API server endpoint"):
-          k3sserver.wait_until_succeeds("stat /var/lib/k3s/tokens/sensuclient")
+          k3sserver.wait_for_file("/var/lib/k3s/tokens/sensuclient")
           k3sserver.wait_until_succeeds("${masterSensuCheck "kube-apiserver"}")
           k3sserver.wait_until_succeeds("${masterSensuCheck "kube-nodes-ready"}")
 

--- a/tests/open-webui.nix
+++ b/tests/open-webui.nix
@@ -37,7 +37,8 @@ import ./make-test-python.nix (
 
       # open webui is slow to boot, but should eventually respond
       # with http status 200
-      machine.wait_until_succeeds("curl http://192.168.3.1:8080", timeout=30)
+      machine.wait_for_open_port(8080, "192.168.3.1", timeout=90)
+      machine.wait_until_succeeds("curl -f http://192.168.3.1:8080")
     '';
   }
 )


### PR DESCRIPTION
@flyingcircusio/release-managers

PL-133850

## Release process

- [ ] Created changelog entry using `./changelog.sh`
  no: internal

## PR release workflow (internal)

- [ ] PR has internal ticket
- [ ] internal issue ID (PL-…) part of branch name
- [ ] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - None, only internal testing, not part of prod
- [x] Security requirements tested? (EVIDENCE)
