### PR TITLE
[25.05] fc.qemu: update to fix KVM host maintenance-enter guard

### DIFF
--- a/changelog.d/20251203_132454_PL-134247-fc-qemu-nested-exit-codes_scriv.md
+++ b/changelog.d/20251203_132454_PL-134247-fc-qemu-nested-exit-codes_scriv.md
@@ -1,0 +1,29 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+<!-- Impact means "when this change is rolled out, there
+     might be interruptions/downtimes/required actions/... that
+     IMPACT THE RUNNING APPLICATION NEGATIVELY.
+
+     Having new features or changed is not an "impact". That's what
+     the main changelog (see below) is for.
+     -->
+
+
+### NixOS XX.XX platform
+
+- KVM hosts: fix a regression in maintenance handling (PL-134247)
+  fc.qemu accidentally scrapped return codes set via sys.exit and replaced them with a 0, rendering maintenance guards ineffective. \
+  Has been released as a hotfix to affected hosts ahead of schedule.

--- a/pkgs/fc/default.nix
+++ b/pkgs/fc/default.nix
@@ -55,8 +55,8 @@ rec {
       repo = "fc.qemu";
       # The release tooling didn't upgrade properly so we had to pick a specific
       # commit instead.
-      rev = "87a19869ddfd04d2b0f275de8271ccc3995fa594";
-      hash = "sha256-dOXk1oLxfxRDR6W9B56LQgG2yAQlKlus/pj1Emy7bLE=";
+      rev = "4bf2741d7f2eef2fabf093df9bf207ff8c825b32";
+      hash = "sha256-BoVRouaic7Q9GczShQN+nyTnOhj02pXLLAK/yrKakUw=";
     };
     fc-ceph = ceph;
     qemu_ceph = pkgs.qemu-ceph-nautilus;


### PR DESCRIPTION
PL-134247

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - fixed a critical issue that caused downtime
  - fix was derived from observing the live issue and tracking down the changeset introducing it
- [x] Security requirements tested? (EVIDENCE)
  - [x] extended test coverage
  - [x] automated tests pass https://github.com/flyingcircusio/fc-nixos/pull/2016
  - [x] manually tested in test cluster:
    - without fix:
    ```
    root@kyle06 /home/os # fc-qemu maintenance enter
    rbd: lock is already held by someone else
    
    root@kyle06 /home/os # echo $?
    0
    ``` 
    - with fix:
    ```
    root@kyle09 ~ # fc-qemu maintenance enter
    rbd: lock is already held by someone else
    
    root@kyle09 ~ # echo $?
    75
    ```
    - tested that maintenance enter hooks block a maintenance correctly
