### PR TITLE
Pl 134153 fc qemu burst fix

### DIFF
--- a/changelog.d/20251111_214431_fc-25.05-dev_scriv.md
+++ b/changelog.d/20251111_214431_fc-25.05-dev_scriv.md
@@ -1,0 +1,29 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+<!-- Impact means "when this change is rolled out, there
+     might be interruptions/downtimes/required actions/... that
+     IMPACT THE RUNNING APPLICATION NEGATIVELY.
+
+     Having new features or changed is not an "impact". That's what
+     the main changelog (see below) is for.
+     -->
+
+- A bullet item for the Impact category.
+
+
+### NixOS XX.XX platform
+
+- Multiple bugfixes in fc.qemu for edge cases improving resiliency.

--- a/pkgs/fc/default.nix
+++ b/pkgs/fc/default.nix
@@ -54,8 +54,8 @@ rec {
       repo = "fc.qemu";
       # The release tooling didn't upgrade properly so we had to pick a specific
       # commit instead.
-      rev = "e0a1578849fe2f3261b38928fa41f06956ab511d";
-      hash = "sha256-QOFjdD62IjdS/5kYR7R1HMZiT23OTojnR+mrbCribo4=";
+      rev = "0bd0bf02345cbb9caf1d96f95fb6fb8b1356b771";
+      hash = "sha256-LAGvvfZZQdJN40QciiGuTLISRknpcokmZUMsYFc97Hk=";
     };
     fc-ceph = ceph;
     qemu_ceph = pkgs.qemu-ceph-nautilus;


### PR DESCRIPTION
@flyingcircusio/release-managers

PL-134153, PL-133939

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.

n/a

- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

na/

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

improve resiliency

- [x] Security requirements tested? (EVIDENCE)

automated tests