### PR TITLE
relax clamav database age check

### DIFF
--- a/pkgs/fc/sensuplugins/fc/sensuplugins/clamav_database.py
+++ b/pkgs/fc/sensuplugins/fc/sensuplugins/clamav_database.py
@@ -25,9 +25,9 @@ def main():
     check_age_cmd = [
         "check_file_age",
         "-w",
-        "93600",
+        "180000",  # 50h
         "-c",
-        "172800",
+        "345600",  # 4d
     ]
 
     max_returncode = 0


### PR DESCRIPTION
intervals that exceeded the previous 26h warning age during 2025 and jan + feb of 2026: 1 day, 3:22:35
1 day, 9:15:27
1 day, 22:05:10
1 day, 22:52:00
2 days, 0:00:25
2 days, 0:00:27
2 days, 0:01:09
3 days, 1:05:33
3 days, 12:38:47

this change allows for a single skipped day without a warning (7/9 previous warnings) and 3 skipped days without a critical warning (the remaining 2 warnings)

@flyingcircusio/release-managers
PL-134093

## Release process

This change should be backported:

- [x] Created changelog entry using `./changelog.sh`
  - internal change
- [x] Add `backport release-25.11` label

This change should only reach this branch:

- [ ] Created changelog entry using `./changelog.sh`
or
- [ ] Add a upgrade node in `doc/upgrade.md`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [x] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - reduce noise during monitoring
- [ ] Security requirements tested? (EVIDENCE)
