### PR TITLE
router/ipxe: add 25.11 and replace 24.11 with 25.05

### DIFF
--- a/nixos/roles/router/flyingcircus.ipxe
+++ b/nixos/roles/router/flyingcircus.ipxe
@@ -6,7 +6,7 @@ set menu-timeout 30000
 
 iseq ${platform} efi && set menu-default local_efi || set menu-default local_bios
 
-set installer_url https://hydra.flyingcircus.io/job/flyingcircus/fc-24.11-production/images.netboot/latest/download/netboot.ipxe
+set installer_url https://hydra.flyingcircus.io/job/flyingcircus/fc-25.05-production/images.netboot/latest/download/netboot.ipxe
 
 # Lets assume network has already been initialized from our ipxe bootstrap script and we'd like to save time here.
 # dhcp || error
@@ -23,7 +23,8 @@ item local_efi              Boot machine from local disk (EFI)
 item netboot                Launch netboot.xyz (various live images and tools)
 item --gap --               --- Install ---
 item --gap --               Installer: ${installer_url}
-item install_nixos_24_11    Set installer to NixOS 24.11 install image
+item install_nixos_25_11    Set installer to NixOS 25.11 install image
+item install_nixos_25_05    Set installer to NixOS 25.05 install image
 item install_nixos_dev      Set installer to NixOS development install image
 item install_edit_url       Manually edit installer URL
 item install_start          Boot selected installer
@@ -35,8 +36,12 @@ choose --timeout ${menu-timeout} --default ${menu-default} selected || goto canc
 set menu-timeout 0
 goto ${selected}
 
-:install_nixos_24_11
-set installer_url https://hydra.flyingcircus.io/job/flyingcircus/fc-24.11-production/images.netboot/latest/download/netboot.ipxe
+:install_nixos_25_11
+set installer_url https://hydra.flyingcircus.io/job/flyingcircus/fc-25.11-production/images.netboot/latest/download/netboot.ipxe
+goto start
+
+:install_nixos_25_05
+set installer_url https://hydra.flyingcircus.io/job/flyingcircus/fc-25.05-production/images.netboot/latest/download/netboot.ipxe
 goto start
 
 :install_nixos_dev


### PR DESCRIPTION
PL-133850

@flyingcircusio/release-managers

## Release process

- [ ] Created changelog entry using `./changelog.sh`
  no: internal

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [x] Security requirements tested? (EVIDENCE)
  - tested that IPXE boot works in dev
