### PR TITLE
Routers: keeplived ignore mgm link down & update masquerade rules

### DIFF
--- a/nixos/roles/router/default.nix
+++ b/nixos/roles/router/default.nix
@@ -277,9 +277,10 @@ in
     networking.nat.extraCommands = ''
       #############
       # Masquerading rules for the uplink interfaces
-      ${lib.concatMapStringsSep "\n" (
-        iface: "iptables -t nat -A nixos-nat-post -o ${iface} -s 172.16.0.0/12 -j MASQUERADE"
-      ) uplinkInterfaces}
+      ${lib.concatMapStringsSep "\n" (iface: ''
+        iptables -t nat -A nixos-nat-post -o ${iface} -s 172.16.0.0/12 -j MASQUERADE
+        iptables -t nat -A nixos-nat-post -o ${iface} -s 10.0.0.0/8 -j MASQUERADE
+      '') uplinkInterfaces}
     '';
 
     networking.firewall.extraStopCommands = ''

--- a/nixos/roles/router/keepalived/dev.conf
+++ b/nixos/roles/router/keepalived/dev.conf
@@ -62,6 +62,7 @@ vrrp_instance mgm {
     priority 100
     advert_int 1
     garp_master_refresh 30
+    dont_track_primary
 
     virtual_ipaddress {
         2a06:3a80:300:1::1/64 preferred_lft 0

--- a/nixos/roles/router/keepalived/dev2.conf
+++ b/nixos/roles/router/keepalived/dev2.conf
@@ -62,6 +62,7 @@ vrrp_instance mgm {
     priority 100
     advert_int 1
     garp_master_refresh 30
+    dont_track_primary
 
     virtual_ipaddress {
         172.21.85.1/27

--- a/nixos/roles/router/keepalived/rzob.conf
+++ b/nixos/roles/router/keepalived/rzob.conf
@@ -62,6 +62,7 @@ vrrp_instance mgm {
     priority 100
     advert_int 1
     garp_master_refresh 30
+    dont_track_primary
 
     virtual_ipaddress {
         2a06:3a80:200:1::1/64

--- a/nixos/roles/router/keepalived/test.conf
+++ b/nixos/roles/router/keepalived/test.conf
@@ -55,6 +55,7 @@ vrrp_instance mgm {
     priority 100
     advert_int 1
     garp_master_refresh 30
+    dont_track_primary
 
     virtual_ipaddress {
         fdfc:c12:c05:1::1/64 preferred_lft 0

--- a/nixos/roles/router/keepalived/whq.conf
+++ b/nixos/roles/router/keepalived/whq.conf
@@ -62,6 +62,7 @@ vrrp_instance mgm {
     priority 100
     advert_int 1
     garp_master_refresh 30
+    dont_track_primary
 
     virtual_ipaddress {
         2a06:3a80:0:1::1/64

--- a/tests/router/default.nix
+++ b/tests/router/default.nix
@@ -617,11 +617,18 @@ import ../make-test-python.nix (
             router1.r.wait_until_is_primary()
             router2.r.wait_until_is_secondary()
 
-          with subtest("router1: pull mgm, should switch to router2"):
+          with subtest("router1: pull mgm, should NOT switch to router2"):
             router1.send_monitor_command("set_link virtio-net-pci.1 off")
-            router1.r.wait_until_is_secondary()
-            router2.r.wait_until_is_primary()
+            router1.sleep(3)
+            router2.r.wait_until_is_secondary()
+            router1.r.wait_until_is_primary()
             router1.send_monitor_command("set_link virtio-net-pci.1 on")
+
+          with subtest("router1: write stopper file, should switch to router2"):
+            router1.succeed("sed -i 'c 1' /etc/keepalived/stop")
+            router2.r.wait_until_is_primary()
+            router1.r.wait_until_is_secondary()
+            router1.succeed("sed -i 'c 0' /etc/keepalived/stop")
 
           with subtest("router2: pull fe, should switch to router1"):
             router2.send_monitor_command("set_link virtio-net-pci.2 off")
@@ -634,12 +641,6 @@ import ../make-test-python.nix (
             router1.r.wait_until_is_secondary()
             router2.r.wait_until_is_primary()
             router1.send_monitor_command("set_link virtio-net-pci.3 on")
-
-          with subtest("router2: write stopper file, should switch to router1"):
-            router2.succeed("sed -i 'c 1' /etc/keepalived/stop")
-            router1.r.wait_until_is_primary()
-            router2.r.wait_until_is_secondary()
-            router2.succeed("sed -i 'c 0' /etc/keepalived/stop")
 
           print(router1.succeed("journalctl -xb -u keepalived"))
           print(router2.succeed("journalctl -xb -u keepalived"))


### PR DESCRIPTION
This change adjusts the keepalived configs in all locations to ignore link-up/link-down status of ethmgm. We want the floating gateway addresses on this interface to be managed by keepalived, but mgm is not considered a critical network, so we don't want sites to completely fall off the internet because the top of rack switch in the comms rack has a fault. This should improve resilience and make switch maintenance easier.

Additionally, this change also adds 10.0.0.0/8 to the list of networks which we masquerade on egress towards upstreams, in order to correctly handle test networks in the lab and handle possible future sites which might be numbered out of this space.

PL-135054

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh` => none, internal change.

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [x] ensure the merge bot has determined a merge date
- [x] ensure all checks are green
- [x] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - None, this is a resilience improvement.
- [x] Security requirements tested? (EVIDENCE)
  - keepalived config verified manually in dev (manually setting the mgm ports up and down on the switch side).
  - Masquerading configuration verified manually in dev.