### PR TITLE
nixos/redis: ignore more fields in telegraf introduced in NixOS 25.11

### DIFF
--- a/nixos/services/redis.nix
+++ b/nixos/services/redis.nix
@@ -84,6 +84,9 @@ let
     "rdb_last_bgsave_status"
     "used_memory_dataset_perc"
     "used_memory_peak_perc"
+    "io_thread_0"
+    "module"
+    "redis_version"
   ];
 
   telegrafInputs =


### PR DESCRIPTION
PL-134139

@flyingcircusio/release-managers

## Release process

- [ ] Created changelog entry using `./changelog.sh`
  no: internal

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [ ] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [x] Security requirements tested? (EVIDENCE)
  - tested on dev vm
  - no relevant metrics for dashboard in newly ignored metrics (proven by comparison with 25.05 and looking at the contents)