### PR TITLE
pkgs: add custom package for nixos discourse

### DIFF
--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -206,6 +206,21 @@ builtins.mapAttrs (_: patchPhps phpLogPermissionPatch) {
 
   docsplit = super.callPackage ./docsplit { };
 
+  # Heavy build, required to not OOM the customer machine
+  discourseWithNixosPlugins = super.discourse.override {
+    plugins = (
+      with super.discourse.plugins;
+      [
+        discourse-bbcode-color
+        discourse-docs
+        discourse-events
+        discourse-prometheus
+        discourse-saved-searches
+        discourse-yearly-review
+      ]
+    );
+  };
+
   dool = super.dool.overrideAttrs (old: {
     patches = old.patches or [ ] ++ [ ./dool-interface-altnames.patch ];
   });


### PR DESCRIPTION
The build is quite heavy and we don't want to overload the customer VM.

FC-50312

@flyingcircusio/release-managers

## Release process

- [ ] Created changelog entry using `./changelog.sh`
  - No, internal change

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [x] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [x] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [x] Security requirements tested? (EVIDENCE)
  None, just to cache the build