### PR TITLE
fc.qemu: lower evacuation timeout in dev

### DIFF
--- a/changelog.d/20260107_125250_PL-134247-configurable-evac-timeout_scriv.md
+++ b/changelog.d/20260107_125250_PL-134247-configurable-evac-timeout_scriv.md
@@ -1,0 +1,21 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+
+### NixOS XX.XX platform
+
+- kvm_host: make evacuation timeout configurable via platform config (PL-134247)
+
+  This allows us to set shorter evacuation timeouts in our dev environment, to properly trigger QA for retry behaviour.

--- a/nixos/roles/kvm/default.nix
+++ b/nixos/roles/kvm/default.nix
@@ -81,6 +81,16 @@ in
         description = "Network to use for migration";
       };
 
+      maintenanceEvacuationTimeout = lib.mkOption {
+        type = lib.types.ints.positive;
+        # in dev, we deliberately provide insufficient time to test the postpone and retry paths
+        default = if (location == "dev") then 60 else 300;
+        defaultText = "60s for dev, everywhere else 300s";
+        description = ''
+          Evacuation timeout in seconds for the maintenance enter guard.
+                    If VMs are remaining after this time, the maintenance fails temporarily.'';
+      };
+
     };
   };
 
@@ -152,6 +162,7 @@ in
         ; VNC ACL because it gets mixed up with ::1.
         vnc = 127.0.0.1:{id}
         timeout-graceful = 120
+        maintenance-evacuation-timeout = ${toString cfg.maintenanceEvacuationTimeout}
         migration-address = tcp:${migration_address}:{id}
         migration-ctl-address = ${migration_ctl_address}:0
         migration-bandwidth = ${toString cfg.migrationBandwidth}

--- a/pkgs/fc/default.nix
+++ b/pkgs/fc/default.nix
@@ -57,8 +57,8 @@ rec {
       repo = "fc.qemu";
       # The release tooling didn't upgrade properly so we had to pick a specific
       # commit instead.
-      rev = "4bf2741d7f2eef2fabf093df9bf207ff8c825b32";
-      hash = "sha256-BoVRouaic7Q9GczShQN+nyTnOhj02pXLLAK/yrKakUw=";
+      rev = "341227f920b14defa1dc21e81af7b466f59798c0";
+      hash = "sha256-hyIUZMNOvtknaHQDj9OFZzaJmvz35ODYLMK4eZJTcjE=";
     };
     fc-ceph = ceph;
     qemu_ceph = pkgs.qemu-ceph-nautilus;

--- a/tests/kvm_host_ceph-nautilus.nix
+++ b/tests/kvm_host_ceph-nautilus.nix
@@ -362,117 +362,121 @@ import ./make-test-python.nix (
       host2 = makeHostConfig { id = 2; };
     };
 
-    testScript = ''
-      import textwrap
-      import time
-      import json
+    testScript =
+      { nodes, ... }:
+      ''
+        import textwrap
+        import time
+        import json
 
-      time_waiting = 0
-      start_all()
+        time_waiting = 0
+        start_all()
 
-      def show(host, cmd):
-        print(cmd)
-        code, output = host.execute(cmd)
-        print(output)
-        if code:
-          raise RuntimeError(
-            f"Command `cmd` failed with exit code {code}")
-        return output.strip()
+        def show(host, cmd):
+          print(cmd)
+          code, output = host.execute(cmd)
+          print(output)
+          if code:
+            raise RuntimeError(
+              f"Command `cmd` failed with exit code {code}")
+          return output.strip()
 
-      def wait(fun, *args, **kw):
-        global time_waiting
-        print(f"Waiting for `{fun.__name__}(*{args}, **{kw})` ...")
-        start = time.time()
-        tries = 1
-        while True:
-          try:
-            return fun(*args, **kw)
-          except Exception:
-            if time.time() - start < 60:
-              time_waiting += tries*2
-              time.sleep(tries*2)
-            else:
-              raise
+        def wait(fun, *args, **kw):
+          global time_waiting
+          print(f"Waiting for `{fun.__name__}(*{args}, **{kw})` ...")
+          start = time.time()
+          tries = 1
+          while True:
+            try:
+              return fun(*args, **kw)
+            except Exception:
+              if time.time() - start < 60:
+                time_waiting += tries*2
+                time.sleep(tries*2)
+              else:
+                raise
 
-      show(host1, "for x in /etc/ceph/*; do echo $x ; cat $x; echo '========='; done")
-      host1.execute("systemctl stop fc-ceph-mon")
-      host1.execute("systemctl stop fc-ceph-mgr")
+        show(host1, "for x in /etc/ceph/*; do echo $x ; cat $x; echo '========='; done")
+        host1.execute("systemctl stop fc-ceph-mon")
+        host1.execute("systemctl stop fc-ceph-mgr")
 
-      with subtest("fc-qemu-scrub timer is correctly activated"):
-        _, output = host1.execute("systemctl list-timers | grep fc-qemu-scrub")
-        print(output)
-        assert "fc-qemu-scrub" in output
-        assert "min left "
-        assert not output.startswith("n/a")
-        assert output.count("n/a") <= 2
+        with subtest("fc-qemu-scrub timer is correctly activated"):
+          _, output = host1.execute("systemctl list-timers | grep fc-qemu-scrub")
+          print(output)
+          assert "fc-qemu-scrub" in output
+          assert "min left "
+          assert not output.startswith("n/a")
+          assert output.count("n/a") <= 2
 
-      host1.execute("systemctl stop fc-qemu-scrub.timer")
-      host2.execute("systemctl stop fc-qemu-scrub.timer")
+        host1.execute("systemctl stop fc-qemu-scrub.timer")
+        host2.execute("systemctl stop fc-qemu-scrub.timer")
 
-      host1.wait_for_unit("consul")
-      host2.wait_for_unit("consul")
+        host1.wait_for_unit("consul")
+        host2.wait_for_unit("consul")
 
-      wait(show, host1, "consul members")
-      wait(show, host2, "consul members")
+        wait(show, host1, "consul members")
+        wait(show, host2, "consul members")
 
-      host1.wait_for_unit("nginx", timeout=10)
+        host1.wait_for_unit("nginx", timeout=10)
 
-      with subtest("Run tests"):
-        host1.succeed("run-tests ${testOpts}", timeout=30*60)
+        with subtest("Run tests"):
+          host1.succeed("run-tests ${testOpts}", timeout=30*60)
 
-      # XXX the following tests should be migrated to fc.qemu at some point
-      show(host1, "rbd rm rbd/.fc-qemu.maintenance || true")
+        # XXX the following tests should be migrated to fc.qemu at some point
+        show(host1, "rbd rm rbd/.fc-qemu.maintenance || true")
 
-      with subtest("Check maintenance enter/exit works"):
-        result = show(host1, "/run/current-system/sw/bin/fc-qemu --verbose maintenance enter")
-        assert "D enter-maintenance" in result
-        assert "D ensure-maintenance-volume" in result
-        assert "D creating maintenance volume" in result
-        assert "D acquire-maintenance-lock" in result
-        assert "I request-evacuation" in result
-        assert "I evacuation-pending" in result
-        assert "I evacuation-running" in result
-        assert "I evacuation-success" in result
+        with subtest("Check maintenance enter/exit works"):
+          result = show(host1, "/run/current-system/sw/bin/fc-qemu --verbose maintenance enter")
+          assert "D enter-maintenance" in result
+          assert "D ensure-maintenance-volume" in result
+          assert "D creating maintenance volume" in result
+          assert "D acquire-maintenance-lock" in result
+          assert "I request-evacuation" in result
+          assert "maintenance_evacuation_timeout=${toString nodes.host1.flyingcircus.roles.kvm_host.maintenanceEvacuationTimeout}" in result, \
+              "maintenance_evacuation_timeout not overridden correctly"
+          assert "I evacuation-pending" in result
+          assert "I evacuation-running" in result
+          assert "I evacuation-success" in result
 
-        result = show(host1, "/run/current-system/sw/bin/fc-qemu --verbose maintenance leave")
+          result = show(host1, "/run/current-system/sw/bin/fc-qemu --verbose maintenance leave")
 
-        result = show(host1, "/run/current-system/sw/bin/fc-qemu --verbose maintenance enter")
-        assert "D enter-maintenance" in result
-        assert "D ensure-maintenance-volume" in result
-        assert "D creating maintenance volume" not in result
-        assert "D acquire-maintenance-lock" in result
-        assert "I request-evacuation" in result
-        assert "I evacuation-pending" in result
-        assert "I evacuation-running" in result
-        assert "I evacuation-success" in result
+          result = show(host1, "/run/current-system/sw/bin/fc-qemu --verbose maintenance enter")
+          assert "D enter-maintenance" in result
+          assert "D ensure-maintenance-volume" in result
+          assert "D creating maintenance volume" not in result
+          assert "D acquire-maintenance-lock" in result
+          assert "I request-evacuation" in result
+          assert "I evacuation-pending" in result
+          assert "I evacuation-running" in result
+          assert "I evacuation-success" in result
 
-      with subtest("Exercise standalone fc-qemu features"):
-        result = show(host1, "fc-qemu --help")
-        assert result.startswith("usage: fc-qemu"), "Unexpected help output"
+        with subtest("Exercise standalone fc-qemu features"):
+          result = show(host1, "fc-qemu --help")
+          assert result.startswith("usage: fc-qemu"), "Unexpected help output"
 
-        host1.execute("rm -f /etc/qemu/vm/* /etc/qemu/vm/.*")
-        host1.execute("pkill -f qemu")
-        host1.execute("rm -rf /run/qemu.*")
-        host1.succeed("cp /etc/simplevm.cfg /etc/qemu/vm/")
-        host1.succeed("fc-qemu start simplevm")
-        result = show(host1, "fc-qemu ls")
-        assert "I simplevm              online                         cores=1 memory_booked='256'" in result, repr(result)
-        assert "memory_pss='" in result, repr(result)
-        assert "memory_swap='0'" in result, repr(result)
-        result = show(host1, "fc-qemu check")
-        assert "OK - 1 VMs - " in result, result
-        assert " MiB used - " in result, result
-        assert " MiB expected" in result, result
+          host1.execute("rm -f /etc/qemu/vm/* /etc/qemu/vm/.*")
+          host1.execute("pkill -f qemu")
+          host1.execute("rm -rf /run/qemu.*")
+          host1.succeed("cp /etc/simplevm.cfg /etc/qemu/vm/")
+          host1.succeed("fc-qemu start simplevm")
+          result = show(host1, "fc-qemu ls")
+          assert "I simplevm              online                         cores=1 memory_booked='256'" in result, repr(result)
+          assert "memory_pss='" in result, repr(result)
+          assert "memory_swap='0'" in result, repr(result)
+          result = show(host1, "fc-qemu check")
+          assert "OK - 1 VMs - " in result, result
+          assert " MiB used - " in result, result
+          assert " MiB expected" in result, result
 
-        result = show(host1, "fc-qemu report-supported-cpu-models")
-        assert "I supported-cpu-model            architecture='x86' description=''' id='qemu64-v1'" in result, result
+          result = show(host1, "fc-qemu report-supported-cpu-models")
+          assert "I supported-cpu-model            architecture='x86' description=''' id='qemu64-v1'" in result, result
 
-        result = show(host1, "fc-qemu-scrub")
-        assert "I simplevm              running-ensure                 generation=0" in result, result
+          result = show(host1, "fc-qemu-scrub")
+          assert "I simplevm              running-ensure                 generation=0" in result, result
 
-      host1.copy_from_vm('/tmp/coverage', './')
-      host1.copy_from_vm('/tmp/fc.qemu-report.xml', './')
+        host1.copy_from_vm('/tmp/coverage', './')
+        host1.copy_from_vm('/tmp/fc.qemu-report.xml', './')
 
-    '';
+      '';
   }
 )


### PR DESCRIPTION
@flyingcircusio/release-managers

Pass a lower evacuation timeout value to `fc-qemu maintenance enter` in dev, to make our dev QA stage also run into retry behaviour.

Updated fc.qemu includes changes of PL-134247, PL-134280, PL-130990.

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - [x] improve our QA pipeline in dev to also test not immediately successful evacuations, following a regression that slipped through
  - [x] ensure the correct value is passed to fc.qemu
- [x] Security requirements tested? (EVIDENCE)
  - [x] extended integration test suite verifies that the correct value is passed to fc-qemu
  - [x] manually verify in dev that the default time value triggers retry behaviour
