### PR TITLE
nixos/k3s/frontend: use cluster dns for resolving cluster addresses

### DIFF
--- a/changelog.d/20251124_131146_HEAD_scriv.md
+++ b/changelog.d/20251124_131146_HEAD_scriv.md
@@ -1,0 +1,28 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+<!-- Impact means "when this change is rolled out, there
+     might be interruptions/downtimes/required actions/... that
+     IMPACT THE RUNNING APPLICATION NEGATIVELY.
+
+     Having new features or changed is not an "impact". That's what
+     the main changelog (see below) is for.
+     -->
+
+- A bullet item for the Impact category.
+
+### NixOS XX.XX platform
+
+- nixos/k3s: Fix resolving of cluster-internal hostnames in our frontend module (PL-134217)

--- a/nixos/services/k3s/frontend.nix
+++ b/nixos/services/k3s/frontend.nix
@@ -50,11 +50,11 @@ let
         n:
         "${
           lib.replaceStrings [ ".gocept.net" ] [ "" ] n.address
-        } ${head n.ips}:${toString conf.lbServicePort} check"
+        } ${head n.ips}:${toString conf.lbServicePort} check resolvers cluster"
         + (lib.optionalString conf.sslBackend " ssl verify none");
 
       svcServer =
-        "service ${serviceFqdn}:${toString conf.servicePort} check"
+        "service ${serviceFqdn}:${toString conf.servicePort} check resolvers cluster"
         + (lib.optionalString conf.sslBackend " ssl verify none");
 
       podOptions = lib.concatStringsSep " " [
@@ -300,8 +300,6 @@ in
           accepted_payload_size 8192 # allow larger DNS payloads
       '';
     };
-
-    networking.nameservers = lib.mkOverride 90 (lib.take 3 ([ netCfg.clusterDns ] ++ fcNameservers));
 
     services.k3s =
       let


### PR DESCRIPTION
PL-134217

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [x] Security requirements tested? (EVIDENCE)
    Tested that HAProxy error resolves.