### PR TITLE
[FC-52192] fixup: redis check auth

### DIFF
--- a/nixos/services/redis.nix
+++ b/nixos/services/redis.nix
@@ -75,7 +75,7 @@ let
           if enabledServers.${name}.requirePass != null then
             "export REDISCLI_AUTH=${enabledServers.${name}.requirePass}"
           else if enabledServers.${name}.requirePassFile != null then
-            "export REDISCLI_AUTH=$(sudo cat ${enabledServers.${name}.requirePassFile})"
+            "export REDISCLI_AUTH=$(<${enabledServers.${name}.requirePassFile})"
           else
             ""
         }


### PR DESCRIPTION
@flyingcircusio/release-managers

fixes the generated redis checks in FC-52192 

relates to #2208 

## Release process

This change should be backported:

- [ ] Created changelog entry using `./changelog.sh`
  - no, fixup for a previous unreleased change
- [x] Add `backport release-25.11` label

This change should only reach this branch:

- [ ] Created changelog entry using `./changelog.sh`
or
- [ ] Add a upgrade node in `doc/upgrade.md`

## PR release workflow (internal)

- [ ] PR has internal ticket
- [ ] internal issue ID (PL-…) part of branch name
- [ ] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [x] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - fix an issue in the check
- [x] Security requirements tested? (EVIDENCE)
  - [x] tested on a dev-vm