### PR TITLE
Change AS number for routing lab

### DIFF
--- a/nixos/roles/router/bird2/dev.conf
+++ b/nixos/roles/router/bird2/dev.conf
@@ -123,7 +123,7 @@ protocol bgp peer_whq_kenny01_6 from peer_whq_6 {
 
 template bgp peer_routerlab {
   local as 64512;
-  neighbor as 64514;
+  neighbor as 64515;
 
   passive;
 

--- a/nixos/roles/router/bird2/dev2.conf
+++ b/nixos/roles/router/bird2/dev2.conf
@@ -67,7 +67,7 @@ filter default_route_6 {
 }
 
 template bgp peer_dev {
-  local as 64514;
+  local as 64515;
   neighbor as 64512;
 
   bfd;

--- a/nixos/roles/router/bird2/dev2.conf
+++ b/nixos/roles/router/bird2/dev2.conf
@@ -48,12 +48,14 @@ protocol kernel kernel_6 {
 
 filter net_routerlab_4 {
   if net ~ [ 172.21.82.0/24, 172.21.83.0/24 ] then {
+    bgp_med = UPLINK_MED;
     accept;
   } else reject;
 }
 
 filter net_routerlab_6 {
   if net ~ [ 2a06:3a80:0300:100::/56+ ] then {
+    bgp_med = UPLINK_MED;
     accept;
   } else reject;
 }


### PR DESCRIPTION
This change updates the AS number used for the routing lab, as it spend a while offline and the AS number it was using was allocated elsewhere in the meantime by accident.

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`  => none, internal change

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Avoid collisions with production routing configurations.
- [x] Security requirements tested? (EVIDENCE)
  - Running in local checkouts on various dev routers.
