### PR TITLE
fc-ceph: fix gc-s3-traffic command

### DIFF
--- a/nixos/roles/ceph/rgw.nix
+++ b/nixos/roles/ceph/rgw.nix
@@ -284,7 +284,7 @@ in
         description = "Timer for GCing old object-store log data";
         wantedBy = [ "timers.target" ];
         timerConfig = {
-          OnCalendar = "*-*-* 14:00:00";
+          OnCalendar = "*-*-* 14:30:00";
         };
       };
 

--- a/pkgs/fc/ceph/src/fc/ceph/logs.py
+++ b/pkgs/fc/ceph/src/fc/ceph/logs.py
@@ -13,8 +13,8 @@ import re
 from pathlib import Path
 
 import IPy
-from fc.ceph.util import directory, run
-from fc.ceph.util.opslog import OpsLog, OpsLogState
+from fc.ceph.util import directory
+from fc.ceph.util.opslog import OpsLog
 
 R_OSD = re.compile(r"osd\.[0-9]+")
 
@@ -59,7 +59,7 @@ class LogTasks(object):
 
     def account_s3_traffic(self, state_file: Path, enc_file: Path):
         final_stats = []
-        with directory.directory_connection(enc_file, ring=0) as d:
+        with directory.directory_connection(enc_file, ring="max") as d:
             with open(enc_file) as f:
                 enc = json.load(f)
                 location = enc["parameters"]["location"]

--- a/pkgs/fc/ceph/src/fc/ceph/util/opslog.py
+++ b/pkgs/fc/ceph/src/fc/ceph/util/opslog.py
@@ -41,7 +41,9 @@ class OpsLogState:
 
 
 class OpsLog:
-    def __init__(self, state_file: Path, internal_networks: list[IPy.IP]):
+    def __init__(
+        self, state_file: Path, internal_networks: list[IPy.IP] | None = None
+    ):
         self.state_file = state_file
         self.internal_networks = internal_networks
         self.opslog_ptrn = re.compile(
@@ -135,6 +137,8 @@ class OpsLog:
             day += timedelta(days=1)
 
     def get_object(self, name: str):
+        assert self.internal_networks is not None
+
         result = run.json.radosgw_admin("log", "show", f"--object={name}")
 
         # We filter out internal traffic, so the log_sum is wrong. Hence, delete it to

--- a/tests/ceph-nautilus.nix
+++ b/tests/ceph-nautilus.nix
@@ -342,6 +342,7 @@ import ./make-test-python.nix (
         check_key_file_cmd = testlib.sensuCheckCmd nodes.host1 "keystickMounted";
       in
       ''
+        import datetime
         import time
         import json
 
@@ -627,6 +628,13 @@ import ./make-test-python.nix (
           accounting_data = json.loads(host1.succeed("cat /var/lib/fc-ceph-s3-accounting/s3-accounting-state"))
           t.assertIn("last_processed_datetime", accounting_data)
           t.assertIn("last_gced_day", accounting_data)
+
+          # GC works
+          accounting_data["last_gced_day"] = (datetime.date.today() - datetime.timedelta(days=5)).isoformat()
+          host1.succeed(f"echo '{json.dumps(accounting_data)}' > /var/lib/fc-ceph-s3-accounting/s3-accounting-state")
+          host1.succeed("systemctl start fc-ceph-gc-s3-traffic-data")
+          accounting_data = json.loads(host1.succeed("cat /var/lib/fc-ceph-s3-accounting/s3-accounting-state"))
+          t.assertEqual(accounting_data["last_gced_day"], (datetime.date.today() - datetime.timedelta(days=2)).isoformat())
 
         with subtest("Destroy and re-create first mon"):
           host1.succeed('fc-ceph mon destroy')


### PR DESCRIPTION
PL-128135

@flyingcircusio/release-managers

The gc_s3_traffic method previously initalized OpsLog without the required internal_networks parameter.
This change changes the OpsLog class so that internal_networks isn't required for initalization as the gc_log_objects function doesn't use it.

## Release process

- [ ] Created changelog entry using `./changelog.sh`
  no: follow-up to #2142 in the same release cycle

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [x] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [x] Security requirements tested? (EVIDENCE)
  - tested functionality in dev
  - added basic automated regression test