### PR TITLE
Do not override haproxy global options in k3s frontend role

### DIFF
--- a/changelog.d/20260120_102533_fc-25.11-dev_scriv.md
+++ b/changelog.d/20260120_102533_fc-25.11-dev_scriv.md
@@ -1,0 +1,23 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+
+
+### NixOS XX.XX platform
+
+- k3s: ensure that the frontend role does not set conflicting global
+  mode options in the haproxy configuration. This should avoid issues
+  when enabling the k3s roles in resource groups with existing haproxy
+  configuration. (PL-135086)

--- a/doc/src/kubernetes.md
+++ b/doc/src/kubernetes.md
@@ -3,8 +3,9 @@
 # Kubernetes Cluster (k3s)
 
 :::{note}
-Kubernetes/k3s is complex. Feel free to use it but we suggest contacting
-our support before putting anything into production.
+Kubernetes/k3s is complex and our Kubernetes support should currently be
+considered beta-quality. Feel free to use it but we suggest contacting our support
+before putting anything into production.
 :::
 
 [Kubernetes](https://kubernetes.io) is an open-source system for automating

--- a/nixos/services/k3s/frontend.nix
+++ b/nixos/services/k3s/frontend.nix
@@ -270,13 +270,6 @@ in
     flyingcircus.services.haproxy = {
       enable = true;
       enableStructuredConfig = true;
-      defaults = {
-        mode = "tcp";
-        options = [
-          "tcplog"
-          "dontlognull"
-        ];
-      };
       listen = {
         "_stats" = {
           mode = "http";


### PR DESCRIPTION
When the k3s-frontend role is enabled, it overrides the default haproxy global options which are set in our haproxy NixOS module, in particular the connection mode (the default "http" is overridden with "tcp"). This can break existing haproxy configurations which rely on the connection mode in frontend and backend configuration being implicitly inherited from the global defaults – especially as the k3s-frontend role is silently turned on when other hosts in the same resource group have other k3s roles added.

This change removes the override in the k3s-frontend role to avoid this footgun. The haproxy stanzas which are configured by k3s-frontend all have explicit connection mode settings, so there is no dependency on implicit configuration inheritance in this role.

PL-135086

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Principle of least astonishment for downstream users.
  - This can break existing haproxy configurations which rely on inspecting http request properties such as headers.
- [x] Security requirements tested? (EVIDENCE)
  - Frontend node in the test cluster has explicit connection modes for all configuration originating from the k3s-frontend role, applying this patch changes only the global settings to align with the default settings from the webgateway role.