### PR TITLE
[PL-135231] alloy configuration for k3s logs

### DIFF
--- a/changelog.d/20260311_133045_PL-135231_k3s_logs_scriv.md
+++ b/changelog.d/20260311_133045_PL-135231_k3s_logs_scriv.md
@@ -1,0 +1,8 @@
+### Impact
+
+-
+
+
+### NixOS XX.XX platform
+
+- Provide a new alloy configuration snippet that exports the running pod's journal to a loki instance (PL-135231)

--- a/nixos/platform/alloy.nix
+++ b/nixos/platform/alloy.nix
@@ -9,14 +9,15 @@ let
   # collector process.
 
   prometheusServer = fclib.findOneService "statshost-master-collector";
-  prometheusHost = lib.replaceStrings [ "gocept.net" ] [ "fcio.net" ] prometheusServer.address;
+  prometheusHost = builtins.head prometheusServer.ips;
   prometheusPort = 9090;
 
   lokiServer = fclib.findOneService "loki-collector";
-  tempoServer = fclib.findOneService "tempo-collector";
+  lokiHost = builtins.head lokiServer.ips;
   lokiPort = 3100;
 
-  tempoHost = lib.replaceStrings [ "gocept.net" ] [ "fcio.net" ] tempoServer.address;
+  tempoServer = fclib.findOneService "tempo-collector";
+  tempoHost = builtins.head tempoServer.ips;
   tempoPort = 4317;
 in
 {
@@ -42,7 +43,7 @@ in
       environment.etc."alloy/loki.alloy".text = ''
         loki.write "fcio_rg_loki" {
           endpoint {
-            url = "http://${lokiServer.address}:${toString lokiPort}/loki/api/v1/push"
+            url = "http://${lokiHost}:${toString lokiPort}/loki/api/v1/push"
           }
 
           // there are server side limits to how many labels loki

--- a/nixos/roles/k3s/default.nix
+++ b/nixos/roles/k3s/default.nix
@@ -11,6 +11,8 @@
 }:
 let
   inherit (config.flyingcircus.kubernetes.network) enableIPv6;
+  location = lib.attrByPath [ "parameters" "location" ] "standalone" config.flyingcircus.enc;
+  lokiServer = config.fclib.findOneService "loki-collector";
 in
 {
   imports = with lib; [
@@ -134,6 +136,87 @@ in
             ];
           }
         ];
+      })
+
+      (lib.mkIf (server && (!builtins.isNull lokiServer)) {
+        systemd.services.alloy = lib.mkIf config.services.alloy.enable {
+          requires = [ "k3s.service" ];
+          after = [ "k3s.service" ];
+
+          serviceConfig.LoadCredential = "bearer_token_file:/var/lib/k3s/tokens/alloy";
+          environment.BEARER_TOKEN_FILE = "%d/bearer_token_file";
+          environment.API_SERVER = "https://127.0.0.1:6443";
+          environment.CLUSTER_LOCATION = location;
+          reloadTriggers = [
+            config.environment.etc."alloy/k3s_events.alloy".source
+            config.environment.etc."alloy/pod_logs.alloy".source
+          ];
+        };
+
+        environment.etc."alloy/pod_logs.alloy".text = ''
+          discovery.kubernetes "pods" {
+            role = "pod"
+            selectors {
+              role = "pod"
+            }
+            api_server = sys.env("API_SERVER")
+            bearer_token_file = sys.env("BEARER_TOKEN_FILE")
+            tls_config {
+              insecure_skip_verify = true
+            }
+          }
+
+          discovery.relabel "pods" {
+            targets = discovery.kubernetes.pods.targets
+
+            rule {
+              source_labels = ["__meta_kubernetes_pod_container_name"]
+              action = "replace"
+              target_label = "container"
+            }
+
+            rule {
+              source_labels = ["__meta_kubernetes_pod_phase"]
+              action = "replace"
+              target_label = "phase"
+            }
+          }
+
+          loki.source.kubernetes "pod_logs" {
+            targets    = discovery.relabel.pods.output
+            forward_to = [loki.process.pod_logs.receiver]
+            client {
+              api_server = sys.env("API_SERVER")
+              bearer_token_file = sys.env("BEARER_TOKEN_FILE")
+              tls_config {
+                insecure_skip_verify = true
+              }
+            }
+          }
+
+          loki.process "pod_logs" {
+            stage.static_labels {
+                values = {
+                  cluster = sys.env("CLUSTER_LOCATION"),
+                }
+            }
+
+            forward_to = [loki.write.fcio_rg_loki.receiver]
+          }
+        '';
+
+        environment.etc."alloy/k3s_events.alloy".text = ''
+          loki.source.kubernetes_events "k3s_events" {
+            forward_to = [loki.write.fcio_rg_loki.receiver]
+            client {
+              api_server = sys.env("API_SERVER")
+              bearer_token_file = sys.env("BEARER_TOKEN_FILE")
+              tls_config {
+                insecure_skip_verify = true
+              }
+            }
+          }
+        '';
       })
     ];
 }

--- a/nixos/roles/k3s/server.nix
+++ b/nixos/roles/k3s/server.nix
@@ -15,7 +15,6 @@ let
 
   location = lib.attrByPath [ "parameters" "location" ] "standalone" config.flyingcircus.enc;
   srvFQDN = "${config.networking.hostName}.fcio.net";
-
   lokiServer = fclib.findOneService "loki-collector";
 
   # We allow frontend access to the dashboard at the moment
@@ -232,7 +231,43 @@ let
             }
           ];
         })
-      ];
+      ]
+      ++ (lib.optionals (!builtins.isNull lokiServer) [
+        (serviceAccount "alloy")
+        (serviceAccountSecret "alloy")
+        (clusterRole {
+          metadata.name = "flyingcircus:alloy";
+          rules = [
+            {
+              apiGroups = [ "" ];
+              resources = [
+                "pods"
+                "pods/log"
+              ];
+              verbs = [
+                "get"
+                "list"
+                "watch"
+              ];
+            }
+          ];
+        })
+        (clusterRoleBinding {
+          metadata.name = "flyingcircus:alloy:viewer";
+          roleRef = {
+            apiGroup = "rbac.authorization.k8s.io";
+            kind = "ClusterRole";
+            name = "flyingcircus:alloy";
+          };
+          subjects = [
+            {
+              kind = "ServiceAccount";
+              name = "io.flyingcircus.service.alloy";
+              namespace = "kube-system";
+            }
+          ];
+        })
+      ]);
       renderedManifests = lib.concatStringsSep "\n" (
         lib.flatten (
           map (m: [
@@ -251,26 +286,18 @@ let
   authTokenScript = pkgs.writeShellScriptBin "kubernetes-write-auth-token" ''
     set -o pipefail
 
-    user="$1"
+    tokenname="$1"
     secretname="$2"
+    user="$3"
+    group="$4"
 
     tokendir=/var/lib/k3s/tokens
     export KUBECONFIG=${defaultKubeconfig}
 
-    if [ -z "$secretname" ]; then
-      echo 'missing kubernetes secret name' 2>&1
-      exit 1
-    fi
-
-    if [ -z "$user" ]; then
-      echo 'missing service account name' 2>&1
-      exit 1
-    fi
-
     mkdir -p "$tokendir"
-    install -o "$user" -g "$user" -m 600 /dev/null "$tokendir/$user.b64"
-    install -o "$user" -g "$user" -m 600 /dev/null "$tokendir/$user.tmp"
-    install -o "$user" -g "$user" -m 600 /dev/null "$tokendir/$user.cfg.tmp"
+    install -o "$user" -g "$group" -m 600 /dev/null "$tokendir/$tokenname.b64"
+    install -o "$user" -g "$group" -m 600 /dev/null "$tokendir/$tokenname.tmp"
+    install -o "$user" -g "$group" -m 600 /dev/null "$tokendir/$tokenname.cfg.tmp"
 
     # this service may race with k3s loading and processing the vendor
     # manifests from disk -- they are not present on first run, and k3s only
@@ -281,8 +308,8 @@ let
     rc=0
     for i in 1 2 3 4 5 6 7 8 9 10; do
       kubectl get -n kube-system -o jsonpath='{.data.token}' \
-        secret "$secretname" > "$tokendir/$user.b64" && \
-        test -s "$tokendir/$user.b64"
+        secret "$secretname" > "$tokendir/$tokenname.b64" && \
+        test -s "$tokendir/$tokenname.b64"
       rc="$?"
 
       if [ "$rc" = 0 ]; then
@@ -296,49 +323,56 @@ let
       exit 1
     fi
 
-    base64 -d "$tokendir/$user.b64" > "$tokendir/$user.tmp"
+    base64 -d "$tokendir/$tokenname.b64" > "$tokendir/$tokenname.tmp"
     if [ "$?" != 0 ]; then
       echo 'could not decode secret token' 2>&1
       exit 1
     fi
 
     remarshal "$KUBECONFIG" -if yaml -of json | \
-      jq --rawfile token "$tokendir/$user.tmp" \
+      jq --rawfile token "$tokendir/$tokenname.tmp" \
       '.users[0].user |= (del(."client-key-data", ."client-certificate-data") | .token = $token)' \
-      > "$tokendir/$user.cfg.tmp"
+      > "$tokendir/$tokenname.cfg.tmp"
     if [ "$?" != 0 ]; then
       echo 'could not generate kubeconfig from token' 2>&1
       exit 1
     fi
 
-    mv "$tokendir/$user.tmp" "$tokendir/$user"
-    mv "$tokendir/$user.cfg.tmp" "$tokendir/$user.cfg"
-    echo "Successfully initialised token for secret \"$secretname\" for user \"$user\"."
-    rm -f "$tokendir/$user.b64"
+    mv "$tokendir/$tokenname.tmp" "$tokendir/$tokenname"
+    mv "$tokendir/$tokenname.cfg.tmp" "$tokendir/$tokenname.cfg"
+    echo "Successfully initialised token with name \"$tokenname\" for secret \"$secretname\" for user \"$user\" in group \"$group\"."
+    rm -f "$tokendir/$tokennname.b64"
   '';
 
-  makeAuthTokenService = user: secret: {
-    wantedBy = [ "multi-user.target" ];
-    requires = [
-      "k3s.service"
-    ];
-    after = [
-      "k3s.service"
-    ];
-    path = with pkgs; [
-      coreutils
-      kubectl
-      remarshal
-      jq
-    ];
-    serviceConfig = {
-      RemainAfterExit = true;
-      Type = "oneshot";
-      Restart = "on-failure";
-      RestartSec = 10;
-      ExecStart = "${authTokenScript}/bin/kubernetes-write-auth-token ${user} ${secret}";
+  makeAuthTokenService =
+    {
+      user,
+      secret,
+      group ? user,
+      tokenname ? user,
+    }:
+    {
+      wantedBy = [ "multi-user.target" ];
+      requires = [
+        "k3s.service"
+      ];
+      after = [
+        "k3s.service"
+      ];
+      path = with pkgs; [
+        coreutils
+        kubectl
+        remarshal
+        jq
+      ];
+      serviceConfig = {
+        RemainAfterExit = true;
+        Type = "oneshot";
+        Restart = "on-failure";
+        RestartSec = 10;
+        ExecStart = "${authTokenScript}/bin/kubernetes-write-auth-token '${tokenname}' '${secret}' '${user}' '${group}'";
+      };
     };
-  };
 
   podPendingScript = pkgs.writeScriptBin "check-kube-pending-pods" ''
     set -euo pipefail
@@ -596,10 +630,24 @@ in
           "L+ /var/lib/k3s/server/manifests/flyingcircus/flyingcircus.yaml - - - - ${additionalManifests}/flyingcircus.yaml"
         ];
 
-        systemd.services.fc-k3s-token-telegraf = makeAuthTokenService "telegraf" "io.flyingcircus.service-token.telegraf";
-        systemd.services.fc-k3s-token-sensuclient = makeAuthTokenService "sensuclient" "io.flyingcircus.service-token.sensu-client";
+        systemd.services.fc-k3s-token-telegraf = makeAuthTokenService {
+          user = "telegraf";
+          secret = "io.flyingcircus.service-token.telegraf";
+        };
+        systemd.services.fc-k3s-token-sensuclient = makeAuthTokenService {
+          user = "sensuclient";
+          secret = "io.flyingcircus.service-token.sensu-client";
+        };
+        systemd.services.fc-k3s-token-alloy = lib.mkIf (!builtins.isNull lokiServer) (makeAuthTokenService {
+          user = "root";
+          tokenname = "alloy";
+          secret = "io.flyingcircus.service-token.alloy";
+        });
         systemd.services.telegraf.after = [ "fc-k3s-token-telegraf.service" ];
         systemd.services.sensu-client.after = [ "fc-k3s-token-sensuclient.service" ];
+        systemd.services.alloy.after = lib.optionals (!builtins.isNull lokiServer) [
+          "fc-k3s-token-alloy.service"
+        ];
 
         ### Dashboard
         flyingcircus.services.nginx.enable = true;
@@ -703,18 +751,6 @@ in
           "ip_vs_sh"
         ];
       }
-
-      (lib.mkIf (!builtins.isNull lokiServer) {
-        systemd.services.alloy = lib.mkIf config.services.alloy.enable {
-          reloadTriggers = [ config.environment.etc."alloy/k3s_events.alloy".source ];
-        };
-
-        environment.etc."alloy/k3s_events.alloy".text = ''
-          loki.source.kubernetes_events "k3s_events" {
-            forward_to = [loki.write.fcio_rg_loki.receiver]
-          }
-        '';
-      })
     ]
   );
 }

--- a/tests/k3s/default.nix
+++ b/tests/k3s/default.nix
@@ -51,6 +51,14 @@ import ../make-test-python.nix (
         ];
         service = "k3s-frontend";
       }
+      {
+        address = "k3sserver.fcio.net";
+        ips = [
+          masterSrv4
+          masterSrv6
+        ];
+        service = "loki-collector";
+      }
     ];
 
     # synthetic default routes are required so that connections to the
@@ -69,7 +77,6 @@ import ../make-test-python.nix (
   {
 
     name = "k3s";
-
     nodes = {
 
       master =
@@ -85,6 +92,7 @@ import ../make-test-python.nix (
           config = {
             flyingcircus.encServices = encServices;
             flyingcircus.roles.k3s-server.enable = true;
+            flyingcircus.roles.loki.enable = true;
             flyingcircus.kubernetes.network.enableIPv6 = enableIPv6;
             networking.domain = "fcio.net";
             networking.hostName = lib.mkForce "k3sserver";
@@ -94,6 +102,9 @@ import ../make-test-python.nix (
               6443
             ];
             networking.firewall.allowedUDPPorts = [ 53 ];
+
+            environment.variables.LOKI_ADDR = "http://127.0.0.1:3100";
+            environment.systemPackages = [ pkgs.grafana-loki ];
 
             services.nginx.virtualHosts."kubernetes.test.fcio.net" = {
               enableACME = false;
@@ -226,6 +237,9 @@ import ../make-test-python.nix (
       { nodes, ... }:
       let
         masterSensuCheck = testlib.sensuCheckCmd nodes.master;
+        testscript = pkgs.writeShellScript "test-podlog-in-loki.sh" ''
+          test $(logcli -q query '{container="redis"} |= `Redis is starting`' | wc -l) -gt 0
+        '';
       in
       ''
         import time
@@ -297,6 +311,9 @@ import ../make-test-python.nix (
 
         with subtest("frontend should be able to ping redis pods"):
           frontend.wait_until_succeeds("redis-cli ping | grep PONG")
+
+        with subtest("redis logs are shipped to loki"):
+          k3sserver.succeed('${testscript}')
 
         with subtest("dashboard sensu check should be red after shutting down dashboard"):
           k3sserver.systemctl("stop kube-dashboard")


### PR DESCRIPTION
@flyingcircusio/release-managers

PL-135231

## Release process

This change should be backported:

- [x] Created changelog entry using `./changelog.sh`
- [x] Add `backport release-25.11` label

This change should only reach this branch:

- [ ] Created changelog entry using `./changelog.sh`
or
- [ ] Add a upgrade node in `doc/upgrade.md`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [x] ensure all checks are green
- [x] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [ ] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- provides configuration that exports k3s pod journal logs to a non-public loki instance
- [x] Security requirements tested? (EVIDENCE)
- very similar security requirements to the VM's journal - potentially exposes secrets to another system. the former is considered acceptable risk so this should be too  
