### PR TITLE
pkgs: drop deprecated imagemagick7 alias

### DIFF
--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -320,16 +320,6 @@ builtins.mapAttrs (_: patchPhps phpLogPermissionPatch) {
     }
   );
 
-  imagemagick7 =
-    assert lib.versions.major super.imagemagick.version == "7";
-    lib.warn "'imagemagick7' has been renamed to/replaced by 'imagemagick'" super.imagemagick;
-  imagemagick7Big =
-    assert lib.versions.major super.imagemagickBig.version == "7";
-    lib.warn "'imagemagick7' has been renamed to/replaced by 'imagemagick'" super.imagemagickBig;
-  imagemagick7_light =
-    assert lib.versions.major super.imagemagick_light.version == "7";
-    lib.warn "'imagemagick7' has been renamed to/replaced by 'imagemagick'" super.imagemagick_light;
-
   graylogFrozen = (
     lib.toDerivation (getClosureFromStore /nix/store/yj365yr01p6yp2axj943b4l8ngzzxvkw-graylog-3.3.16)
     // {


### PR DESCRIPTION
PL-133850

@flyingcircusio/release-managers

## Release process

- [ ] Created changelog entry using `./changelog.sh`
  no: internal, with previous warning

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [x] Security requirements tested? (EVIDENCE)
  - had warning in 25.05, so that's already the upgrade note