### PR TITLE
k3s: add IPv6/dual-stack support for clusters with state version 25.11+

### DIFF
--- a/nixos/roles/k3s/default.nix
+++ b/nixos/roles/k3s/default.nix
@@ -9,6 +9,9 @@
   pkgs,
   ...
 }:
+let
+  inherit (config.flyingcircus.kubernetes.network) enableIPv6;
+in
 {
   imports = with lib; [
     ./nfs.nix
@@ -18,15 +21,30 @@
   ];
 
   options = with lib; {
-
     flyingcircus.kubernetes = {
 
       network = {
+        enableIPv6 = mkOption {
+          type = types.bool;
+          default = lib.versionAtLeast config.system.stateVersion "25.11";
+          description = ''
+            Enable IPv6 support for k3s clusters. When enabled, clusters will use
+            dual-stack networking with both IPv4 and IPv6. This option is automatically
+            enabled for clusters with state version >= 25.11, but can be overridden.
+          '';
+        };
 
         clusterDns = mkOption {
           type = types.listOf types.str;
-          default = [ "10.43.0.10" ];
-          description = "Cluster IP that should be used for CoreDNS.";
+          default =
+            if enableIPv6 then
+              [
+                "fd00:43::a"
+                "10.43.0.10"
+              ]
+            else
+              [ "10.43.0.10" ];
+          description = "Cluster IPs that should be used for CoreDNS.";
         };
 
         # These network specifications are supposed to hold at most one network
@@ -36,19 +54,40 @@
         # kubernetes.network.ipv6 = { serviceCidr…; podCidr…;};
         serviceCidr = mkOption {
           type = types.listOf types.str;
-          default = [ "10.43.0.0/16" ];
-          description = "Cluster IPs are assigned to services from the subnet specified here.";
+          default =
+            if enableIPv6 then
+              [
+                "fd00:43::/112"
+                "10.43.0.0/16"
+              ]
+            else
+              [ "10.43.0.0/16" ];
+          description = "IPs are assigned to services from the subnet specified here.";
         };
 
         podCidr = mkOption {
           type = types.listOf types.str;
-          default = [ "10.42.0.0/16" ];
+          default =
+            if enableIPv6 then
+              [
+                "fd00:42::/56"
+                "10.42.0.0/16"
+              ]
+            else
+              [ "10.42.0.0/16" ];
           description = "Kubernetes nodes get a /24 subnet for their pods from the given subnet.";
         };
+
         nodeIps = mkOption {
           type = with types; listOf str;
-          internal = true; # should be managed by a global IPv6 switch instead PL-133774
-          default = [ (head config.fclib.network.srv.v4.addresses) ];
+          internal = true;
+          default = 
+            let
+              v6Addrs = config.fclib.network.srv.v6.addresses or [];
+              v4Addrs = config.fclib.network.srv.v4.addresses or [];
+            in
+            lib.optional (enableIPv6 && v6Addrs != []) (head v6Addrs) ++
+            lib.optional (v4Addrs != []) (head v4Addrs);
         };
       };
     };

--- a/nixos/roles/k3s/server.nix
+++ b/nixos/roles/k3s/server.nix
@@ -549,7 +549,8 @@ in
               "--kube-apiserver-arg enable-admission-plugins=PodNodeSelector"
               # required for anonymous access to apiserver health port
               "--kube-apiserver-arg anonymous-auth=true"
-            ];
+            ]
+            ++ (lib.optional netCfg.enableIPv6 "--flannel-ipv6-masq");
           in
           {
             enable = true;

--- a/nixos/roles/k3s/single-node.nix
+++ b/nixos/roles/k3s/single-node.nix
@@ -132,7 +132,8 @@ in
           "--data-dir=/var/lib/k3s"
           "--kube-apiserver-arg enable-admission-plugins=PodNodeSelector"
           "--disable traefik"
-        ];
+        ]
+        ++ (lib.optional netCfg.enableIPv6 "--flannel-ipv6-masq");
       in
       {
         enable = true;

--- a/tests/k3s/default.nix
+++ b/tests/k3s/default.nix
@@ -5,52 +5,52 @@ import ../make-test-python.nix (
     testlib,
     ...
   }:
-  with builtins;
-
   let
 
-    net4Srv = "10.0.1";
-    frontendSrv = net4Srv + ".1";
-    masterSrv = net4Srv + ".2";
-    nodeSrvA = net4Srv + ".3";
-    nodeSrvB = net4Srv + ".4";
-
-    net4Fe = "10.0.2";
-    frontendFe = net4Fe + ".1";
-    masterFe = net4Fe + ".2";
+    masterSrv4 = testlib.fcIP.srv4 2;
+    masterSrv6 = testlib.fcIP.srv6 2;
+    nodeSrvA4 = testlib.fcIP.srv4 3;
+    nodeSrvA6 = testlib.fcIP.srv6 3;
+    nodeSrvB4 = testlib.fcIP.srv4 4;
+    nodeSrvB6 = testlib.fcIP.srv6 4;
+    frontendSrv4 = testlib.fcIP.fe4 1;
+    frontendSrv6 = testlib.fcIP.fe6 1;
 
     encServices = [
       {
         address = "k3sserver.fcio.net";
-        ips = [ masterSrv ];
+        ips = [
+          masterSrv4
+          masterSrv6
+        ];
         service = "k3s-server-server";
         password = "xvlc";
       }
       {
         address = "k3snodeA.fcio.net";
-        ips = [ nodeSrvA ];
+        ips = [
+          nodeSrvA4
+          nodeSrvA6
+        ];
         service = "k3s-node";
       }
       {
         address = "k3snodeB.fcio.net";
-        ips = [ nodeSrvB ];
+        ips = [
+          nodeSrvB4
+          nodeSrvB6
+        ];
         service = "k3s-node";
       }
       {
         address = "frontend.fcio.net";
-        ips = [ frontendFe ];
+        ips = [
+          frontendSrv4
+          frontendSrv6
+        ];
         service = "k3s-frontend";
       }
     ];
-
-    hosts = ''
-      ${masterSrv} k3sserver.fcio.net
-      ${nodeSrvA} k3snodeA.fcio.net
-      ${nodeSrvB} k3snodeB.fcio.net
-      ${frontendFe} frontend.fcio.net
-      ${masterFe} k3sserver.fe.test.fcio.net
-      ${masterFe} k3s.test.fcio.net
-    '';
 
     redis = import ./redis.nix { inherit pkgs; };
 
@@ -58,45 +58,23 @@ import ../make-test-python.nix (
   {
 
     name = "k3s";
+
+    interactive.sshBackdoor = {
+      enable = true;
+    };
+
     nodes = {
 
       master =
         { lib, ... }:
         {
-          imports = [
-            ../../nixos
-            ../../nixos/roles
-          ];
+          imports = [ (testlib.fcConfig { id = 2; }) ];
 
           config = {
-
-            flyingcircus.enc.parameters = {
-              location = "test";
-              resource_group = "test";
-              interfaces.srv = {
-                bridged = false;
-                mac = "52:54:00:12:01:02";
-                networks = {
-                  "${net4Srv}.0/24" = [ masterSrv ];
-                };
-                gateways = {
-                  "${net4Srv}.0/24" = "${net4Srv}.254";
-                };
-              };
-              interfaces.fe = {
-                bridged = false;
-                mac = "52:54:00:12:02:02";
-                networks = {
-                  "${net4Fe}.0/24" = [ masterFe ];
-                };
-                gateways = { };
-              };
-            };
             flyingcircus.encServices = encServices;
             flyingcircus.roles.k3s-server.enable = true;
             networking.domain = "fcio.net";
             networking.hostName = lib.mkForce "k3sserver";
-            networking.extraHosts = hosts;
 
             networking.firewall.allowedTCPPorts = [
               8888
@@ -136,16 +114,6 @@ import ../make-test-python.nix (
 
             virtualisation.memorySize = 2000;
             virtualisation.diskSize = lib.mkForce 3000;
-            # do not automatically assign addresses based on vlan and
-            # guest id.
-            virtualisation.interfaces = {
-              ethfe = {
-                vlan = 2;
-              };
-              ethsrv = {
-                vlan = 1;
-              };
-            };
             virtualisation.qemu.options = [ "-smp 2" ];
           };
         };
@@ -153,112 +121,47 @@ import ../make-test-python.nix (
       nodeA =
         { ... }:
         {
-          imports = [
-            ../../nixos
-            ../../nixos/roles
-          ];
+          imports = [ (testlib.fcConfig { id = 3; }) ];
 
           config = {
-            flyingcircus.enc.parameters = {
-              resource_group = "test";
-              interfaces.srv = {
-                bridged = false;
-                mac = "52:54:00:12:01:03";
-                networks = {
-                  "${net4Srv}.0/24" = [ nodeSrvA ];
-                };
-                gateways = {
-                  "${net4Srv}.0/24" = "${net4Srv}.254";
-                };
-              };
-            };
             flyingcircus.encServices = encServices;
             flyingcircus.roles.k3s-agent.enable = true;
 
             networking.domain = "fcio.net";
-            networking.extraHosts = hosts;
             networking.hostName = lib.mkForce "k3snodeA";
             networking.nameservers = [ "127.0.0.1" ];
             virtualisation.memorySize = 2000;
             virtualisation.diskSize = 3000;
-            virtualisation.interfaces.ethsrv.vlan = 1;
           };
         };
 
       nodeB =
         { ... }:
         {
-          imports = [
-            ../../nixos
-            ../../nixos/roles
-          ];
+          imports = [ (testlib.fcConfig { id = 4; }) ];
 
           config = {
-            flyingcircus.enc.parameters = {
-              resource_group = "test";
-              interfaces.srv = {
-                bridged = false;
-                mac = "52:54:00:12:01:04";
-                networks = {
-                  "${net4Srv}.0/24" = [ nodeSrvB ];
-                };
-                gateways = {
-                  "${net4Srv}.0/24" = "${net4Srv}.254";
-                };
-              };
-            };
             flyingcircus.encServices = encServices;
             flyingcircus.roles.k3s-agent.enable = true;
 
             networking.domain = "fcio.net";
-            networking.extraHosts = hosts;
             networking.hostName = lib.mkForce "k3snodeB";
             virtualisation.memorySize = 2000;
             virtualisation.diskSize = 3000;
-            virtualisation.interfaces.ethsrv.vlan = 1;
           };
         };
 
       frontend =
         { ... }:
         {
-          imports = [
-            ../../nixos
-            ../../nixos/roles
-          ];
+          imports = [ (testlib.fcConfig { id = 1; }) ];
 
-          flyingcircus.roles.webgateway.enable = true;
-          flyingcircus.enc.parameters = {
-            resource_group = "test";
-            interfaces.srv = {
-              bridged = false;
-              mac = "52:54:00:12:01:01";
-              networks = {
-                "${net4Srv}.0/24" = [ frontendSrv ];
-              };
-              gateways = { };
-            };
-            interfaces.fe = {
-              bridged = false;
-              mac = "52:54:00:12:02:01";
-              networks = {
-                "${net4Fe}.0/24" = [ frontendFe ];
-              };
-              gateways = { };
-            };
-          };
-          networking.domain = "fcio.net";
-          networking.extraHosts = hosts;
-          flyingcircus.encServices = encServices;
-          virtualisation.diskSize = 3000;
-          virtualisation.memorySize = 2000;
-          virtualisation.interfaces = {
-            ethfe = {
-              vlan = 2;
-            };
-            ethsrv = {
-              vlan = 1;
-            };
+          config = {
+            flyingcircus.roles.webgateway.enable = true;
+            networking.domain = "fcio.net";
+            flyingcircus.encServices = encServices;
+            virtualisation.diskSize = 3000;
+            virtualisation.memorySize = 2000;
           };
         };
 
@@ -274,7 +177,10 @@ import ../make-test-python.nix (
 
         with subtest("k3s server should work"):
           k3sserver.wait_for_unit("k3s.service")
-          k3sserver.wait_until_succeeds('k3s kubectl cluster-info | grep -q https://127.0.0.1:6443')
+          k3sserver.wait_until_succeeds('k3s kubectl get --raw=/healthz | grep -q ok')
+          print("Debug: cluster-info output:")
+          print(k3sserver.execute('k3s kubectl cluster-info')[1])
+          k3sserver.succeed('k3s kubectl get node k3sserver -o jsonpath=\'{.status.conditions[?(@.type=="Ready")].status}\' | grep -q True')
 
         k3snodeA.start()
 
@@ -323,8 +229,25 @@ import ../make-test-python.nix (
           k3sserver.succeed("KUBECONFIG=/home/test/kubeconfig k3s kubectl cluster-info")
 
         with subtest("master should be able to reach cluster DNS"):
+          time.sleep(1)
+          print("Debug: kubectl get pods for coredns readiness:")
+          print(k3sserver.execute('k3s kubectl -n kube-system get pods')[1])
           k3sserver.wait_until_succeeds('k3s kubectl -n kube-system get pods | grep coredns | grep -v ContainerCreating | grep Running')
-          k3sserver.wait_until_succeeds('dig redis.default.svc.cluster.local @10.43.0.10 | grep NOERROR')
+          print("Debug: test metrics-server reachability:")
+          print(k3sserver.execute('curl -k --connect-timeout 5 https://fd00:43::f76')[1])
+          time.sleep(5)
+          print("Debug: ip route show:")
+          print(k3sserver.execute('ip route show')[1])
+          print("Debug: iptables -L:")
+          print(k3sserver.execute('iptables -L')[1])
+          print("Debug: iptables -t nat -L:")
+          print(k3sserver.execute('iptables -t nat -L')[1])
+          print("Debug: kubectl get svc in kube-system:")
+          print(k3sserver.execute('k3s kubectl get svc -n kube-system -o wide')[1])
+          print("Debug: kubectl describe svc kube-dns:")
+          print(k3sserver.execute('k3s kubectl describe svc kube-dns -n kube-system')[1])
+          print("Debug: coredns logs:")
+          print(k3sserver.execute('k3s kubectl logs -n kube-system deployment/coredns')[1])
 
         k3snodeB.start()
         time.sleep(5)


### PR DESCRIPTION
Clusters with state version before 25.11 remain IPv4-only and upgrading them to dual-stack is NOT supported by K3s and our platform.

@flyingcircusio/release-managers

## Release process

- [ ] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [ ] PR has internal ticket
- [ ] internal issue ID (PL-…) part of branch name
- [ ] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [ ] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [ ] Security requirements tested? (EVIDENCE)
