### PR TITLE
[hotfix 25.05] fc.qemu: update to fix KVM host maintenance-enter guard

### DIFF
--- a/changelog.d/20251203_132454_PL-134247-fc-qemu-nested-exit-codes_scriv.md
+++ b/changelog.d/20251203_132454_PL-134247-fc-qemu-nested-exit-codes_scriv.md
@@ -1,0 +1,29 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+<!-- Impact means "when this change is rolled out, there
+     might be interruptions/downtimes/required actions/... that
+     IMPACT THE RUNNING APPLICATION NEGATIVELY.
+
+     Having new features or changed is not an "impact". That's what
+     the main changelog (see below) is for.
+     -->
+
+
+### NixOS XX.XX platform
+
+- KVM hosts: fix a regression in maintenance handling (PL-134247)
+  fc.qemu accidentally scrapped return codes set via sys.exit and replaced them with a 0, rendering maintenance guards ineffective. \
+  Has been released as a hotfix to affected hosts ahead of schedule.

--- a/pkgs/fc/default.nix
+++ b/pkgs/fc/default.nix
@@ -55,8 +55,8 @@ rec {
       repo = "fc.qemu";
       # The release tooling didn't upgrade properly so we had to pick a specific
       # commit instead.
-      rev = "87a19869ddfd04d2b0f275de8271ccc3995fa594";
-      hash = "sha256-dOXk1oLxfxRDR6W9B56LQgG2yAQlKlus/pj1Emy7bLE=";
+      rev = "4bf2741d7f2eef2fabf093df9bf207ff8c825b32";
+      hash = "sha256-BoVRouaic7Q9GczShQN+nyTnOhj02pXLLAK/yrKakUw=";
     };
     fc-ceph = ceph;
     qemu_ceph = pkgs.qemu-ceph-nautilus;


### PR DESCRIPTION
DO NOT MERGE, only used to trigger a Hydra build.

Hotfix for https://github.com/flyingcircusio/fc-nixos/pull/2016.