### PR TITLE
fix several k3s checks

### DIFF
--- a/nixos/roles/k3s/server.nix
+++ b/nixos/roles/k3s/server.nix
@@ -34,13 +34,15 @@ let
   ];
 
   fcNameservers = config.flyingcircus.static.nameservers.${location} or [ ];
+  kubectlBin = lib.getExe pkgs.kubectl;
+  jqBin = lib.getExe pkgs.jq;
 
   # Use the same location as NixOS k8s.
   defaultKubeconfig = "/etc/kubernetes/cluster-admin.kubeconfig";
 
   kubernetesMakeKubeconfig =
     let
-      kc = "${pkgs.kubectl}/bin/kubectl";
+      kc = kubectlBin;
       remarshal = "${pkgs.remarshal}/bin/remarshal";
     in
     pkgs.writeScriptBin "kubernetes-make-kubeconfig" ''
@@ -335,10 +337,10 @@ let
 
     ret=0
 
-    kubectl get \
+    ${kubectlBin} get \
       --kubeconfig /var/lib/k3s/tokens/sensuclient.cfg \
       pods -A -o json | \
-      jq -e '.items[] |
+      ${jqBin} -e '.items[] |
         select(.status.phase != "Running") |
         select(.status.phase != "Succeeded") |
         select(.status.conditions | map(.lastTransitionTime | fromdateiso8601 | ((now - .) > 600)) | any) |

--- a/nixos/roles/k3s/server.nix
+++ b/nixos/roles/k3s/server.nix
@@ -244,7 +244,7 @@ let
     set -o pipefail
 
     user="$1"
-    secret="$2"
+    secretname="$2"
 
     tokendir=/var/lib/k3s/tokens
     kubectl="${pkgs.kubectl}/bin/kubectl"
@@ -252,7 +252,7 @@ let
     jq="${pkgs.jq}/bin/jq"
     export KUBECONFIG=${defaultKubeconfig}
 
-    if [ -z "$secret" ]; then
+    if [ -z "$secretname" ]; then
       echo 'missing kubernetes secret name' 2>&1
       exit 1
     fi
@@ -276,7 +276,7 @@ let
     rc=0
     for i in 1 2 3 4 5; do
       "$kubectl" get -n kube-system -o jsonpath='{.data.token}' \
-        secret "$secret" > "$tokendir/$user.b64" && \
+        secret "$secretname" > "$tokendir/$user.b64" && \
         test -s "$tokendir/$user.b64"
       rc="$?"
 
@@ -308,6 +308,7 @@ let
 
     mv "$tokendir/$user.tmp" "$tokendir/$user"
     mv "$tokendir/$user.cfg.tmp" "$tokendir/$user.cfg"
+    echo "Successfully initialised token for secret \"$secretname\" for user \"$user\"."
     rm -f "$tokendir/$user.b64"
   '';
 
@@ -328,7 +329,6 @@ let
       Restart = "on-failure";
       RestartSec = 10;
       ExecStart = "${authTokenScript}/bin/kubernetes-write-auth-token ${user} ${secret}";
-      ExecCondition = "${pkgs.coreutils}/bin/test ! -s /var/lib/k3s/tokens/${user} -o ! -s /var/lib/k3s/tokens/${user}.cfg";
     };
   };
 

--- a/nixos/roles/k3s/server.nix
+++ b/nixos/roles/k3s/server.nix
@@ -337,7 +337,7 @@ let
 
     ret=0
 
-    ${kubectlBin} get \
+    output=$(${kubectlBin} get \
       --kubeconfig /var/lib/k3s/tokens/sensuclient.cfg \
       pods -A -o json | \
       ${jqBin} -e '.items[] |
@@ -349,13 +349,14 @@ let
             "ns": .metadata.namespace,
             "phase": .status.phase,
             "since": .status.conditions[].lastTransitionTime,
-            "message": .status.conditions[].message}' || ret=$?
+            "message": .status.conditions[].message}') || ret=$?
 
     if [ "$ret" -eq "4" ]; then
         # no output, good.
         exit 0
     elif [ "$ret" -eq "0" ]; then
         # critical
+        echo "$output"
         exit 2
     fi
   '';


### PR DESCRIPTION
@flyingcircusio/release-managers

Fixes "check-kube-pending-pods"  and "kube-nodes-ready" checks. For the latter, it is more of a workaround for authentication issues.
Commits have additional details in message.
PL-134216, PL-134228

## Release process

- [ ] Created changelog entry using `./changelog.sh`
  - not released yet, regression fix

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - fix monitoring
  - fix a check that was never functional due to lacking PATH executable access
  - posittive and negative cases need to be accounted for
- [x] Security requirements tested? (EVIDENCE)
  - [x] automated tests still pass
  - [x] ran checks in a test cluster
  - [x] ran checks in situations where they should trigger
