### PR TITLE
backy: make whole object diff configurable and disable by default

### DIFF
--- a/changelog.d/20251209_162439_PL-134246-whole-object-performance_scriv.md
+++ b/changelog.d/20251209_162439_PL-134246-whole-object-performance_scriv.md
@@ -1,0 +1,17 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+
+### NixOS XX.XX platform
+
+- backy: make whole object diff configurable and disable by default. (PL-134246)

--- a/pkgs/backy/default.nix
+++ b/pkgs/backy/default.nix
@@ -13,8 +13,8 @@ let
   src = fetchFromGitHub {
     owner = "flyingcircusio";
     repo = "backy";
-    rev = "1286f7092334c7f0b846425e16304b0afd89d25d";
-    hash = "sha256-ZCQTrLYoiTrt+sZdjnvdWjl2Y+ZAREDRDjaFDeUsd6U=";
+    rev = "11a2b2695cccf6dc81b93c521fee410a0d971f6f";
+    hash = "sha256-KDpqvehr76Luto7Fp2NhoXcIKmeSoSOpZqAhEu+8jEw=";
   };
 
   lib = import "${src}/lib.nix" inputs;


### PR DESCRIPTION
Re PL-134246

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.

made the problematic setting an option in backy

- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

not customer facing

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

no specific requirements

- [x] Security requirements tested? (EVIDENCE)


no specific tests, relying on test suite and manual tests on staging server