### PR TITLE
Add support for dual-stack k3s clusters

### DIFF
--- a/changelog.d/20260121_170410_PL-133774-k3s-ipv6-support_scriv.md
+++ b/changelog.d/20260121_170410_PL-133774-k3s-ipv6-support_scriv.md
@@ -1,0 +1,32 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+<!-- Impact means "when this change is rolled out, there
+     might be interruptions/downtimes/required actions/... that
+     IMPACT THE RUNNING APPLICATION NEGATIVELY.
+
+     Having new features or changed is not an "impact". That's what
+     the main changelog (see below) is for.
+     -->
+
+
+### NixOS XX.XX platform
+
+- k3s: introduce a new NixOS option
+  `flyingcircus.kubernetes.network.enableIPv6` for creating Kubernetes
+  clusters with IPv6 and dual-stack networking enabled. Note that this
+  option should only be set when creating new clusters, and should not
+  be set for existing clusters. For further information, please see
+  the role documentation. (PL-133774)

--- a/doc/src/kubernetes.md
+++ b/doc/src/kubernetes.md
@@ -423,6 +423,30 @@ on your requirements there are a few more options available:
 }
 ```
 
+### IPv6 support
+
+By default, Kubernetes clusters in our environment are configured with
+single-stack IPv4-only networking. This means that pods are only assigned a single
+IPv4 address, and cannot access external IPv6-only hosts.
+
+However, we provide the option to enable dual-stack networking when the cluster is
+first created, so that pods can be assigned both IPv4 and IPv6
+addresses. Dual-stack networking can be enabled by setting the
+`flyingcircus.kubernetes.network.enableIPv6` NixOS option to `true` in the host
+configuration on each node in the cluster, **before** any k3s roles are added to
+the node.
+
+:::{warning}
+It is not possible to change the value of the
+`flyingcircus.kubernetes.network.enableIPv6` option after the cluster is
+created. Changing this value after cluster creation (after the k3s daemon has been
+started for the first time) has the potential to irrecoverably break the cluster,
+and is explicitly not supported.
+
+Migrating an existing cluster with single-stack networking to dual-stack
+networking requires the cluster to be destroyed and recreated.
+:::
+
 ## Storage
 
 Our Kubernetes environment supports two persistent volume types by default:

--- a/nixos/roles/k3s/default.nix
+++ b/nixos/roles/k3s/default.nix
@@ -9,6 +9,9 @@
   pkgs,
   ...
 }:
+let
+  inherit (config.flyingcircus.kubernetes.network) enableIPv6;
+in
 {
   imports = with lib; [
     ./nfs.nix
@@ -18,15 +21,30 @@
   ];
 
   options = with lib; {
-
     flyingcircus.kubernetes = {
 
       network = {
+        enableIPv6 = mkOption {
+          type = types.bool;
+          default = lib.versionAtLeast config.system.stateVersion "26.05";
+          description = ''
+            Enable IPv6 support for k3s clusters. When enabled, clusters will use
+            dual-stack networking with both IPv4 and IPv6. This option is automatically
+            enabled for clusters with state version >= 26.05, but can be overridden.
+          '';
+        };
 
         clusterDns = mkOption {
           type = types.listOf types.str;
-          default = [ "10.43.0.10" ];
-          description = "Cluster IP that should be used for CoreDNS.";
+          default =
+            if enableIPv6 then
+              [
+                "fd00:43::a"
+                "10.43.0.10"
+              ]
+            else
+              [ "10.43.0.10" ];
+          description = "Cluster IPs that should be used for CoreDNS.";
         };
 
         # These network specifications are supposed to hold at most one network
@@ -36,19 +54,40 @@
         # kubernetes.network.ipv6 = { serviceCidr…; podCidr…;};
         serviceCidr = mkOption {
           type = types.listOf types.str;
-          default = [ "10.43.0.0/16" ];
-          description = "Cluster IPs are assigned to services from the subnet specified here.";
+          default =
+            if enableIPv6 then
+              [
+                "fd00:43::/112"
+                "10.43.0.0/16"
+              ]
+            else
+              [ "10.43.0.0/16" ];
+          description = "IPs are assigned to services from the subnet specified here.";
         };
 
         podCidr = mkOption {
           type = types.listOf types.str;
-          default = [ "10.42.0.0/16" ];
+          default =
+            if enableIPv6 then
+              [
+                "fd00:42::/56"
+                "10.42.0.0/16"
+              ]
+            else
+              [ "10.42.0.0/16" ];
           description = "Kubernetes nodes get a /24 subnet for their pods from the given subnet.";
         };
+
         nodeIps = mkOption {
           type = with types; listOf str;
-          internal = true; # should be managed by a global IPv6 switch instead PL-133774
-          default = [ (head config.fclib.network.srv.v4.addresses) ];
+          internal = true;
+          default =
+            let
+              v6Addrs = config.fclib.network.srv.v6.addresses or [ ];
+              v4Addrs = config.fclib.network.srv.v4.addresses or [ ];
+            in
+            lib.optional (enableIPv6 && v6Addrs != [ ]) (head v6Addrs)
+            ++ lib.optional (v4Addrs != [ ]) (head v4Addrs);
         };
       };
     };

--- a/nixos/roles/k3s/server.nix
+++ b/nixos/roles/k3s/server.nix
@@ -549,7 +549,8 @@ in
               "--kube-apiserver-arg enable-admission-plugins=PodNodeSelector"
               # required for anonymous access to apiserver health port
               "--kube-apiserver-arg anonymous-auth=true"
-            ];
+            ]
+            ++ (lib.optional netCfg.enableIPv6 "--flannel-ipv6-masq");
           in
           {
             enable = true;

--- a/nixos/roles/k3s/single-node.nix
+++ b/nixos/roles/k3s/single-node.nix
@@ -132,7 +132,8 @@ in
           "--data-dir=/var/lib/k3s"
           "--kube-apiserver-arg enable-admission-plugins=PodNodeSelector"
           "--disable traefik"
-        ];
+        ]
+        ++ (lib.optional netCfg.enableIPv6 "--flannel-ipv6-masq");
       in
       {
         enable = true;

--- a/nixos/services/k3s/frontend.nix
+++ b/nixos/services/k3s/frontend.nix
@@ -285,7 +285,7 @@ in
       extraConfig = ''
         resolvers cluster
         ${lib.strings.concatImapStringsSep "\n" (
-          i: host: "  nameserver coredns${toString i} ${host}:53"
+          i: host: "  nameserver coredns${toString i} ${fclib.quoteIPv6Address host}:53"
         ) netCfg.clusterDns}
           accepted_payload_size 8192 # allow larger DNS payloads
       '';

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -58,6 +58,7 @@ in
   journal = callTest ./journal.nix { };
   journalbeat = callTest ./journalbeat.nix { };
   k3s = callTest ./k3s { };
+  k3s_ipv6 = callTest ./k3s { enableIPv6 = true; };
   k3s_monitoring = callTest ./k3s/monitoring.nix { };
   kernelconfig = callTest ./kernelconfig.nix { };
   kernelversions = callTest ./kernelversions.nix { };

--- a/tests/k3s/default.nix
+++ b/tests/k3s/default.nix
@@ -5,52 +5,52 @@ import ../make-test-python.nix (
     testlib,
     ...
   }:
-  with builtins;
-
   let
 
-    net4Srv = "10.0.1";
-    frontendSrv = net4Srv + ".1";
-    masterSrv = net4Srv + ".2";
-    nodeSrvA = net4Srv + ".3";
-    nodeSrvB = net4Srv + ".4";
-
-    net4Fe = "10.0.2";
-    frontendFe = net4Fe + ".1";
-    masterFe = net4Fe + ".2";
+    masterSrv4 = testlib.fcIP.srv4 2;
+    masterSrv6 = testlib.fcIP.srv6 2;
+    nodeSrvA4 = testlib.fcIP.srv4 3;
+    nodeSrvA6 = testlib.fcIP.srv6 3;
+    nodeSrvB4 = testlib.fcIP.srv4 4;
+    nodeSrvB6 = testlib.fcIP.srv6 4;
+    frontendSrv4 = testlib.fcIP.fe4 1;
+    frontendSrv6 = testlib.fcIP.fe6 1;
 
     encServices = [
       {
         address = "k3sserver.fcio.net";
-        ips = [ masterSrv ];
+        ips = [
+          masterSrv4
+          masterSrv6
+        ];
         service = "k3s-server-server";
         password = "xvlc";
       }
       {
         address = "k3snodeA.fcio.net";
-        ips = [ nodeSrvA ];
+        ips = [
+          nodeSrvA4
+          nodeSrvA6
+        ];
         service = "k3s-node";
       }
       {
         address = "k3snodeB.fcio.net";
-        ips = [ nodeSrvB ];
+        ips = [
+          nodeSrvB4
+          nodeSrvB6
+        ];
         service = "k3s-node";
       }
       {
         address = "frontend.fcio.net";
-        ips = [ frontendFe ];
+        ips = [
+          frontendSrv4
+          frontendSrv6
+        ];
         service = "k3s-frontend";
       }
     ];
-
-    hosts = ''
-      ${masterSrv} k3sserver.fcio.net
-      ${nodeSrvA} k3snodeA.fcio.net
-      ${nodeSrvB} k3snodeB.fcio.net
-      ${frontendFe} frontend.fcio.net
-      ${masterFe} k3sserver.fe.test.fcio.net
-      ${masterFe} k3s.test.fcio.net
-    '';
 
     redis = import ./redis.nix { inherit pkgs; };
 
@@ -58,45 +58,19 @@ import ../make-test-python.nix (
   {
 
     name = "k3s";
+
     nodes = {
 
       master =
         { lib, ... }:
         {
-          imports = [
-            ../../nixos
-            ../../nixos/roles
-          ];
+          imports = [ (testlib.fcConfig { id = 2; }) ];
 
           config = {
-
-            flyingcircus.enc.parameters = {
-              location = "test";
-              resource_group = "test";
-              interfaces.srv = {
-                bridged = false;
-                mac = "52:54:00:12:01:02";
-                networks = {
-                  "${net4Srv}.0/24" = [ masterSrv ];
-                };
-                gateways = {
-                  "${net4Srv}.0/24" = "${net4Srv}.254";
-                };
-              };
-              interfaces.fe = {
-                bridged = false;
-                mac = "52:54:00:12:02:02";
-                networks = {
-                  "${net4Fe}.0/24" = [ masterFe ];
-                };
-                gateways = { };
-              };
-            };
             flyingcircus.encServices = encServices;
             flyingcircus.roles.k3s-server.enable = true;
             networking.domain = "fcio.net";
             networking.hostName = lib.mkForce "k3sserver";
-            networking.extraHosts = hosts;
 
             networking.firewall.allowedTCPPorts = [
               8888
@@ -136,16 +110,6 @@ import ../make-test-python.nix (
 
             virtualisation.memorySize = 2000;
             virtualisation.diskSize = lib.mkForce 3000;
-            # do not automatically assign addresses based on vlan and
-            # guest id.
-            virtualisation.interfaces = {
-              ethfe = {
-                vlan = 2;
-              };
-              ethsrv = {
-                vlan = 1;
-              };
-            };
             virtualisation.qemu.options = [ "-smp 2" ];
           };
         };
@@ -153,112 +117,47 @@ import ../make-test-python.nix (
       nodeA =
         { ... }:
         {
-          imports = [
-            ../../nixos
-            ../../nixos/roles
-          ];
+          imports = [ (testlib.fcConfig { id = 3; }) ];
 
           config = {
-            flyingcircus.enc.parameters = {
-              resource_group = "test";
-              interfaces.srv = {
-                bridged = false;
-                mac = "52:54:00:12:01:03";
-                networks = {
-                  "${net4Srv}.0/24" = [ nodeSrvA ];
-                };
-                gateways = {
-                  "${net4Srv}.0/24" = "${net4Srv}.254";
-                };
-              };
-            };
             flyingcircus.encServices = encServices;
             flyingcircus.roles.k3s-agent.enable = true;
 
             networking.domain = "fcio.net";
-            networking.extraHosts = hosts;
             networking.hostName = lib.mkForce "k3snodeA";
             networking.nameservers = [ "127.0.0.1" ];
             virtualisation.memorySize = 2000;
             virtualisation.diskSize = 3000;
-            virtualisation.interfaces.ethsrv.vlan = 1;
           };
         };
 
       nodeB =
         { ... }:
         {
-          imports = [
-            ../../nixos
-            ../../nixos/roles
-          ];
+          imports = [ (testlib.fcConfig { id = 4; }) ];
 
           config = {
-            flyingcircus.enc.parameters = {
-              resource_group = "test";
-              interfaces.srv = {
-                bridged = false;
-                mac = "52:54:00:12:01:04";
-                networks = {
-                  "${net4Srv}.0/24" = [ nodeSrvB ];
-                };
-                gateways = {
-                  "${net4Srv}.0/24" = "${net4Srv}.254";
-                };
-              };
-            };
             flyingcircus.encServices = encServices;
             flyingcircus.roles.k3s-agent.enable = true;
 
             networking.domain = "fcio.net";
-            networking.extraHosts = hosts;
             networking.hostName = lib.mkForce "k3snodeB";
             virtualisation.memorySize = 2000;
             virtualisation.diskSize = 3000;
-            virtualisation.interfaces.ethsrv.vlan = 1;
           };
         };
 
       frontend =
         { ... }:
         {
-          imports = [
-            ../../nixos
-            ../../nixos/roles
-          ];
+          imports = [ (testlib.fcConfig { id = 1; }) ];
 
-          flyingcircus.roles.webgateway.enable = true;
-          flyingcircus.enc.parameters = {
-            resource_group = "test";
-            interfaces.srv = {
-              bridged = false;
-              mac = "52:54:00:12:01:01";
-              networks = {
-                "${net4Srv}.0/24" = [ frontendSrv ];
-              };
-              gateways = { };
-            };
-            interfaces.fe = {
-              bridged = false;
-              mac = "52:54:00:12:02:01";
-              networks = {
-                "${net4Fe}.0/24" = [ frontendFe ];
-              };
-              gateways = { };
-            };
-          };
-          networking.domain = "fcio.net";
-          networking.extraHosts = hosts;
-          flyingcircus.encServices = encServices;
-          virtualisation.diskSize = 3000;
-          virtualisation.memorySize = 2000;
-          virtualisation.interfaces = {
-            ethfe = {
-              vlan = 2;
-            };
-            ethsrv = {
-              vlan = 1;
-            };
+          config = {
+            flyingcircus.roles.webgateway.enable = true;
+            networking.domain = "fcio.net";
+            flyingcircus.encServices = encServices;
+            virtualisation.diskSize = 3000;
+            virtualisation.memorySize = 2000;
           };
         };
 
@@ -274,7 +173,8 @@ import ../make-test-python.nix (
 
         with subtest("k3s server should work"):
           k3sserver.wait_for_unit("k3s.service")
-          k3sserver.wait_until_succeeds('k3s kubectl cluster-info | grep -q https://127.0.0.1:6443')
+          k3sserver.wait_until_succeeds('k3s kubectl get --raw=/healthz | grep -q ok')
+          k3sserver.succeed('k3s kubectl get node k3sserver -o jsonpath=\'{.status.conditions[?(@.type=="Ready")].status}\' | grep -q True')
 
         k3snodeA.start()
 
@@ -323,8 +223,8 @@ import ../make-test-python.nix (
           k3sserver.succeed("KUBECONFIG=/home/test/kubeconfig k3s kubectl cluster-info")
 
         with subtest("master should be able to reach cluster DNS"):
+          time.sleep(1)
           k3sserver.wait_until_succeeds('k3s kubectl -n kube-system get pods | grep coredns | grep -v ContainerCreating | grep Running')
-          k3sserver.wait_until_succeeds('dig redis.default.svc.cluster.local @10.43.0.10 | grep NOERROR')
 
         k3snodeB.start()
         time.sleep(5)

--- a/tests/k3s/default.nix
+++ b/tests/k3s/default.nix
@@ -132,7 +132,7 @@ import ../make-test-python.nix (
         };
 
       nodeA =
-        { ... }:
+        { config, ... }:
         {
           imports = [
             (testlib.fcConfig {
@@ -151,11 +151,21 @@ import ../make-test-python.nix (
             networking.nameservers = [ "127.0.0.1" ];
             virtualisation.memorySize = 2000;
             virtualisation.diskSize = 3000;
+
+            # we can't use services.k3s.images here because we run k3s
+            # with a different data directory than the default.
+            systemd.tmpfiles.rules =
+              let
+                images = config.services.k3s.package.airgap-images;
+              in
+              [
+                "L+ /var/lib/k3s/agent/images/airgap-images.tar.zst - - - - ${images}"
+              ];
           };
         };
 
       nodeB =
-        { ... }:
+        { config, ... }:
         {
           imports = [
             (testlib.fcConfig {
@@ -173,6 +183,14 @@ import ../make-test-python.nix (
             networking.hostName = lib.mkForce "k3snodeB";
             virtualisation.memorySize = 2000;
             virtualisation.diskSize = 3000;
+
+            systemd.tmpfiles.rules =
+              let
+                images = config.services.k3s.package.airgap-images;
+              in
+              [
+                "L+ /var/lib/k3s/agent/images/airgap-images.tar.zst - - - - ${images}"
+              ];
           };
         };
 
@@ -219,10 +237,6 @@ import ../make-test-python.nix (
           # Give k3s more time to settle without getting into IO stress when loading images.
           time.sleep(10)
 
-          # XXX: for some reason *implicit* image import via
-          # `services.k3s.images = [ config.services.k3s.package.airgap-images ];` does not work.
-          # Doing a manual import instead.
-          k3snodeA.wait_until_succeeds("echo 'try import' >2; k3s ctr images import ${nodes.nodeA.services.k3s.package.airgap-images} >2")
           k3sserver.wait_until_succeeds("k3s kubectl get nodes | grep k3snodea | grep -vq NotReady")
 
         with subtest("all kube-system images pulled successfully"):
@@ -265,8 +279,6 @@ import ../make-test-python.nix (
         time.sleep(5)
 
         with subtest("adding a second node should work"):
-
-          k3snodeB.wait_until_succeeds("k3s ctr images import ${nodes.nodeA.services.k3s.package.airgap-images} >2")
           k3sserver.wait_until_succeeds("k3s kubectl get nodes | grep k3snodeb | grep -vq NotReady")
 
         with subtest("scaling the deployment should start 4 pods"):

--- a/tests/k3s/default.nix
+++ b/tests/k3s/default.nix
@@ -3,6 +3,7 @@ import ../make-test-python.nix (
     lib,
     pkgs,
     testlib,
+    enableIPv6 ? false,
     ...
   }:
   let
@@ -69,6 +70,7 @@ import ../make-test-python.nix (
           config = {
             flyingcircus.encServices = encServices;
             flyingcircus.roles.k3s-server.enable = true;
+            flyingcircus.kubernetes.network.enableIPv6 = enableIPv6;
             networking.domain = "fcio.net";
             networking.hostName = lib.mkForce "k3sserver";
 
@@ -122,6 +124,7 @@ import ../make-test-python.nix (
           config = {
             flyingcircus.encServices = encServices;
             flyingcircus.roles.k3s-agent.enable = true;
+            flyingcircus.kubernetes.network.enableIPv6 = enableIPv6;
 
             networking.domain = "fcio.net";
             networking.hostName = lib.mkForce "k3snodeA";
@@ -139,6 +142,7 @@ import ../make-test-python.nix (
           config = {
             flyingcircus.encServices = encServices;
             flyingcircus.roles.k3s-agent.enable = true;
+            flyingcircus.kubernetes.network.enableIPv6 = enableIPv6;
 
             networking.domain = "fcio.net";
             networking.hostName = lib.mkForce "k3snodeB";
@@ -154,6 +158,7 @@ import ../make-test-python.nix (
 
           config = {
             flyingcircus.roles.webgateway.enable = true;
+            flyingcircus.kubernetes.network.enableIPv6 = enableIPv6;
             networking.domain = "fcio.net";
             flyingcircus.encServices = encServices;
             virtualisation.diskSize = 3000;

--- a/tests/k3s/default.nix
+++ b/tests/k3s/default.nix
@@ -195,7 +195,7 @@ import ../make-test-python.nix (
         };
 
       frontend =
-        { ... }:
+        { pkgs, ... }:
         {
           imports = [
             (testlib.fcConfig {
@@ -206,11 +206,17 @@ import ../make-test-python.nix (
 
           config = {
             flyingcircus.roles.webgateway.enable = true;
-            flyingcircus.kubernetes.network.enableIPv6 = enableIPv6;
             networking.domain = "fcio.net";
             flyingcircus.encServices = encServices;
             virtualisation.diskSize = 3000;
             virtualisation.memorySize = 2000;
+            environment.systemPackages = [ pkgs.redis ];
+            flyingcircus.kubernetes.network.enableIPv6 = enableIPv6;
+            flyingcircus.kubernetes.frontend.redis = {
+              binds = [ "127.0.0.1:6379" ];
+              servicePort = 6379;
+              mode = "tcp";
+            };
           };
         };
 
@@ -260,8 +266,7 @@ import ../make-test-python.nix (
           frontend.wait_until_succeeds('curl -k http://k3sserver.fcio.net')
 
         with subtest("creating a deployment should work"):
-          k3sserver.wait_until_succeeds("zcat ${redis.image} | k3s ctr images import -")
-          k3snodeA.wait_until_succeeds("zcat ${redis.image} | k3s ctr images import -")
+          k3snodeA.succeed("k3s ctr images import ${redis.image}")
           k3sserver.succeed("k3s kubectl apply -f ${redis.deployment}")
           k3sserver.succeed("k3s kubectl apply -f ${redis.service}")
 
@@ -282,7 +287,7 @@ import ../make-test-python.nix (
           k3sserver.wait_until_succeeds("k3s kubectl get nodes | grep k3snodeb | grep -vq NotReady")
 
         with subtest("scaling the deployment should start 4 pods"):
-          k3snodeB.wait_until_succeeds("zcat ${redis.image} | k3s ctr images import -")
+          k3snodeB.succeed("k3s ctr images import ${redis.image}")
           k3sserver.succeed("k3s kubectl scale deployment redis --replicas=4")
           k3sserver.wait_until_succeeds("k3s kubectl get deployment redis | grep -q 4/4")
 
@@ -290,12 +295,8 @@ import ../make-test-python.nix (
           k3sserver.wait_until_succeeds("k3s kubectl get pods -o wide | grep redis | grep Running | grep -q k3snodea")
           k3sserver.wait_until_succeeds("k3s kubectl get pods -o wide | grep redis | grep Running | grep -q k3snodeb")
 
-        # with subtest("frontend should be able to ping redis pods"):
-        #   print(frontend.execute("iptables -L -v --line-numbers")[1])
-        #   print(k3sserver.execute("k3s kubectl -n kube-system get svc -l k8s-app=kube-dns")[1])
-        #   print(k3sserver.succeed("dig @10.43.0.10 +short \*.redis.default.svc.cluster.local | xargs ${pkgs.fc.multiping}/bin/multiping"))
-        #   print(k3snodeB.succeed("dig @10.43.0.10 +short \*.redis.default.svc.cluster.local | xargs ${pkgs.fc.multiping}/bin/multiping"))
-        #   # print(frontend.succeed("dig @10.43.0.10 +short \*.redis.default.svc.cluster.local | xargs ${pkgs.fc.multiping}/bin/multiping"))
+        with subtest("frontend should be able to ping redis pods"):
+          frontend.wait_until_succeeds("redis-cli ping | grep PONG")
 
         with subtest("dashboard sensu check should be red after shutting down dashboard"):
           k3sserver.systemctl("stop kube-dashboard")

--- a/tests/k3s/default.nix
+++ b/tests/k3s/default.nix
@@ -53,6 +53,16 @@ import ../make-test-python.nix (
       }
     ];
 
+    # synthetic default routes are required so that connections to the
+    # k3s-managed virtual service ips get routed, otherwise the
+    # firewall rules won't trigger.
+    extraEncParameters = {
+      interfaces.srv.gateways = {
+        "${testlib.fcIP.srv4 0}/24" = testlib.fcIP.srv4 254;
+        "${testlib.fcIPMap.srv6.prefix}/64" = testlib.fcIP.srv6 254;
+      };
+    };
+
     redis = import ./redis.nix { inherit pkgs; };
 
   in
@@ -65,7 +75,12 @@ import ../make-test-python.nix (
       master =
         { lib, ... }:
         {
-          imports = [ (testlib.fcConfig { id = 2; }) ];
+          imports = [
+            (testlib.fcConfig {
+              id = 2;
+              inherit extraEncParameters;
+            })
+          ];
 
           config = {
             flyingcircus.encServices = encServices;
@@ -119,7 +134,12 @@ import ../make-test-python.nix (
       nodeA =
         { ... }:
         {
-          imports = [ (testlib.fcConfig { id = 3; }) ];
+          imports = [
+            (testlib.fcConfig {
+              id = 3;
+              inherit extraEncParameters;
+            })
+          ];
 
           config = {
             flyingcircus.encServices = encServices;
@@ -137,7 +157,12 @@ import ../make-test-python.nix (
       nodeB =
         { ... }:
         {
-          imports = [ (testlib.fcConfig { id = 4; }) ];
+          imports = [
+            (testlib.fcConfig {
+              id = 4;
+              inherit extraEncParameters;
+            })
+          ];
 
           config = {
             flyingcircus.encServices = encServices;
@@ -154,7 +179,12 @@ import ../make-test-python.nix (
       frontend =
         { ... }:
         {
-          imports = [ (testlib.fcConfig { id = 1; }) ];
+          imports = [
+            (testlib.fcConfig {
+              id = 1;
+              inherit extraEncParameters;
+            })
+          ];
 
           config = {
             flyingcircus.roles.webgateway.enable = true;

--- a/tests/k3s/monitoring.nix
+++ b/tests/k3s/monitoring.nix
@@ -73,7 +73,8 @@ import ../make-test-python.nix (
       ''
 
         k3sserver.wait_for_unit("k3s.service")
-        k3sserver.wait_until_succeeds('k3s kubectl cluster-info | grep -q https://127.0.0.1:6443')
+        k3sserver.wait_until_succeeds('k3s kubectl get --raw=/healthz | grep -q ok')
+        k3sserver.succeed('k3s kubectl get node k3sserver -o jsonpath=\'{.status.conditions[?(@.type=="Ready")].status}\' | grep -q True')
 
         # telegraf.service fails to start when the token file doesn't exist. Explicitly restart after k3s created it
         k3sserver.wait_for_file("/var/lib/k3s/tokens/telegraf")

--- a/tests/k3s/redis.nix
+++ b/tests/k3s/redis.nix
@@ -74,6 +74,11 @@ rec {
               image = "redis";
               imagePullPolicy = "Never";
               ports = [ { containerPort = 6379; } ];
+              command = [ "/bin/redis-server" ];
+              args = [
+                "--protected-mode"
+                "no"
+              ];
             }
           ];
         };


### PR DESCRIPTION
This change introduces support for k3s Kubernetes clusters with dual-stack networking. In particular, this adds a NixOS option which, when enabled, configures k3s to set up the cluster with dual stack networking. This flag is disabled by default in 25.11, but will become enabled by default starting in 26.05. This flag can only be set before the cluster is first created, and changing its value afterwards is unsupported and will break the cluster. Migration requires wiping and rebuilding the cluster.

The flag ensures that each node in the cluster advertises both IPv4 and IPv6 node IPs, and configures the control plane with dual-stack cluster DNS and both IPv4 and IPv6 subnets for pods and services.

In addition, the tests have been refactored to remove hard-coded address family specific logic. Container image side-loading has been refined to use a mechanism similar to the upstream `services.k3s.images` NixOS option, and there is a new subtest to check the webgateway integration in haproxy functions correctly.

PL-133774

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [x] ensure the merge bot has determined a merge date
- [x] ensure all checks are green
- [x] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
  - Master `flyingcircus.kubernetes.networking.enableIPv6` flag. Off by default for now to avoid impact on existing clusters, will on by default in the next major release.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
  - Flag usage documented in role docs.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Dual-stack networking is desirable for interoperability, however we should not break existing clusters.
  - We introduce some new attack surface, but it's limited to the v6 masqueraded traffic which we consider irrelevant (it's needed for things to function and we don't see additional new risk here). The IPv6 network is a similar "iptables overlay" so that the network isn't easily reachable from neighbouring RGs. 
- [x] Security requirements tested? (EVIDENCE)
  - Manually verified that provisioning of both single and dual-stack clusters works correctly in a test environment.
  - Manually verified that changing the `enableIPv6` flag after cluster creation will irrecoverably break the cluster(!).
  - Hydra tests refactored to be independent of address family, with parameterisation to check both the single-stack and dual-stack cases.