### PR TITLE
fc.qemu: pull in sgdisk output test fix

### DIFF
--- a/pkgs/fc/default.nix
+++ b/pkgs/fc/default.nix
@@ -57,8 +57,8 @@ rec {
       repo = "fc.qemu";
       # The release tooling didn't upgrade properly so we had to pick a specific
       # commit instead.
-      rev = "341227f920b14defa1dc21e81af7b466f59798c0";
-      hash = "sha256-hyIUZMNOvtknaHQDj9OFZzaJmvz35ODYLMK4eZJTcjE=";
+      rev = "e41af01c80eea0d78e65de45744eda280db312dd";
+      hash = "sha256-hhd0NC59UAtiC0gsTrNihnv+oT+nkCafk62tXJSnhU4=";
     };
     fc-ceph = ceph;
     qemu_ceph = pkgs.qemu-ceph-nautilus;


### PR DESCRIPTION
PL-135104

@flyingcircusio/release-managers

## Release process

- [ ] Created changelog entry using `./changelog.sh`
  - no, internal test fix to unblock builds

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - fix QA cycle by unblocking flaky test failures
- [x] Security requirements tested? (EVIDENCE)
  - tested with flakefinder