### PR TITLE
nixos/varnish: adapt default config to upstream changes

### DIFF
--- a/nixos/roles/webproxy.nix
+++ b/nixos/roles/webproxy.nix
@@ -47,13 +47,19 @@ in
   config = lib.mkMerge [
     (lib.mkIf fccfg.enable {
       environment.etc = {
-        "local/varnish/README.txt".text = ''
-          Varnish is enabled on this machine.
+        "local/varnish/README.txt".text =
+          let
+            listen_str = lib.concatMapStringsSep ", " (
+              listenCfg: ''${listenCfg.proto} ${listenCfg.address}:${toString (listenCfg.port or "n/a")}''
+            ) config.services.varnish.listen;
+          in
+          ''
+            Varnish is enabled on this machine.
 
-          Varnish is listening on: ${cfg.http_address}
+            Varnish is listening on: ${listen_str}
 
-          Configure varnish via Nix or put your configuration into `default.vcl` (deprecated, please transition to a Nix config).
-        '';
+            Configure varnish via Nix or put your configuration into `default.vcl` (deprecated, please transition to a Nix config).
+          '';
       };
 
       flyingcircus.services.sensu-client.checks = {
@@ -97,9 +103,10 @@ in
       flyingcircus.services.varnish = {
         enable = true;
         extraCommandLine = "-s malloc,${toString cacheMemory}M";
-        http_address = lib.concatMapStringsSep " -a " (addr: "${addr}:8008") (
-          lib.unique fccfg.listenAddresses
-        );
+        listen = lib.map (addr: {
+          address = addr;
+          port = 8008;
+        }) (lib.unique fccfg.listenAddresses);
         fallbackConfig = lib.mkIf (varnishCfg != null) varnishCfg;
       };
 

--- a/nixos/services/varnish/default.nix
+++ b/nixos/services/varnish/default.nix
@@ -2,6 +2,7 @@
   pkgs,
   lib,
   config,
+  options,
   ...
 }:
 let
@@ -159,14 +160,28 @@ in
       '';
     };
     http_address = mkOption {
-      type = types.str;
-      default = "*:8008";
+      type = types.nullOr types.str;
+      default = null;
       description = ''
         The http address for the varnish service to listen on.
         Unix sockets can technically be used for varnish, but are not currently supported on the FCIO platform due to monitoring constraints.
         Multiple addressess can be specified in a comma-separated fashion in the form of `address[:port][,address[:port][...]`.
         See `varnishd(1)` for details.
       '';
+      visible = false;
+    };
+    listen = mkOption {
+      type = options.services.varnish.listen.type;
+      description = ''
+        Addresses varnish should listen on.
+        Unix sockets can technically be used for varnish, but are not currently supported on the FCIO platform due to monitoring constraints.
+      '';
+      default = [
+        {
+          address = "*";
+          port = 8008;
+        }
+      ];
     };
     virtualHosts = mkOption {
       type = types.attrsOf (
@@ -196,8 +211,16 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    warnings = lib.optionals (cfg.http_address != null) [
+      "The option `flyingcircus.services.varnish.http_address` is deprecated. Use `flyingcircus.services.varnish.listen` instead."
+    ];
     services.varnish = {
-      inherit (cfg) enable extraCommandLine http_address;
+      inherit (cfg)
+        enable
+        extraCommandLine
+        http_address
+        listen
+        ;
 
       enableConfigCheck = false;
       config = ''


### PR DESCRIPTION
PL-134106

@flyingcircusio/release-managers

## Release process

- [ ] Created changelog entry using `./changelog.sh`
  no: in release

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  Ensured by tests, equivalent config
- [x] Security requirements tested? (EVIDENCE)
