### PR TITLE
[PL-133027] add a simple nixos test for loki

### DIFF
--- a/changelog.d/20251202_115847_PL-133027_loki-nixos-test_scriv.md
+++ b/changelog.d/20251202_115847_PL-133027_loki-nixos-test_scriv.md
@@ -1,0 +1,27 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+<!-- Impact means "when this change is rolled out, there
+     might be interruptions/downtimes/required actions/... that
+     IMPACT THE RUNNING APPLICATION NEGATIVELY.
+
+     Having new features or changed is not an "impact". That's what
+     the main changelog (see below) is for.
+     -->
+
+
+### NixOS XX.XX platform
+
+- add a simple NixOS tests that verifies that loki is running and accepting the syslog

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -75,6 +75,7 @@ in
   lampVm84 = callTest ./lamp/vm-test.nix { version = "lamp_php84"; };
 
   locale = callTest ./locale.nix { };
+  loki = callTest ./loki.nix { };
   loghost = callTest ./loghost.nix { };
   login = callTest ./login.nix { };
   logrotate = callTest ./logrotate.nix { };

--- a/tests/loki.nix
+++ b/tests/loki.nix
@@ -1,0 +1,70 @@
+import ./make-test-python.nix (
+  {
+    testlib,
+    pkgs,
+    ...
+  }:
+  {
+    name = "loki";
+    nodes.alloy =
+      {
+        lib,
+        pkgs,
+        ...
+      }:
+      {
+        imports = [
+
+          ../nixos
+          ../nixos/roles
+          (testlib.fcConfig { net.fe = false; })
+        ];
+        flyingcircus.roles.loki.enable = true;
+
+        flyingcircus.encServices = [
+          {
+            address = "127.0.0.1";
+            service = "loki-collector";
+          }
+        ];
+
+        environment.variables = {
+          LOKI_ADDR = "http://127.0.0.1:3100";
+        };
+
+        environment.systemPackages = [
+          pkgs.grafana-loki
+        ];
+
+        # test service to spam something easily greppable into syslog
+        systemd.services.testservice = {
+          enable = true;
+          wantedBy = [ "multi-user.target" ];
+          after = [
+            "network.target"
+            "loki.service"
+            "alloy.service"
+          ];
+          serviceConfig.ExecStart = pkgs.writeShellScript "testservice.sh" ''
+            while true; do
+              echo "test message"
+              sleep 1
+            done
+          '';
+        };
+      };
+
+    testScript =
+      { nodes, ... }:
+      let
+        testscript = pkgs.writeShellScript "test-syslog-in-loki.sh" ''
+          test $(logcli -q query '{hostname="alloy", systemd_unit="testservice.service"} |= `test message`' | wc -l) -gt 0
+        '';
+      in
+      ''
+        alloy.wait_for_unit("testservice.service")
+        alloy.sleep(1)
+        alloy.succeed('${testscript}')
+      '';
+  }
+)


### PR DESCRIPTION
@flyingcircusio/release-managers

PL-133027

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [x] Security requirements tested? (EVIDENCE)
- none, just a new nixos test