### PR TITLE
webgateway: fix nginx_config sensu check

### DIFF
--- a/changelog.d/20260312_164138_HEAD_scriv.md
+++ b/changelog.d/20260312_164138_HEAD_scriv.md
@@ -1,0 +1,26 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+<!-- Impact means "when this change is rolled out, there
+     might be interruptions/downtimes/required actions/... that
+     IMPACT THE RUNNING APPLICATION NEGATIVELY.
+
+     Having new features or changed is not an "impact". That's what
+     the main changelog (see below) is for.
+     -->
+
+### NixOS XX.XX platform
+
+- webgateway: fix nginx_config sensu check (PL-135234)

--- a/nixos/services/nginx/default.nix
+++ b/nixos/services/nginx/default.nix
@@ -29,7 +29,7 @@ let
   nginxCheckConfig = pkgs.writeScriptBin "nginx-check-config" ''
     #!${pkgs.runtimeShell}
     echo "Running built-in Nginx config validation (must pass in order to activate a config)..."
-    ${lib.getExe nginxCfg.package} -t || exit 2
+    ${lib.getExe nginxCfg.package} -c /etc/nginx/nginx.conf -g "user nginx;" -t || exit 2
     echo "Running gixy security checker (just informational)..."
     ${pkgs.gixy}/bin/gixy /etc/nginx/nginx.conf || exit 1
   '';

--- a/tests/nginx.nix
+++ b/tests/nginx.nix
@@ -158,6 +158,12 @@ import ./make-test-python.nix (
             server = "1.2.3.4";
             password = "foo";
           };
+
+          specialisation.brokenconfig.configuration = {
+            flyingcircus.services.nginx.virtualHosts.server.locations."/proxy".extraConfig = ''
+              not_existing_option true;
+            '';
+          };
         };
 
       server2 = mkFCServer {
@@ -309,6 +315,15 @@ import ./make-test-python.nix (
         sensuCheck = testlib.sensuCheckCmd nodes.server1;
       in
       ''
+        def switch_specialisation(name, expected_fail: bool):
+            path = "${nodes.server1.system.build.toplevel}/bin/switch-to-configuration" \
+              if name is None \
+              else f"${nodes.server1.system.build.toplevel}/specialisation/{name}/bin/switch-to-configuration"
+            if expected_fail:
+              server1.fail(f"{path} test")
+            else:
+              server1.succeed(f"{path} test")
+
         def prep(server):
           server.wait_for_unit('nginx.service')
           server.wait_for_open_port(81)
@@ -439,6 +454,21 @@ import ./make-test-python.nix (
           server1.succeed("${sensuCheck "nginx_config"}")
           server1.succeed("${sensuCheck "nginx_worker_age"}")
           server1.succeed("${sensuCheck "nginx_status"}")
+
+        with subtest("sensu checks should not mess with cache directory"):
+          # When running with a wrong user, nginx might change permissions of the directories in /var/cache/nginx.
+          # If running with a wrong config, it might create files in /tmp instead
+          files = server1.succeed("ls /var/cache/nginx").rstrip().split("\n")
+          for file in files:
+            assert_file_permissions("700:nginx:nginx", f"/var/cache/nginx/{file}")
+
+          # one of the files that would be created, see http-proxy-temp-path in nginx package
+          server1.fail("test -e /tmp/nginx_proxy")
+
+        with subtest("nginx_config check should be red when config is invalid"):
+          switch_specialisation("brokenconfig", True)
+          server1.fail("${sensuCheck "nginx_config"}")
+          switch_specialisation(None, False)
 
         with subtest("killing the nginx process should trigger an automatic restart"):
           server1.succeed("pkill -9 -F /run/nginx/nginx.pid");


### PR DESCRIPTION
@flyingcircusio/release-managers

Run it with the correct user and correct config file and extend NixOS
test with possible effects if the check is configured wrong.

PL-135234

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [x] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [x] Security requirements tested? (EVIDENCE)
  - Tested that file permissions are correct on test vm
  - Tested that check fails when config is invalid
  - Extended automated testing with the effects noticed on the affected VM.