### PR TITLE
Patch FRR to fix networking for routed PUB VMs

### DIFF
--- a/changelog.d/20251021_163225_PL-134136-routed-pub-broken_scriv.md
+++ b/changelog.d/20251021_163225_PL-134136-routed-pub-broken_scriv.md
@@ -1,0 +1,21 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+
+### NixOS XX.XX platform
+
+- hardware: fix networking for VMs with routed PUB interfaces. This
+  was silently broken due to a previous fix for improving network
+  stability. (PL-134136)

--- a/pkgs/frr/0001-Don-t-throw-error-when-log-directory-already-exists.patch
+++ b/pkgs/frr/0001-Don-t-throw-error-when-log-directory-already-exists.patch
@@ -22,5 +22,5 @@ index ea0ce6fc9c..37bdff4b59 100755
          logging.basicConfig(
              filename="/var/log/frr/frr-reload.log",
 -- 
-2.39.5 (Apple Git-154)
+2.50.1 (Apple Git-155)
 

--- a/pkgs/frr/0002-zebra-dplane-sleep-after-writing-batches-to-netlink.patch
+++ b/pkgs/frr/0002-zebra-dplane-sleep-after-writing-batches-to-netlink.patch
@@ -53,5 +53,5 @@ index 561f16609f..f938193eb4 100644
  
  enum netlink_msg_status netlink_batch_add_msg(
 -- 
-2.39.5 (Apple Git-154)
+2.50.1 (Apple Git-155)
 

--- a/pkgs/frr/0003-netlink-don-t-manage-kernel-neighbour-table-entries-.patch
+++ b/pkgs/frr/0003-netlink-don-t-manage-kernel-neighbour-table-entries-.patch
@@ -1,36 +1,48 @@
-From f871a5a7aff5d98e7d9fe186fa9bb9a69b6651f0 Mon Sep 17 00:00:00 2001
+From 35a2e872869405af5443558ab73ecdb0f9411566 Mon Sep 17 00:00:00 2001
 From: Molly Miller <mm@flyingcircus.io>
 Date: Tue, 1 Jul 2025 16:11:41 +0200
 Subject: [PATCH 3/3] netlink: don't manage kernel neighbour table entries for
- evpn
+ L2-VNI
 
 From experience, zebra's tracking of MAC-IP mappings for SVI
-interfaces doesn't always stay in sync with the kernel, which can lead
-to it advertising stuck routes for IP addresses which are no longer
-locally assigned.
+interfaces in L2 VPNs doesn't always stay in sync with the kernel,
+which can lead to it advertising stuck type-2 routes with mappings for
+IP addresses which are no longer locally assigned.
 
 To hedge against this on the receiving side, let's stop populating the
-neighbour table with mappings learned from EVPN, and let the kernel
-fall back to dynamic neighbour discovery.
----
- zebra/kernel_netlink.c | 4 ++++
- 1 file changed, 4 insertions(+)
+neighbour table with mappings learned from EVPN -- but only for L2
+VPNs. For L3 VPNs, the neighbour table is used for resolving the
+nexthop MAC address for IP routes inside the VPN, so we can't stub out
+neighbour table management on the data plane side entirely.
 
-diff --git a/zebra/kernel_netlink.c b/zebra/kernel_netlink.c
-index f938193eb4..3466a644d1 100644
---- a/zebra/kernel_netlink.c
-+++ b/zebra/kernel_netlink.c
-@@ -1617,6 +1617,10 @@ static enum netlink_msg_status nl_put_msg(struct nl_batch *bth,
- 	case DPLANE_OP_NEIGH_INSTALL:
- 	case DPLANE_OP_NEIGH_UPDATE:
- 	case DPLANE_OP_NEIGH_DELETE:
-+		/* no-op: don't attempt to insert kernel neighbour
-+		 * table entries for evpn */
-+		return FRR_NETLINK_SUCCESS;
-+
- 	case DPLANE_OP_VTEP_ADD:
- 	case DPLANE_OP_VTEP_DELETE:
- 	case DPLANE_OP_NEIGH_DISCOVER:
+In L2 VPNs, the kernel will fall back to dynamic neighbour discovery
+with ARP and NDP.
+---
+ zebra/zebra_evpn_neigh.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/zebra/zebra_evpn_neigh.c b/zebra/zebra_evpn_neigh.c
+index 81705d4e85..28df725f87 100644
+--- a/zebra/zebra_evpn_neigh.c
++++ b/zebra/zebra_evpn_neigh.c
+@@ -159,7 +159,7 @@ int zebra_evpn_rem_neigh_install(struct zebra_evpn *zevpn,
+ 		flags |= DPLANE_NTF_ROUTER;
+ 	ZEBRA_NEIGH_SET_ACTIVE(n);
+ 
+-	dplane_rem_neigh_add(vlan_if, &n->ip, &n->emac, flags, was_static);
++	/* dplane_rem_neigh_add(vlan_if, &n->ip, &n->emac, flags, was_static); */
+ 
+ 	return ret;
+ }
+@@ -824,7 +824,7 @@ static int zebra_evpn_neigh_uninstall(struct zebra_evpn *zevpn,
+ 	ZEBRA_NEIGH_SET_INACTIVE(n);
+ 	n->loc_seq = 0;
+ 
+-	dplane_rem_neigh_delete(vlan_if, &n->ip);
++	/* dplane_rem_neigh_delete(vlan_if, &n->ip); */
+ 
+ 	return 0;
+ }
 -- 
-2.39.5 (Apple Git-154)
+2.50.1 (Apple Git-155)
 


### PR DESCRIPTION
In #1637 we stubbed out the neighbour table management functions of FRR as a workaround to avoid stochastic problems with stuck routes. However, it turns out that we stubbed out too much, as the implementation of routed L3 networks (used for the PUB network) *requires* the neighbour table to be managed in the associated VRF.

This change updates our FRR patches to take a different approach to stubbing out the neighbour table management where it's been causing us problems. zebra uses an internal IPC between the routing engine and the dataplane code (in our case kernel netlink). Previously we patched out the neighbour table handling on the dataplane side, however this means that neighbour table updates related to routed L3 networks also get dropped. Instead, we now patch the parts of the code which generate these updates for L2 networks, which leaves L3 network management unmodified.

PL-134136

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [x] ensure the merge bot has determined a merge date
- [x] ensure all checks are green
- [x] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - RFC 1925, Section 2, number 1: it has to work.
- [x] Security requirements tested? (EVIDENCE)
  - Tested in DEV and manually verified on a development router and development KVM server.