### PR TITLE
Allow service users to interact with k3s clusters

### DIFF
--- a/changelog.d/20260121_161749_PL-134284-k3s-service-user-access_scriv.md
+++ b/changelog.d/20260121_161749_PL-134284-k3s-service-user-access_scriv.md
@@ -1,0 +1,20 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+
+### NixOS XX.XX platform
+
+- k3s: allow service users to access the default Kubernetes config
+  file and interact with the cluster. (PL-134284)

--- a/nixos/roles/k3s/server.nix
+++ b/nixos/roles/k3s/server.nix
@@ -566,6 +566,8 @@ in
           script = ''
             echo "Grant sudo-srv access to k3s config file..."
             setfacl -m g:sudo-srv:r ${defaultKubeconfig}
+            echo "Grant service access to k3s config file..."
+            setfacl -m g:service:r ${defaultKubeconfig}
             echo "Grant kubernetes user access to k3s config file..."
             setfacl -m u:kubernetes:r ${defaultKubeconfig}
           '';

--- a/nixos/roles/k3s/single-node.nix
+++ b/nixos/roles/k3s/single-node.nix
@@ -148,6 +148,8 @@ in
       script = ''
         echo "Grant sudo-srv access to k3s config file..."
         setfacl -m g:sudo-srv:r ${defaultKubeconfig}
+        echo "Grant service access to k3s config file..."
+        setfacl -m g:service:r ${defaultKubeconfig}
         echo "Grant kubernetes user access to k3s config file..."
         setfacl -m u:kubernetes:r ${defaultKubeconfig}
       '';


### PR DESCRIPTION
This change expands the ACLs set on the cluster admin Kubernetes config file to additionally allow service users to read the file and hence interact with the cluster.

PL-134284

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Service users should be able to interact with the Kubernetes control plane so that e.g. applications can be deployed into the cluster.
- [x] Security requirements tested? (EVIDENCE)
  - Manually verified on the dev cluster.