### PR TITLE
[26.05] nixos: replace deprecated lib.fold with lib.foldr

### DIFF
--- a/nixos/lib/files.nix
+++ b/nixos/lib/files.nix
@@ -36,7 +36,7 @@ rec {
         filter (filename: hasSuffix "json" filename) (files path)
       );
 
-      mergedObject = fold (obj: acc: acc // obj) { } objects;
+      mergedObject = foldr (obj: acc: acc // obj) { } objects;
 
       duplicates = fclib.duplicateAttrNames objects;
     in

--- a/nixos/platform/default.nix
+++ b/nixos/platform/default.nix
@@ -485,7 +485,7 @@ in
         '';
 
         # concat script snippets for all local config dirs
-        cfgScript = lib.fold (name: acc: acc + "\n" + (snippet name)) "" (lib.attrNames cfgDirs);
+        cfgScript = lib.foldr (name: acc: acc + "\n" + (snippet name)) "" (lib.attrNames cfgDirs);
 
         fromCfgDirs = {
           fc-local-config = lib.stringAfter [ "users" "groups" ] cfgScript;


### PR DESCRIPTION
lib.fold is an alias to lib.foldr. The behavior is equivalent.

PL-134240

@flyingcircusio/release-managers

## Release process

- [ ] Created changelog entry using `./changelog.sh`
  no: internal

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [x] Security requirements tested? (EVIDENCE)
  - Checked that `lib.fold` is an alias for `lib.foldr`