### PR TITLE
Revert rejection of outgoing martian packets in router firewall

### DIFF
--- a/nixos/roles/router/default.nix
+++ b/nixos/roles/router/default.nix
@@ -41,10 +41,6 @@ let
     fclib.filterConfiguredNetworks static.routerUplinkNetworks."${location}"
   );
 
-  downlinkInterfaces = map (network: fclib.network."${network}".interface) (
-    fclib.filterConfiguredNetworks (static.routerDownlinkNetworks."${location}" or [ ])
-  );
-
   gatewayInterfaces =
     map (network: fclib.network."${network}")
       static.floatingGatewayNetworks."${location}";
@@ -56,7 +52,7 @@ let
       network:
       lib.concatMapStringsSep "\n" (
         iface: "${fclib.iptables network} -A nixos-fw -i ${iface} -s ${network} -j DROP"
-      ) (uplinkInterfaces ++ downlinkInterfaces)
+      ) uplinkInterfaces
     ) martianNetworks
   );
 
@@ -66,7 +62,7 @@ let
         network:
         lib.concatMapStringsSep "\n" (
           iface: "${fclib.iptables network} -A fc-router-forward -i ${iface} -s ${network} -j DROP"
-        ) (uplinkInterfaces ++ downlinkInterfaces)
+        ) uplinkInterfaces
       )
       # Also drop link-local addresses here.
       (martianNetworks ++ [ "fe80::/10" ])
@@ -77,7 +73,7 @@ let
       network:
       lib.concatMapStringsSep "\n" (
         iface: "${fclib.iptables network} -A fc-router-forward -o ${iface} -d ${network} -j REJECT"
-      ) (uplinkInterfaces ++ downlinkInterfaces)
+      ) uplinkInterfaces
     ) (martianNetworks ++ [ "fe80::/10" ])
   );
 

--- a/nixos/roles/router/default.nix
+++ b/nixos/roles/router/default.nix
@@ -51,30 +51,21 @@ let
     lib.concatMapStringsSep "\n" (
       network:
       lib.concatMapStringsSep "\n" (
-        iface: "${fclib.iptables network} -A nixos-fw -i ${iface} -s ${network} -j DROP"
+        iface: "${fclib.iptables network} -A nixos-fw -i ${iface} " + "-s ${network} -j DROP"
       ) uplinkInterfaces
     ) martianNetworks
   );
 
-  martianIptablesForwardIngress = (
+  martianIptablesForward = (
     lib.concatMapStringsSep "\n"
       (
         network:
         lib.concatMapStringsSep "\n" (
-          iface: "${fclib.iptables network} -A fc-router-forward -i ${iface} -s ${network} -j DROP"
+          iface: "${fclib.iptables network} -A fc-router-forward -i ${iface} " + "-s ${network} -j DROP"
         ) uplinkInterfaces
       )
       # Also drop link-local addresses here.
       (martianNetworks ++ [ "fe80::/10" ])
-  );
-
-  martianIptablesForwardEgress = (
-    lib.concatMapStringsSep "\n" (
-      network:
-      lib.concatMapStringsSep "\n" (
-        iface: "${fclib.iptables network} -A fc-router-forward -o ${iface} -d ${network} -j REJECT"
-      ) uplinkInterfaces
-    ) (martianNetworks ++ [ "fe80::/10" ])
   );
 
   locationSensuServer = lib.findFirst (
@@ -213,8 +204,7 @@ in
           ip46tables -N fc-router-forward || true
           ip46tables -A FORWARD -j fc-router-forward
         ''
-        martianIptablesForwardIngress
-        martianIptablesForwardEgress
+        martianIptablesForward
         ''
           # Suppress multicast forwarding
           iptables -A fc-router-forward -s 224.0.0.0/4 -j DROP


### PR DESCRIPTION
The changes in #2097 have broken IPv4 forwarding in DEV due to interactions with the WHQ firewall. Let's back these out and think about them again.

PL-134258

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh` => none, internal change

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - none
- [x] Security requirements tested? (EVIDENCE)
  - reverting to previous state.