### PR TITLE
nixpkgs: bump revision to include grub updates

### DIFF
--- a/changelog.d/20260130_145035_FC-51697-grub-xfs-patches_scriv.md
+++ b/changelog.d/20260130_145035_FC-51697-grub-xfs-patches_scriv.md
@@ -1,0 +1,28 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+<!-- Impact means "when this change is rolled out, there
+     might be interruptions/downtimes/required actions/... that
+     IMPACT THE RUNNING APPLICATION NEGATIVELY.
+
+     Having new features or changed is not an "impact". That's what
+     the main changelog (see below) is for.
+     -->
+
+
+
+### NixOS XX.XX platform
+
+- grub: apply patches to make boots from XFS more resilient

--- a/flake.lock
+++ b/flake.lock
@@ -168,11 +168,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1769487368,
-        "narHash": "sha256-4q0vJ+AOzFvDRvEzvNyvmxmxV2TRdYkZDUSPN/YIUvQ=",
+        "lastModified": 1769766978,
+        "narHash": "sha256-N61Id1Pgt6Q+nTQEYclaqfUac3jU1Y/kwAVDUocuqQs=",
         "owner": "flyingcircusio",
         "repo": "nixpkgs",
-        "rev": "f1b310cc8f3cb1da9511fd299c29018ab57c08b8",
+        "rev": "6a65fc462ed6e81df13c0db634e91fc9f152c524",
         "type": "github"
       },
       "original": {

--- a/release/versions.json
+++ b/release/versions.json
@@ -8,10 +8,10 @@
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/"
   },
   "nixpkgs": {
-    "hash": "sha256-4q0vJ+AOzFvDRvEzvNyvmxmxV2TRdYkZDUSPN/YIUvQ=",
+    "hash": "sha256-N61Id1Pgt6Q+nTQEYclaqfUac3jU1Y/kwAVDUocuqQs=",
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "f1b310cc8f3cb1da9511fd299c29018ab57c08b8"
+    "rev": "6a65fc462ed6e81df13c0db634e91fc9f152c524"
   },
   "poetry2nix": {
     "hash": "sha256-nzgO/ZCSBzWjbMkYDxG+yl9Z2eGbCgQu06Oku3ir5D4=",


### PR DESCRIPTION
pulls in https://github.com/flyingcircusio/nixpkgs/pull/1119

PL-135139

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - improve resilience of grub reading boot files from an XFS partition
- [x] Security requirements tested? (EVIDENCE)
  - in PL-135139, we were able to recover a stuck machine with these patches (25.11 branch)
  - smoke test: a testVM with an updated grub still boots
