### PR TITLE
fc.qemu: update to fix race condition

### DIFF
--- a/changelog.d/20251125_162607_PL-134195-qemu-race-condition_scriv.md
+++ b/changelog.d/20251125_162607_PL-134195-qemu-race-condition_scriv.md
@@ -1,0 +1,29 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+<!-- Impact means "when this change is rolled out, there
+     might be interruptions/downtimes/required actions/... that
+     IMPACT THE RUNNING APPLICATION NEGATIVELY.
+
+     Having new features or changed is not an "impact". That's what
+     the main changelog (see below) is for.
+     -->
+
+- A bullet item for the Impact category.
+
+
+### NixOS XX.XX platform
+
+- fc.qemu: fix a race condition between inner and outer shutdown (PL-134195)

--- a/pkgs/fc/default.nix
+++ b/pkgs/fc/default.nix
@@ -55,8 +55,8 @@ rec {
       repo = "fc.qemu";
       # The release tooling didn't upgrade properly so we had to pick a specific
       # commit instead.
-      rev = "98cdf966e5e6b836642bb77703e41b0682645f97";
-      hash = "sha256-XlP2VQtMTXVOFik3mW3rVoersEhNcbS7hIKjyREWVPI=";
+      rev = "87a19869ddfd04d2b0f275de8271ccc3995fa594";
+      hash = "sha256-dOXk1oLxfxRDR6W9B56LQgG2yAQlKlus/pj1Emy7bLE=";
     };
     fc-ceph = ceph;
     qemu_ceph = pkgs.qemu-ceph-nautilus;


### PR DESCRIPTION
Re PL-134195

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.

n/a

- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

n/a

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

general availability

- [x] Security requirements tested? (EVIDENCE)

test coverage