### PR TITLE
mail: fix roundcube with STARTTLS deprecation

### DIFF
--- a/changelog.d/20251210_142647_HEAD_scriv.md
+++ b/changelog.d/20251210_142647_HEAD_scriv.md
@@ -1,0 +1,30 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+<!-- Impact means "when this change is rolled out, there
+     might be interruptions/downtimes/required actions/... that
+     IMPACT THE RUNNING APPLICATION NEGATIVELY.
+
+     Having new features or changed is not an "impact". That's what
+     the main changelog (see below) is for.
+     -->
+
+
+### NixOS XX.XX platform
+
+- mail: fix roundcube with STARTTLS deprecation (PL-134260)
+
+  Roundcube instances on 25.11 had problems with connecting to the mail server.
+  This change fixes this.

--- a/nixos/services/mail/roundcube.nix
+++ b/nixos/services/mail/roundcube.nix
@@ -60,7 +60,8 @@ lib.mkMerge [
         $config['password_confirm_current'] = true;
         $config['password_driver'] = 'chpasswd';
         $config['password_minimum_length'] = 10;
-        $config['smtp_server'] = 'tls://${role.mailHost}';
+        $config['imap_host'] = 'ssl://${role.mailHost}';
+        $config['smtp_host'] = 'ssl://${role.mailHost}';
         $config['smtp_user'] = '%u';
         $config['smtp_pass'] = '%p';
       '';


### PR DESCRIPTION
PL-134260

fits to the behavior of https://github.com/roundcube/roundcubemail/blob/1.6.11/program/lib/Roundcube/rcube_utils.php#L868

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [x] Security requirements tested? (EVIDENCE)
  - Tested logging in and sending mail on a test VM 