### PR TITLE
Update WHQ router configs for new uplink topology

### DIFF
--- a/nixos/lib/network.nix
+++ b/nixos/lib/network.nix
@@ -198,6 +198,12 @@ rec {
       ''
     );
 
+  # Given a list of networks (such as router uplink networks), return
+  # the subset of those networks which are actually present in this
+  # host's configuration
+  filterConfiguredNetworks =
+    nets: map (n: n.vlan) (filter (v: v != null) (map (net: fclib.network."${net}" or null) nets));
+
   # Adapted 'ip' command which says what it is doing and ignores errno 2 (file
   # exists) to make it idempotent.
   relaxedIp = pkgs.writeScriptBin "ip" ''

--- a/nixos/platform/static.nix
+++ b/nixos/platform/static.nix
@@ -199,7 +199,10 @@ with lib;
       # VLANs on which we accept connectivity to the outside world
       routerUplinkNetworks = {
         dev = [ "tr" ];
-        whq = [ "tr-whq-sl" ];
+        whq = [
+          "tr-up-a"
+          "tr-up-b"
+        ];
         rzob = [
           "tr-kamp-a"
           "tr-kamp-b"
@@ -247,7 +250,6 @@ with lib;
           "mgm"
           "srv"
           "fe"
-          "tr-whq-sl"
           "video"
           "access"
         ];

--- a/nixos/platform/static.nix
+++ b/nixos/platform/static.nix
@@ -83,7 +83,6 @@ with lib;
         "srv2" = 17;
         # transfer 3 (blue): tertiary router-router connection
         "tr3" = 18;
-        "tr-whq-sl" = 18;
         # dynamic hardware pool: local endpoints for Kamp DHP tunnels
         "dhp" = 19;
         # underlay: EVPN-VXLAN network virtualisation underlay

--- a/nixos/platform/static.nix
+++ b/nixos/platform/static.nix
@@ -89,8 +89,6 @@ with lib;
         "ul" = 20;
         # routed frontend: frontend network using routed layer 3 transport
         "pub" = 21;
-        # video surveillance
-        "video" = 23;
         # access network for unmanaged hosts
         "access" = 41;
         # uplink vlans for kamp in rzob
@@ -250,7 +248,6 @@ with lib;
           "mgm"
           "srv"
           "fe"
-          "video"
           "access"
         ];
         rzob = [
@@ -269,7 +266,6 @@ with lib;
       # Additional networks for which the routers provide DHCP service
       additionalDhcpNetworks = {
         whq = [
-          "video"
           "access"
         ];
       };

--- a/nixos/roles/router/bird2/default.nix
+++ b/nixos/roles/router/bird2/default.nix
@@ -65,7 +65,8 @@ in
     networking.firewall.extraCommands =
       let
         bgpNetworks =
-          static.routerUplinkNetworks."${location}" ++ (static.routerDownlinkNetworks."${location}" or [ ]);
+          (fclib.filterConfiguredNetworks static.routerUplinkNetworks."${location}")
+          ++ (static.routerDownlinkNetworks."${location}" or [ ]);
         bgpInterfaces = map (network: fclib.network."${network}".interface) bgpNetworks;
       in
       ''

--- a/nixos/roles/router/bird2/default.nix
+++ b/nixos/roles/router/bird2/default.nix
@@ -33,6 +33,8 @@ let
       head fclib.network."${network}".v4.addresses
     );
 
+  hostConfig = role.extraBirdConfig;
+
   commonConfig = ''
     log syslog all;
 
@@ -50,6 +52,10 @@ in
     type = lib.types.ints.unsigned;
     default = 0;
   };
+  options.flyingcircus.roles.router.extraBirdConfig = lib.mkOption {
+    type = lib.types.lines;
+    default = "";
+  };
 
   config = lib.mkIf role.enable {
     services.bird = {
@@ -57,6 +63,7 @@ in
       package = pkgs.bird2;
       config = lib.concatStringsSep "\n\n" [
         (if role.isPrimary then primaryConfig else secondaryConfig)
+        hostConfig
         commonConfig
         locationConfig
       ];

--- a/nixos/roles/router/bird2/whq.conf
+++ b/nixos/roles/router/bird2/whq.conf
@@ -1,38 +1,58 @@
-protocol static uplink_whq_4 {
+# host config must include: PEER_IPV4, PEER_IPV6
+
+protocol static local_whq_4 {
   ipv4 {
     table master4;
   };
 
-  route 0.0.0.0/0 via 185.105.255.1%brfe onlink yes;
+  route 185.105.255.0/25 unreachable;
+  route 185.105.255.160/27 unreachable;
+  route 185.105.255.192/27 unreachable;
 }
 
-protocol static uplink_whq_6 {
+protocol static local_whq_6 {
   ipv6 {
     table master6;
   };
 
-  route ::/0 via 2a06:3a80:0400:ff01::1;
+  route 2a06:3a80::/40 unreachable;
 }
+
 
 protocol device {
   scan time 60;
 }
 
-protocol bfd {
-  strict bind on;
-  interface "ethtr";
+# bfd config in host-specific config in this location because the
+# parser does not allow using defines for interface names.
+#
+# protocol bfd {
+#   strict bind on;
+#   interface ...;
+# }
+
+function net_whq_4() -> bool {
+  if net ~ [ 185.105.255.0/25+, 185.105.255.160/27+, 185.105.255.192/27+ ] then {
+    return true;
+  } else return false;
 }
 
-filter net_dev_4 {
+function net_whq_6() -> bool {
+  if net ~ [ 2a06:3a80::/40+ ] then {
+    return true;
+  } else return false;
+}
+
+function net_dev_4() -> bool {
   if net ~ [ 172.20.0.0/16+, 172.30.0.0/16+ ] then {
-    accept;
-  } else reject;
+    return true;
+  } else return false;
 }
 
-filter net_dev_6 {
+function net_dev_6() -> bool {
   if net ~ [ 2a06:3a80:0300::/40+ ] then {
-    accept;
-  } else reject;
+    return true;
+  } else return false;
 }
 
 filter default_route_4 {
@@ -65,6 +85,58 @@ protocol kernel kernel_6 {
   merge paths on;
 }
 
+template bgp peer_saltlabs {
+  local as 64513;
+  neighbor as 64514;
+
+  bfd;
+  connect retry time 15;
+  error wait time 5,10;
+}
+
+template bgp peer_saltlabs_v4 from peer_saltlabs {
+  ipv4 {
+    table master4;
+    import filter default_route_4;
+
+    export filter {
+      if net_whq_4() then {  # private dev networks not exported
+        bgp_med = UPLINK_MED;
+        accept;
+      }
+      reject;
+    };
+
+    import keep filtered on;
+  };
+}
+
+template bgp peer_saltlabs_v6 from peer_saltlabs {
+  ipv6 {
+    table master6;
+    import filter default_route_6;
+
+    export filter {
+      if net_whq_6() || net_dev_6() then {
+        bgp_med = UPLINK_MED;
+        accept;
+      }
+      reject;
+    };
+
+    import keep filtered on;
+  };
+}
+
+protocol bgp peer_saltlabs_01_v4 from peer_saltlabs_v4 {
+  neighbor PEER_IPV4;
+}
+
+protocol bgp peer_saltlabs_01_v6 from peer_saltlabs_v6 {
+  neighbor PEER_IPV6;
+}
+
+
 template bgp peer_dev {
   local as 64513;
 
@@ -78,7 +150,7 @@ template bgp peer_dev {
 template bgp peer_dev_4 from peer_dev {
   ipv4 {
     table master4;
-    import filter net_dev_4;
+    import where net_dev_4();
     export filter default_route_4;
   };
 }
@@ -86,7 +158,7 @@ template bgp peer_dev_4 from peer_dev {
 template bgp peer_dev_6 from peer_dev {
   ipv6 {
     table master6;
-    import filter net_dev_6;
+    import where net_dev_6();
     export filter default_route_6;
   };
 }

--- a/nixos/roles/router/chrony.nix
+++ b/nixos/roles/router/chrony.nix
@@ -32,7 +32,7 @@ lib.mkIf role.enable {
 
   networking.firewall.extraCommands =
     let
-      uplinkNetworks = static.routerUplinkNetworks."${location}";
+      uplinkNetworks = fclib.filterConfiguredNetworks (static.routerUplinkNetworks."${location}");
       uplinkIfaces = map (network: fclib.network."${network}".interface) uplinkNetworks;
     in
     (lib.concatMapStringsSep "\n" (

--- a/nixos/roles/router/default.nix
+++ b/nixos/roles/router/default.nix
@@ -37,9 +37,9 @@ let
       fi
     '';
 
-  uplinkInterfaces = map (
-    network: fclib.network."${network}".interface
-  ) static.routerUplinkNetworks."${location}";
+  uplinkInterfaces = map (network: fclib.network."${network}".interface) (
+    fclib.filterConfiguredNetworks static.routerUplinkNetworks."${location}"
+  );
 
   gatewayInterfaces =
     map (network: fclib.network."${network}")

--- a/nixos/roles/router/keepalived/whq.conf
+++ b/nixos/roles/router/keepalived/whq.conf
@@ -36,7 +36,7 @@ track_file check_maint_file {
 }
 
 vrrp_sync_group router {
-    group { mgm fe srv video access }
+    group { mgm fe srv access }
 
     notify_master "/etc/keepalived/fc-keepalived notify master"
     notify_backup "/etc/keepalived/fc-keepalived notify backup"
@@ -100,23 +100,6 @@ vrrp_instance srv {
     }
     virtual_ipaddress_excluded {
         172.16.48.1/20
-    }
-}
-
-vrrp_instance video {
-    interface ethvideo
-    state BACKUP
-    virtual_router_id 51
-    priority 100
-    advert_int 1
-    garp_master_refresh 30
-    dont_track_primary
-
-    virtual_ipaddress {
-        2a06:3a80:0:23::1/64
-    }
-    virtual_ipaddress_excluded {
-        172.17.112.1/20
     }
 }
 

--- a/nixos/roles/router/keepalived/whq.conf
+++ b/nixos/roles/router/keepalived/whq.conf
@@ -36,7 +36,7 @@ track_file check_maint_file {
 }
 
 vrrp_sync_group router {
-    group { mgm fe srv tr video access }
+    group { mgm fe srv video access }
 
     notify_master "/etc/keepalived/fc-keepalived notify master"
     notify_backup "/etc/keepalived/fc-keepalived notify backup"
@@ -117,27 +117,6 @@ vrrp_instance video {
     }
     virtual_ipaddress_excluded {
         172.17.112.1/20
-    }
-}
-
-vrrp_instance tr {
-    interface ethtr-whq-sl
-    state BACKUP
-    virtual_router_id 51
-    priority 100
-    advert_int 1
-    garp_master_refresh 30
-
-    virtual_ipaddress {
-        2a06:3a80:0400:ff01::2/125
-    }
-    virtual_ipaddress_excluded {
-        185.105.255.130/29
-    }
-    virtual_routes {
-        # We don't have a sufficiently large transfer net so we
-        # need to use the default route only when we're the primary.
-        default via 185.105.255.129 dev ethtr-whq-sl
     }
 }
 


### PR DESCRIPTION
This change updates the WHQ router configuration for the new uplink topology, where the shared layer 2 `tr-whq-sl` network has been replaced with two `tr-up-a` and `tr-up-b` point-to-point links between the routers and the upstream. Routing is now managed using BGP instead of keepalived as well.

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh` => none, internal change.

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Physical redundancy between WHQ and the upstream router.
- [x] Security requirements tested? (EVIDENCE)
  - These configs are already running live from a dev checkout.