### PR TITLE
add basic nixd config

### DIFF
--- a/.nixd.json
+++ b/.nixd.json
@@ -1,0 +1,10 @@
+{
+  "nixpkgs": {
+    "expr": "import <nixpkgs> { }"
+  },
+  "options": {
+    "nixos": {
+      "expr": "(import <nixpkgs/nixos> { configuration.imports = [ <fc/nixos> <fc/nixos/roles> ]; }).options"
+    }
+  }
+}


### PR DESCRIPTION
This adds basic entry point information for the nixd LSP. It assumes that the NIX_PATH has been set up accordingly, e.g. by entering a `nix develop` shell or automatic direnv environment setup, as recommended in the README.

@flyingcircusio/release-managers

## Release process

This change should only reach this branch:

- [ ] Created changelog entry using `./changelog.sh`
  - no, internal developer quality of life improvements 

## PR release workflow (internal)

- [ ] PR has internal ticket
- [ ] internal issue ID (PL-…) part of branch name
- [ ] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [x] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - n/a
- [x] Security requirements tested? (EVIDENCE)
