### PR TITLE
[21.05] ceph-nautilus: backport msg: fix deadlock when handling existing but closed v2 connection

### DIFF
--- a/pkgs/ceph/nautilus/0001-msg-fix-deadlock-when-handling-existing-but-closed-v.patch
+++ b/pkgs/ceph/nautilus/0001-msg-fix-deadlock-when-handling-existing-but-closed-v.patch
@@ -1,0 +1,63 @@
+From 61dfb4f7ae1e88e0b0037b055eedb5bb15c3b7eb Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Rados=C5=82aw=20Zarzy=C5=84ski?= <rzarzyns@redhat.com>
+Date: Fri, 17 Jun 2022 14:17:25 +0200
+Subject: [PATCH] msg: fix deadlock when handling existing but closed v2
+ connection
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The deadlock is illustrated best by the following snippet
+provided by jianwei zhang who also made the problem analysis
+(many thanks!).
+
+```
+thread-35
+AsyncMessenger::shutdown_connections         hold             AsyncMessenger::lock            std::lock_guard l{lock}
+AsyncConnection::stop                         wait                AsyncConnection::lock            lock.lock()
+
+thread-3
+ProtocolV2::handle_existing_connection        hold                AsyncConnection::lock            std::lock_guard<std::mutex> l(existing->lock)
+AsyncMessenger::accept_conn                wait                AsyncMessenger::lock            std::lock_guard l{lock}
+```
+
+Fixes: https://tracker.ceph.com/issues/55355
+Signed-off-by: Radosław Zarzyński <rzarzyns@redhat.com>
+(cherry picked from commit a6fcb1ccbc44e60416eb5f4e2c7291afe3a9d44d)
+(cherry picked from commit 244b6a161ce62fc05431f772ee71c3386b791667)
+---
+ src/msg/async/ProtocolV2.cc | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/src/msg/async/ProtocolV2.cc b/src/msg/async/ProtocolV2.cc
+index b8a805e91c7..15f78b43b59 100644
+--- a/src/msg/async/ProtocolV2.cc
++++ b/src/msg/async/ProtocolV2.cc
+@@ -2500,7 +2500,7 @@ CtPtr ProtocolV2::handle_reconnect(ceph::bufferlist &payload)
+ CtPtr ProtocolV2::handle_existing_connection(AsyncConnectionRef existing) {
+   ldout(cct, 20) << __func__ << " existing=" << existing << dendl;
+ 
+-  std::lock_guard<std::mutex> l(existing->lock);
++  std::unique_lock<std::mutex> l(existing->lock);
+ 
+   ProtocolV2 *exproto = dynamic_cast<ProtocolV2 *>(existing->protocol.get());
+   if (!exproto) {
+@@ -2511,6 +2511,7 @@ CtPtr ProtocolV2::handle_existing_connection(AsyncConnectionRef existing) {
+   if (exproto->state == CLOSED) {
+     ldout(cct, 1) << __func__ << " existing " << existing << " already closed."
+                   << dendl;
++    l.unlock();
+     return send_server_ident();
+   }
+ 
+@@ -2540,6 +2541,7 @@ CtPtr ProtocolV2::handle_existing_connection(AsyncConnectionRef existing) {
+         << dendl;
+     existing->protocol->stop();
+     existing->dispatch_queue->queue_reset(existing.get());
++    l.unlock();
+     return send_server_ident();
+   }
+ 
+-- 
+2.50.1 (Apple Git-155)
+

--- a/pkgs/ceph/nautilus/default.nix
+++ b/pkgs/ceph/nautilus/default.nix
@@ -153,6 +153,7 @@ rec {
       ./0000-fix-SPDK-build-env.patch
       ./0001-fix-iterator.patch
       ./rgw-reduce-log-verbosity.patch
+      ./0001-msg-fix-deadlock-when-handling-existing-but-closed-v.patch
     ]
     ++ (
       if tmp-patches then

--- a/pkgs/ceph/nautilus/default.nix
+++ b/pkgs/ceph/nautilus/default.nix
@@ -1,38 +1,68 @@
-{ stdenv, runCommand, fetchzip
-, lib, ensureNewerSourcesHook
-, cmake, pkgconfig
-, which, git
-, boost, python3Packages
-, libxml2, zlib, lz4
-, openldap, lttng-ust
-, babeltrace, gperf
-, gtest
-, cunit, snappy
-, makeWrapper
-, leveldb, oathToolkit
-, libnl, libcap_ng
-, rdkafka
+{
+  stdenv,
+  runCommand,
+  fetchzip,
+  lib,
+  ensureNewerSourcesHook,
+  cmake,
+  pkgconfig,
+  which,
+  git,
+  boost,
+  python3Packages,
+  libxml2,
+  zlib,
+  lz4,
+  openldap,
+  lttng-ust,
+  babeltrace,
+  gperf,
+  gtest,
+  cunit,
+  snappy,
+  makeWrapper,
+  leveldb,
+  oathToolkit,
+  libnl,
+  libcap_ng,
+  rdkafka,
 
-# Optional Dependencies
-, yasm ? null, fcgi ? null, expat ? null
-, curl ? null, fuse ? null
-, libedit ? null, libatomic_ops ? null
-, libs3 ? null
+  # Optional Dependencies
+  yasm ? null,
+  fcgi ? null,
+  expat ? null,
+  curl ? null,
+  fuse ? null,
+  libedit ? null,
+  libatomic_ops ? null,
+  libs3 ? null,
 
-# Mallocs
-, jemalloc ? null, gperftools ? null
+  # Mallocs
+  jemalloc ? null,
+  gperftools ? null,
 
-# Crypto Dependencies
-, cryptopp ? null
-, nss ? null, nspr ? null
+  # Crypto Dependencies
+  cryptopp ? null,
+  nss ? null,
+  nspr ? null,
 
-# Linux Only Dependencies
-, linuxHeaders, utillinux, libuuid, udev, keyutils, rdma-core, rabbitmq-c
-, libaio ? null, libxfs ? null, zfs ? null
-, tmp-patches ? false
-# tool dependencies
-, bash, coreutils, xfsprogs
-, ...
+  # Linux Only Dependencies
+  linuxHeaders,
+  utillinux,
+  libuuid,
+  udev,
+  keyutils,
+  rdma-core,
+  rabbitmq-c,
+  libaio ? null,
+  libxfs ? null,
+  zfs ? null,
+  tmp-patches ? false,
+  # tool dependencies
+  bash,
+  coreutils,
+  xfsprogs,
+  ...
 }:
 
 # We must have one crypto library
@@ -64,16 +94,23 @@ let
 
   hasRadosgw = optFcgi != null && optExpat != null && optCurl != null && optLibedit != null;
 
-
   # Malloc implementation (can be jemalloc, tcmalloc or null)
   malloc = if optJemalloc != null then optJemalloc else optGperftools;
 
   # We prefer nss over cryptopp
-  cryptoStr = if optNss != null && optNspr != null then "nss" else
-    if optCryptopp != null then "cryptopp" else "none";
+  cryptoStr =
+    if optNss != null && optNspr != null then
+      "nss"
+    else if optCryptopp != null then
+      "cryptopp"
+    else
+      "none";
 
   cryptoLibsMap = {
-    nss = [ optNss optNspr ];
+    nss = [
+      optNss
+      optNspr
+    ];
     cryptopp = [ optCryptopp ];
     none = [ ];
   };
@@ -106,7 +143,8 @@ let
     url = "http://download.ceph.com/tarballs/ceph-${version}.tar.gz";
     sha256 = "sha256-L/SnaAZHURiynJILBW+c9FMyV3IMG36CmZ9x6Psd3hQ";
   };
-in rec {
+in
+rec {
   ceph = stdenv.mkDerivation {
     pname = "ceph";
     inherit version src;
@@ -115,39 +153,83 @@ in rec {
       ./0000-fix-SPDK-build-env.patch
       ./0001-fix-iterator.patch
       ./rgw-reduce-log-verbosity.patch
-    ] ++
-    (if tmp-patches then
-      [  ./0002-rgwadmin-put-bucket-remove-explicit-placement.patch
-         ./0002-rgwadmin-jsonlines-index.patch
-      ]
-      else []
+    ]
+    ++ (
+      if tmp-patches then
+        [
+          ./0002-rgwadmin-put-bucket-remove-explicit-placement.patch
+          ./0002-rgwadmin-jsonlines-index.patch
+        ]
+      else
+        [ ]
     );
 
     nativeBuildInputs = [
       cmake
-      pkgconfig which git python3Packages.wrapPython makeWrapper
+      pkgconfig
+      which
+      git
+      python3Packages.wrapPython
+      makeWrapper
       python3Packages.python # for the toPythonPath function
       (ensureNewerSourcesHook { year = "1980"; })
     ];
 
-    buildInputs = cryptoLibsMap.${cryptoStr} ++ [
-      boost ceph-python-env libxml2 optYasm optLibatomic_ops optLibs3
-      malloc zlib openldap lttng-ust babeltrace gperf gtest cunit
-      snappy lz4 oathToolkit leveldb libnl libcap_ng rdkafka
-    ] ++ optionals stdenv.isLinux [
-      linuxHeaders utillinux libuuid udev keyutils optLibaio optLibxfs optZfs
-      # ceph 14
-      rdma-core rabbitmq-c
-    ] ++ optionals hasRadosgw [
-      optFcgi optExpat optCurl optFuse optLibedit
-    ];
+    buildInputs =
+      cryptoLibsMap.${cryptoStr}
+      ++ [
+        boost
+        ceph-python-env
+        libxml2
+        optYasm
+        optLibatomic_ops
+        optLibs3
+        malloc
+        zlib
+        openldap
+        lttng-ust
+        babeltrace
+        gperf
+        gtest
+        cunit
+        snappy
+        lz4
+        oathToolkit
+        leveldb
+        libnl
+        libcap_ng
+        rdkafka
+      ]
+      ++ optionals stdenv.isLinux [
+        linuxHeaders
+        utillinux
+        libuuid
+        udev
+        keyutils
+        optLibaio
+        optLibxfs
+        optZfs
+        # ceph 14
+        rdma-core
+        rabbitmq-c
+      ]
+      ++ optionals hasRadosgw [
+        optFcgi
+        optExpat
+        optCurl
+        optFuse
+        optLibedit
+      ];
 
-    pythonPath = [ ceph-python-env "${placeholder "out"}/${ceph-python-env.sitePackages}" ];
+    pythonPath = [
+      ceph-python-env
+      "${placeholder "out"}/${ceph-python-env.sitePackages}"
+    ];
 
     # create and split out debug symbols
     separateDebugInfo = true;
 
-    preConfigure =''
+    preConfigure = ''
       substituteInPlace src/common/module.c --replace "/sbin/modinfo"  "modinfo"
       substituteInPlace src/common/module.c --replace "/sbin/modprobe" "modprobe"
 
@@ -164,7 +246,6 @@ in rec {
       # using an unpatched system rocksdb might break bluestore, see https://github.com/NixOS/nixpkgs/pull/113137/
       "-DWITH_SYSTEM_ROCKSDB=OFF"
       "-DCMAKE_INSTALL_DATADIR=${placeholder "lib"}/lib"
-
 
       "-DWITH_SYSTEM_BOOST=ON"
       "-DWITH_SYSTEM_GTEST=ON"
@@ -187,15 +268,27 @@ in rec {
 
     enableParallelBuilding = true;
 
-    outputs = [ "out" "lib" "dev" "doc" "man" ];
+    outputs = [
+      "out"
+      "lib"
+      "dev"
+      "doc"
+      "man"
+    ];
 
     doCheck = false; # uses pip to install things from the internet
 
     meta = {
       homepage = "https://ceph.com/";
       description = "Distributed storage system";
-      license = with licenses; [ lgpl21 gpl2 bsd3 mit publicDomain ];
-      maintainers = with maintainers; [];
+      license = with licenses; [
+        lgpl21
+        gpl2
+        bsd3
+        mit
+        publicDomain
+      ];
+      maintainers = with maintainers; [ ];
       platforms = [ "x86_64-linux" ];
       priority = 5;
     };
@@ -205,48 +298,74 @@ in rec {
     };
   };
 
-  ceph-client = runCommand "ceph-client-${version}" {
-     meta = {
-        homepage = "https://ceph.com/";
-        description = "Tools needed to mount Ceph's RADOS Block Devices";
-        license = with licenses; [ lgpl21 gpl2 bsd3 mit publicDomain ];
-        maintainers = with maintainers; [ adev ak johanot krav ];
-        platforms = [ "x86_64-linux" ];
-        priority = 10;
-      };
-     passthru = {
-       inherit codename version;
-     };
-     nativeBuildInputs = [ makeWrapper ];
-     # TODO cleanup, this was
+  ceph-client =
+    runCommand "ceph-client-${version}"
+      {
+        meta = {
+          homepage = "https://ceph.com/";
+          description = "Tools needed to mount Ceph's RADOS Block Devices";
+          license = with licenses; [
+            lgpl21
+            gpl2
+            bsd3
+            mit
+            publicDomain
+          ];
+          maintainers = with maintainers; [
+            adev
+            ak
+            johanot
+            krav
+          ];
+          platforms = [ "x86_64-linux" ];
+          priority = 10;
+        };
+        passthru = {
+          inherit codename version;
+        };
+        nativeBuildInputs = [ makeWrapper ];
+        # TODO cleanup, this was
 
-     outputs = [ "out" "man" ];
-    } (
-    let scriptDependencies = [ bash utillinux udev coreutils xfsprogs python3Packages.python ];
-    in
-      ''
-      mkdir -p $out/{bin,etc,${sitePackages}}
-      cp -r ${ceph}/bin/{ceph,.ceph-wrapped,rados,rbd,rbdmap} $out/bin
-      cp -r ${ceph}/bin/ceph-{authtool,conf,dencoder,rbdnamer,syn} $out/bin
-      cp -r ${ceph}/bin/rbd-replay* $out/bin
-      cp -r ${ceph}/${sitePackages}/* $out/${sitePackages}
-      cp -r ${ceph}/etc/bash_completion.d $out/etc
-      # wrapPythonPrograms modifies .ceph-wrapped, so let's just update its paths
-      substituteInPlace $out/bin/ceph          --replace ${ceph} $out
-      substituteInPlace $out/bin/.ceph-wrapped --replace ${ceph} $out
+        outputs = [
+          "out"
+          "man"
+        ];
+      }
+      (
+        let
+          scriptDependencies = [
+            bash
+            utillinux
+            udev
+            coreutils
+            xfsprogs
+            python3Packages.python
+          ];
+        in
+        ''
+          mkdir -p $out/{bin,etc,${sitePackages}}
+          cp -r ${ceph}/bin/{ceph,.ceph-wrapped,rados,rbd,rbdmap} $out/bin
+          cp -r ${ceph}/bin/ceph-{authtool,conf,dencoder,rbdnamer,syn} $out/bin
+          cp -r ${ceph}/bin/rbd-replay* $out/bin
+          cp -r ${ceph}/${sitePackages}/* $out/${sitePackages}
+          cp -r ${ceph}/etc/bash_completion.d $out/etc
+          # wrapPythonPrograms modifies .ceph-wrapped, so let's just update its paths
+          substituteInPlace $out/bin/ceph          --replace ${ceph} $out
+          substituteInPlace $out/bin/.ceph-wrapped --replace ${ceph} $out
 
-      mkdir -p "$man/"
-      cp -r "${ceph.man}/share" "$man/"
+          mkdir -p "$man/"
+          cp -r "${ceph.man}/share" "$man/"
 
-      cp -r "${src}/udev" "$out/etc/"
-      substituteInPlace $out/etc/udev/* --replace "/usr/bin/" "$out/bin/"
+          cp -r "${src}/udev" "$out/etc/"
+          substituteInPlace $out/etc/udev/* --replace "/usr/bin/" "$out/bin/"
 
-      install -D -m 755 ${./rbd-locktool.py} $out/bin/.rbd-locktool.py
-      makeWrapper $out/bin/.rbd-locktool.py $out/bin/rbd-locktool \
-        --set PATH "${lib.makeBinPath scriptDependencies}:$out/bin"
+          install -D -m 755 ${./rbd-locktool.py} $out/bin/.rbd-locktool.py
+          makeWrapper $out/bin/.rbd-locktool.py $out/bin/rbd-locktool \
+            --set PATH "${lib.makeBinPath scriptDependencies}:$out/bin"
 
-      install -D -m 755 ${./rbd-mount.sh} $out/bin/.rbd-mount.sh
-      makeWrapper $out/bin/.rbd-mount.sh $out/bin/rbd-mount \
-        --set PATH "${lib.makeBinPath scriptDependencies}:$out/bin"
-   '');
+          install -D -m 755 ${./rbd-mount.sh} $out/bin/.rbd-mount.sh
+          makeWrapper $out/bin/.rbd-mount.sh $out/bin/rbd-mount \
+            --set PATH "${lib.makeBinPath scriptDependencies}:$out/bin"
+        ''
+      );
 }


### PR DESCRIPTION
@flyingcircusio/release-managers

backport of https://github.com/ceph/ceph/pull/48254 by applying as a
patch

Mainly designed to be pulled in by a current fc-nixos.

PL-133952

## Release process

- [ ] Created changelog entry using `./changelog.sh`
  - internal

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - backport a regression fix from a future ceph release
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still pass