### PR TITLE
Fix handling in KVM VRF check script

### DIFF
--- a/pkgs/fc/check-kvm-vrf-integrity/check_kvm_vrf_integrity.py
+++ b/pkgs/fc/check-kvm-vrf-integrity/check_kvm_vrf_integrity.py
@@ -73,17 +73,16 @@ def main():
         rd = vni["rd"]
         frr_routes = vtysh_routes(rd)
 
-        if rd not in frr_routes:
-            errors.add(f"table {table}: could not find FRR routes for RD {rd}")
-            continue
-
-        frr_routes = frr_routes[rd]
-        frr_routes = {
-            path["ip"]
-            for route in frr_routes.values()
-            if isinstance(route, dict)
-            for path in route["paths"]
-        }
+        if rd in frr_routes:
+            frr_routes = frr_routes[rd]
+            frr_routes = {
+                path["ip"]
+                for route in frr_routes.values()
+                if isinstance(route, dict)
+                for path in route["paths"]
+            }
+        else:
+            frr_routes = set()
 
         if kernel_routes.difference(frr_routes):
             errors.add(


### PR DESCRIPTION
This change fixes a problem with the KVM VRF check script being too strict in the output it expects from FRR. The route distinguisher may be absent from the route data JSON if there aren't any routes to report, so its absence is not an error.

PL-134290

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh` => none, internal change.

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [x] ensure the merge bot has determined a merge date
- [x] ensure all checks are green
- [x] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Don't falsely alarm on normal conditions.
- [x] Security requirements tested? (EVIDENCE)
  - Script tested on a few production machines reporting the erroneous warning.