### PR TITLE
Update FRR to 10.4.2

### DIFF
--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -211,12 +211,12 @@ builtins.mapAttrs (_: patchPhps phpLogPermissionPatch) {
   });
 
   frr = super.frr.overrideAttrs (old: rec {
-    version = "10.4.1";
+    version = "10.4.2";
     src = super.fetchFromGitHub {
       owner = "FRRouting";
       repo = old.pname;
       rev = "${old.pname}-${version}";
-      hash = "sha256-pEnMOy1/gIs8a/XCGixF3ZkSwUZ1PPuaSFBminY86DA=";
+      hash = "sha256-cWb3bCmHYUrDw2Xa5eVBaAlTLbm8o0FiFD5dA+G4kso=";
     };
 
     patches = [


### PR DESCRIPTION
FRR upstream released 10.4.2 the day after we merged #2099 with 10.4.1. This change bumps the version to the newer point release, see the previous PR for further details.

PL-135068

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh` => none, internal change

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - See previous PR.
- [x] Security requirements tested? (EVIDENCE)
  - Hydra tests pass, dev and staging will provide further QA.