### PR TITLE
k3s: structured netCfg

### DIFF
--- a/changelog.d/20251118_191955_PL-133889-clusterdns-firewall_scriv.md
+++ b/changelog.d/20251118_191955_PL-133889-clusterdns-firewall_scriv.md
@@ -1,0 +1,38 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+<!-- Impact means "when this change is rolled out, there
+     might be interruptions/downtimes/required actions/... that
+     IMPACT THE RUNNING APPLICATION NEGATIVELY.
+
+     Having new features or changed is not an "impact". That's what
+     the main changelog (see below) is for.
+     -->
+
+- k3s clusters with custom `clusterDNS`, `podCidr`, `serviceCidr` will fail to evaluate until adapted. See the change description below for details.
+
+
+### NixOS XX.XX platform
+
+- k3s clusters: options `clusterDns`, `podCidr`, `serviceCidr` are now a list
+
+  affected roles: `k3s-agent`, `k3s-server`, `k3s-single-node`, `webgateway` when in a resource group with k3s nodes (PL-133889)
+
+  The options `clusterDns`, `podCidr`, `serviceCidr` in the namespace `flyingcircus.kubernetes.network` have changed
+  from option type *string* to a *list of strings*. This better reflects the ability to specify multiple IP
+  address entries and process them at other parts of the configuration. \
+  Deployments deviating from the default option value require manual adjustment of the option. The new system
+  will fail to evaluate, preventing this release from bein installed automatically until the configuration
+  value has been adjusted.

--- a/nixos/roles/k3s/agent.nix
+++ b/nixos/roles/k3s/agent.nix
@@ -123,7 +123,7 @@ in
         role = "agent";
         serverAddr = "https://${serverAddress}:6443";
         inherit tokenFile;
-        extraFlags = lib.concatStringsSep " " k3sFlags;
+        extraFlags = k3sFlags;
       };
 
       users.groups.kubernetes.gid = config.ids.gids.kubernetes;

--- a/nixos/roles/k3s/agent.nix
+++ b/nixos/roles/k3s/agent.nix
@@ -9,17 +9,17 @@ with builtins;
 
 let
   cfg = config.flyingcircus.roles.k3s-agent;
+  netCfg = config.flyingcircus.kubernetes.network;
   fclib = config.fclib;
   server = fclib.findOneService "k3s-server-server";
   agents = fclib.findServices "k3s-agent-agent";
   agentNames = map (service: head (lib.splitString "." service.address)) agents;
   otherAgentNames = filter (m: m != config.networking.hostName) agentNames;
   serverAddress = lib.replaceStrings [ "gocept.net" ] [ "fcio.net" ] server.address or "";
-  agentAddress = head fclib.network.srv.v4.addresses;
   tokenFile = "/var/lib/k3s/secret_token";
   k3sFlags = [
     "--flannel-iface=${fclib.network.srv.interface}"
-    "--node-ip=${agentAddress}"
+    "--node-ip='${concatStringsSep "," netCfg.nodeIps}'"
     "--data-dir=/var/lib/k3s"
     # k3s disables this port by default, we re-enable it to conform to
     # standard k8s behaviour.

--- a/nixos/roles/k3s/default.nix
+++ b/nixos/roles/k3s/default.nix
@@ -45,6 +45,11 @@
           default = [ "10.42.0.0/16" ];
           description = "Kubernetes nodes get a /24 subnet for their pods from the given subnet.";
         };
+        nodeIps = mkOption {
+          type = with types; listOf str;
+          internal = true; # should be managed by a global IPv6 switch instead PL-133774
+          default = [ (head config.fclib.network.srv.v4.addresses) ];
+        };
       };
     };
   };

--- a/nixos/roles/k3s/default.nix
+++ b/nixos/roles/k3s/default.nix
@@ -24,20 +24,25 @@
       network = {
 
         clusterDns = mkOption {
-          type = types.str;
-          default = "10.43.0.10";
+          type = types.listOf types.str;
+          default = [ "10.43.0.10" ];
           description = "Cluster IP that should be used for CoreDNS.";
         };
 
+        # These network specifications are supposed to hold at most one network
+        # per IP family. Once platform-level IPv6 support for k3s arrives, it
+        # makes sense to restructure this to single options of
+        # kubernetes.network.ipv4 = { serviceCidr…; podCidr…;};
+        # kubernetes.network.ipv6 = { serviceCidr…; podCidr…;};
         serviceCidr = mkOption {
-          type = types.str;
-          default = "10.43.0.0/16";
+          type = types.listOf types.str;
+          default = [ "10.43.0.0/16" ];
           description = "Cluster IPs are assigned to services from the subnet specified here.";
         };
 
         podCidr = mkOption {
-          type = types.str;
-          default = "10.42.0.0/16";
+          type = types.listOf types.str;
+          default = [ "10.42.0.0/16" ];
           description = "Kubernetes nodes get a /24 subnet for their pods from the given subnet.";
         };
       };

--- a/nixos/roles/k3s/server.nix
+++ b/nixos/roles/k3s/server.nix
@@ -555,7 +555,7 @@ in
           {
             enable = true;
             role = "server";
-            extraFlags = lib.concatStringsSep " " k3sFlags;
+            extraFlags = k3sFlags;
           };
 
         systemd.services.fc-set-k3s-config-permissions = {

--- a/nixos/roles/k3s/server.nix
+++ b/nixos/roles/k3s/server.nix
@@ -15,7 +15,6 @@ let
 
   location = lib.attrByPath [ "parameters" "location" ] "standalone" config.flyingcircus.enc;
   srvFQDN = "${config.networking.hostName}.fcio.net";
-  nodeAddress = head fclib.network.srv.v4.addresses;
 
   lokiServer = fclib.findOneService "loki-collector";
 
@@ -539,7 +538,7 @@ in
               "--cluster-cidr='${concatStringsSep "," netCfg.podCidr}'"
               "--service-cidr='${concatStringsSep "," netCfg.serviceCidr}'"
               "--cluster-dns='${concatStringsSep "," netCfg.clusterDns}'"
-              "--node-ip=${nodeAddress}"
+              "--node-ip='${concatStringsSep "," netCfg.nodeIps}'"
               "--write-kubeconfig=${defaultKubeconfig}"
               "--node-taint=node-role.kubernetes.io/server=true:NoSchedule"
               "--flannel-backend=host-gw"

--- a/nixos/roles/k3s/server.nix
+++ b/nixos/roles/k3s/server.nix
@@ -437,9 +437,18 @@ in
         flyingcircus.services.sensu-client =
           let
             kc = "${pkgs.k3s}/bin/k3s kubectl";
+
+            mkDnsCheck =
+              idx: host:
+              lib.nameValuePair "cluster-dns-${toString idx}" {
+                notification = "Cluster DNS (CoreDNS) at ${host} is not healthy";
+                command = ''
+                  ${pkgs.monitoring-plugins}/bin/check_http -j HEAD -H '${host}' -p 9153 -u /metrics
+                '';
+              };
           in
           {
-            checks = {
+            checks = lib.listToAttrs (lib.imap0 mkDnsCheck netCfg.clusterDns) // {
               kube-events-warning = {
                 notification = "Events of type 'Warning' occured in the Kubernetes cluster!";
                 command = ''
@@ -448,13 +457,6 @@ in
                     ${kc} events --types=Warning
                     exit 2
                   fi
-                '';
-              };
-
-              cluster-dns = {
-                notification = "Cluster DNS (CoreDNS) is not healthy";
-                command = ''
-                  ${pkgs.monitoring-plugins}/bin/check_http -j HEAD -H ${netCfg.clusterDns} -p 9153 -u /metrics
                 '';
               };
 
@@ -533,10 +535,11 @@ in
 
         services.k3s =
           let
+            inherit (builtins) concatStringsSep;
             k3sFlags = [
-              "--cluster-cidr=${netCfg.podCidr}"
-              "--service-cidr=${netCfg.serviceCidr}"
-              "--cluster-dns=${netCfg.clusterDns}"
+              "--cluster-cidr='${concatStringsSep "," netCfg.podCidr}'"
+              "--service-cidr='${concatStringsSep "," netCfg.serviceCidr}'"
+              "--cluster-dns='${concatStringsSep "," netCfg.clusterDns}'"
               "--node-ip=${nodeAddress}"
               "--write-kubeconfig=${defaultKubeconfig}"
               "--node-taint=node-role.kubernetes.io/server=true:NoSchedule"

--- a/nixos/roles/k3s/server.nix
+++ b/nixos/roles/k3s/server.nix
@@ -33,7 +33,6 @@ let
     srvFQDN
   ];
 
-  fcNameservers = config.flyingcircus.static.nameservers.${location} or [ ];
   kubectlBin = lib.getExe pkgs.kubectl;
   jqBin = lib.getExe pkgs.jq;
 

--- a/nixos/roles/k3s/single-node.nix
+++ b/nixos/roles/k3s/single-node.nix
@@ -138,7 +138,7 @@ in
       in
       {
         enable = true;
-        extraFlags = lib.concatStringsSep " " k3sFlags;
+        extraFlags = k3sFlags;
       };
 
     systemd.services.fc-set-k3s-config-permissions = {

--- a/nixos/roles/k3s/single-node.nix
+++ b/nixos/roles/k3s/single-node.nix
@@ -20,8 +20,6 @@ let
   netCfg = config.flyingcircus.kubernetes.network;
   fclib = config.fclib;
 
-  nodeAddress = head fclib.network.srv.v4.addresses;
-
   # Use the same location as NixOS k8s.
   defaultKubeconfig = "/etc/kubernetes/cluster-admin.kubeconfig";
 
@@ -127,7 +125,7 @@ in
           "--cluster-cidr='${concatStringsSep "," netCfg.podCidr}'"
           "--service-cidr='${concatStringsSep "," netCfg.serviceCidr}'"
           "--cluster-dns='${concatStringsSep "," netCfg.clusterDns}'"
-          "--node-ip=${nodeAddress}"
+          "--node-ip='${concatStringsSep "," netCfg.nodeIps}'"
           "--write-kubeconfig=${defaultKubeconfig}"
           "--flannel-backend=host-gw"
           "--flannel-iface=ethsrv"

--- a/nixos/roles/k3s/single-node.nix
+++ b/nixos/roles/k3s/single-node.nix
@@ -20,10 +20,7 @@ let
   netCfg = config.flyingcircus.kubernetes.network;
   fclib = config.fclib;
 
-  location = lib.attrByPath [ "parameters" "location" ] "standalone" config.flyingcircus.enc;
   nodeAddress = head fclib.network.srv.v4.addresses;
-
-  fcNameservers = config.flyingcircus.static.nameservers.${location} or [ ];
 
   # Use the same location as NixOS k8s.
   defaultKubeconfig = "/etc/kubernetes/cluster-admin.kubeconfig";

--- a/nixos/roles/k3s/single-node.nix
+++ b/nixos/roles/k3s/single-node.nix
@@ -90,30 +90,34 @@ in
       bridge-utils
     ];
 
-    flyingcircus.services.sensu-client.checks = {
+    flyingcircus.services.sensu-client.checks =
+      let
+        mkDnsCheck =
+          idx: host:
+          lib.nameValuePair "cluster-dns-${toString idx}" {
+            notification = "Cluster DNS (CoreDNS) at ${host} is not healthy";
+            command = ''
+              ${pkgs.monitoring-plugins}/bin/check_http -j HEAD -H '${host}' -p 9153 -u /metrics
+            '';
+          };
+      in
+      lib.listToAttrs (lib.imap0 mkDnsCheck netCfg.clusterDns)
+      // {
+        k3s-kubelet = {
+          notification = "K3s kubelet is not working";
+          command = ''
+            ${pkgs.monitoring-plugins}/bin/check_http -H localhost -p 10248 -u /healthz
+          '';
+        };
 
-      cluster-dns = {
-        notification = "Cluster DNS (CoreDNS) is not healthy";
-        command = ''
-          ${pkgs.monitoring-plugins}/bin/check_http -j HEAD -H ${netCfg.clusterDns} -p 9153 -u /metrics
-        '';
+        k3s-proxy = {
+          notification = "K3s proxy is not working";
+          command = ''
+            ${pkgs.monitoring-plugins}/bin/check_http -H localhost -p 10256 -u /healthz
+          '';
+        };
+
       };
-
-      k3s-kubelet = {
-        notification = "K3s kubelet is not working";
-        command = ''
-          ${pkgs.monitoring-plugins}/bin/check_http -H localhost -p 10248 -u /healthz
-        '';
-      };
-
-      k3s-proxy = {
-        notification = "K3s proxy is not working";
-        command = ''
-          ${pkgs.monitoring-plugins}/bin/check_http -H localhost -p 10256 -u /healthz
-        '';
-      };
-
-    };
 
     networking.firewall.extraCommands = ''
       ip46tables -I nixos-fw 1 -i cni+ -j ACCEPT
@@ -121,10 +125,11 @@ in
 
     services.k3s =
       let
+        inherit (builtins) concatStringsSep;
         k3sFlags = [
-          "--cluster-cidr=${netCfg.podCidr}"
-          "--service-cidr=${netCfg.serviceCidr}"
-          "--cluster-dns=${netCfg.clusterDns}"
+          "--cluster-cidr='${concatStringsSep "," netCfg.podCidr}'"
+          "--service-cidr='${concatStringsSep "," netCfg.serviceCidr}'"
+          "--cluster-dns='${concatStringsSep "," netCfg.clusterDns}'"
           "--node-ip=${nodeAddress}"
           "--write-kubeconfig=${defaultKubeconfig}"
           "--flannel-backend=host-gw"

--- a/nixos/services/k3s/frontend.nix
+++ b/nixos/services/k3s/frontend.nix
@@ -21,11 +21,6 @@ let
   serverAddress = lib.replaceStrings [ "gocept.net" ] [ "fcio.net" ] server.address or "";
   tokenFile = "/var/lib/k3s/secret_token";
 
-  serverRoleEnabled = config.flyingcircus.roles.k3s-server.enable;
-  agentRoleEnabled = config.flyingcircus.roles.k3s-agent.enable;
-  location = lib.attrByPath [ "parameters" "location" ] "standalone" config.flyingcircus.enc;
-  fcNameservers = config.flyingcircus.static.nameservers.${location} or [ ];
-
   serviceListenConfigs = lib.mapAttrs (
     name: conf:
     let

--- a/nixos/services/k3s/frontend.nix
+++ b/nixos/services/k3s/frontend.nix
@@ -314,7 +314,7 @@ in
         role = "agent";
         serverAddr = "https://${serverAddress}:6443";
         inherit tokenFile;
-        extraFlags = lib.concatStringsSep " " k3sFlags;
+        extraFlags = k3sFlags;
       };
 
     ### Fixes for upstream issues

--- a/nixos/services/k3s/frontend.nix
+++ b/nixos/services/k3s/frontend.nix
@@ -296,7 +296,9 @@ in
       // serviceListenConfigs;
       extraConfig = ''
         resolvers cluster
-          nameserver coredns ${netCfg.clusterDns}:53
+        ${lib.strings.concatImapStringsSep "\n" (
+          i: host: "  nameserver coredns${toString i} ${host}:53"
+        ) netCfg.clusterDns}
           accepted_payload_size 8192 # allow larger DNS payloads
       '';
     };

--- a/nixos/services/k3s/frontend.nix
+++ b/nixos/services/k3s/frontend.nix
@@ -300,10 +300,9 @@ in
 
     services.k3s =
       let
-        nodeAddress = head fclib.network.srv.v4.addresses;
         k3sFlags = [
           "--flannel-iface=${fclib.network.srv.interface}"
-          "--node-ip=${nodeAddress}"
+          "--node-ip='${concatStringsSep "," netCfg.nodeIps}'"
           "--node-taint=node-role.kubernetes.io/server=true:NoSchedule"
           "--data-dir=/var/lib/k3s"
         ];


### PR DESCRIPTION
@flyingcircusio/release-managers

This makes several parts of our kubernetes network configuration more flexible by making the options of type "list". This simplifies overriding the network configuration for our IPv6-enabled cluster prototypes, and also fixes several places here these values are used.

Includes some additional resolver fixes left from #1920.

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - make structure of our exposed k3s config options reflect the underlying kubelet options
  - structured options can be easier covered with individual checks for each configured option value
- [x] Security requirements tested? (EVIDENCE)
a dual-stack enabled cluster and inspect)
  - [x] in a dual-stack enabled cluster: inspect the generated `resolv.conf`s and the pods and service ipsgenerated.
  - [x] verify that name resolution from cluster frontend to pods still works
  - [x] inspected diff in k3s.service ExecStart command flags
  - [x] automated tests still pass