### PR TITLE
pkgs.writers.writePython3BinFromFile: move from fclib

### DIFF
--- a/changelog.d/20260312_202537_os-python3BinFromFile_scriv.md
+++ b/changelog.d/20260312_202537_os-python3BinFromFile_scriv.md
@@ -1,0 +1,27 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+<!-- Impact means "when this change is rolled out, there
+     might be interruptions/downtimes/required actions/... that
+     IMPACT THE RUNNING APPLICATION NEGATIVELY.
+
+     Having new features or changed is not an "impact". That's what
+     the main changelog (see below) is for.
+     -->
+
+
+### NixOS XX.XX platform
+
+- `pkgs.writers.writePython3BinFromFile`: provide helper function for packaging single-file python scripts

--- a/nixos/lib/utils.nix
+++ b/nixos/lib/utils.nix
@@ -182,48 +182,4 @@ rec {
       filter (u: any (g: g == group) (getAttr currentRG u.permissions)) config.flyingcircus.users.userData
     );
 
-  /**
-     python3BinFromFile takes a path to a python file and an attributeset with some further options.
-     It outputs a directory with `bin/basename_of_python_file`.
-     Attrset options:
-     - dependencies: list of packages with executables that are added to PATH for the python program
-     - all other options are passed through to `writePython3Bin`.
-
-     # Examples
-     :::{.example}
-     ## `python3BinFromFile` usage example
-
-     ```nix
-     python3BinFromFile ./pkgs/test.py {
-       dependencies = [ pkgs.sl ];
-       libraries = [ pkgs.python3Packages.pyyaml ];
-     }
-     ```
-
-     :::
-  */
-  python3BinFromFile =
-    path:
-    {
-      dependencies ? [ ],
-      ...
-    }@args:
-    let
-      progname = removeSuffix ".py" (builtins.baseNameOf path);
-      writerArgs = lib.removeAttrs args [ "dependencies" ];
-      python3Writer = pkgs.writers.writePython3Bin progname writerArgs (lib.readFile path);
-      pathWrapper =
-        pkgs.runCommand "wrap-${progname}"
-          {
-            nativeBuildInputs = [ pkgs.makeBinaryWrapper ];
-            meta.mainProgram = progname;
-          }
-          ''
-            mkdir -p $out/bin
-            makeBinaryWrapper ${lib.getExe python3Writer} $out/bin/${progname} \
-              --prefix PATH : "${lib.makeBinPath dependencies}"
-          '';
-    in
-    if dependencies == [ ] then python3Writer else pathWrapper;
-
 }

--- a/nixos/platform/journalbeat.nix
+++ b/nixos/platform/journalbeat.nix
@@ -10,7 +10,7 @@ with lib;
 let
   fclib = config.fclib;
   cfg = config.flyingcircus.journalbeat;
-  journalSetCursor = fclib.python3BinFromFile ./filebeat-journal-set-cursor.py { };
+  journalSetCursor = pkgs.writers.writePython3BinFromFile ./filebeat-journal-set-cursor.py { };
 
 in
 {

--- a/nixos/roles/consul/default.nix
+++ b/nixos/roles/consul/default.nix
@@ -12,7 +12,7 @@ let
   enc = config.flyingcircus.enc;
   secrets = enc.parameters.secrets;
   public_fqdn = "${enc.name}.fe.${enc.parameters.location}.fcio.net";
-  server_secret_script = fclib.python3BinFromFile ./update-server-secrets.py { };
+  server_secret_script = pkgs.writers.writePython3BinFromFile ./update-server-secrets.py { };
   cfg = config.flyingcircus.roles.consul_server;
 in
 {

--- a/nixos/roles/webproxy.nix
+++ b/nixos/roles/webproxy.nix
@@ -50,7 +50,7 @@ in
         "local/varnish/README.txt".text =
           let
             listen_str = lib.concatMapStringsSep ", " (
-              listenCfg: ''${listenCfg.proto} ${listenCfg.address}:${toString (listenCfg.port or "n/a")}''
+              listenCfg: "${listenCfg.proto} ${listenCfg.address}:${toString (listenCfg.port or "n/a")}"
             ) config.services.varnish.listen;
           in
           ''
@@ -70,7 +70,7 @@ in
         };
         varnish_http =
           let
-            check-varnish-http = fclib.python3BinFromFile ./check-varnish-http.py {
+            check-varnish-http = pkgs.writers.writePython3BinFromFile ./check-varnish-http.py {
               dependencies = [
                 cfg.package
                 pkgs.monitoring-plugins

--- a/nixos/services/consul/default.nix
+++ b/nixos/services/consul/default.nix
@@ -12,7 +12,7 @@ let
   cfg = config.flyingcircus.services.consul;
   enc = config.flyingcircus.enc;
   secrets = enc.parameters.secrets;
-  client_secret_script = fclib.python3BinFromFile ./update-client-secrets.py { };
+  client_secret_script = pkgs.writers.writePython3BinFromFile ./update-client-secrets.py { };
 in
 {
   options = {

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -652,5 +652,51 @@ builtins.mapAttrs (_: patchPhps phpLogPermissionPatch) {
         pname = "tcpdump-vxlan";
       });
 
+  # XXX: consider upstreaming these
+  writers = super.writers // {
+    /**
+       writePython3BinFromFile takes a path to a python file and an attributeset with some further options.
+       It outputs a directory with `bin/basename_of_python_file`.
+       Attrset options:
+       - dependencies: list of packages with executables that are added to PATH for the python program
+       - all other options are passed through to `writePython3Bin`.
+
+       # Examples
+       :::{.example}
+       ## `writePython3BinFromFile` usage example
+
+       ```nix
+       writePython3BinFromFile ./pkgs/test.py {
+         dependencies = [ pkgs.sl ];
+         libraries = [ pkgs.python3Packages.pyyaml ];
+       }
+       ```
+
+       :::
+    */
+    writePython3BinFromFile =
+      path:
+      {
+        dependencies ? [ ],
+        ...
+      }@args:
+      let
+        progname = lib.removeSuffix ".py" (builtins.baseNameOf path);
+        writerArgs = lib.removeAttrs args [ "dependencies" ];
+        python3Writer = self.writers.writePython3Bin progname writerArgs (lib.readFile path);
+        pathWrapper =
+          self.runCommand "wrap-${progname}"
+            {
+              nativeBuildInputs = [ self.makeBinaryWrapper ];
+              meta.mainProgram = progname;
+            }
+            ''
+              mkdir -p $out/bin
+              makeBinaryWrapper ${lib.getExe python3Writer} $out/bin/${progname} \
+                --prefix PATH : "${lib.makeBinPath dependencies}"
+            '';
+      in
+      if dependencies == [ ] then python3Writer else pathWrapper;
+  };
   xtrabackup = lib.warn "The `xtrabackup` package has been renamed to `percona-xtrabackup`." self.percona-xtrabackup;
 }


### PR DESCRIPTION
The previous utility function `python3BinFromFile` was only accessible from within the NixOS module system, used for qucikly packaging single-file python scripts with external dependencies. There have been situations where I'd also wanted to use it for standalone-defined package attributes that can be used and accessed independently of the module system.

@flyingcircusio/release-managers

## Release process

This change should be backported:

This change should only reach this branch:

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [ ] PR has internal ticket
- [ ] internal issue ID (PL-…) part of branch name
- [ ] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [x] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - plain refactoring of a utility function, must not introduce regressions 
- [x] Security requirements tested? (EVIDENCE)
  - automated tests still pass