### PR TITLE
nixos/mail: correct dns.zone file with a non-default dkimSelector

### DIFF
--- a/changelog.d/20251205_135026_HEAD_scriv.md
+++ b/changelog.d/20251205_135026_HEAD_scriv.md
@@ -1,0 +1,27 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+<!-- Impact means "when this change is rolled out, there
+     might be interruptions/downtimes/required actions/... that
+     IMPACT THE RUNNING APPLICATION NEGATIVELY.
+
+     Having new features or changed is not an "impact". That's what
+     the main changelog (see below) is for.
+     -->
+
+
+### NixOS XX.XX platform
+
+- nixos/mail: correct dns.zone file with a non-default dkimSelector (PL-134262)

--- a/nixos/services/mail/zone.nix
+++ b/nixos/services/mail/zone.nix
@@ -8,7 +8,7 @@ let
   readDKIM =
     domain:
     let
-      path = "/var/dkim/${domain}.mail.txt";
+      path = "/var/dkim/${domain}.${config.mailserver.dkimSelector}.txt";
     in
     lib.optionalString (pathExists path) (readFile path);
 in
@@ -33,7 +33,11 @@ in
         autoconfig.${d}. CNAME ${mailHost}.
         _dmarc.${d}. TXT "v=DMARC1; p=none"
       ''
-      + replaceStrings [ "mail._domainkey" ] [ "mail._domainkey.${d}." ] (readDKIM d)
+      +
+        replaceStrings
+          [ "${config.mailserver.dkimSelector}._domainkey" ]
+          [ "${config.mailserver.dkimSelector}._domainkey.${d}." ]
+          (readDKIM d)
     )
   ) (attrNames (filterAttrs (domain: config: config.enable) domains))
 ))


### PR DESCRIPTION
PL-134262

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [x] Security requirements tested? (EVIDENCE)
  Tested that the file is generated correctly on a test VM