### PR TITLE
PULL_REQUEST_TEMPLATE: remove PR ready step

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -10,7 +10,6 @@
 - [ ] internal issue ID (PL-…) part of branch name
 - [ ] internal issue ID mentioned in PR description text
 - [ ] ticket is on Platform agile board
-- [ ] ticket state set to *Pull request ready*
 - [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
 <!---->
 - [ ] set urgency and risk labels


### PR DESCRIPTION
We removed the *Pull request ready* state from our workflow. Contributors from the platform team are now responsible to track progress of their *In Progress* tickets themselfs.

@flyingcircusio/release-managers

## Release process

- [ ] Created changelog entry using `./changelog.sh`
  - no, meta

## PR release workflow (internal)

- [ ] PR has internal ticket
- [ ] internal issue ID (PL-…) part of branch name
- [ ] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - n/a 
- [x] Security requirements tested? (EVIDENCE)
  - n/a
