### PR TITLE
doc: update redis docs regarding password changes

### DIFF
--- a/doc/src/redis.md
+++ b/doc/src/redis.md
@@ -95,22 +95,11 @@ The authentication password is automatically generated upon installation
 and can be read *and changed* by service users. It can be found in
 {file}`/etc/local/redis/password`.
 
-It can also be specified in the
-`flyingcircus.services.redis.password` option where the password
-will have a higher priority than the one in the filesystem. Setting
-the `password` option makes the password world-readable to processes
-on the VM since it will be stored in the nix store.
+After you changed the password, please restart the systemd services that use it:
 
-Overriding the `password` to `foobarpass` looks like this:
-
-```nix
-# /etc/local/nixos/redis.nix
-{ ... }:
-{
-    flyingcircus.services.redis = {
-        password = "foobarpass"; # Makes the password world readable
-    };
-}
+```
+sudo systemctl restart redis
+sudo systemctl restart telegraf
 ```
 
 ## Interaction

--- a/nixos/services/redis.nix
+++ b/nixos/services/redis.nix
@@ -364,6 +364,9 @@ in
 
       You can find the password for the redis in the `password` file.
       You can also change the redis password by changing the `password` file.
+      After changing the password, please restart the systemd services that use it:
+        systemctl restart redis
+        systemctl restart telegraf
 
       Changing the config via custom.conf is not supported anymore. Please use a NixOS module
       with the option `services.redis.servers."".settings` instead.


### PR DESCRIPTION
This also removes the old way of setting the redis password with a Nix expression, because that leads to the password being stored world-readable. This is still possible, but we don't want to advertise this.

PL-134135

@flyingcircusio/release-managers

## Release process

- [ ] Created changelog entry using `./changelog.sh`
  no: doc change only

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  None
- [x] Security requirements tested? (EVIDENCE)