### PR TITLE
redis: fix high entropy in metrics labels

### DIFF
--- a/changelog.d/20260217_105346_HEAD_scriv.md
+++ b/changelog.d/20260217_105346_HEAD_scriv.md
@@ -1,0 +1,27 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+<!-- Impact means "when this change is rolled out, there
+     might be interruptions/downtimes/required actions/... that
+     IMPACT THE RUNNING APPLICATION NEGATIVELY.
+
+     Having new features or changed is not an "impact". That's what
+     the main changelog (see below) is for.
+     -->
+
+
+### NixOS XX.XX platform
+
+- redis: fix high entropy in metrics labels (dbN_distrib_*) (PL-135178)

--- a/nixos/services/redis.nix
+++ b/nixos/services/redis.nix
@@ -87,6 +87,7 @@ let
     "io_thread_0"
     "module"
     "redis_version"
+    "db*_distrib_*"
   ];
 
   telegrafInputs =


### PR DESCRIPTION
`dbN_distrib_{string,sets,...}_{items,sizes}` (`N`: int) have high entropy, making the labels useless and spam our prometheus.

PL-135178

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [x] Security requirements tested? (EVIDENCE)
  - Tested on affected staging machine. The labels weren't created on our internal testing machines, so we couldn't really notice this earlier with the current configuration