### PR TITLE
Update FRR to 10.4.1

### DIFF
--- a/pkgs/frr/0001-Don-t-throw-error-when-log-directory-already-exists.patch
+++ b/pkgs/frr/0001-Don-t-throw-error-when-log-directory-already-exists.patch
@@ -1,4 +1,4 @@
-From 845b44566a41cfb81887ffac074d70bbd4ad1181 Mon Sep 17 00:00:00 2001
+From 86890af444c1655c3bb9e38fb26c44fa796821e1 Mon Sep 17 00:00:00 2001
 From: Molly Miller <mm@flyingcircus.io>
 Date: Wed, 26 Jun 2024 17:08:15 +0200
 Subject: [PATCH 1/3] Don't throw error when log directory already exists
@@ -9,18 +9,18 @@ Co-authored-by: Christian Theune <ct@flyingcircus.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/tools/frr-reload.py b/tools/frr-reload.py
-index ea0ce6fc9c..37bdff4b59 100755
+index fcd64bae3e..451f27a8a1 100755
 --- a/tools/frr-reload.py
 +++ b/tools/frr-reload.py
-@@ -1998,7 +1998,7 @@ if __name__ == "__main__":
- 
-     elif args.reload:
-         if not os.path.isdir("/var/log/frr/"):
--            os.makedirs("/var/log/frr/", mode=0o0755)
-+            os.makedirs("/var/log/frr/", mode=0o0755, exist_ok=True)
- 
-         logging.basicConfig(
-             filename="/var/log/frr/frr-reload.log",
+@@ -2164,7 +2164,7 @@ if __name__ == "__main__":
+         )
+     if args.reload:
+         if not os.path.isdir(os.path.dirname(args.logfile)):
+-            os.makedirs(os.path.dirname(args.logfile), mode=0o0755)
++            os.makedirs(os.path.dirname(args.logfile), mode=0o0755, exist_ok=True)
+         handler = logging.FileHandler(args.logfile)
+     if args.stdout:
+         handler = logging.StreamHandler(sys.stdout)
 -- 
 2.50.1 (Apple Git-155)
 

--- a/pkgs/frr/0002-zebra-dplane-sleep-after-writing-batches-to-netlink.patch
+++ b/pkgs/frr/0002-zebra-dplane-sleep-after-writing-batches-to-netlink.patch
@@ -1,4 +1,4 @@
-From 4e5a945339b4157cfd236758c30600cc4990241d Mon Sep 17 00:00:00 2001
+From f5a9f37c6ebeaff916b708401e7c190a7ecb33e7 Mon Sep 17 00:00:00 2001
 From: Molly Miller <mm@flyingcircus.io>
 Date: Tue, 29 Apr 2025 16:12:01 +0200
 Subject: [PATCH 2/3] zebra-dplane: sleep after writing batches to netlink
@@ -20,7 +20,7 @@ and resize the hashtables in the background.
  1 file changed, 8 insertions(+)
 
 diff --git a/zebra/kernel_netlink.c b/zebra/kernel_netlink.c
-index 561f16609f..f938193eb4 100644
+index 4c239f0a4f..2ad9138249 100644
 --- a/zebra/kernel_netlink.c
 +++ b/zebra/kernel_netlink.c
 @@ -5,6 +5,7 @@
@@ -31,7 +31,7 @@ index 561f16609f..f938193eb4 100644
  
  #ifdef HAVE_NETLINK
  #include <linux/netlink.h>
-@@ -1482,6 +1483,7 @@ static void nl_batch_init(struct nl_batch *bth,
+@@ -1467,6 +1468,7 @@ static void nl_batch_init(struct nl_batch *bth,
  static void nl_batch_send(struct nl_batch *bth)
  {
  	struct zebra_dplane_ctx *ctx;
@@ -39,7 +39,7 @@ index 561f16609f..f938193eb4 100644
  	bool err = false;
  
  	if (bth->curlen != 0 && bth->zns != NULL) {
-@@ -1516,6 +1518,12 @@ static void nl_batch_send(struct nl_batch *bth)
+@@ -1501,6 +1503,12 @@ static void nl_batch_send(struct nl_batch *bth)
  	}
  
  	nl_batch_reset(bth);

--- a/pkgs/frr/0003-netlink-don-t-manage-kernel-neighbour-table-entries-.patch
+++ b/pkgs/frr/0003-netlink-don-t-manage-kernel-neighbour-table-entries-.patch
@@ -1,4 +1,4 @@
-From 35a2e872869405af5443558ab73ecdb0f9411566 Mon Sep 17 00:00:00 2001
+From 82e37721b57cf96efe812a6aa831316f75632e38 Mon Sep 17 00:00:00 2001
 From: Molly Miller <mm@flyingcircus.io>
 Date: Tue, 1 Jul 2025 16:11:41 +0200
 Subject: [PATCH 3/3] netlink: don't manage kernel neighbour table entries for
@@ -22,7 +22,7 @@ with ARP and NDP.
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/zebra/zebra_evpn_neigh.c b/zebra/zebra_evpn_neigh.c
-index 81705d4e85..28df725f87 100644
+index a2fcd77fe0..439f94c690 100644
 --- a/zebra/zebra_evpn_neigh.c
 +++ b/zebra/zebra_evpn_neigh.c
 @@ -159,7 +159,7 @@ int zebra_evpn_rem_neigh_install(struct zebra_evpn *zevpn,

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -211,12 +211,12 @@ builtins.mapAttrs (_: patchPhps phpLogPermissionPatch) {
   });
 
   frr = super.frr.overrideAttrs (old: rec {
-    version = "10.1.4";
+    version = "10.4.1";
     src = super.fetchFromGitHub {
       owner = "FRRouting";
       repo = old.pname;
       rev = "${old.pname}-${version}";
-      hash = "sha256-rH/MuOrCKrWepZH8w/FQBuwx0OkKL9+o6JkhWtzffvo=";
+      hash = "sha256-pEnMOy1/gIs8a/XCGixF3ZkSwUZ1PPuaSFBminY86DA=";
     };
 
     patches = [


### PR DESCRIPTION
We've been having issues with unreliable handling of VRFs in FRR, and the advice from upstream has been to upgrade to a more recent version, as there have been VRF-related refactorings and bugfixes which haven't necessarily been backported to older versions. This change bumps the version pin and refreshes the patches.

PL-135068

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh` => none, internal change.

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Staying up to date with versions of critical software which are actively maintained.
- [x] Security requirements tested? (EVIDENCE)
  - The Hydra tests pass, we're relying on dev and staging to provide a real-world workload test.