### PR TITLE
statshost-{master,global}: change default hostName to grafana.<rg>.fcio.net

### DIFF
--- a/changelog.d/20251215_092753_HEAD_scriv.md
+++ b/changelog.d/20251215_092753_HEAD_scriv.md
@@ -1,0 +1,31 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+<!-- Impact means "when this change is rolled out, there
+     might be interruptions/downtimes/required actions/... that
+     IMPACT THE RUNNING APPLICATION NEGATIVELY.
+
+     Having new features or changed is not an "impact". That's what
+     the main changelog (see below) is for.
+     -->
+
+- stashost-master, statshost-global: if you are using the default URL of `<hostname>.fe.<location>.fcio.net/grafana`, you need to change `flyingcircus.roles.statshost.hostName` to the URL you use.
+
+  Almost all instances already use the new URL `grafana.<resource group>.fcio.net`, so likely you don't need to change anything.
+
+
+### NixOS XX.XX platform
+
+- statshost-master: change default URL to `grafana.<resource group>.fcio.net` (PL-134242)

--- a/nixos/roles/statshost/default.nix
+++ b/nixos/roles/statshost/default.nix
@@ -128,7 +128,8 @@ in
       supportsContainers = fclib.mkDisableDevhostSupport;
 
       hostName = mkOption {
-        default = fclib.fqdn { vlan = "fe"; };
+        default = "grafana.${config.flyingcircus.enc.parameters.resource_group}.fcio.net";
+        defaultText = "grafana.<resource group>.fcio.net";
         type = types.str;
         description = ''
           Host name for the Grafana frontend.


### PR DESCRIPTION
PL-134242

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [x] Security requirements tested? (EVIDENCE)
  tested in dev