### PR TITLE
k3s: document agent maintenance handling

### DIFF
--- a/changelog.d/20260127_144014_PL-135128-k3s-maintenance-drain-docs_scriv.md
+++ b/changelog.d/20260127_144014_PL-135128-k3s-maintenance-drain-docs_scriv.md
@@ -1,0 +1,29 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+<!-- Impact means "when this change is rolled out, there
+     might be interruptions/downtimes/required actions/... that
+     IMPACT THE RUNNING APPLICATION NEGATIVELY.
+
+     Having new features or changed is not an "impact". That's what
+     the main changelog (see below) is for.
+     -->
+
+
+### NixOS XX.XX platform
+
+- k3s: document maintenance integration. Agent nodes will be
+  gracefully drained of workloads before entering
+  maintenance. (PL-135128)

--- a/doc/src/kubernetes.md
+++ b/doc/src/kubernetes.md
@@ -74,6 +74,10 @@ the following roles:
   Nodes never receive public IP addresses. All traffic from outside the
   resource group must pass through the webgateway.
 
+  Nodes are automatically drained before running maintenance and uncordoned
+  afterwards. Only one node in the cluster will perform maintenance at a time, to
+  avoid excess load on the rest of the cluster due to pods being rescheduled.
+
 - **Persistent volume storage (NFS subdir, optional)**
 
   Minimal resource requirements: 1 CPU, 8 GiB RAM, 50 GiB SSD
@@ -479,5 +483,3 @@ data.
 - By default our setup uses a cluster network that allows 253 nodes and 253
   ports per node. This can be adjusted but may require larger interventions
   with downtime if done in a production system.
-- We currently do not drain/uncordon nodes when performing service or VM
-  restarts in scheduled maintenance windows.


### PR DESCRIPTION
This change updates and corrects the documentation with details of the maintenance integration on k3s-agent hosts.

PL-135128

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - None
- [x] Security requirements tested? (EVIDENCE)
  - None