### PR TITLE
nixos/gitlab: fix nginx enableACME implicit activations

### DIFF
--- a/changelog.d/20251126_093001_HEAD_scriv.md
+++ b/changelog.d/20251126_093001_HEAD_scriv.md
@@ -1,0 +1,27 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+<!-- Impact means "when this change is rolled out, there
+     might be interruptions/downtimes/required actions/... that
+     IMPACT THE RUNNING APPLICATION NEGATIVELY.
+
+     Having new features or changed is not an "impact". That's what
+     the main changelog (see below) is for.
+     -->
+
+
+### NixOS XX.XX platform
+
+- gitlab: fix false-positive nginx enableACME warning (PL-131381)

--- a/nixos/roles/gitlab.nix
+++ b/nixos/roles/gitlab.nix
@@ -244,6 +244,7 @@ in
               access_log /var/log/nginx/gitlab_access.log gitlab_access;
               add_header Strict-Transport-Security "${hstsOpts}" always;
             '';
+          enableACME = true;
           forceSSL = true;
           locations = {
             "/" = {
@@ -338,6 +339,7 @@ in
       flyingcircus.services.nginx.virtualHosts = {
 
         "${cfg.dockerHostName}" = {
+          enableACME = true;
           forceSSL = true;
           locations."/" = {
             proxyPass = "http://127.0.0.1:${toString config.services.gitlab.registry.port}";


### PR DESCRIPTION
This does not change anything, but resolves warnings for our AppOps team. Already fixed in 25.11, this is only for clearer warning communication.

PL-131381

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [x] Security requirements tested? (EVIDENCE)
  Automatic test still works, behavior equal to before.