### PR TITLE
update nixpkgs lock after mailman change

### DIFF
--- a/changelog.d/20251105_075420_HEAD_scriv.md
+++ b/changelog.d/20251105_075420_HEAD_scriv.md
@@ -1,0 +1,19 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+
+### NixOS XX.XX platform
+
+- mailman: fix role throwing evaluation error on NixOS 25.05 (PL-133981)

--- a/flake.lock
+++ b/flake.lock
@@ -168,11 +168,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1762142212,
-        "narHash": "sha256-6DodLOmDBphx75Hq9SfAzyus9glBROSqsbMLUnyrYOk=",
+        "lastModified": 1762294772,
+        "narHash": "sha256-72kX5ER7BT4MC349DVvKvqxzqoFesuUB7ZxleQbuqOU=",
         "owner": "flyingcircusio",
         "repo": "nixpkgs",
-        "rev": "137d2c9ca673424c7f7c80dd4eb8e854f5eb22e5",
+        "rev": "d181bb5ce22aad7814ea1bfa92d2dacd2a01b0cb",
         "type": "github"
       },
       "original": {

--- a/release/versions.json
+++ b/release/versions.json
@@ -8,10 +8,10 @@
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/"
   },
   "nixpkgs": {
-    "hash": "sha256-6DodLOmDBphx75Hq9SfAzyus9glBROSqsbMLUnyrYOk=",
+    "hash": "sha256-72kX5ER7BT4MC349DVvKvqxzqoFesuUB7ZxleQbuqOU=",
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "137d2c9ca673424c7f7c80dd4eb8e854f5eb22e5"
+    "rev": "d181bb5ce22aad7814ea1bfa92d2dacd2a01b0cb"
   },
   "poetry2nix": {
     "hash": "sha256-nzgO/ZCSBzWjbMkYDxG+yl9Z2eGbCgQu06Oku3ir5D4=",


### PR DESCRIPTION
PL-133981

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [x] Security requirements tested? (EVIDENCE)
  - dry-build on our mailman host, ensuring that the system configuration builds again (see https://github.com/flyingcircusio/nixpkgs/pull/1116)