### PR TITLE
Fix k3s monitoring test flakiness and add some missing permissions

### DIFF
--- a/nixos/roles/k3s/server.nix
+++ b/nixos/roles/k3s/server.nix
@@ -170,6 +170,11 @@ let
                 "list"
               ];
             }
+            {
+              apiGroups = [ "" ];
+              resources = [ "secrets" ];
+              verbs = [ "list" ];
+            }
           ];
         })
         (clusterRole {
@@ -203,6 +208,11 @@ let
             {
               apiGroups = [ "apps" ];
               resources = [ "daemonsets" ];
+              verbs = [ "get" ];
+            }
+            {
+              apiGroups = [ "" ];
+              resources = [ "pods" ];
               verbs = [ "get" ];
             }
           ];

--- a/nixos/roles/k3s/server.nix
+++ b/nixos/roles/k3s/server.nix
@@ -245,9 +245,6 @@ let
     secretname="$2"
 
     tokendir=/var/lib/k3s/tokens
-    kubectl="${pkgs.kubectl}/bin/kubectl"
-    remarshal="${pkgs.remarshal}/bin/remarshal"
-    jq="${pkgs.jq}/bin/jq"
     export KUBECONFIG=${defaultKubeconfig}
 
     if [ -z "$secretname" ]; then
@@ -272,8 +269,8 @@ let
     # attempting to load this authentication token.
 
     rc=0
-    for i in 1 2 3 4 5; do
-      "$kubectl" get -n kube-system -o jsonpath='{.data.token}' \
+    for i in 1 2 3 4 5 6 7 8 9 10; do
+      kubectl get -n kube-system -o jsonpath='{.data.token}' \
         secret "$secretname" > "$tokendir/$user.b64" && \
         test -s "$tokendir/$user.b64"
       rc="$?"
@@ -295,8 +292,8 @@ let
       exit 1
     fi
 
-    "$remarshal" "$KUBECONFIG" -if yaml -of json | \
-      "$jq" --rawfile token "$tokendir/$user.tmp" \
+    remarshal "$KUBECONFIG" -if yaml -of json | \
+      jq --rawfile token "$tokendir/$user.tmp" \
       '.users[0].user |= (del(."client-key-data", ."client-certificate-data") | .token = $token)' \
       > "$tokendir/$user.cfg.tmp"
     if [ "$?" != 0 ]; then
@@ -314,13 +311,16 @@ let
     wantedBy = [ "multi-user.target" ];
     requires = [
       "k3s.service"
-      "fc-k3s-load-manifests.service"
     ];
     after = [
       "k3s.service"
-      "fc-k3s-load-manifests.service"
     ];
-    path = [ pkgs.coreutils ];
+    path = with pkgs; [
+      coreutils
+      kubectl
+      remarshal
+      jq
+    ];
     serviceConfig = {
       RemainAfterExit = true;
       Type = "oneshot";
@@ -578,37 +578,13 @@ in
           };
         };
 
-        systemd.services.fc-k3s-load-manifests = {
-          wantedBy = [ "multi-user.target" ];
-          requires = [ "k3s.service" ];
-          after = [ "k3s.service" ];
-          serviceConfig = {
-            RemainAfterExit = true;
-            Type = "oneshot";
-          };
-          path = [ pkgs.rsync ];
-          restartTriggers = [ additionalManifests ];
-          script = ''
-            # copy additional vendor manifests into k3s's manifest
-            # directory.
-            set -x
-
-            # this service may race with k3s creating its data
-            # directory in the filesystem post-startup, so we give k3s
-            # some grace time to complete this startup step.
-
-            for i in 1 2 3 4 5; do
-                if [ ! -d /var/lib/k3s/server/manifests ]; then
-                    sleep 0.5s
-                else
-                    rsync --delete -rL ${additionalManifests}/ /var/lib/k3s/server/manifests/flyingcircus
-                    exit $?
-                fi
-            done
-
-            exit 1
-          '';
-        };
+        # upstream provides the option services.k3s.manifests which
+        # also uses tmpfiles rules for managing external manifests,
+        # however we can't use this option as we use a different data
+        # directory from the default.
+        systemd.tmpfiles.rules = [
+          "L+ /var/lib/k3s/server/manifests/flyingcircus/flyingcircus.yaml - - - - ${additionalManifests}/flyingcircus.yaml"
+        ];
 
         systemd.services.fc-k3s-token-telegraf = makeAuthTokenService "telegraf" "io.flyingcircus.service-token.telegraf";
         systemd.services.fc-k3s-token-sensuclient = makeAuthTokenService "sensuclient" "io.flyingcircus.service-token.sensu-client";


### PR DESCRIPTION
Our k3s monitoring integration test is known to be flaky, and is a frequent source of spurious failures due to race conditions in loading our external vendor manifests into the k3s server in the test.

This change reworks how we handle the vendor manifests, and removes the systemd service which runs rsync in favour of symlinks managed by systemd-tmpfiles. This is similar to the upstream `services.k3s.manifests` NixOS option, which we're unable to use as we use a different data directory for k3s than upstream. The timeouts in the scripts which read the access tokens for the telegraf and sensu-client ServiceAccounts have also been raised to reduce the chance they race with a slow-starting k3s server.

Additionally, this change adds some missing permissions which have become necessary in the time since the monitoring integration was originally implemented. Telegraf now wants to be able to list the Secret resources in the cluster (without needing access to the contents), and our maintenance integration which ensures that nodes are properly drains needs to be able to inspect running pods as well.

PL-133298

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh` => none, internal change

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [x] ensure the merge bot has determined a merge date
- [x] ensure all checks are green
- [x] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - The integration tests should help, not hinder.
  - Existing components now need additional cluster permissions due to changes in functionality. Telegraf in particular now wants to be able to enumerate the Secrets in the cluster, but it does not require the `get` permission, which would allow reading the contents of secrets.
- [x] Security requirements tested? (EVIDENCE)
  - Hydra test should now be more reliable.
  - Upgrade path from vendor manifests copied with rsync to symlinks managed by tmpfiles manually verified in dev. Copied file gets overwritten by the symlink, and the k3s server automatically picks up and applies the changes in the manifest.
  - Manually verified telegraf no longer prints error messages about not being able to access secrets in the cluster.
  - Manually verified that maintenance integration works correctly without throwing exceptions due to missing cluster permissions.