### PR TITLE
fixup! telegraf: enable `nstat` module by default

### DIFF
--- a/nixos/platform/monitoring.nix
+++ b/nixos/platform/monitoring.nix
@@ -65,8 +65,8 @@ let
     kernel = [ { } ];
     mem = [ { } ];
     netstat = [ { } ];
-    net = [ { ignore_protocol_stats = false; } ]; # PL-133683
-    nstat = [ { } ]; # PL-133683
+    net = [ { ignore_protocol_stats = true; } ]; # basic network metrics
+    nstat = [ { } ]; # protocol-specific network metrics
     processes = [ { } ];
     system = [ { } ];
     swap = [ { } ];


### PR DESCRIPTION
@flyingcircusio/release-managers

Fixup for #1604, I fell victim to double-negation and insufficient testing after last-minute changes.
To **disable** the deprecated metrics, we need to **enable** (true) the **ignoring** m)

## Release process

- [x] Created changelog entry using `./changelog.sh`
  - already exists in the commit to be fixed

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - no changes 
- [x] Security requirements tested? (EVIDENCE)
  - this time tested again on a test machine and looked at emitted metrics