### PR TITLE
nixos/mail: remove monitoring for port 143 when it's deactivated

### DIFF
--- a/nixos/services/mail/default.nix
+++ b/nixos/services/mail/default.nix
@@ -222,7 +222,7 @@ in
                 notification = "Postfix listening on submission port 587";
                 command = "${plug}/check_smtp -H ${role.mailHost} -p 587 -S " + "-F ${fqdn} -w 5 -c 30";
               };
-              dovecot_imap = {
+              dovecot_imap = lib.mkIf (config.mailserver.enableImap) {
                 notification = "Dovecot listening on IMAP port 143";
                 command = "${plug}/check_imap -H ${role.mailHost} -w 5 -c 30";
               };


### PR DESCRIPTION
NixOS mailserver 25.11 disables port 143 by default, as it's deprecated by a RFC. Our monitoring still alerts for that.

PL-134249

@flyingcircusio/release-managers

## Release process

- [ ] Created changelog entry using `./changelog.sh`
  no: internal monitoring fluke

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x]  ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - We want to monitor when the port is supposed to be open, therefore here is a mkIf that activates the check when it's necessary.
- [x] Security requirements tested? (EVIDENCE)
