### PR TITLE
telegraf net input: disable legacy protocol metrics

### DIFF
--- a/doc/src/upgrade.md
+++ b/doc/src/upgrade.md
@@ -178,6 +178,21 @@ With the transition to the NixOS upstream module, we removed two minor functiona
 - Modifying the owner of log files with every reload and restart of nginx: All process involved in processing the log
   files already set the correct owner and permissions
 
+
+### Network Protocol Metrics
+
+Protocol-specific networking metrics have changed their name. Metrics of the scheme `net_$someProtocol_…` have been deprecated and are replaced with an equivalent metric from the `nstat_$SomeProtocol…` name space. This reflects a change in the Telegraf metrics collector used by our platform. \
+For example: \
+`net_udp_indatagrams` -> `nstat_UDP_InDatagrams`
+
+#### What needs to be done
+
+1. **Update dashboards** and other metrics consumers: modify your Grafana panels to query `nstat_*` metrics in addition.
+2. **Keep legacy metrics temporarily**: Flying Circus NixOS ≥ 25.05 will emit both `net_` and `nstat_` metrics side‑by‑side for an overlap period.
+3. **Remove legacy metrics**: once all hosts are running *Flying Circus NixOS ≥ 25.05* and the history of `nstat_*` metrics is at least a few months old, you can drop references to `net_*`. *Flying Circus NixOS 25.11* stops emitting the legacy `net_$someProtocol` metrics.
+
+`nstat_*` metrics have similar names to their legacy equivalent and are easy to discover via Grafana’s **Explore** page. Additionally, the [Telegraf nstat plugin documentation](https://github.com/influxdata/telegraf/blob/v1.36.3/plugins/inputs/nstat/README.md#metrics) lists all available metric names.
+
 ## Known issues
 
 ## Significant package updates

--- a/nixos/platform/monitoring.nix
+++ b/nixos/platform/monitoring.nix
@@ -65,8 +65,8 @@ let
     kernel = [ { } ];
     mem = [ { } ];
     netstat = [ { } ];
-    net = [ { ignore_protocol_stats = true; } ]; # basic network metrics
-    nstat = [ { } ]; # protocol-specific network metrics
+    net = [ { ignore_protocol_stats = true; } ]; # general network metrics
+    nstat = [ { } ]; # network protocol-specific metrics
     processes = [ { } ];
     system = [ { } ];
     swap = [ { } ];


### PR DESCRIPTION
Collection network protocol stats via the `net_` plugins has been deprecated in telegraf, disabled by default, and even the opt-in parameter for keeping that behaviour during a transitioning period will be disabled in telegraf-1.37.
We fully disable the legacy metrics for the upcoming platform release and provide clear guidance in the upgrade notes to enable customers to swithc to the new metrics.

Requires https://github.com/flyingcircusio/grafana/pull/19 to be merged first.

PL-133683

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`
  - kind of, mentioned in Upgrade docs

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - time breaking changes to new releases
  - provide guidance and transitioning period
- [x] Security requirements tested? (EVIDENCE)
  - investigated metrics of a testvm with the updated dashboard
  - checked rendered documentation
