### PR TITLE
nixos/antivirus: fix tcp listening by correctly deactivating systemd socket

### DIFF
--- a/nixos/roles/antivirus.nix
+++ b/nixos/roles/antivirus.nix
@@ -71,7 +71,7 @@ in
     };
 
     # Disable systemd socket activation as this limits two max. 2 listen addresses
-    systemd.sockets.clamav-daemon = fclib.mkPlatform { };
+    systemd.sockets.clamav-daemon = lib.mkForce { };
 
     systemd.services.clamav-init-database = {
       # Shouldn't have a dependency on clamav-freshclam to avoid unneccessary


### PR DESCRIPTION
The mkIf used upstream doesn't get overriden by mkPlatform, we need to use mkForce here.

fixes 7ebf848

PL-134219

@flyingcircusio/release-managers

## Release process

- [ ] Created changelog entry using `./changelog.sh`
  no: followup in release

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [x] Security requirements tested? (EVIDENCE)
  tested on VM that showed the wrong behavior that mkForce is necessary
  updating the NixOS test is hard, as is tests quite other things and has no internet, so clamav-daemon cannot get the correct antivirus files.