### PR TITLE
Add monitoring for VRF routing state on KVM servers

### DIFF
--- a/nixos/roles/kvm/default.nix
+++ b/nixos/roles/kvm/default.nix
@@ -301,7 +301,14 @@ in
         commands = [ "${cfg.package}/bin/fc-qemu check" ];
         groups = [ "sensuclient" ];
       }
-    ];
+    ]
+    ++ (lib.optionals (vrfInterfaces != { }) [
+      {
+        commands = [ "${pkgs.fc.check-kvm-vrf-integrity}/bin/check_kvm_vrf_integrity" ];
+        groups = [ "sensuclient" ];
+        runAs = ":frrvty";
+      }
+    ]);
 
     systemd.services.fc-qemu-reattach-taps = {
       description = "Reattach all VM taps if needed.";
@@ -444,7 +451,19 @@ in
           notification = "Qemu health check";
           command = "sudo ${cfg.package}/bin/fc-qemu check";
         };
-      };
+      }
+      // (lib.optionalAttrs (vrfInterfaces != { }) {
+        kvm_vrf_integrity = {
+          notification = "VRF routing does not match kernel network state";
+          interval = 300;
+          command =
+            let
+              tables = lib.concatMapStringsSep " " (i: toString i.vrfTable) (attrValues vrfInterfaces);
+            in
+            "sudo -g frrvty ${pkgs.fc.check-kvm-vrf-integrity}/bin/check_kvm_vrf_integrity ${tables}";
+        };
+      });
+
       # each qemu process connects directly to multiple OSD's in the
       # ceph cluster for at least 3-4 volumes. let's
       expectedConnections =

--- a/pkgs/fc/check-kvm-vrf-integrity/check_kvm_vrf_integrity.py
+++ b/pkgs/fc/check-kvm-vrf-integrity/check_kvm_vrf_integrity.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Check KVM VRF guest routes are announced correctly."""
+
+import argparse
+import json
+import subprocess
+import sys
+
+ROUTE_PROTO = "fc-qemu"
+
+
+def json_cmd(*args, **kwargs):
+    data = subprocess.check_output(*args, **kwargs)
+    return json.loads(data.decode("utf-8"))
+
+
+def vtysh_cmd(cmd):
+    return json_cmd(["vtysh", "-c", cmd])
+
+
+def vtysh_vni(table):
+    return vtysh_cmd(f"show bgp l2vpn evpn vni {table} json")
+
+
+def vtysh_routes(key):
+    return vtysh_cmd(f"show bgp l2vpn evpn rd {key} json")
+
+
+def kvm_routes(ip_version, table):
+    return json_cmd(
+        [
+            "ip",
+            "-j",
+            f"-{ip_version}",
+            "route",
+            "show",
+            "table",
+            f"{table}",
+            "proto",
+            ROUTE_PROTO,
+        ]
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "tables",
+        metavar="table",
+        nargs="+",
+        type=int,
+        help="Table IDs of VRFs to check",
+    )
+
+    args = parser.parse_args()
+
+    oks = set()
+    warnings = set()
+    errors = set()
+
+    for table in args.tables:
+        kernel_routes = []
+        for version in [4, 6]:
+            kernel_routes.extend(kvm_routes(version, table))
+
+        kernel_routes = {x["dst"] for x in kernel_routes}
+
+        vni = vtysh_vni(table)
+        if "rd" not in vni:
+            errors.add(f"table {table}: could not find RD for VNI in FRR")
+            continue
+
+        rd = vni["rd"]
+        frr_routes = vtysh_routes(rd)
+
+        if rd not in frr_routes:
+            errors.add(f"table {table}: could not find FRR routes for RD {rd}")
+            continue
+
+        frr_routes = frr_routes[rd]
+        frr_routes = {
+            path["ip"]
+            for route in frr_routes.values()
+            if isinstance(route, dict)
+            for path in route["paths"]
+        }
+
+        if kernel_routes.difference(frr_routes):
+            errors.add(
+                f"table {table}: FRR announcing {len(frr_routes)} "
+                f"of {len(kernel_routes)} kernel routes"
+            )
+        elif frr_routes.difference(kernel_routes):
+            warnings.add(
+                f"table {table}: FRR announcing {len(frr_routes)} routes, "
+                f"{len(kernel_routes)} exist in kernel"
+            )
+        else:
+            oks.add(
+                f"table {table}: FRR and kernel routing table match "
+                f"({len(kernel_routes)} routes)"
+            )
+
+    if errors:
+        print(
+            f"{len(errors)} CHECKS CRITICAL - VRF routes not announced properly"
+        )
+    elif warnings:
+        print(f"{len(warnings)} CHECKS WARNING - extra VRF routes announced")
+    else:
+        print(f"{len(oks)} CHECKS OK - VRF routes announced as expected")
+
+    for msg in sorted(errors):
+        print(f"ERROR - {msg}")
+    for msg in sorted(warnings):
+        print(f"WARNING - {msg}")
+    for msg in sorted(oks):
+        print(f"OK - {msg}")
+
+    if errors:
+        sys.exit(2)
+    elif warnings:
+        sys.exit(1)
+    else:
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/pkgs/fc/check-kvm-vrf-integrity/default.nix
+++ b/pkgs/fc/check-kvm-vrf-integrity/default.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  stdenv,
+  makeWrapper,
+  python3,
+  iproute2,
+  frr,
+}:
+
+stdenv.mkDerivation rec {
+  version = "1";
+  pname = "check-kvm-vrf-integrity";
+
+  src = ./.;
+  unpackPhase = ":";
+  dontBuild = true;
+  dontConfigure = true;
+  nativeBuildInputs = [ makeWrapper ];
+  propagatedBuildInputs = [
+    python3
+    iproute2
+    frr
+  ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cd $src
+    install check_kvm_vrf_integrity.py $out/bin/check_kvm_vrf_integrity
+    wrapProgram $out/bin/check_kvm_vrf_integrity --prefix PATH : \
+      ${lib.makeBinPath propagatedBuildInputs}
+  '';
+
+  meta = with lib; {
+    description = "Sensu check for monitoring KVM VRF routes";
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/fc/default.nix
+++ b/pkgs/fc/default.nix
@@ -29,6 +29,7 @@ rec {
   };
   check-haproxy = callPackage ./check-haproxy { };
   check-journal = callPackage ./check-journal.nix { };
+  check-kvm-vrf-integrity = callPackage ./check-kvm-vrf-integrity { };
   check-link-redundancy = callPackage ./check-link-redundancy { };
   check-mongodb = pyPackages.callPackage ./check-mongodb { };
   check-postfix = callPackage ./check-postfix { };


### PR DESCRIPTION
This change adds sensu check scripts for VRF routing state on KVM servers, to detect cases where FRR is not announcing guest routes in VRF routing tables correctly

PL-134136

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh` => none, internal change

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Monitoring the network is functioning correctly
- [x] Security requirements tested? (EVIDENCE)
  - Manual verification that the positive and negative case are both detected correctly.