### PR TITLE
fc-ceph maintenance leave: stagger osd recovery

### DIFF
--- a/changelog.d/20260120_192752_PL-133952-staggered-noup-unset_scriv.md
+++ b/changelog.d/20260120_192752_PL-133952-staggered-noup-unset_scriv.md
@@ -1,0 +1,28 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+<!-- Impact means "when this change is rolled out, there
+     might be interruptions/downtimes/required actions/... that
+     IMPACT THE RUNNING APPLICATION NEGATIVELY.
+
+     Having new features or changed is not an "impact". That's what
+     the main changelog (see below) is for.
+     -->
+
+
+
+### NixOS XX.XX platform
+
+- ceph: stagger unset of "noup" flag at maintenance leave to reduce peering storm impact (PL-133952)

--- a/pkgs/fc/ceph/src/fc/ceph/maintenance/nautilus.py
+++ b/pkgs/fc/ceph/src/fc/ceph/maintenance/nautilus.py
@@ -1,6 +1,7 @@
 """Configure pools on Ceph storage servers according to the directory."""
 
 import json
+import re
 import socket
 import subprocess
 import sys
@@ -13,7 +14,7 @@ from fc.ceph.api.cluster import CephCmdError
 from fc.ceph.maintenance.images_nautilus import (
     load_vm_images as load_vm_images_task,
 )
-from fc.ceph.util import kill, mount_status, run
+from fc.ceph.util import run
 
 
 class ResourcegroupPoolEquivalence(object):
@@ -132,6 +133,23 @@ def get_host_crush_buckets() -> tuple[set[str], set[str]]:
     return host_map_entries, osds
 
 
+def filter_noup_osds(osd_ids: set[str]) -> set[str]:
+    """Filters the input set of OSD IDs to return only the OSDs that currently
+    have a NOUP flag."""
+    matched_noup_osds = set()
+    ceph_health = run.json.ceph("health", "detail")
+
+    match_fmt = re.compile(r"^osd.(?P<osdid>\d+) has flags noup$")
+    try:
+        for detail in ceph_health["checks"]["OSD_FLAGS"]["detail"]:
+            if match_result := match_fmt.match(detail["message"]):
+                matched_noup_osds.add(match_result.group("osdid"))
+    except KeyError:
+        # no such health warning issued
+        pass
+    return matched_noup_osds & osd_ids
+
+
 class MaintenanceTasks(object):
     """Controller that holds a number of maintenance-related methods."""
 
@@ -246,9 +264,8 @@ class MaintenanceTasks(object):
         # not automatically return.
         try:
             host_buckets, osd_ids = get_host_crush_buckets()
-            if host_buckets:
-                run.ceph("osd", "set-group", "noup", *sorted(host_buckets))
             if osd_ids:
+                run.ceph("osd", "set-group", "noup", *sorted(osd_ids))
                 run.ceph("osd", "down", *sorted(osd_ids))
         except Exception:
             self.leave()
@@ -257,7 +274,14 @@ class MaintenanceTasks(object):
     def leave(self):
         host_buckets, osd_ids = get_host_crush_buckets()
         if host_buckets:
+            # PL-133952: still needed for getting hosts upgrading from the
+            # previous mechanism out of maintenance. Remove later.
             run.ceph("osd", "unset-group", "noup", *sorted(host_buckets))
+
+        for osd_id in sorted(filter_noup_osds(osd_ids)):
+            # remove noup flags in a staggered fashion, to reduce peering storm
+            run.ceph("osd", "unset-group", "noup", str(osd_id))
+            time.sleep(15)
 
         last_exc = None
         for _ in range(self.UNLOCK_MAX_RETRIES):

--- a/pkgs/fc/ceph/src/fc/ceph/tests/fc-ceph/test_maintenance.py
+++ b/pkgs/fc/ceph/src/fc/ceph/tests/fc-ceph/test_maintenance.py
@@ -1,9 +1,36 @@
 import subprocess
 import time
+import json
 from unittest import mock
+from subprocess import CalledProcessError
 
-import fc.ceph.maintenance
 import pytest
+
+# taken from a live nautilus cluster: `ceph --format=json-pretty health detail`
+CEPH_HEALTH_NOUP_DATA = json.loads("""
+{
+    "checks": {
+        "OSD_FLAGS": {
+            "severity": "HEALTH_WARN",
+            "summary": {
+                "message": "3 OSDs or CRUSH {nodes, device-classes} have {NOUP,NODOWN,NOIN,NOOUT} flags set"
+            },
+            "detail": [
+                {
+                    "message": "osd.13 has flags noup"
+                },
+                {
+                    "message": "osd.14 has flags noup"
+                },
+                {
+                    "message": "osd.27 has flags noup"
+                }
+            ]
+        }
+    },
+    "status": "HEALTH_WARN"
+}
+""")
 
 
 @pytest.fixture
@@ -41,7 +68,7 @@ def ceph_calls(monkeypatch):
 
 
 def test_successful_maintenance_cycle(
-    ceph_json_calls, ceph_calls, locktoolcalls, maintenance_manager
+    ceph_json_calls, ceph_calls, locktoolcalls, maintenance_manager, nosleep
 ):
     maintenance_task = maintenance_manager.MaintenanceTasks()
 
@@ -81,6 +108,8 @@ def test_successful_maintenance_cycle(
                 },
             ]
         },
+        # health detail
+        CEPH_HEALTH_NOUP_DATA,
     ]
 
     # (un)set-group and down commands
@@ -88,19 +117,20 @@ def test_successful_maintenance_cycle(
     maintenance_task.enter()
     maintenance_task.leave()
 
-    assert ceph_json_calls.call_count == 3
-    assert ceph_calls.call_count == 3
+    assert ceph_json_calls.call_count == 4
+    assert ceph_calls.call_count == 6
     assert locktoolcalls.call_count == 4
 
     ceph_calls.assert_has_calls(
         [
-            mock.call(
-                "osd", "set-group", "noup", "localhost", "localhost-ssd"
-            ),
+            mock.call("osd", "set-group", "noup", "13", "14", "27"),
             mock.call("osd", "down", "13", "14", "27"),
             mock.call(
                 "osd", "unset-group", "noup", "localhost", "localhost-ssd"
             ),
+            mock.call("osd", "unset-group", "noup", "13"),
+            mock.call("osd", "unset-group", "noup", "14"),
+            mock.call("osd", "unset-group", "noup", "27"),
         ]
     )
 
@@ -126,6 +156,8 @@ def test_maintenance_enter_lock_timeout_causes_leave(
     ceph_json_calls.side_effect = [
         # osd tree
         {"nodes": []},
+        # health detail
+        {},
     ]
 
     with pytest.raises(SystemExit, match="75"):
@@ -185,6 +217,8 @@ def test_lockimage_created_on_leave(
     ceph_json_calls.side_effect = [
         # osd tree
         {"nodes": []},
+        # health detail
+        {},
     ]
 
     maintenance_task.leave()
@@ -243,12 +277,14 @@ def test_postpone_and_leave_when_unclean(
         {"status": "HEALTH_ERR"},
         # osd tree
         {"nodes": []},
+        # health detail
+        {},
     ]
 
     with pytest.raises(SystemExit, match="69"):
         maintenance_task.enter()
 
-    assert ceph_json_calls.call_count == 2
+    assert ceph_json_calls.call_count == 3
     locktoolcalls.assert_has_calls(
         [
             mock.call("-q", "-i", "rbd/.maintenance", timeout=30),
@@ -279,6 +315,8 @@ def test_leave_unlock_timeout_retries(
     ceph_json_calls.side_effect = [
         # osd tree
         {"nodes": []},
+        # health detail
+        {},
     ]
 
     maintenance_task.leave()
@@ -292,6 +330,28 @@ def test_leave_unlock_timeout_retries(
     )
 
     assert locktoolcalls.call_count == 10
+
+
+def test_leave_filter_noup_exception_stay_locked(
+    locktoolcalls, ceph_calls, ceph_json_calls, nosleep, maintenance_manager
+):
+    """If an exception during `filter_noup_osds` appears, the maintenance image
+    stays locked and the exception bubbles up."""
+    maintenance_task = maintenance_manager.MaintenanceTasks()
+
+    locktoolcalls.side_effect = []
+
+    ceph_json_calls.side_effect = [
+        # osd tree
+        {"nodes": []},
+        # health detail
+        CalledProcessError("foo", cmd="ceph --format=json health detail"),
+    ]
+
+    with pytest.raises(CalledProcessError):
+        maintenance_task.leave()
+
+    assert locktoolcalls.call_count == 0
 
 
 def test_leave_unlock_timeout_retries_exceeded(
@@ -309,6 +369,8 @@ def test_leave_unlock_timeout_retries_exceeded(
     ceph_json_calls.side_effect = [
         # osd tree
         {"nodes": []},
+        # health detail
+        {},
     ]
 
     with pytest.raises(subprocess.TimeoutExpired):
@@ -344,6 +406,8 @@ def test_lockimage_check_timeout(
     ceph_json_calls.side_effect = [
         # osd tree
         {"nodes": []},
+        # health detail
+        {},
     ]
 
     with pytest.raises(SystemExit, match="75"):
@@ -406,3 +470,43 @@ def test_check_cluster_maintenance(maintenance_manager):
             },
         }
     )
+
+
+def test_filter_noup_osds_has_matching_noup(
+    ceph_json_calls, maintenance_manager_legacy
+):
+    ceph_json_calls.side_effect = [CEPH_HEALTH_NOUP_DATA, CEPH_HEALTH_NOUP_DATA]
+    expected = set(("13", "14", "27"))
+    assert maintenance_manager_legacy.filter_noup_osds(expected) == expected
+    assert (
+        maintenance_manager_legacy.filter_noup_osds(expected | set("5"))
+        == expected
+    )
+
+
+def test_filter_noup_osds_has_mismatching_noup(
+    ceph_json_calls, maintenance_manager_legacy
+):
+    ceph_json_calls.side_effect = [CEPH_HEALTH_NOUP_DATA]
+    assert (
+        maintenance_manager_legacy.filter_noup_osds(set(("21", "22", "23")))
+        == set()
+    )
+
+
+def test_filter_noup_osds_empty(ceph_json_calls, maintenance_manager_legacy):
+    ceph_json_calls.side_effect = [{}]
+    assert (
+        maintenance_manager_legacy.filter_noup_osds(set(("13", "14", "27")))
+        == set()
+    )
+
+
+def test_filter_noup_osds_runtime_exception(
+    ceph_json_calls, maintenance_manager_legacy
+):
+    ceph_json_calls.side_effect = [
+        CalledProcessError("foo", cmd="ceph --format=json health detail")
+    ]
+    with pytest.raises(CalledProcessError):
+        maintenance_manager_legacy.filter_noup_osds(set(("6", "8", "13")))


### PR DESCRIPTION
Stagger the removal of the `noup` flag on individual OSDs when leaving maintenance. This reduces the peering storm stress on the cluster. We hope that this can resolve the stuck, inactive PGs encountered in PL-133952.

To allow migration from the previous mechanism, we keep unsetting the noup flags on the host-level crush nodes. This will become a no-op after all hosts have migrated to this new code, then that part can be removed.

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - attempt at enabling ceph host automatic maintenance again
  - as the staggered unset causes a longer runtime of the maintenance leave hook, only consider own OSDs if work is required
  - consider migration from old maintenance hook 
- [x] Security requirements tested? (EVIDENCE)
  - keep blanket instructions for leaving the previous maintenance mechanism
  - tested on host in dev cluster:
    - maintenance migration from previous mechanism
    - maintenance cacle in the new mechanism
    - standalone command as well as fc-agent hook integration
  - extended and updated test coverage