### PR TITLE
webgateway: fix regression that virtual hosts with useACMEHost don't eval

### DIFF
--- a/changelog.d/20260303_105644_HEAD_scriv.md
+++ b/changelog.d/20260303_105644_HEAD_scriv.md
@@ -1,0 +1,26 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+<!-- Impact means "when this change is rolled out, there
+     might be interruptions/downtimes/required actions/... that
+     IMPACT THE RUNNING APPLICATION NEGATIVELY.
+
+     Having new features or changed is not an "impact". That's what
+     the main changelog (see below) is for.
+     -->
+
+### NixOS XX.XX platform
+
+- webgateway: fix regression that virtual hosts with `useACMEHost` don't eval

--- a/nixos/services/nginx/default.nix
+++ b/nixos/services/nginx/default.nix
@@ -74,10 +74,9 @@ let
     _: vhost: vhost.onlySSL || vhost.addSSL || vhost.forceSSL
   ) nginxCfg.virtualHosts;
 
-  # Split TLS vhosts in ACME and non-ACME vhosts
-  acmeVhostsWithTLS = lib.filterAttrs (_: vhost: vhost.enableACME) vhostsWithTLS;
-
-  nonAcmeVhostsWithTLS = lib.filterAttrs (_: vhost: !vhost.enableACME) vhostsWithTLS;
+  nonAcmeVhostsWithTLS = lib.filterAttrs (
+    _: vhost: (!vhost.enableACME && vhost.useACMEHost == null)
+  ) vhostsWithTLS;
 
   mainConfig = ''
     worker_processes ${toString cfg.workerProcesses};

--- a/tests/nginx.nix
+++ b/tests/nginx.nix
@@ -151,6 +151,13 @@ import ./make-test-python.nix (
           services.nginx.serverTokens = true;
 
           security.acme.certs.server.keyType = "rsa4096";
+
+          # To test that sensu rules successfully eval
+          flyingcircus.services.sensu-client = {
+            enable = true;
+            server = "1.2.3.4";
+            password = "foo";
+          };
         };
 
       server2 = mkFCServer {
@@ -264,6 +271,35 @@ import ./make-test-python.nix (
               service = "loki-collector";
             }
           ];
+        };
+
+      # Eval only server. Should test that a vhost with useACMEHost successfully evals.
+      server8 =
+        { lib, pkgs, ... }:
+        {
+          imports = [
+            (testlib.fcConfig { id = 8; })
+          ];
+
+          flyingcircus.services.sensu-client = {
+            enable = true;
+            server = "1.2.3.4";
+            password = "foo";
+          };
+
+          flyingcircus.roles.webgateway.enable = true;
+          flyingcircus.services.nginx = {
+            virtualHosts.server = {
+              useACMEHost = "server";
+              forceSSL = true;
+              enableACME = false;
+            };
+          };
+          security.acme.certs.server = {
+            dnsProvider = "pdns";
+            credentialsFile = pkgs.writeText "pdns-cred" "";
+            group = "nginx";
+          };
         };
     };
 


### PR DESCRIPTION
PL-135214

@flyingcircusio/release-managers

## Release process

This change should only reach this branch:

- [x] Created changelog entry using `./changelog.sh`


## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [x] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [x] Security requirements tested? (EVIDENCE)
  - Tested on affected machine
  - Added automated test