### PR TITLE
nixos/open-webui: add WEBUI_URL configuration option which is used as oauth redirect

### DIFF
--- a/changelog.d/20251124_132751_PL-134218-ai-chat-flyingcircus.io-redirects-wrong_scriv.md
+++ b/changelog.d/20251124_132751_PL-134218-ai-chat-flyingcircus.io-redirects-wrong_scriv.md
@@ -21,8 +21,6 @@ branches.
      the main changelog (see below) is for.
      -->
 
-- open-webui role: login flow redirects to correct host
-
 
 ### NixOS XX.XX platform
 

--- a/changelog.d/20251124_132751_PL-134218-ai-chat-flyingcircus.io-redirects-wrong_scriv.md
+++ b/changelog.d/20251124_132751_PL-134218-ai-chat-flyingcircus.io-redirects-wrong_scriv.md
@@ -1,0 +1,29 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+<!-- Impact means "when this change is rolled out, there
+     might be interruptions/downtimes/required actions/... that
+     IMPACT THE RUNNING APPLICATION NEGATIVELY.
+
+     Having new features or changed is not an "impact". That's what
+     the main changelog (see below) is for.
+     -->
+
+- open-webui role: login flow redirects to correct host
+
+
+### NixOS XX.XX platform
+
+- open-webui role: login flow redirects to correct host (FC-134218)

--- a/nixos/roles/open-webui.nix
+++ b/nixos/roles/open-webui.nix
@@ -89,6 +89,8 @@ in
 
         ENABLE_VERSION_UPDATE_CHECK = "False";
         CORS_ALLOW_ORIGIN = "https://${cfg.hostName}";
+        WEBUI_URL = "https://${cfg.hostName}";
+
         ENABLE_EVALUATION_ARENA_MODELS = "False";
       };
     };


### PR DESCRIPTION

@flyingcircusio/release-managers

PL-134218

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [x] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [x] Security requirements tested? (EVIDENCE)
  - this changes the documented env var "WEBUI_URL" of openwebui to our hostName which is configured to the correct and expected host and semantically already has the role of this configuration option
  - I checked on a dev vm that open webui gets the env var
