### PR TITLE
tests.backyserver_volumes: Reduce flakyness

### DIFF
--- a/nixos/platform/full-disk-encryption.nix
+++ b/nixos/platform/full-disk-encryption.nix
@@ -52,7 +52,7 @@ in
         readOnly = true;
         internal = true;
         default = {
-          device = "/dev/vgkeys/keys";
+          device = "/dev/disk/by-label/keys";
           fsType = "xfs";
           options = [
             "nofail"

--- a/pkgs/fc/ceph/src/fc/ceph/backup.py
+++ b/pkgs/fc/ceph/src/fc/ceph/backup.py
@@ -29,8 +29,7 @@ class BackupManager:
 # XXX: Once the external crypt header logic is obsolete, we might be able to
 # adopt XFSVolume for this directly.
 class BackyVolume(AutomountActivationMixin):
-    # nrext64 is default but requires kernel 6.6+
-    MKFS_OPTS = ["-K", "-i", "nrext64=0"]
+    MKFS_OPTS = ["-K"]
     MOUNT_OPTS = "nodev,nosuid,noatime,nodiratime"
     FSTYPE = "xfs"
 

--- a/pkgs/fc/ceph/src/fc/ceph/backup.py
+++ b/pkgs/fc/ceph/src/fc/ceph/backup.py
@@ -4,8 +4,9 @@ from fc.ceph.lvm import (
     AutomountActivationMixin,
     GenericLogicalVolume,
     MdraidDevice,
+    XFSVolume,
 )
-from fc.ceph.util import console, run
+from fc.ceph.util import console
 
 
 class BackupManager:
@@ -43,8 +44,7 @@ class BackyVolume:
         self.lv = GenericLogicalVolume.create(
             self.name, vgname, raid, encrypt, size="100%vg"
         )
-        run.mkfs_xfs("-f", "-L", self.name, *self.MKFS_OPTS, self.device)
-        run.sync()
+        XFSVolume.mkfs(self.device, self.name, self.MKFS_OPTS)
 
         if os.path.exists(ext_header := f"{self.mountpoint}.luks"):
             console.print(

--- a/pkgs/fc/ceph/src/fc/ceph/backup.py
+++ b/pkgs/fc/ceph/src/fc/ceph/backup.py
@@ -17,22 +17,32 @@ class BackupManager:
         disks: list[str],
         encrypt: bool,
         mountpoint: str,
+        automount: bool,
     ):
         console.print(
             f"Creating new backup volume {vgname}/{name} on disks {', '.join(disks)}…"
         )
-        vol = BackyVolume(name, mountpoint)
+        vol = BackyVolume(name, mountpoint, automount)
         vol.create(disks, vgname, encrypt)
 
 
-class BackyVolume:
+# XXX: Once the external crypt header logic is obsolete, we might be able to
+# adopt XFSVolume for this directly.
+class BackyVolume(AutomountActivationMixin):
     # nrext64 is default but requires kernel 6.6+
     MKFS_OPTS = ["-K", "-i", "nrext64=0"]
     MOUNT_OPTS = "nodev,nosuid,noatime,nodiratime"
+    FSTYPE = "xfs"
 
-    def __init__(self, name: str, mountpoint: str):
+    def __init__(
+        self,
+        name: str,
+        mountpoint: str,
+        automount=True,  # generally, this is created on backy servers that already have the mountpoint configured
+    ):
         self.name = name
         self.mountpoint = mountpoint
+        self.automount = automount
         self.lv = GenericLogicalVolume(self.name)
 
     def create(
@@ -65,6 +75,7 @@ class BackyVolume:
 
     def activate(self):
         self.lv.activate()
+        super().activate()
         # for the mdraid, we rely on the OS for automatically assembling it
 
     @property

--- a/pkgs/fc/ceph/src/fc/ceph/lvm.py
+++ b/pkgs/fc/ceph/src/fc/ceph/lvm.py
@@ -76,6 +76,7 @@ class MdraidDevice(GenericBlockDevice):
             f"--raid-devices={len(main_disks)}",
             *main_disks,
         )
+        run.udevadm("settle")
         # add spare disk
         run.mdadm("--add", obj.blockdevice, spare_disk)
         return obj
@@ -379,6 +380,7 @@ class LogicalVolume(GenericLogicalVolume):
             size, f"-n{self.name}",
             vg_name,
         )  # fmt: skip
+        run.udevadm("settle")
 
     @staticmethod
     def ensure_vg(vg_name: str, base_device: Optional[GenericBlockDevice]):
@@ -394,6 +396,7 @@ class LogicalVolume(GenericLogicalVolume):
         run.pvcreate(blockdevice_underlay)
         run.vgcreate(vg_name, blockdevice_underlay)
         base_device.ensure_partition_type("8e00")
+        run.udevadm("settle")
 
     def purge(self, lv_only=False):
         # Delete LVs
@@ -518,6 +521,7 @@ class EncryptedLogicalVolume(GenericLogicalVolume):
                 self.underlay.device,
                 self.name,
             )  # fmt: skip
+            run.udevadm("settle")
         self._ready = True
 
     def deactivate(self):

--- a/pkgs/fc/ceph/src/fc/ceph/lvm.py
+++ b/pkgs/fc/ceph/src/fc/ceph/lvm.py
@@ -69,7 +69,7 @@ class MdraidDevice(GenericBlockDevice):
         obj = cls(name)
         run.mdadm(
             "--create",
-            f"/dev/md/{obj.name}",
+            obj.name,
             "--level=6",
             "--name=backy",
             "--bitmap=internal",

--- a/pkgs/fc/ceph/src/fc/ceph/lvm.py
+++ b/pkgs/fc/ceph/src/fc/ceph/lvm.py
@@ -584,6 +584,31 @@ class XFSVolume(AutomountActivationMixin, GenericCephVolume):
     MOUNT_OPTS = "nodev,nosuid,noatime,nodiratime,logbsize=256k"
     FSTYPE = "xfs"
 
+    @staticmethod
+    def mkfs(device: str, label: str, opts: list[str], retries: int = 5):
+        """Create XFS filesystem with retry on 'Device or resource busy' errors."""
+        for attempt in range(retries):
+            try:
+                run.mkfs_xfs("-f", "-L", label, *opts, device)
+                run.sync()
+                return
+            except CalledProcessError as e:
+                stderr = (
+                    e.stderr.decode("ascii", errors="replace")
+                    if e.stderr
+                    else ""
+                )
+                if "Device or resource busy" in stderr:
+                    if attempt < retries - 1:
+                        console.print(
+                            f"Device {device} busy, retrying...",
+                            style="yellow",
+                        )
+                        run.udevadm("settle")
+                        time.sleep(1)
+                        continue
+                raise
+
     def __init__(self, name: str, mountpoint: str, automount=False):
         self.name = name
         self.mountpoint = mountpoint
@@ -619,13 +644,7 @@ class XFSVolume(AutomountActivationMixin, GenericCephVolume):
             size=size,
         )
         # Create OSD filesystem
-        run.mkfs_xfs(
-            "-f",
-            "-L", self.name,
-            *self.MKFS_OPTS,
-            self.device,
-        )  # fmt: skip
-        run.sync()
+        self.mkfs(self.device, self.name, self.MKFS_OPTS)
         self.activate()
 
     def activate(self):

--- a/pkgs/fc/ceph/src/fc/ceph/main.py
+++ b/pkgs/fc/ceph/src/fc/ceph/main.py
@@ -664,6 +664,12 @@ def luks(args=sys.argv[1:]):
         help="Initial mountpoint after creation.\n"
         "Note: Subsequent mounts might use another automatic mountpoint.",
     )
+    parser_create.add_argument(
+        "--automount",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Rely on the system automatically mounting the resulting volume.",
+    )
     parser_create.set_defaults(action="create")
 
     # extract parsed arguments from object into a dict

--- a/pkgs/fc/ceph/src/fc/ceph/tests/fc-ceph/test_lvm.py
+++ b/pkgs/fc/ceph/src/fc/ceph/tests/fc-ceph/test_lvm.py
@@ -1,0 +1,105 @@
+from subprocess import CalledProcessError
+from unittest import mock
+
+import pytest
+
+from fc.ceph.lvm import XFSVolume
+
+
+class FailNTimes:
+    """Helper that raises an exception for the first N calls, then succeeds."""
+
+    def __init__(self, exception, fail_count):
+        self.exception = exception
+        self.fail_count = fail_count
+        self.call_count = 0
+
+    def __call__(self, *args):
+        self.call_count += 1
+        if self.call_count <= self.fail_count:
+            raise self.exception
+
+
+def test_mkfs_success_first_attempt(monkeypatch):
+    """mkfs succeeds on first attempt."""
+    mock_mkfs = mock.Mock()
+    mock_sync = mock.Mock()
+    monkeypatch.setattr("fc.ceph.lvm.run.mkfs_xfs", mock_mkfs)
+    monkeypatch.setattr("fc.ceph.lvm.run.sync", mock_sync)
+
+    XFSVolume.mkfs("/dev/test", "testlabel", ["-K"])
+
+    mock_mkfs.assert_called_once_with("-f", "-L", "testlabel", "-K", "/dev/test")
+    mock_sync.assert_called_once()
+
+
+def test_mkfs_retries_on_device_busy(monkeypatch):
+    """mkfs retries when device is busy, then succeeds."""
+    busy_error = CalledProcessError(1, "mkfs.xfs")
+    busy_error.stderr = (
+        b"mkfs.xfs: cannot open /dev/test: Device or resource busy"
+    )
+
+    fail_twice = FailNTimes(busy_error, fail_count=2)
+    mock_sync = mock.Mock()
+    mock_udevadm = mock.Mock()
+    monkeypatch.setattr("fc.ceph.lvm.run.mkfs_xfs", fail_twice)
+    monkeypatch.setattr("fc.ceph.lvm.run.sync", mock_sync)
+    monkeypatch.setattr("fc.ceph.lvm.run.udevadm", mock_udevadm)
+
+    XFSVolume.mkfs("/dev/test", "testlabel", ["-K"])
+
+    assert fail_twice.call_count == 3
+    assert mock_udevadm.call_count == 2
+    mock_udevadm.assert_called_with("settle")
+    mock_sync.assert_called_once()
+
+
+def test_mkfs_raises_after_max_retries(monkeypatch):
+    """mkfs raises after exhausting all retries."""
+    busy_error = CalledProcessError(1, "mkfs.xfs")
+    busy_error.stderr = (
+        b"mkfs.xfs: cannot open /dev/test: Device or resource busy"
+    )
+
+    mock_mkfs = mock.Mock(side_effect=busy_error)
+    mock_udevadm = mock.Mock()
+    monkeypatch.setattr("fc.ceph.lvm.run.mkfs_xfs", mock_mkfs)
+    monkeypatch.setattr("fc.ceph.lvm.run.udevadm", mock_udevadm)
+
+    with pytest.raises(CalledProcessError):
+        XFSVolume.mkfs("/dev/test", "testlabel", ["-K"], retries=3)
+
+    assert mock_mkfs.call_count == 3
+    assert mock_udevadm.call_count == 2
+
+
+def test_mkfs_raises_immediately_on_other_errors(monkeypatch):
+    """mkfs raises immediately for non-busy errors."""
+    other_error = CalledProcessError(1, "mkfs.xfs")
+    other_error.stderr = b"mkfs.xfs: /dev/test is not a block device"
+
+    mock_mkfs = mock.Mock(side_effect=other_error)
+    mock_udevadm = mock.Mock()
+    monkeypatch.setattr("fc.ceph.lvm.run.mkfs_xfs", mock_mkfs)
+    monkeypatch.setattr("fc.ceph.lvm.run.udevadm", mock_udevadm)
+
+    with pytest.raises(CalledProcessError):
+        XFSVolume.mkfs("/dev/test", "testlabel", ["-K"])
+
+    mock_mkfs.assert_called_once()
+    mock_udevadm.assert_not_called()
+
+
+def test_mkfs_handles_none_stderr(monkeypatch):
+    """mkfs handles CalledProcessError with None stderr."""
+    error = CalledProcessError(1, "mkfs.xfs")
+    error.stderr = None
+
+    mock_mkfs = mock.Mock(side_effect=error)
+    monkeypatch.setattr("fc.ceph.lvm.run.mkfs_xfs", mock_mkfs)
+
+    with pytest.raises(CalledProcessError):
+        XFSVolume.mkfs("/dev/test", "testlabel", ["-K"])
+
+    mock_mkfs.assert_called_once()

--- a/tests/backy_volumes.nix
+++ b/tests/backy_volumes.nix
@@ -7,13 +7,11 @@ import ./make-test-python.nix (
   }:
   let
     migrationScript = pkgs.writeShellScript "backy-reencrypter" ''
-      PLAIN_DEVICE="/dev/disk/by-id/md-name-legacyBacky:md0"
-      systemctl stop backy.service
+      PLAIN_DEVICE="/dev/disk/by-id/md-name-legacyBacky:backyPlain"
       umount /srv/backy
-      systemd-run --property=Type=oneshot -r -u backy-reencrypt cryptsetup -q reencrypt --encrypt  --header /srv/backy.luks --pbkdf=argon2id -d /mnt/keys/$(hostname).key --resilience=journal $PLAIN_DEVICE backy
-      sleep 30
+      systemd-run --property=Type=oneshot -r -u backy-reencrypt cryptsetup -q reencrypt --encrypt  --header /srv/backy.luks --pbkdf=argon2id -d /mnt/keys/$(hostname).key --resilience=journal "$PLAIN_DEVICE" backy
+      udevadm settle
       mount /dev/mapper/backy /srv/backy
-      systemctl start backy.service
       # create an early header backup
       cp /srv/backy.luks /mnt/keys/
     '';
@@ -35,6 +33,9 @@ import ./make-test-python.nix (
         flyingcircus.services.ceph.client.enable = lib.mkForce false;
         flyingcircus.services.consul.enable = lib.mkForce false;
         flyingcircus.enc.name = "machine";
+        # backy fails to start anyways due to missing enc data, and we do not
+        # actually require the daemon here
+        systemd.services.backy.enable = lib.mkForce false;
 
         virtualisation.emptyDiskImages = [
           1000
@@ -48,7 +49,7 @@ import ./make-test-python.nix (
         virtualisation.fileSystems."/mnt/keys" =
           config.flyingcircus.infrastructure.fullDiskEncryption.fsOptions;
         virtualisation.fileSystems."/srv/backy" = config.flyingcircus.roles.backyserver.fsOptions;
-        # Cotherwise fc-luks OOMs
+        # otherwise fc-luks OOMs
         virtualisation.memorySize = 1200;
       };
 
@@ -58,8 +59,9 @@ import ./make-test-python.nix (
 
     nodes = {
       # as specialisations do not persist reboots, just sequentially use 2 different machines with slightly adjusted config
+      # XXX: Once all re-encrypted backup hosts are gone, this shall be removed
       legacyBacky = mkMachine {
-        blockDevice = "/dev/disk/by-id/md-name-legacyBacky:md0";
+        blockDevice = "/dev/disk/by-id/md-name-legacyBacky:backyPlain";
         externalCryptHeader = true;
       };
       newBacky = mkMachine { };
@@ -99,19 +101,20 @@ import ./make-test-python.nix (
 
         print(legacyBacky.succeed("lsblk"))
         # preparing an unencrypted legacy RAID setup
-        legacyBacky.succeed(f"mdadm --create /dev/md/md0 --level=6 --bitmap=internal --raid-devices=4 /dev/vdb /dev/vdc /dev/vdd /dev/vde > /dev/stderr")
-        legacyBacky.succeed(f"mdadm --add /dev/md/md0 /dev/vdf > /dev/stderr")
+        legacyBacky.succeed(f"mdadm --create backyPlain --level=6 --bitmap=internal --raid-devices=4 /dev/vdb /dev/vdc /dev/vdd /dev/vde > /dev/stderr")
+        legacyBacky.wait_until_succeeds("stat /dev/md/backyPlain")
+        legacyBacky.succeed(f"mdadm --add /dev/md/backyPlain /dev/vdf > /dev/stderr")
 
         print(legacyBacky.succeed("ls -l /dev/disk/by-id/"))
 
-        legacyBacky.succeed(f"mkfs.xfs -L backy /dev/md/md0 > /dev/stderr")
+        legacyBacky.succeed(f"mkfs.xfs -L backy /dev/md/backyPlain > /dev/stderr")
         legacyBacky.execute("systemctl daemon-reload")
         legacyBacky.succeed("systemctl start srv-backy.mount > /dev/stderr")
         print(legacyBacky.succeed("lsblk"))
 
         setupKeystore(legacyBacky)
 
-        with subtest("manual reencryptioon of a legacy device:"):
+        with subtest("manual reencryption of a legacy device:"):
           legacyBacky.succeed("${pkgs.util-linux}/bin/findmnt /srv/backy > /dev/stderr")
           legacyBacky.execute("echo FOOTEST > /srv/backy/testfile")
           legacyBacky.succeed("${migrationScript}")
@@ -131,7 +134,8 @@ import ./make-test-python.nix (
 
         with subtest("Creating new backy volume from scratch"):
           newBacky.succeed('echo -e "adminphrase\ny\n" | setsid -w fc-luks backup create /dev/vdb /dev/vdc /dev/vdd /dev/vde /dev/vdf > /dev/stderr')
-          newBacky.succeed("${pkgs.util-linux}/bin/findmnt /srv/backy > /dev/stderr")
+          newBacky.execute("udevadm settle")
+          newBacky.wait_until_succeeds("${pkgs.util-linux}/bin/findmnt /srv/backy > /dev/stderr", timeout=30) # allow retries, as there might be delays due to things like fs checks
 
         test_reboot_automount(newBacky)
 


### PR DESCRIPTION
@flyingcircusio/release-managers

Contains a multitude of improvements to the backyserver_volumes test and the actual fc-luks code to address commonly experienced test failures.

PL-133765

## Release process

- [ ] Created changelog entry using `./changelog.sh`
  - no, just internal test improvements

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!---->
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - introduces additional I/O barriers, which are conservative changes
  - extend unit test coverage
  - improve overall integration tests reliablity 
- [x] Security requirements tested? (EVIDENCE)
  - [x] tests pass
