### PR TITLE
[PL-135092] fix mailstub config hostname

### DIFF
--- a/changelog.d/20260116_103527_PL-135092_mailstub-config-hostname_scriv.md
+++ b/changelog.d/20260116_103527_PL-135092_mailstub-config-hostname_scriv.md
@@ -1,0 +1,20 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+- restart of the postfix service due to configuration changes if the mailstub role is active
+
+### NixOS XX.XX platform
+
+- fix an issue with the Postfix configuration when using the mailstub service that would lead to an unintended hostname in SMTP HELO and EHLO commands

--- a/nixos/services/mail/stub.nix
+++ b/nixos/services/mail/stub.nix
@@ -66,7 +66,7 @@ in
           fclib.configFromFile "/etc/local/postfix/master.cf" ""
         );
         settings.main = {
-          hostname = role.mailHost;
+          myhostname = role.mailHost;
           recipient_canonical_maps = lib.mkDefault "pcre:${recipientCanonical}";
           # Trust all networks on the SRV interface.
           mynetworks = lib.mkDefault (


### PR DESCRIPTION
@flyingcircusio/release-managers

PL-135092

This PR fixes a flaw in the postfix configuration when the mailstub service is enabled.
The correct option name is `myhostname` instead of `hostname`. The latter has no effect while the former affects the default value of other options such as `smtp_helo_name` which defaults to `$myhostname`.

https://www.postfix.org/postconf.5.html#myhostname
https://www.postfix.org/postconf.5.html#smtp_helo_name

Since the value of the 'smtp_helo_name' parameter determines how Postfix advertises itself when sending emails, an incorrect value can lead to issues with deliverability, since the receiving end might decide to reject the affected emails and eventually block the sender outright. Hence, I have labelled this as high risk and urgent.

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [x] Security requirements tested? (EVIDENCE)

This change has no impact on incoming mails or other security-relevant settings of the postfix service and only affects outgoing mails.