### PR TITLE
Reject outgoing martian packets in router firewall

### DIFF
--- a/nixos/roles/router/default.nix
+++ b/nixos/roles/router/default.nix
@@ -41,6 +41,10 @@ let
     fclib.filterConfiguredNetworks static.routerUplinkNetworks."${location}"
   );
 
+  downlinkInterfaces = map (network: fclib.network."${network}".interface) (
+    fclib.filterConfiguredNetworks (static.routerDownlinkNetworks."${location}" or [ ])
+  );
+
   gatewayInterfaces =
     map (network: fclib.network."${network}")
       static.floatingGatewayNetworks."${location}";
@@ -52,7 +56,7 @@ let
       network:
       lib.concatMapStringsSep "\n" (
         iface: "${fclib.iptables network} -A nixos-fw -i ${iface} -s ${network} -j DROP"
-      ) uplinkInterfaces
+      ) (uplinkInterfaces ++ downlinkInterfaces)
     ) martianNetworks
   );
 
@@ -62,7 +66,7 @@ let
         network:
         lib.concatMapStringsSep "\n" (
           iface: "${fclib.iptables network} -A fc-router-forward -i ${iface} -s ${network} -j DROP"
-        ) uplinkInterfaces
+        ) (uplinkInterfaces ++ downlinkInterfaces)
       )
       # Also drop link-local addresses here.
       (martianNetworks ++ [ "fe80::/10" ])
@@ -73,7 +77,7 @@ let
       network:
       lib.concatMapStringsSep "\n" (
         iface: "${fclib.iptables network} -A fc-router-forward -o ${iface} -d ${network} -j REJECT"
-      ) uplinkInterfaces
+      ) (uplinkInterfaces ++ downlinkInterfaces)
     ) (martianNetworks ++ [ "fe80::/10" ])
   );
 

--- a/nixos/roles/router/default.nix
+++ b/nixos/roles/router/default.nix
@@ -51,21 +51,30 @@ let
     lib.concatMapStringsSep "\n" (
       network:
       lib.concatMapStringsSep "\n" (
-        iface: "${fclib.iptables network} -A nixos-fw -i ${iface} " + "-s ${network} -j DROP"
+        iface: "${fclib.iptables network} -A nixos-fw -i ${iface} -s ${network} -j DROP"
       ) uplinkInterfaces
     ) martianNetworks
   );
 
-  martianIptablesForward = (
+  martianIptablesForwardIngress = (
     lib.concatMapStringsSep "\n"
       (
         network:
         lib.concatMapStringsSep "\n" (
-          iface: "${fclib.iptables network} -A fc-router-forward -i ${iface} " + "-s ${network} -j DROP"
+          iface: "${fclib.iptables network} -A fc-router-forward -i ${iface} -s ${network} -j DROP"
         ) uplinkInterfaces
       )
       # Also drop link-local addresses here.
       (martianNetworks ++ [ "fe80::/10" ])
+  );
+
+  martianIptablesForwardEgress = (
+    lib.concatMapStringsSep "\n" (
+      network:
+      lib.concatMapStringsSep "\n" (
+        iface: "${fclib.iptables network} -A fc-router-forward -o ${iface} -d ${network} -j REJECT"
+      ) uplinkInterfaces
+    ) (martianNetworks ++ [ "fe80::/10" ])
   );
 
   locationSensuServer = lib.findFirst (
@@ -204,7 +213,8 @@ in
           ip46tables -N fc-router-forward || true
           ip46tables -A FORWARD -j fc-router-forward
         ''
-        martianIptablesForward
+        martianIptablesForwardIngress
+        martianIptablesForwardEgress
         ''
           # Suppress multicast forwarding
           iptables -A fc-router-forward -s 224.0.0.0/4 -j DROP


### PR DESCRIPTION
The router firewall blocks incoming martian traffic from upstream interfaces. However, we hitherto did not have rules to reject outgoing martians generated by hosts in our own network, which meant that we were inadvertently liable to send martian packets to our upstreams and also caused issues where outgoing connections to invalid addresses would hang or time out instead of being immediately rejected.

This change introduces new rules to reject outgoing martians for fast failure behaviour. Additionally, we also filter martian packets to and from downstream networks too, to avoid unexpected surprises with downstream networks reaching into places they shouldn't be able to.

PL-134258

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh` => none, internal change.

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - It's a best common practice to filter outgoing martian traffic.
- [x] Security requirements tested? (EVIDENCE)
  - Manually verified in dev.