### PR TITLE
roles/{loki,tempo}: fix object store credentials

### DIFF
--- a/nixos/roles/loki.nix
+++ b/nixos/roles/loki.nix
@@ -204,10 +204,10 @@ in
 
             script = ''
               if [ -z $AWS_ACCESS_KEY_ID ]; then
-                AWS_ACCESS_KEY_ID=$(cat ${config.flyingcircus.encPath} | ${lib.getExe pkgs.jq} '.role_configuration.loki.object_store_access_key')
+                AWS_ACCESS_KEY_ID=$(cat ${config.flyingcircus.encPath} | ${lib.getExe pkgs.jq} -r '.role_configuration.loki.object_store_access_key')
               fi
               if [ -z $AWS_SECRET_ACCESS_KEY ]; then
-                AWS_SECRET_ACCESS_KEY=$(cat ${config.flyingcircus.encPath} | ${lib.getExe pkgs.jq} '.role_configuration.loki.object_store_secret_key')
+                AWS_SECRET_ACCESS_KEY=$(cat ${config.flyingcircus.encPath} | ${lib.getExe pkgs.jq} -r '.role_configuration.loki.object_store_secret_key')
               fi
 
               export AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY

--- a/nixos/roles/tempo.nix
+++ b/nixos/roles/tempo.nix
@@ -137,10 +137,10 @@ in
 
             script = ''
               if [ -z $AWS_ACCESS_KEY_ID ]; then
-                AWS_ACCESS_KEY_ID=$(cat ${config.flyingcircus.encPath} | ${lib.getExe pkgs.jq} '.role_configuration.tempo.object_store_access_key')
+                AWS_ACCESS_KEY_ID=$(cat ${config.flyingcircus.encPath} | ${lib.getExe pkgs.jq} -r '.role_configuration.tempo.object_store_access_key')
               fi
               if [ -z $AWS_SECRET_ACCESS_KEY ]; then
-                AWS_SECRET_ACCESS_KEY=$(cat ${config.flyingcircus.encPath} | ${lib.getExe pkgs.jq} '.role_configuration.tempo.object_store_secret_key')
+                AWS_SECRET_ACCESS_KEY=$(cat ${config.flyingcircus.encPath} | ${lib.getExe pkgs.jq} -r '.role_configuration.tempo.object_store_secret_key')
               fi
 
               export AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY


### PR DESCRIPTION
Quotes must not be part of the `AWS_…` credentials.

Fixup for #2173

PL-135168

@flyingcircusio/release-managers

## Release process

This change should be backported:

- [ ] Created changelog entry using `./changelog.sh`
  - no, fixup for a change that has a changelog entry
- [x] Add `backport release-26.05` label

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [x] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - fix regression discovered during monitoring review
- [x] Security requirements tested? (EVIDENCE)
  - [x] tested on affected system
  - [ ] automated tests pass
