### PR TITLE
nixfmt-rfc-style -> nixfmt

### DIFF
--- a/doc/src/base.md
+++ b/doc/src/base.md
@@ -59,7 +59,7 @@ You can look up packages and their descriptions via:
 - netcat
 - ngrep
 - nix-top
-- nixfmt-rfc-style
+- nixfmt
 - nmap
 - nvd
 - openssl

--- a/flake.nix
+++ b/flake.nix
@@ -159,7 +159,7 @@
                 with pkgs;
                 [
                   jq
-                  nixfmt-rfc-style
+                  nixfmt
                 ]
                 ++ (
                   with self'.packages;

--- a/nixos/platform/packages.nix
+++ b/nixos/platform/packages.nix
@@ -51,7 +51,7 @@
         netcat
         ngrep
         nix-top
-        nixfmt-rfc-style
+        nixfmt
         nmap
         nvd
         openssl


### PR DESCRIPTION
resolves
> nixfmt-rfc-style is now the same as pkgs.nixfmt which should be used
instead.

@flyingcircusio/release-managers

## Release process

- [ ] Created changelog entry using `./changelog.sh`
  - no, internal and pre-release

## PR release workflow (internal)

- [ ] PR has internal ticket
- [ ] internal issue ID (PL-…) part of branch name
- [ ] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [x] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - resolves an eval warning
- [x] Security requirements tested? (EVIDENCE)
  - packages are equivalent
