### PR TITLE
nixos/infrastructure/fc-virtual: update systemd-oomd option

### DIFF
--- a/nixos/infrastructure/flyingcircus-virtual.nix
+++ b/nixos/infrastructure/flyingcircus-virtual.nix
@@ -105,7 +105,7 @@ mkIf (cfg.infrastructureModule == "flyingcircus") {
     enableSystemSlice = true;
     enableUserSlices = true;
 
-    extraConfig = {
+    settings.OOM = {
       SwapUsedLimit = "50%";
       DefaultMemoryPressureDurationSec = "20s";
     };


### PR DESCRIPTION
extraConfig -> settings attribute migration in 25.11.

@flyingcircusio/release-managers

## Release process

- [ ] Created changelog entry using `./changelog.sh`
  - no, unreleased changes

## PR release workflow (internal)

- [ ] PR has internal ticket
- [ ] internal issue ID (PL-…) part of branch name
- [ ] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - no extra requirements, just an option name migration resulting in equal configuration
- [x] Security requirements tested? (EVIDENCE)
  - [x] automated tests still pass
  - [x] 
checked on a test VM that `/etc/systemd/oomd.conf` remains the same