### PR TITLE
nginx: Add certificate validation for non-acme vhosts

### DIFF
--- a/changelog.d/20251121_180304_PL-134018-check-non-acme-certs_scriv.md
+++ b/changelog.d/20251121_180304_PL-134018-check-non-acme-certs_scriv.md
@@ -1,0 +1,16 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### NixOS XX.XX platform
+
+- nginx/webgateway: all TLS certificates are monitored for expiration now, by connecting to the HTTPS endpoint (check names `nginx_https_*`) and checking the certificate file directly: `ssl_cert_acme_*` (as before) or `ssl_cert_nginx_*` (added for non-ACME certs). Before, we only generated monitoring checks for ACME certs. (PL-134018)

--- a/nixos/platform/acme.nix
+++ b/nixos/platform/acme.nix
@@ -6,24 +6,7 @@
 }:
 let
   inherit (config) fclib;
-  checkCert = pkgs.writeShellScript "check-local-acme-cert" ''
-    certificate_path="$1"
-    critical_sec=$((14 * 24 * 3600))
-    warning_sec=$((25 * 24 * 3600))
-
-    openssl x509 -in "$certificate_path" -noout -enddate
-
-    if ! openssl x509 -checkend $critical_sec -noout -in "$certificate_path" > /dev/null
-    then
-        exit 2
-    fi
-
-    if ! openssl x509 -checkend $warning_sec -noout -in "$certificate_path" > /dev/null
-    then
-        exit 1
-    fi
-  '';
-
+  checkCert = "${pkgs.fc.check-tls-cert}/bin/check_tls_cert";
 in
 lib.mkMerge [
   {
@@ -41,7 +24,7 @@ lib.mkMerge [
       n: cert:
       lib.nameValuePair "ssl_cert_acme_${n}" {
         notification = "ACME (Letsencrypt) certificate for ${n} is invalid or will expire soon";
-        command = "/run/wrappers/bin/sudo ${checkCert} ${cert.directory}/fullchain.pem";
+        command = "sudo ${checkCert} ${cert.directory}/fullchain.pem ${n}";
         interval = 3600;
       }
     ) config.security.acme.certs;

--- a/nixos/services/nginx/default.nix
+++ b/nixos/services/nginx/default.nix
@@ -18,6 +18,8 @@ let
   nginxCfg = config.services.nginx;
   fclib = config.fclib;
 
+  checkCert = "${pkgs.fc.check-tls-cert}/bin/check_tls_cert";
+
   lokiServer = fclib.findOneService "loki-collector";
 
   nginxShowConfig = pkgs.writeScriptBin "nginx-show-config" ''
@@ -68,15 +70,14 @@ let
   package = config.services.nginx.package;
   localCfgDir = config.flyingcircus.localConfigPath + "/nginx";
 
-  acmeVhostsWithTLS = (
-    lib.filterAttrs (
-      _: vhost:
-      let
-        hasSSL = vhost.onlySSL || vhost.addSSL || vhost.forceSSL;
-      in
-      vhost.enableACME && hasSSL
-    ) nginxCfg.virtualHosts
-  );
+  vhostsWithTLS = lib.filterAttrs (
+    _: vhost: vhost.onlySSL || vhost.addSSL || vhost.forceSSL
+  ) nginxCfg.virtualHosts;
+
+  # Split TLS vhosts in ACME and non-ACME vhosts
+  acmeVhostsWithTLS = lib.filterAttrs (_: vhost: vhost.enableACME) vhostsWithTLS;
+
+  nonAcmeVhostsWithTLS = lib.filterAttrs (_: vhost: !vhost.enableACME) vhostsWithTLS;
 
   mainConfig = ''
     worker_processes ${toString cfg.workerProcesses};
@@ -437,7 +438,20 @@ in
             command = "check_http -p 443 -S --sni -C 25,14 -H ${host} -t 15";
             interval = 600;
           }
-        ) acmeVhostsWithTLS);
+        ) vhostsWithTLS)
+        # Add certificate file checks for non-ACME hosts specified in nginx config.
+        # ACME certificates in general (nginx enableACME or others) are covered in platform/acme.nix.
+        // (lib.mapAttrs' (
+          n: vhost:
+          let
+            host = if vhost.serverName != null then vhost.serverName else n;
+          in
+          lib.nameValuePair "ssl_cert_nginx_${n}" {
+            notification = "SSL certificate for non-ACME nginx vhost ${n} is invalid or will expire soon";
+            command = "sudo ${checkCert} ${vhost.sslCertificate} ${host}";
+            interval = 3600;
+          }
+        ) nonAcmeVhostsWithTLS);
 
         networking.firewall.allowedTCPPorts = [
           80
@@ -449,6 +463,8 @@ in
             commands = [ (lib.getExe nginxCheckConfig) ];
             groups = [ "sensuclient" ];
           }
+          # sensuclient also needs check-tls-cert but that rule already defined in
+          # nixos/platform/acme.nix.
         ];
 
         services.nginx =

--- a/pkgs/fc/check-tls-cert/check_tls_cert.py
+++ b/pkgs/fc/check-tls-cert/check_tls_cert.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""TLS certificate file checker.
+
+Checks for certs that are:
+- expiring soon (with configurable warning and critical days thresholds)
+- expired
+"""
+
+import argparse
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+
+SECONDS_PER_DAY = 86400
+
+
+class Severity(Enum):
+    """Severity levels for certificate check results."""
+
+    OK = 0
+    WARNING = 1
+    CRITICAL = 2
+
+
+@dataclass
+class CertificateCheckResult:
+    """Result of certificate validation with automatic severity calculation."""
+
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    ok_info: list[str] = field(default_factory=list)
+
+    def format_output(self) -> str:
+        if self.errors:
+            return "CRITICAL: " + "\n".join(self.errors + self.warnings)
+
+        if self.warnings:
+            return "WARNING: " + "\n".join(self.warnings)
+
+        if self.ok_info:
+            return "OK: " + "\n".join(self.ok_info)
+
+        return "OK"
+
+    @property
+    def severity(self) -> Severity:
+        """Calculate severity based on errors and warnings.
+
+        Returns:
+            Severity.CRITICAL if self.errors has items
+            Severity.WARNING if self.warnings has items (and no errors)
+            Severity.OK if both lists are empty
+        """
+        if self.errors:
+            return Severity.CRITICAL
+        elif self.warnings:
+            return Severity.WARNING
+        else:
+            return Severity.OK
+
+
+def run_openssl_x509_noout(
+    cert_path: Path, *args
+) -> subprocess.CompletedProcess:
+    """Run OpenSSL x509 command with -noout and return the result.
+
+    Args:
+        cert_path: Path to certificate file
+        args: x509 command args
+
+    Returns:
+        subprocess.CompletedProcess with stdout, stderr, and returncode
+    """
+    return subprocess.run(
+        ["openssl", "x509", "-in", cert_path, "-noout", *args],
+        capture_output=True,
+        text=True,
+    )
+
+
+def check_certificate(
+    cert_path: Path, hostname: str | None = None, crit_days=14, warn_days=25
+) -> CertificateCheckResult:
+    """Validate certificate using OpenSSL x509 -checkend command.
+
+    Only checks if certificate is expired or will expire within critical time.
+    """
+
+    result = CertificateCheckResult()
+    # Create hostname prefix for messages
+    msg_prefix = f"Certificate for {hostname}" if hostname else "Certificate"
+
+    # Check if certificate file exists and is readable
+    if not cert_path.exists():
+        result.errors.append(f"{msg_prefix} file not found: {cert_path}")
+        return result
+
+    if not cert_path.is_file():
+        result.errors.append(f"{msg_prefix} path is not a file: {cert_path}")
+        return result
+
+    # We use -checkend three times, first to check if the cert IS already expired.
+    proc = run_openssl_x509_noout(cert_path, "-checkend", "0")
+    # OpenSSL 3.6.0 always returns 0 so we have to check the output, too.
+    # https://github.com/openssl/openssl/issues/28928
+    if proc.returncode == 1 or "Certificate will expire" in proc.stdout:
+        result.errors.append(f"{msg_prefix} has expired.")
+        return result
+
+    # Second check: WILL the cert expire within <crit_days>?
+    crit_sec = crit_days * SECONDS_PER_DAY
+    proc = run_openssl_x509_noout(cert_path, "-checkend", str(crit_sec))
+    if proc.returncode == 1 or "Certificate will expire" in proc.stdout:
+        result.errors.append(
+            f"{msg_prefix} expires within critical time ({crit_days} days)."
+        )
+        return result
+
+    # Third check: WILL the cert expire within <warn_days>?
+    warn_sec = warn_days * SECONDS_PER_DAY
+    proc = run_openssl_x509_noout(cert_path, "-checkend", str(warn_sec))
+    if proc.returncode == 1 or "Certificate will expire" in proc.stdout:
+        result.warnings.append(
+            f"{msg_prefix} expires within warning time ({warn_days} days)."
+        )
+        return result
+
+    result.ok_info.append(
+        f"{msg_prefix} is valid for more than {warn_days} days."
+    )
+    return result
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="TLS certificate checker")
+    parser.add_argument("cert_path", type=Path, help="Path to certificate file")
+    parser.add_argument(
+        "hostname", nargs="?", help="Hostname the certificate is used for"
+    )
+    parser.add_argument(
+        "-w",
+        "--warn",
+        type=int,
+        default=25,
+        help="Warning threshold in days (default: 25)",
+    )
+    parser.add_argument(
+        "-c",
+        "--crit",
+        type=int,
+        default=14,
+        help="Critical threshold in days (default: 14)",
+    )
+
+    args = parser.parse_args()
+
+    # Validate thresholds
+    if args.crit >= args.warn:
+        parser.error("Critical threshold must be less than warning threshold!")
+
+    result = check_certificate(
+        args.cert_path, args.hostname, args.crit, args.warn
+    )
+
+    exit_code = result.severity.value
+    output = result.format_output()
+    # Add optional details, just the end date for now.
+    try:
+        end_date = run_openssl_x509_noout(
+            args.cert_path, "-enddate"
+        ).stdout.strip()
+        output += f" ({end_date})"
+    except Exception:  # noqa
+        # It's ok, no need to crash the check for missing extra info.
+        pass
+
+    print(output)
+    sys.exit(exit_code)
+
+
+if __name__ == "__main__":
+    main()

--- a/pkgs/fc/check-tls-cert/default.nix
+++ b/pkgs/fc/check-tls-cert/default.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  openssl,
+  buildPythonApplication,
+  pytestCheckHook,
+  setuptools,
+}:
+buildPythonApplication {
+  pname = "check-tls-cert";
+  version = "1.0";
+  pyproject = true;
+  src = ./.;
+
+  __structuredAttrs = true;
+
+  build-system = [ setuptools ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  makeWrapperArgs = [
+    "--prefix"
+    "PATH"
+    ":"
+    "${lib.makeBinPath [ openssl ]}"
+  ];
+
+  preCheck = ''
+    export PATH="${openssl}/bin:$PATH"
+  '';
+
+  meta = with lib; {
+    description = "TLS certificate checker for monitoring";
+    homepage = "https://github.com/flyingcircusio/fc-nixos";
+    license = licenses.mit;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/fc/check-tls-cert/pyproject.toml
+++ b/pkgs/fc/check-tls-cert/pyproject.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "check-tls-cert"
+version = "1.0.0"
+description = "TLS certificate checker for monitoring"
+requires-python = ">=3.13"
+dependencies = [
+    "pytest"
+]
+
+[project.scripts]
+check_tls_cert = "check_tls_cert:main"
+
+[tool.setuptools]
+py-modules = ["check_tls_cert"]
+
+[tool.pytest.ini_options]
+testpaths = ["."]
+addopts = "-v"

--- a/pkgs/fc/check-tls-cert/test_check_tls_cert.py
+++ b/pkgs/fc/check-tls-cert/test_check_tls_cert.py
@@ -1,0 +1,118 @@
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+from check_tls_cert import Severity, check_certificate
+
+
+def create_test_certificate(cert_path, days_valid=30, start_date=None) -> None:
+    """Creates a certificate using the openssl command."""
+    if start_date is None:
+        start_date = datetime.now(timezone.utc)
+
+    end_date = start_date + timedelta(days=days_valid)
+
+    cmd = [
+        "openssl",
+        "req",
+        "-x509",
+        "-newkey",
+        "rsa:2048",
+        "-keyout",
+        cert_path.with_suffix(".key"),
+        "-out",
+        cert_path,
+        "-nodes",
+        "-subj",
+        "/CN=test.example.com",
+        "-set_serial",
+        "1",
+        "-not_before",
+        start_date.strftime("%Y%m%d%H%M%SZ"),
+        "-not_after",
+        end_date.strftime("%Y%m%d%H%M%SZ"),
+    ]
+
+    subprocess.run(cmd, check=True, capture_output=True)
+
+
+@pytest.fixture
+def cert_path(tmp_path) -> Path:
+    cert_path = tmp_path / "test.crt"
+    create_test_certificate(cert_path)
+    return cert_path
+
+
+def test_valid_certificate(cert_path):
+    result = check_certificate(cert_path, "test.example.com")
+
+    assert result.severity == Severity.OK
+    assert not result.errors
+    assert not result.warnings
+    assert result.ok_info == [
+        "Certificate for test.example.com is valid for more than 25 days."
+    ]
+
+
+def test_warn_days_threshold(cert_path):
+    result = check_certificate(cert_path, "test.example.com", warn_days=31)
+    assert result.severity == Severity.WARNING
+    assert result.warnings == [
+        "Certificate for test.example.com expires within warning time (31 days)."
+    ]
+
+
+def test_crit_days_threshold(cert_path):
+    result = check_certificate(
+        cert_path, "test.example.com", warn_days=31, crit_days=30
+    )
+    assert result.severity == Severity.CRITICAL
+    assert result.errors == [
+        "Certificate for test.example.com expires within critical time (30 days)."
+    ]
+
+
+def test_critical_for_expired_cert(tmp_path):
+    cert_path = tmp_path / "expired.crt"
+    # Create certificate that expired yesterday
+    past_date = datetime.now(timezone.utc) - timedelta(days=2)
+    create_test_certificate(cert_path, days_valid=1, start_date=past_date)
+
+    result = check_certificate(cert_path, "test.example.com")
+
+    assert result.severity == Severity.CRITICAL
+    assert result.errors == ["Certificate for test.example.com has expired."]
+
+
+def test_critical_when_path_is_missing():
+    result = check_certificate(Path("/nonexistent/cert.crt"))
+
+    assert result.severity == Severity.CRITICAL
+    assert "file not found" in result.errors[0]
+
+
+def test_critical_when_path_is_a_dir(tmp_path):
+    result = check_certificate(tmp_path)
+
+    assert result.severity == Severity.CRITICAL
+    assert "path is not a file" in result.errors[0]
+
+
+def test_cli_integration(cert_path):
+    """Test that calling the script works for the happy path."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(Path(__file__).parent / "check_tls_cert.py"),
+            str(cert_path),
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert "OK:" in result.stdout
+    assert "notAfter" in result.stdout
+    assert not result.stderr

--- a/pkgs/fc/check-tls-cert/uv.lock
+++ b/pkgs/fc/check-tls-cert/uv.lock
@@ -1,0 +1,75 @@
+version = 1
+revision = 3
+requires-python = ">=3.13"
+
+[[package]]
+name = "check-tls-cert"
+version = "1.0.0"
+source = { editable = "." }
+dependencies = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "pytest" }]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.19.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/07/56/f013048ac4bc4c1d9be45afd4ab209ea62822fb1598f40687e6bf45dcea4/pytest-9.0.1.tar.gz", hash = "sha256:3e9c069ea73583e255c3b21cf46b8d3c56f6e3a1a8f6da94ccb0fcf57b9d73c8", size = 1564125, upload-time = "2025-11-12T13:05:09.333Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/8b/6300fb80f858cda1c51ffa17075df5d846757081d11ab4aa35cef9e6258b/pytest-9.0.1-py3-none-any.whl", hash = "sha256:67be0030d194df2dfa7b556f2e56fb3c3315bd5c8822c6951162b92b32ce7dad", size = 373668, upload-time = "2025-11-12T13:05:07.379Z" },
+]

--- a/pkgs/fc/default.nix
+++ b/pkgs/fc/default.nix
@@ -35,6 +35,7 @@ rec {
   check-postfix = callPackage ./check-postfix { };
   check-rib-integrity = callPackage ./check-rib-integrity { };
   check-skvaider = callPackage ./check-skvaider { };
+  check-tls-cert = pyPackages.callPackage ./check-tls-cert { };
   check-vrf-default-routes = callPackage ./check-vrf-default-routes { };
   check-xfs-broken = callPackage ./check-xfs-broken { };
 


### PR DESCRIPTION
- replace shell-based cert checker from ACME module with reusable Python implementation
- check-tls-cert command is also globally installed for manual cert checks

PL-134018

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [x] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - monitoring: detect invalid certs used in nginx vhosts 
- [x] Security requirements tested? (EVIDENCE)
  -  verified on a test VM that file-based and HTTPS-based Sensu checks stil work for ACME cert
  -  verified on a test VM that file-based and HTTPS-based Sensu checks also work for non-ACME certs
