### PR TITLE
[FC-52143] k3s: adjust the default image garbage collection thresholds

### DIFF
--- a/changelog.d/20260303_112547_FC-52143_lower-k3s-image-gc-thresholds_scriv.md
+++ b/changelog.d/20260303_112547_FC-52143_lower-k3s-image-gc-thresholds_scriv.md
@@ -1,0 +1,5 @@
+### Impact
+
+### NixOS XX.XX platform
+
+- Adjusted the defaut threshold for k3s' automatic image garbage collection (FC-52143)

--- a/nixos/roles/k3s/default.nix
+++ b/nixos/roles/k3s/default.nix
@@ -116,8 +116,11 @@ in
           }
         ];
 
-        services.k3s.package = config.fclib.mkPlatform pkgs.k3s_1_32;
-
+        services.k3s = {
+          package = config.fclib.mkPlatform pkgs.k3s_1_32;
+          extraKubeletConfig.imageGCLowThresholdPercent = config.fclib.mkPlatform 70;
+          extraKubeletConfig.imageGCHighThresholdPercent = config.fclib.mkPlatform 75;
+        };
       }
 
       (lib.mkIf (server || agent) {


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

FC-52143

This change should be backported:

- [x] Created changelog entry using `./changelog.sh`
- [ ] Add `backport release-25.11` label

This change should only reach this branch:

- [x] Created changelog entry using `./changelog.sh`
or
- [ ] Add a upgrade node in `doc/upgrade.md`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [ ] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [ ] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- this pr adjusts some defaults to make the service work better with the way our platform is set up, no security-relevant changes
- [ ] Security requirements tested? (EVIDENCE)
