### PR TITLE
pkgs: replace utillinux with util-linux

### DIFF
--- a/pkgs/ceph/nautilus/default.nix
+++ b/pkgs/ceph/nautilus/default.nix
@@ -48,7 +48,7 @@
 
   # Linux Only Dependencies
   linuxHeaders,
-  utillinux,
+  util-linux,
   libuuid,
   udev,
   keyutils,
@@ -203,7 +203,7 @@ rec {
       ]
       ++ optionals stdenv.isLinux [
         linuxHeaders
-        utillinux
+        util-linux
         libuuid
         udev
         keyutils
@@ -336,7 +336,7 @@ rec {
         let
           scriptDependencies = [
             bash
-            utillinux
+            util-linux
             udev
             coreutils
             xfsprogs

--- a/pkgs/fc/qemu/default.nix
+++ b/pkgs/fc/qemu/default.nix
@@ -20,7 +20,7 @@
   stdenv,
   strace,
   systemd,
-  utillinux,
+  util-linux,
   xfsprogs,
 }:
 
@@ -74,7 +74,7 @@ py.buildPythonPackage rec {
     procps
     qemu_ceph
     systemd
-    utillinux
+    util-linux
     xfsprogs
     py.requests
     py.future


### PR DESCRIPTION
renamed upstream

PL-133850

@flyingcircusio/release-managers

## Release process

- [ ] Created changelog entry using `./changelog.sh`
  internal only

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [x] Security requirements tested? (EVIDENCE)
  - equivalency tested
  - backwards-compatibility still exists for the 25.11 cycle upstream