### PR TITLE
memory management: improve memory exhaustion behaviour

### DIFF
--- a/changelog.d/20251113_133110_PL-130935-improve-oom-swap-handling_scriv.md
+++ b/changelog.d/20251113_133110_PL-130935-improve-oom-swap-handling_scriv.md
@@ -1,0 +1,30 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+<!-- Impact means "when this change is rolled out, there
+     might be interruptions/downtimes/required actions/... that
+     IMPACT THE RUNNING APPLICATION NEGATIVELY.
+
+     Having new features or changed is not an "impact". That's what
+     the main changelog (see below) is for.
+     -->
+
+- A bullet item for the Impact category.
+
+
+### NixOS XX.XX platform
+
+- Revert deactivation of swap and switch to a more fine-grained approach to
+  handle out-of-memory situations. (PL-130935)

--- a/doc/src/upgrade.md
+++ b/doc/src/upgrade.md
@@ -152,14 +152,21 @@ These options will be removed with fc-nixos 26.05. Please migrate your client or
 
 ## Other notable changes
 
-### swap
+### Handling of out-of-memory situations (virtual machines only)
 
-We had a couple of incidents related to changed memory usage patterns that resulted in subsequent problems related to
-swapping.
-In our experience, swap doesn't help much for VMs: it should almost always be unused and when it gets used, the system
-gets a significant lower performance when it needs to swap contents in.
+We have evolved the handling of situations where systems run out of memory. This
+has resulted in a more proactive monitoring of memory conditions with the goal
+to avoid kernel stalls and long periods of lockup on virtual machines.
 
-We decided to disable swap on our hardware nodes and virtual machines.
+`systemd-oomd` is now actively being used and configured to start killing (and
+restarting) suspect services if a system starts using more than 50% of the
+available swap. Our tests have shown that this results in faster automated
+recoveries with only very short periods of downtime in cases of extreme and
+sudden memory pressure. If this happens we receive automatic tickets to follow
+up on this event during regular office hours.
+
+Some low-level services (like `sshd`, `dbus` and a few others) are never swapped
+and will never be killed by `systemd-oomd`.
 
 ### Mail server
 

--- a/nixos/infrastructure/flyingcircus-virtual.nix
+++ b/nixos/infrastructure/flyingcircus-virtual.nix
@@ -99,6 +99,22 @@ mkIf (cfg.infrastructureModule == "flyingcircus") {
     };
   };
 
+  swapDevices = [ { device = "/dev/disk/by-label/swap"; } ];
+
+  systemd.oomd = {
+    enableSystemSlice = true;
+    enableUserSlices = true;
+
+    extraConfig = {
+      SwapUsedLimit = "50%";
+      DefaultMemoryPressureDurationSec = "20s";
+    };
+  };
+
+  systemd.slices."-".sliceConfig = {
+    ManagedOOMSwap = "kill";
+  };
+
   flyingcircus.initrd = {
     upgradeXFS = {
       "/dev/disk/by-label/root" = [
@@ -121,6 +137,8 @@ mkIf (cfg.infrastructureModule == "flyingcircus") {
     '';
     hostName = config.fclib.mkPlatform (attrByPath [ "name" ] "default" cfg.enc);
   };
+
+  flyingcircus.systemd.protectedServices = [ "qemu-guest-agent" ];
 
   services = {
     qemuGuest.enable = true;

--- a/nixos/platform/default.nix
+++ b/nixos/platform/default.nix
@@ -297,7 +297,7 @@ in
       ];
 
       kernel.sysctl = {
-        "vm.swappiness" = mkDefault 1;
+        "vm.swappiness" = mkDefault 100;
         "vm.dirty_background_bytes" = fclib.mkPlatform 16777216; # 16 mib, or hopefully at most 15s of flushing time
         "vm.dirty_bytes" = fclib.mkPlatform 67108864; # 64 mib
       };

--- a/nixos/platform/systemd.nix
+++ b/nixos/platform/systemd.nix
@@ -21,6 +21,11 @@ in
         type = types.listOf types.str;
       };
 
+      protectedServices = mkOption {
+        description = "Names of services that should be protected from OOM conditions.";
+        type = types.listOf types.str;
+      };
+
     };
   };
 
@@ -76,6 +81,21 @@ in
       DefaultStartLimitInterval = 60;
       DefaultStartLimitBurst = 5;
     };
+
+    flyingcircus.systemd.protectedServices = [
+      "sshd"
+      "telegraf"
+      "nscd"
+      "dbus"
+    ]; # make it so that this isn't a default that gets immediately overwritten but extended
+
+    systemd.services = lib.genAttrs cfg.protectedServices (svc: {
+      serviceConfig = {
+        ManagedOOMPreference = "omit";
+        MemorySwapMax = 0;
+        OOMScoreAdjust = -1000;
+      };
+    });
 
     systemd.units =
       let


### PR DESCRIPTION
Under memory exhaustion we strive to stay live and adhere to "crash early". This works better with swap enabled and using swap as a pressure indicator and respond with a user-space based oom trigger.

Also limit our internal tooling to predictable values that likely will not exhaust resources.

PL-130935

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

improve general resiliency, no specific coding requirements applicable

- [x] Security requirements tested? (EVIDENCE)

automated tests
