### PR TITLE
[FC-52192] redis: add a sensu check for the rdb save status

### DIFF
--- a/changelog.d/20260303_105345_FC-52192_rdb-status-monitoring_scriv.md
+++ b/changelog.d/20260303_105345_FC-52192_rdb-status-monitoring_scriv.md
@@ -1,0 +1,6 @@
+### Impact
+
+
+### NixOS XX.XX platform
+
+- Add a sensu check for redis that watches the status of the server's persistent background saves (FC-52192)

--- a/nixos/services/redis.nix
+++ b/nixos/services/redis.nix
@@ -41,7 +41,7 @@ let
 
   bind = bindAddrs: head (lib.splitString " " bindAddrs);
 
-  mkSensuCheck =
+  mkPingCheck =
     name: connArgs:
     let
       # If a Redis server requires password authentication (i.e. requirePass or requirePassFile
@@ -55,7 +55,7 @@ let
         else
           null;
     in
-    lib.nameValuePair (redisServiceName name) {
+    lib.nameValuePair "${(redisServiceName name)}-ping-check" {
       notification = "Redis" + lib.optionalString (name != "") " (instance ${name})" + " alive";
       command = ''
         ${pkgs.sensu-plugins-redis}/bin/check-redis-ping.rb \
@@ -63,17 +63,50 @@ let
       '';
     };
 
-  checks = lib.listToAttrs (
-    lib.forEach (serversByConnection.tcp or [ ]) (
-      name:
-      mkSensuCheck name "-h ${bind enabledServers.${name}.bind} -p ${
-        toString enabledServers.${name}.port
-      }"
-    )
-    ++ lib.forEach (serversByConnection.uds or [ ]) (
-      name: mkSensuCheck name "-s ${enabledServers.${name}.unixSocket}"
-    )
-  );
+  mkRDBCheck =
+    name: connArgs:
+    lib.nameValuePair "${(redisServiceName name)}-rdb-check" {
+      notification =
+        "Redis "
+        + lib.optionalString (name != "") " (instance ${name})"
+        + " failed to save persistence data to disk";
+      command = ''
+        ${
+          if enabledServers.${name}.requirePass != null then
+            "export REDISCLI_AUTH=${enabledServers.${name}.requirePass}"
+          else if enabledServers.${name}.requirePassFile != null then
+            "export REDISCLI_AUTH=$(sudo cat ${enabledServers.${name}.requirePassFile})"
+          else
+            ""
+        }
+        if ${cfg.package}/bin/redis-cli ${connArgs} INFO persistence | grep -i "bgsave_status:ok"; then
+          echo "last bgsave completed successfully"
+        else
+          echo "last bgsave for the redis server '${name}' did not complete successfully"
+          exit 2
+        fi
+      '';
+    };
+
+  checks =
+    let
+      mkChecks =
+        name: connArgs:
+        [
+          (mkPingCheck name connArgs)
+        ]
+        # don't enable this check if rdb persistence is disabled
+        ++ lib.optional (enabledServers.${name}.save != [ ]) (mkRDBCheck name connArgs);
+    in
+    lib.listToAttrs (
+      lib.concatMap (
+        name:
+        mkChecks name "-h ${bind enabledServers.${name}.bind} -p ${toString enabledServers.${name}.port}"
+      ) (serversByConnection.tcp or [ ])
+      ++ lib.concatMap (name: mkChecks name "-s ${enabledServers.${name}.unixSocket}") (
+        serversByConnection.uds or [ ]
+      )
+    );
 
   # Drop string fields. They are converted to labels in Prometheus
   # which blows up the number of metrics.

--- a/tests/redis.nix
+++ b/tests/redis.nix
@@ -138,8 +138,10 @@ import ./make-test-python.nix (
             redis.succeed('sudo -u redis touch /etc/local/redis/password')
 
         with subtest("Sensu checks correctly configured"):
-            redis.succeed("${pkgs.writeShellScript "sensu-redis" sensuChecks.redis.command}")
-            redis.succeed("${pkgs.writeShellScript "sensu-redis-gitlab" sensuChecks.redis-gitlab.command}")
+            redis.succeed("${pkgs.writeShellScript "sensu-redis-ping" sensuChecks.redis-ping-check.command}")
+            redis.succeed("${pkgs.writeShellScript "sensu-redis-gitlab-ping" sensuChecks.redis-gitlab-ping-check.command}")
+            redis.succeed("${pkgs.writeShellScript "sensu-redis-rdb" sensuChecks.redis-rdb-check.command}")
+            redis.succeed("${pkgs.writeShellScript "sensu-redis-gitlab-rdb" sensuChecks.redis-gitlab-rdb-check.command}")
 
         with subtest("Metrics for servers are scraped by telegraf"):
             ret_val = query_prom('redis_uptime{port="6379"}')
@@ -173,8 +175,10 @@ import ./make-test-python.nix (
             t.assertNotEqual(password, from_pw_string)
             redis.succeed(f"redis-cli -a {from_pw_string} ping | grep PONG")
 
-            redis.succeed("${pkgs.writeShellScript "sensu-redis" sensuChecksWithPW.redis.command}")
-            redis.succeed("${pkgs.writeShellScript "sensu-redis-gitlab" sensuChecksWithPW.redis-gitlab.command}")
+            redis.succeed("${pkgs.writeShellScript "sensu-redis-ping" sensuChecksWithPW.redis-ping-check.command}")
+            redis.succeed("${pkgs.writeShellScript "sensu-redis-gitlab-ping" sensuChecksWithPW.redis-gitlab-ping-check.command}")
+            redis.succeed("${pkgs.writeShellScript "sensu-redis-rdb" sensuChecksWithPW.redis-rdb-check.command}")
+            redis.succeed("${pkgs.writeShellScript "sensu-redis-gitlab-rdb" sensuChecksWithPW.redis-gitlab-rdb-check.command}")
 
             # We don't generate a password if /etc/local/redis/password already
             # exists, even if there are no other settings.


### PR DESCRIPTION
@flyingcircusio/release-managers

FC-52192

## Release process

This change should be backported:

- [x] Created changelog entry using `./changelog.sh`
- [ ] Add `backport release-25.11` label

This change should only reach this branch:

- [x] Created changelog entry using `./changelog.sh`
or
- [ ] Add a upgrade node in `doc/upgrade.md`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [ ] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [ ] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- this PR just adds a sensu check that verifies that redis' background save complete successfully. no security implications
- [ ] Security requirements tested? (EVIDENCE)
