### PR TITLE
Add Ollama CPU offload sensu check

### DIFF
--- a/changelog.d/20251210_014323_PL-134226-sensu-ollama-cpu-offload-check_scriv.md
+++ b/changelog.d/20251210_014323_PL-134226-sensu-ollama-cpu-offload-check_scriv.md
@@ -1,0 +1,28 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+<!-- Impact means "when this change is rolled out, there
+     might be interruptions/downtimes/required actions/... that
+     IMPACT THE RUNNING APPLICATION NEGATIVELY.
+
+     Having new features or changed is not an "impact". That's what
+     the main changelog (see below) is for.
+     -->
+
+
+
+### NixOS XX.XX platform
+
+- Adds a sensu check to check for ollama loading models into CPU memory which degrades performance. (PL-134226)

--- a/nixos/roles/ai-model-server.nix
+++ b/nixos/roles/ai-model-server.nix
@@ -12,6 +12,37 @@ let
   cfg = config.flyingcircus.roles.ai-model-server;
   scfg = config.services.ollama;
 
+  checkOllamaCpuOffload = pkgs.writeShellApplication {
+    name = "check_ollama_cpu_offload";
+    runtimeInputs = [
+      pkgs.curl
+      pkgs.jq
+    ];
+    text = ''
+      url="http://${scfg.host}:${toString scfg.port}/api/ps"
+
+      if ! response=$(curl -s --fail "$url"); then
+        echo "CRITICAL: Failed to connect to Ollama at $url"
+        exit 2
+      fi
+
+      # Check for models loaded into CPU
+      # We look for models where size > size_vram
+      # We output the names of such models
+
+      offloaded_models=$(echo "$response" | jq -r '.models[] | select(.size > .size_vram) | "\(.name) (size: \(.size), vram: \(.size_vram))"')
+
+      if [ -n "$offloaded_models" ]; then
+        echo "WARNING: Some models are partially or fully loaded into CPU:"
+        echo "$offloaded_models"
+        exit 1
+      else
+        echo "OK: All models are fully loaded into GPU"
+        exit 0
+      fi
+    '';
+  };
+
 in
 {
   options = {
@@ -102,6 +133,12 @@ in
           ollama_health = {
             notification = "Ollama service health check";
             command = "check_http -H ${scfg.host} -p ${toString scfg.port} -u /api/tags";
+            interval = 300;
+          };
+
+          ollama_cpu_offload = {
+            notification = "Ollama CPU offload check";
+            command = "${checkOllamaCpuOffload}/bin/check_ollama_cpu_offload";
             interval = 300;
           };
         };


### PR DESCRIPTION
See PL-134226 where we experienced Ollama loading models into CPU partially which degraded performance. The exact scenario is unclear and it has not occured regurlarly. We will monitor the situation and this PR adds a sensu check for exactly this condition.

According to the ollama source code, one can determine this from the `size_vram` and `size` fields of the `/api/ps` endpoint: https://github.com/ollama/ollama/blob/76f88caf437c3f48b68ff6df649e283f7370b27b/cmd/cmd.go#L747C2-L775C1

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - few dependencies required (curl, jq) hooks into already existing sensu check infrastructure
- [x] Security requirements tested? (EVIDENCE)
  - verified working and detecting model load condition
