### PR TITLE
nixos: enable storage auto-optimisation

### DIFF
--- a/changelog.d/20251125_125259_PL-134223-nix-store-auto-optimise_scriv.md
+++ b/changelog.d/20251125_125259_PL-134223-nix-store-auto-optimise_scriv.md
@@ -1,0 +1,34 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+<!-- Impact means "when this change is rolled out, there
+     might be interruptions/downtimes/required actions/... that
+     IMPACT THE RUNNING APPLICATION NEGATIVELY.
+
+     Having new features or changed is not an "impact". That's what
+     the main changelog (see below) is for.
+     -->
+
+- A bullet item for the Impact category.
+
+
+### NixOS XX.XX platform
+
+- nix: enable opportunistic nix store auto-optimisation (PL-134223)
+
+  This is a preparatory step and will reduce storage needs for the
+  nix store in the future with more aggressive changes coming up
+  in the 25.11 release. Enabling opportunistic optimisation here
+  will reduce the required effort to scan the store when upgrading.

--- a/nixos/platform/collect-garbage.nix
+++ b/nixos/platform/collect-garbage.nix
@@ -37,6 +37,8 @@ in
       systemd.tmpfiles.rules = [
         "f ${log}"
       ];
+
+      nix.settings.auto-optimise-store = true;
     }
 
     (lib.mkIf cfg.agent.collect-garbage {


### PR DESCRIPTION
This will (lazily) start maintaining a CAS store that will hard-link duplicate content in the future.

Re PL-134223

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.

this is a toggle.

- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

will add documentation within PL-134223 later

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

no specific requirements

- [x] Security requirements tested? (EVIDENCE)

manually tested for the 25.11 branch, this is a cherry pick