### PR TITLE
Add monitoring for underlay BGP sessions

### DIFF
--- a/changelog.d/20251022_094903_PL-133897-monitor-frr-sessions_scriv.md
+++ b/changelog.d/20251022_094903_PL-133897-monitor-frr-sessions_scriv.md
@@ -1,0 +1,22 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+
+
+### NixOS XX.XX platform
+
+- hardware: monitor BGP sessions on underlay links, to allow detection
+  of and alerting on conditions which would otherwise cause them to
+  fail silently. (PL-133897)

--- a/nixos/platform/network.nix
+++ b/nixos/platform/network.nix
@@ -1099,6 +1099,15 @@ in
             in
             "sudo -g frrvty ${pkgs.fc.check-rib-integrity}/bin/check_rib_integrity check-evpn-rib ${args}";
         };
+        underlay_bgp_sessions = {
+          notification = "Underlay BGP sessions";
+          interval = 60;
+          command =
+            let
+              links = lib.concatMapStringsSep " " (link: "-i ${link.link}") fclib.underlay.links;
+            in
+            "sudo -g frrvty ${pkgs.fc.check-bgp-sessions}/bin/check_bgp_sessions ${links}";
+        };
       };
 
       flyingcircus.passwordlessSudoRules = lib.optionals (!isNull fclib.underlay) [
@@ -1108,6 +1117,11 @@ in
         }
         {
           commands = [ "${pkgs.fc.check-rib-integrity}/bin/check_rib_integrity" ];
+          groups = [ "sensuclient" ];
+          runAs = ":frrvty";
+        }
+        {
+          commands = [ "${pkgs.fc.check-bgp-sessions}/bin/check_bgp_sessions" ];
           groups = [ "sensuclient" ];
           runAs = ":frrvty";
         }

--- a/pkgs/fc/check-bgp-sessions/check_bgp_sessions.py
+++ b/pkgs/fc/check-bgp-sessions/check_bgp_sessions.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Check that FRR BGP sessions are up."""
+
+import argparse
+import json
+import subprocess
+import sys
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-i",
+        "--interface",
+        dest="interfaces",
+        action="append",
+        default=[],
+        help="Check BGP session for named interface",
+    )
+    parser.add_argument(
+        "-c",
+        "--critical-age",
+        default=60,
+        metavar="SECONDS",
+        help="Report critical status if session not in established state for longer than SECONDS seconds",
+    )
+
+    args = parser.parse_args()
+
+    data = subprocess.check_output(["vtysh", "-c", "show bgp summary json"])
+    data = json.loads(data.decode("utf-8"))
+    data = data["ipv4Unicast"]["peers"]
+
+    oks = set()
+    errors = {}
+    warnings = {}
+    for iface in args.interfaces:
+        if iface not in data:
+            errors.update({iface: "no bgp session configured for interface"})
+            continue
+
+        if data[iface]["state"] == "Established":
+            oks.add(iface)
+            continue
+
+        age = int(data[iface]["peerUptimeMsec"] / 1000)
+
+        if age <= args.critical_age:
+            warnings.update(
+                {iface: f"bgp session not established since {age} seconds"}
+            )
+        else:
+            errors.update(
+                {iface: f"bgp session not established since {age} seconds"}
+            )
+
+    if errors:
+        print("SESSIONS CRITICAL - {}".format(", ".join(errors.keys())))
+    elif warnings:
+        print("SESSIONS WARNING - {}".format(", ".join(warnings.keys())))
+    else:
+        print("SESSIONS OK - {}".format(", ".join(args.interfaces)))
+
+    for iface, error in errors.items():
+        print(f"CRITICAL {iface}: {error}")
+    for iface, warning in warnings.items():
+        print(f"WARN {iface}: {warning}")
+    for iface in oks:
+        print(f"OK {iface}")
+
+    if errors:
+        sys.exit(2)
+    elif warnings:
+        sys.exit(1)
+    else:
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/pkgs/fc/check-bgp-sessions/default.nix
+++ b/pkgs/fc/check-bgp-sessions/default.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  stdenv,
+  makeWrapper,
+  python3,
+  frr,
+}:
+
+stdenv.mkDerivation rec {
+  version = "1";
+  pname = "check-bgp-sessions";
+
+  src = ./.;
+  unpackPhase = ":";
+  dontBuild = true;
+  dontConfigure = true;
+  nativeBuildInputs = [ makeWrapper ];
+  propagatedBuildInputs = [
+    python3
+    frr
+  ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cd $src
+    install check_bgp_sessions.py $out/bin/check_bgp_sessions
+    wrapProgram $out/bin/check_bgp_sessions --prefix PATH : \
+      ${lib.makeBinPath propagatedBuildInputs}
+  '';
+
+  meta = with lib; {
+    description = "Sensu check for checking BGP session state";
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/fc/default.nix
+++ b/pkgs/fc/default.nix
@@ -22,6 +22,7 @@ rec {
   };
 
   check-age = callPackage ./check-age { };
+  check-bgp-sessions = callPackage ./check-bgp-sessions { };
   check-ceph-nautilus = callPackage ./check-ceph/nautilus {
     inherit (pkgs.ceph-nautilus) ceph-client;
     python3Packages = pkgs.python38Packages;


### PR DESCRIPTION
We have occasional recurring problems where after a reboot some hardware machines aren't able to bring the BGP sessions on their underlay interfaces up after a reboot, due to a suspected problem on the switch side. This change adds an additional sensu check to ensure that the configured BGP sessions are actually up, which can then be fed into the statuspage for better visibility over this problem.

PL-133897

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [x] ensure all checks are green
- [x] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Better visibility into network functions to allow problems to be recognised and treated promptly.
- [x] Security requirements tested? (EVIDENCE)
  - Check script manually tested and verified in dev.