### PR TITLE
nixos/k3s/agent: fix telegraf invocation

### DIFF
--- a/nixos/roles/k3s/agent.nix
+++ b/nixos/roles/k3s/agent.nix
@@ -84,9 +84,8 @@ in
           {
             # Works without auth on localhost.
             url = "http://localhost:10255";
-            # If the string isn't defined, the kubernetes plugin uses a default location
-            # for the bearer token which we don't use.
-            bearer_token_string = "doesntmatter";
+            # The bearer token file must be set.
+            bearer_token = pkgs.writeText "telegraf-kube-bearer-token" "";
           }
         ];
       };


### PR DESCRIPTION
PL-133850

@flyingcircusio/release-managers

## Release process

- [ ] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [x] Security requirements tested? (EVIDENCE)
  telegraf no longer fails on test vm