### PR TITLE
Add separate sensu check for underlay interfaces for differentiated monitoring and alerting

### DIFF
--- a/changelog.d/20251021_100158_PL-134114-monitor-critical-interfaces_scriv.md
+++ b/changelog.d/20251021_100158_PL-134114-monitor-critical-interfaces_scriv.md
@@ -1,0 +1,22 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+
+
+### NixOS XX.XX platform
+
+- hardware: introduce a separate sensu check for the underlay network
+  interfaces, to allow problems with these interfaces to be monitored
+  and alerted upon separately. (PL-134114)

--- a/nixos/platform/network.nix
+++ b/nixos/platform/network.nix
@@ -1108,6 +1108,21 @@ in
             in
             "sudo -g frrvty ${pkgs.fc.check-bgp-sessions}/bin/check_bgp_sessions ${links}";
         };
+
+        # PL-134114: the underlay interfaces operating at the wrong
+        # speed can be very disruptive, e.g. to vm live
+        # migration. This is a duplicate of the standard "interfaces"
+        # check which only monitors the underlay interfaces, which can
+        # then be included in status page alerting rules.
+        critical_interfaces = {
+          notification = "Critical network interfaces are healthy";
+          interval = 60;
+          command =
+            "sudo ${pkgs.fc.sensuplugins}/bin/check_interfaces "
+            + (lib.concatMapStringsSep " " (
+              link: "-i ${link.link},${toString link.minimumPortSpeed}:"
+            ) fclib.underlay.links);
+        };
       };
 
       flyingcircus.passwordlessSudoRules = lib.optionals (!isNull fclib.underlay) [


### PR DESCRIPTION
We've encountered problems where an underlay interface on a KVM server has negotiated the wrong speed, which has had a severe impact on network performance and led to problems with failing live-migrations. In general, problems with the underlay network interfaces need immediate attention, as these can cause significant higher-order performance and stability issues for the rest of our infrastructure.

This change introduces a new `critical_interfaces` check on hardware with underlay links. This is a copy of the existing interfaces check which monitors only the underlay links, which will allow us to introduce separate status page alerting specifically for underlay network problems without also alerting for other non-critical interfaces in the existing check.

Remarks: interfaces negotiating the wrong speed (e.g. 1G instead of 10G) appears to only be a problem on copper links. I've tested manual adjustments to the link speed on 25G fibre interfaces, and if interface is manually set to a speed other than the one supported by the installed SFP+ module, then the interface drops the carrier entirely. Our existing interface check script checks if interfaces are up, have carrier, and are running at the correct speed, and we have a hardcoded default minimum port speed of 10G for underlay links. However, as our equipment which runs at speeds greater than 10G is all fibre, any deviation from the native speed of the SFP+ module will cause the link to go down, so we don't need any runtime detection of what speed of module is installed in each machine.

PL-134114

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Critical network functions require fine-grained monitoring so that problems can be addressed and remedied in a timely manner.
- [x] Security requirements tested? (EVIDENCE)
  - Manually verified on hosts with both built-in copper 10G cards and also with SFP+ cards with 25G fibre modules installed.