### PR TITLE
[PL-135106] adjust the thunderbird autoconfig after changes to imap and smtp ports

### DIFF
--- a/changelog.d/20260127_155727_PL-135106_fix-thunderbird-autoconfig_scriv.md
+++ b/changelog.d/20260127_155727_PL-135106_fix-thunderbird-autoconfig_scriv.md
@@ -1,0 +1,6 @@
+### Impact
+
+
+### NixOS XX.XX platform
+
+- Adjust the Thunderbird auto-configuration XML after the default ports for IMAP and SMTP were adjusted in accordance with RFC8314 4.1

--- a/nixos/services/mail/autoconfig.nix
+++ b/nixos/services/mail/autoconfig.nix
@@ -19,15 +19,15 @@ pkgs.writeTextFile {
         <displayShortName>${head (lib.splitString "." domain)}</displayShortName>
         <incomingServer type="imap">
           <hostname>${mailHost}</hostname>
-          <port>143</port>
-          <socketType>STARTTLS</socketType>
+          <port>993</port>
+          <socketType>SSL</socketType>
           <authentication>password-cleartext</authentication>
           <username>%EMAILADDRESS%</username>
         </incomingServer>
         <outgoingServer type="smtp">
           <hostname>${mailHost}</hostname>
-          <port>587</port>
-          <socketType>STARTTLS</socketType>
+          <port>465</port>
+          <socketType>SSL</socketType>
           <authentication>password-cleartext</authentication>
           <username>%EMAILADDRESS%</username>
         </outgoingServer>


### PR DESCRIPTION
@flyingcircusio/release-managers

PL-135106

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [ ] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [ ] Security requirements tested? (EVIDENCE)
