### PR TITLE
[25.11] imagemagick6: issue deprecation warnings in preparation for 26.05

### DIFF
--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -618,3 +618,9 @@ builtins.mapAttrs (_: patchPhps phpLogPermissionPatch) {
 
   xtrabackup = lib.warn "The `xtrabackup` package has been renamed to `percona-xtrabackup`." self.percona-xtrabackup;
 }
+// lib.genAttrs [ "imagemagick6" "imagemagick6Big" "imagemagick6_light" ] (
+  pkgname:
+  lib.warn
+    "${pkgname}: imagemagick6 has known vulnerabilites. From platform 26.05 on this package is not permitted by default anymore. Update your applications to work with a current version of imagemagick, or add this to `flyingcircus.permittedInsecurePackages`."
+    super."${pkgname}"
+)


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

This change should only reach this branch:

- [x] introduced eval warning for future behaviour change (#2185)

## PR release workflow (internal)

- [ ] PR has internal ticket
- [ ] internal issue ID (PL-…) part of branch name
- [ ] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [x] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - stop allowing known vulnerable packages by default
- [x] Security requirements tested? (EVIDENCE)
  - tested eval to show that warning