### PR TITLE
[26.05] nixos/mail: remove deprecated option `services.postfix.extraConfig`

### DIFF
--- a/doc/src/upgrade.md
+++ b/doc/src/upgrade.md
@@ -106,8 +106,13 @@ time-window.
 
 ## Significant breaking changes
 
-## Other notable changes
+### Mailserver / Mailstub
 
+Configuring postfix via `services.postfix.extraConfig` or `/etc/local/postfix/main.cf`
+is not allowed anymore.
+Please migrate to structured config with `services.postfix.settings.main`.
+
+## Other notable changes
 
 ## Known issues
 

--- a/nixos/services/mail/default.nix
+++ b/nixos/services/mail/default.nix
@@ -159,27 +159,6 @@ in
             }
           ];
 
-          warnings =
-            lib.optionals
-              (config.services.postfix.extraConfig != null && builtins.pathExists "/etc/local/mail/main.cf")
-              [
-                ''
-                  Configuring postfix via /etc/local/mail/main.cf is deprecated.
-                  Please migrate to structured config with services.postfix.settings.main.
-                  This option of configuring will be removed with fc-nixos 26.05.
-                ''
-              ]
-            ++
-              lib.optionals
-                (config.services.postfix.extraConfig != null && (!builtins.pathExists "/etc/local/mail/main.cf"))
-                [
-                  ''
-                    services.postfix.extraConfig is deprecated.
-                    Please migrate to structured config with services.postfix.settings.main.
-                    This option of configuring will be removed with fc-nixos 26.05.
-                  ''
-                ];
-
           environment = {
             etc = {
               "local/mail/dns.zone".text = import ./zone.nix { inherit config lib; };
@@ -429,11 +408,6 @@ in
                 value = copyToStore path;
               }) dynamicMapFiles
             );
-
-            extraConfig = lib.mkIf (builtins.pathExists "/etc/local/mail/main.cf") ''
-              # included from /etc/local/mail/main.cf
-              ${fclib.configFromFile "/etc/local/mail/main.cf" ""}
-            '';
 
             extraAliases = ''
               abuse: root

--- a/nixos/services/mail/stub.nix
+++ b/nixos/services/mail/stub.nix
@@ -49,19 +49,9 @@ in
 
   config = (
     lib.mkIf config.flyingcircus.services.postfix.enable {
-      warnings = lib.optionals (builtins.pathExists "/etc/local/postfix/main.cf") [
-        ''
-          Configuring postfix via /etc/local/postfix/main.cf is deprecated.
-          Please migrate to structured config with services.postfix.settings.main.
-          This option of configuring will be removed with fc-nixos 26.05.
-        ''
-      ];
       services.postfix = {
         enable = true;
         enableSubmission = true;
-        extraConfig = lib.mkIf (builtins.pathExists "/etc/local/postfix/main.cf") (
-          fclib.configFromFile "/etc/local/postfix/main.cf" ""
-        );
         extraMasterConf = lib.mkIf (builtins.pathExists "/etc/local/postfix/master.cf") (
           fclib.configFromFile "/etc/local/postfix/master.cf" ""
         );


### PR DESCRIPTION
@flyingcircusio/release-managers

This fixes the eval of fc-26.05-dev

PL-134240 

## Release process

- [ ] Created changelog entry using `./changelog.sh`
  upgrade notes instead

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [x] Security requirements tested? (EVIDENCE)
  - ensured by automated tests