### PR TITLE
raid_md check: ensure dm-raid module is loaded

### DIFF
--- a/changelog.d/20260306_145354_PL-135206-dm-raid_scriv.md
+++ b/changelog.d/20260306_145354_PL-135206-dm-raid_scriv.md
@@ -1,0 +1,29 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+<!-- Impact means "when this change is rolled out, there
+     might be interruptions/downtimes/required actions/... that
+     IMPACT THE RUNNING APPLICATION NEGATIVELY.
+
+     Having new features or changed is not an "impact". That's what
+     the main changelog (see below) is for.
+     -->
+
+- A bullet item for the Impact category.
+
+
+### NixOS XX.XX platform
+
+- flyingcircus.raid: ensure dm-raid module is loaded (PL-135206)

--- a/nixos/services/raid/default.nix
+++ b/nixos/services/raid/default.nix
@@ -28,11 +28,12 @@
       command = "${pkgs.check_md_raid}/bin/check_md_raid";
     };
 
-    # MegaRAID
-
     boot.initrd.kernelModules = [
+      # MegaRAID
       "megaraid_sas"
       "mpt3sas"
+      # md_raid
+      "dm-raid"
     ];
 
     environment.systemPackages = with pkgs; [


### PR DESCRIPTION
All hosts executing the `check_md_raid` check need to ensure that the dm-raid kernel module is loaded, otherwise the required `/proc/mdstat` pseudo-file is not present.

PL-135206

@flyingcircusio/release-managers

## Release process

This change should be backported:

- [x] Created changelog entry using `./changelog.sh`
- [ ] Add `backport release-25.11` label

This change should only reach this branch:

- [x] Created changelog entry using `./changelog.sh`
or
- [ ] Add a upgrade node in `doc/upgrade.md`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [x] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - ensure that requisites for enabled checks are available
- [x] Security requirements tested? (EVIDENCE)
  - [x] manually loaded `dm-raid` on a host with a failing check
