### PR TITLE
[PL-133773] Add initial ModSecurity implementation

### DIFF
--- a/nixos/platform/default.nix
+++ b/nixos/platform/default.nix
@@ -42,6 +42,7 @@ in
     ./ipmi.nix
     ./kernel.nix
     ./mailutils.nix
+    ./modsecurity
     ./monitoring.nix
     ./network.nix
     ./nix.nix

--- a/nixos/platform/modsecurity/default.nix
+++ b/nixos/platform/modsecurity/default.nix
@@ -1,0 +1,110 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.flyingcircus.modsecurity;
+
+  mkModsecurityConfig =
+    rules:
+    (import ./mk-modsecurity-config.nix) {
+      inherit lib pkgs rules;
+    };
+
+  rulesetOptionsModule = {
+    options = import ./modsecurity-options.nix {
+      inherit config lib pkgs;
+    };
+  };
+
+  rulesetImplModule =
+    { config, name, ... }:
+    {
+      options = with lib; {
+        nginxMode = mkOption {
+          type = (
+            types.enum [
+              "On"
+              "Off"
+              "Transparent"
+            ]
+          );
+          default = "Transparent";
+        };
+
+        transactionID = mkOption {
+          type = types.str;
+          default = "$request_id";
+        };
+
+        configContent = mkOption {
+          type = types.str;
+          internal = true;
+        };
+
+        rulesFile = mkOption {
+          type = types.path;
+          internal = true;
+        };
+
+        nginxConfig = mkOption {
+          type = types.str;
+        };
+
+        mkNginxConfig = mkOption {
+          internal = true;
+        };
+      };
+
+      config = {
+        configContent = mkModsecurityConfig config;
+        rulesFile = pkgs.writeText name config.configContent;
+        nginxConfig = config.mkNginxConfig config.nginxMode "";
+        mkNginxConfig =
+          nginxMode: extraConfig:
+          lib.concatStringsSep ";\n" [
+            (lib.optionalString (nginxMode != "Transparent") "modsecurity ${(lib.toSentenceCase nginxMode)}")
+            "modsecurity_rules_file ${config.rulesFile}"
+            "modsecurity_transaction_id ${config.transactionID}"
+            extraConfig
+          ];
+      };
+    };
+
+  nginxIntegrationSubmodule =
+    { config, name, ... }:
+    {
+      config = lib.mkIf cfg.enable {
+        extraConfig = lib.mkBefore (
+          lib.optionalString (lib.hasAttr name cfg.rulesets) cfg.rulesets.${name}.nginxConfig
+        );
+      };
+    };
+
+in
+{
+  options = with lib; {
+    flyingcircus.modsecurity = {
+
+      enable = mkEnableOption { };
+
+      rulesets = mkOption {
+        type =
+          with lib.types;
+          lazyAttrsOf (submodule [
+            rulesetOptionsModule
+            rulesetImplModule
+          ]);
+        default = { };
+      };
+    };
+
+    services.nginx.virtualHosts = mkOption {
+      type = types.attrsOf (types.submodule nginxIntegrationSubmodule);
+    };
+
+  };
+
+}

--- a/nixos/platform/modsecurity/mk-modsecurity-config.nix
+++ b/nixos/platform/modsecurity/mk-modsecurity-config.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  pkgs,
+  rules,
+}:
+''
+  ${
+    if rules.coreRuleSet.blocking then
+      ''
+        SecRuleEngine On
+
+        SecDefaultAction "phase:1,log,auditlog,pass"
+        SecDefaultAction "phase:2,log,auditlog,pass"
+
+        SecAction \
+         "id:900110,\
+          phase:1,\
+          nolog,\
+          pass,\
+          t:none,\
+          setvar:tx.inbound_anomaly_score_threshold=${toString rules.coreRuleSet.anomalyThreshold.inbound},\
+          setvar:tx.outbound_anomaly_score_threshold=${toString rules.coreRuleSet.anomalyThreshold.outbound}"
+      ''
+    else
+      ''
+        SecRuleEngine DetectionOnly
+
+        SecDefaultAction "phase:1,log,auditlog,pass"
+        SecDefaultAction "phase:2,log,auditlog,pass"
+      ''
+  }
+
+  SecRequestBodyAccess ${if rules.requestBody.access then "On" else "Off"}
+  SecDebugLog ${rules.debugLog.path}
+  SecDebugLogLevel ${toString rules.debugLog.level}
+  SecAuditEngine ${rules.audit.engine}
+  SecAuditLogParts ${rules.audit.log.parts}
+  SecAuditLogFormat ${rules.audit.log.format}
+  SecAuditLogType ${rules.audit.log.type}
+  SecAuditLog ${rules.audit.log.path}
+  SecUnicodeMapFile ${pkgs.libmodsecurity.src}/unicode.mapping 20127
+  SecCollectionTimeout ${toString rules.collectionTimeout}
+
+  ${lib.optionalString (rules.coreRuleSet.enable) ''
+    SecAction \
+     "id:900990,\
+      phase:1,\
+      nolog,\
+      pass,\
+      t:none,\
+      setvar:tx.crs_setup_version=${pkgs.modsecurity-crs.version}"
+
+    include ${pkgs.modsecurity-crs}/rules/*.conf
+  ''}
+
+  ${rules.extraConfig}
+''

--- a/nixos/platform/modsecurity/modsecurity-options.nix
+++ b/nixos/platform/modsecurity/modsecurity-options.nix
@@ -1,0 +1,92 @@
+{ lib, ... }:
+
+with lib;
+
+{
+  debugLog = {
+    path = mkOption {
+      type = types.str;
+      default = "/tmp/debug.log";
+    };
+    level = mkOption {
+      type = types.ints.positive;
+      default = 3;
+    };
+  };
+  audit = {
+    engine = mkOption {
+      type = (
+        types.enum [
+          "On"
+          "Off"
+          "RelevantOnly"
+        ]
+      );
+      default = "RelevantOnly";
+    };
+    # Logrotate for "/var/log/nginx/modsec_*.log" is already configured
+    log = {
+      format = mkOption {
+        type = (
+          types.enum [
+            "JSON"
+            "Native"
+          ]
+        );
+        default = "Native";
+      };
+      parts = mkOption {
+        type = types.str;
+        default = "ABIJDFHZ";
+      };
+      path = mkOption {
+        type = types.str;
+        default = "/var/log/nginx/modsec_audit.log";
+      };
+      type = mkOption {
+        type = (
+          types.enum [
+            "Serial"
+            "Concurrent"
+            "HTTPS"
+          ]
+        );
+        default = "Serial";
+      };
+    };
+  };
+  requestBody = {
+    access = mkOption {
+      type = types.bool;
+      default = true;
+    };
+  };
+  collectionTimeout = mkOption {
+    type = types.ints.positive;
+    default = 600;
+  };
+  extraConfig = mkOption {
+    type = types.lines;
+    default = "";
+    description = ''
+      Rules to append to the config module file verbatim.
+    '';
+  };
+  coreRuleSet = {
+    enable = mkEnableOption "OWASP Core Rule Set";
+    blocking = mkOption {
+      type = types.bool;
+      default = false;
+    };
+    anomalyThreshold = {
+      inbound = mkOption {
+        type = types.ints.positive;
+        default = 5;
+      };
+      outbound = mkOption {
+        type = types.ints.positive;
+        default = 4;
+      };
+    };
+  };
+}


### PR DESCRIPTION
@flyingcircusio/release-managers

## PR release workflow (internal)

- [X] PR has internal ticket
- [X] internal issue ID (PL-…) part of branch name
- [X] internal issue ID mentioned in PR description text
- [X] ticket is on Platform agile board
- [x] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [X] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [X] Provide warnings in previous platform version and upgrade notes when introducing a breaking change --> no breaking changes

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
No specific requirements
- [x] Security requirements tested? (EVIDENCE)
Manual tests on dev server



This PR adds a minimal initial integration of ModSecurity. It is intended to be properly documented and supported with tests, after a bit of practical testing and further development.

See PL-133773