### PR TITLE
[backport-26.05] kernel: WARN_ALL_UNSEEDED_RANDOM option was removed

### DIFF
--- a/nixos/platform/kernel.nix
+++ b/nixos/platform/kernel.nix
@@ -77,7 +77,6 @@ in
       VLAN_8021Q_GVRP y
       XFS_POSIX_ACL y
       XFS_QUOTA y
-      WARN_ALL_UNSEEDED_RANDOM n
       ## Crash-debugging related options
       IPMI_PANIC_EVENT y
       IPMI_PANIC_STRING y

--- a/tests/kernelconfig.nix
+++ b/tests/kernelconfig.nix
@@ -153,7 +153,6 @@ import ./make-test-python.nix (
       VHOST_NET m
       VLAN_8021Q m
       VXLAN m
-      WARN_ALL_UNSEEDED_RANDOM n
       X86_ACPI_CPUFREQ m
 
       X86_PCC_CPUFREQ m


### PR DESCRIPTION
Don't enforce that WARN_ALL_UNSEEDED_RANDOM is being set to "no", as that config option has been removed in the upstream kernel now, due to excessive log spamming.
See https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.12.75

Fixes build.

partial port of #2223

@flyingcircusio/release-managers

## Release process


- [ ] Created changelog entry using `./changelog.sh`
  - internal maintenance only
or
- [ ] Add a upgrade node in `doc/upgrade.md`

## PR release workflow (internal)

- [ ] PR has internal ticket
- [ ] internal issue ID (PL-…) part of branch name
- [ ] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [x] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - config adjusted to kernel upstream changes
- [x] Security requirements tested? (EVIDENCE)
  - checked changelog