### PR TITLE
gitlab: 18.9.1 -> 18.9.2 (via nixpkgs update)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -168,11 +168,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1772945633,
-        "narHash": "sha256-ZsJoWClgXiG1BsukG+AEwPCQvDAIQM9wdsQTyMw6+WA=",
+        "lastModified": 1773240846,
+        "narHash": "sha256-xNMNYSQUTWmuK6eQiGi5Zx48Xwd/PiqRoC53Jq4wGSs=",
         "owner": "flyingcircusio",
         "repo": "nixpkgs",
-        "rev": "084d8250d1fd43db12541971ffbc56bed8f4e602",
+        "rev": "5a19bc344f0254c87a7d88caf27daae20c0055be",
         "type": "github"
       },
       "original": {

--- a/release/package-versions.json
+++ b/release/package-versions.json
@@ -220,9 +220,9 @@
     "version": "2.51.2"
   },
   "gitaly": {
-    "name": "gitaly-18.9.1",
+    "name": "gitaly-18.9.2",
     "pname": "gitaly",
-    "version": "18.9.1"
+    "version": "18.9.2"
   },
   "github-runner": {
     "name": "github-runner-2.332.0",
@@ -230,9 +230,9 @@
     "version": "2.332.0"
   },
   "gitlab": {
-    "name": "gitlab-18.9.1",
+    "name": "gitlab-18.9.2",
     "pname": "gitlab",
-    "version": "18.9.1"
+    "version": "18.9.2"
   },
   "gitlab-container-registry": {
     "name": "gitlab-container-registry-4.37.0",
@@ -240,14 +240,14 @@
     "version": "4.37.0"
   },
   "gitlab-ee": {
-    "name": "gitlab-ee-18.9.1",
+    "name": "gitlab-ee-18.9.2",
     "pname": "gitlab-ee",
-    "version": "18.9.1"
+    "version": "18.9.2"
   },
   "gitlab-pages": {
-    "name": "gitlab-pages-18.9.1",
+    "name": "gitlab-pages-18.9.2",
     "pname": "gitlab-pages",
-    "version": "18.9.1"
+    "version": "18.9.2"
   },
   "gitlab-runner": {
     "name": "gitlab-runner-18.8.0",
@@ -255,9 +255,9 @@
     "version": "18.8.0"
   },
   "gitlab-workhorse": {
-    "name": "gitlab-workhorse-18.9.1",
+    "name": "gitlab-workhorse-18.9.2",
     "pname": "gitlab-workhorse",
-    "version": "18.9.1"
+    "version": "18.9.2"
   },
   "glibc": {
     "name": "glibc-2.40-218",

--- a/release/versions.json
+++ b/release/versions.json
@@ -8,10 +8,10 @@
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/"
   },
   "nixpkgs": {
-    "hash": "sha256-ZsJoWClgXiG1BsukG+AEwPCQvDAIQM9wdsQTyMw6+WA=",
+    "hash": "sha256-xNMNYSQUTWmuK6eQiGi5Zx48Xwd/PiqRoC53Jq4wGSs=",
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "084d8250d1fd43db12541971ffbc56bed8f4e602"
+    "rev": "5a19bc344f0254c87a7d88caf27daae20c0055be"
   },
   "poetry2nix": {
     "hash": "sha256-nzgO/ZCSBzWjbMkYDxG+yl9Z2eGbCgQu06Oku3ir5D4=",


### PR DESCRIPTION
Pull in an out-of-schedule nixpkgs update with a cherry-picked gitlab update.
Reason: Fix for migration issues reported upstream https://support.gitlab.com/hc/en-us/articles/25992549646364-Upgrade-to-18-9-0-fails-with-PG-CheckViolation-on-commit-user-mentions

@flyingcircusio/release-managers

## Release process

This change should be backported:

- [x] Created changelog entry using `./changelog.sh`
  - kind of, via package-versions update

## PR release workflow (internal)

- [ ] PR has internal ticket
- [ ] internal issue ID (PL-…) part of branch name
- [ ] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [x] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Resolution of an upstream-reported regression in the migration process. Due to uncertainty regarding the scope of potentially affected deployments, the defensive approach is to include the fixes.
- [ ] Security requirements tested? (EVIDENCE)
  - [x] upstream tests pass
  - [ ] all integration tests pass