### PR TITLE
statshost: fix OIDC role mapping

### DIFF
--- a/changelog.d/20251024_102859_PL-134142-statshost-oidc-fix-role-mapping_scriv.md
+++ b/changelog.d/20251024_102859_PL-134142-statshost-oidc-fix-role-mapping_scriv.md
@@ -1,0 +1,19 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+
+### NixOS XX.XX platform
+
+- statshost: fix Admin role mapping for OIDC. Note that OIDC is not enabled by default, yet, so instances with default configuration haven't been affected by this issue. (PL-134142)

--- a/nixos/roles/statshost/default.nix
+++ b/nixos/roles/statshost/default.nix
@@ -563,7 +563,7 @@ in
                 name_attribute_path = "full_name";
                 auth_url = "${realmUrl}/protocol/openid-connect/auth";
                 token_url = "${realmUrl}/protocol/openid-connect/token";
-                role_attribute_path = "'Admin'";
+                role_attribute_path = "\"'Admin'\"";
               };
           })
         ];


### PR DESCRIPTION
Like for LDAP, we want to assign Admin privileges to all users logged in via OIDC. We have to escape the 'Admin' properly so it's interpreted as a static role name instead of triggering an attribute lookup.

Discovered when working on PL-134048, OIDC will become the default on 25.11. We also want this for 25.05 because it's already possible to enable OIDC manually. 

PL-134142

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [x] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
  - OIDC was already disabled by default and has to be enabled by a feature toggle on 25.05 
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - align permission for OIDC users with those logged in with LDAP  
- [x] Security requirements tested? (EVIDENCE)
  - verified on a test VM that OIDC users become Admin, like with LDAP 