### PR TITLE
imagemagick6: remove from permittedInsecurePackages

### DIFF
--- a/doc/src/upgrade.md
+++ b/doc/src/upgrade.md
@@ -393,6 +393,8 @@ rabbitmq_unreachable_cluster_peers_count
 
 ## Other notable changes
 
+- The `imagemagick6` family of packages has known vulnerabilities and is not permitted by default anymore. Update your applications to work with a current version of imagemagick, or add this to `flyingcircus.permittedInsecurePackages`.
+
 ## Known issues
 
 None.

--- a/nixpkgs-config.nix
+++ b/nixpkgs-config.nix
@@ -10,7 +10,6 @@
   ];
 
   permittedInsecurePackages = [
-    "imagemagick-6.9.13-38" # Legacy, but gets updates. Customer still needs it.
     "openssl-1.1.1w" # EOL 2023-09-11, needed for Percona and older PHP versions.
     "python-2.7.18.12" # Needed for some legacy customer applications.
     "ruby-2.7.8" # EOL 2023-03-31, needed for Sensu checks


### PR DESCRIPTION
Most known customer projects appear to have moved on. No need to mention this in the release notes, because fc-25.11 will issue an evaluation warning as a preparatory step.

@flyingcircusio/release-managers

## Release process

This change should only reach this branch:

- [ ] Created changelog entry using `./changelog.sh`
or
- [x] Add a upgrade node in `doc/upgrade.md`

Not necessary, deprecation warnings are added to 25.11 in a separate PR

## PR release workflow (internal)

- [ ] PR has internal ticket
- [ ] internal issue ID (PL-…) part of branch name
- [ ] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [x] Provide warnings in previous platform version and upgrade notes when introducing a breaking change
  - yes, separate PR

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - stop allowing known vulnerable packages by default
- [x] Security requirements tested? (EVIDENCE)
  - packages throw an eval error by default now
