### PR TITLE
[FC-52201] add package lamp_php85

### DIFF
--- a/changelog.d/20260227_140110_FC-52201_lamp-php85_scriv.md
+++ b/changelog.d/20260227_140110_FC-52201_lamp-php85_scriv.md
@@ -1,0 +1,5 @@
+### Impact
+
+### NixOS XX.XX platform
+
+- Add package lamp_php85 (FC-52201)

--- a/doc/src/lamp.md
+++ b/doc/src/lamp.md
@@ -217,6 +217,7 @@ Supported packages:
 - `pkgs.lamp_php82`
 - `pkgs.lamp_php83`
 - `pkgs.lamp_php84` (default)
+- `pkgs.lamp_php85`
 
 The `lamp_php_*` packages provided by our platform include commonly used
 PHP extensions, currently:

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -91,6 +91,18 @@ builtins.mapAttrs (_: patchPhps phpLogPermissionPatch) {
     {
       inherit (super) php83 php84;
     }
+//
+  builtins.mapAttrs
+    (
+      _:
+      patchPhps (fetchpatch {
+        url = "https://github.com/flyingcircusio/php-src/commit/7f5f62ff1bedc46df43d048920a3bc80bef22500.diff?full_index=1";
+        hash = "sha256-yInMJrzlNZsqnePv7aesDdZYOynCWs+d7FrYNQ5Teug=";
+      })
+    )
+    {
+      inherit (super) php85;
+    }
 // {
   pythonPackagesExtensions = super.pythonPackagesExtensions ++ [
     (python-self: python-super: {
@@ -441,6 +453,17 @@ builtins.mapAttrs (_: patchPhps phpLogPermissionPatch) {
   );
 
   lamp_php84 = self.php84.withExtensions (
+    { enabled, all }:
+    enabled
+    ++ [
+      all.bcmath
+      all.imagick
+      all.memcached
+      all.redis
+    ]
+  );
+
+  lamp_php85 = self.php85.withExtensions (
     { enabled, all }:
     enabled
     ++ [

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -74,6 +74,7 @@ in
   lampVm82 = callTest ./lamp/vm-test.nix { version = "lamp_php82"; };
   lampVm83 = callTest ./lamp/vm-test.nix { version = "lamp_php83"; };
   lampVm84 = callTest ./lamp/vm-test.nix { version = "lamp_php84"; };
+  lampVm85 = callTest ./lamp/vm-test.nix { version = "lamp_php85"; };
 
   locale = callTest ./locale.nix { };
   loki = callTest ./loki.nix { };


### PR DESCRIPTION
@flyingcircusio/release-managers

FC-52201

## Release process

This change should be backported:

- [x] Created changelog entry using `./changelog.sh`
- [ ] Add `backport release-25.11` label

This change should only reach this branch:

- [x] Created changelog entry using `./changelog.sh`
or
- [ ] Add a upgrade node in `doc/upgrade.md`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [x] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
does not apply
- [x] Security requirements tested? (EVIDENCE)
