### PR TITLE
Allow overriding resolver addresses in KVM firewall for L3 routed guest interfaces

### DIFF
--- a/nixos/roles/kvm/default.nix
+++ b/nixos/roles/kvm/default.nix
@@ -21,9 +21,6 @@ let
   virtualGatewayV6 = "fe80::1";
 
   vrfInterfaces = lib.filterAttrs (n: v: v.routed or false) fclib.network;
-  locationNameserverV4 = head config.flyingcircus.static.nameservers."${location}";
-  locationNameserverV6 = head config.flyingcircus.static.nameservers6."${location}";
-
   vrfV6Resolvers = iface: map (net: "${net.network}1") iface.v6.networkAttrs;
 
   ubuntuUpdateScript = pkgs.writeShellApplication {
@@ -79,6 +76,19 @@ in
         default = fclib.network.sto;
         defaultText = "The `sto` network";
         description = "Network to use for migration";
+      };
+
+      routedResolverV4 = lib.mkOption {
+        type = lib.types.str;
+        default = head config.flyingcircus.static.nameservers."${location}";
+        defaultText = "The platfrom default IPv4 resolver for this location";
+        description = "Routing destination for DNS queries received on the IPv4 virtual gateway address";
+      };
+      routedResolverV6 = lib.mkOption {
+        type = lib.types.str;
+        default = head config.flyingcircus.static.nameservers6."${location}";
+        defaultText = "The platform default IPv6 resolver for this location";
+        description = "Routing destination for DNS queries received on the IPv6 virtual resolver address(es)";
       };
 
       maintenanceEvacuationTimeout = lib.mkOption {
@@ -628,8 +638,8 @@ in
       # to the location-wide resolver
       ${lib.concatStringsSep "\n" (
         lib.mapAttrsToList (name: _: ''
-          iptables -t nat -A nixos-nat-pre -i t${name}+ -d ${virtualGatewayV4} -p udp --dport 53 -j DNAT --to-destination ${locationNameserverV4}
-          iptables -t nat -A nixos-nat-pre -i t${name}+ -d ${virtualGatewayV4} -p tcp --dport 53 -j DNAT --to-destination ${locationNameserverV4}
+          iptables -t nat -A nixos-nat-pre -i t${name}+ -d ${virtualGatewayV4} -p udp --dport 53 -j DNAT --to-destination ${cfg.routedResolverV4}
+          iptables -t nat -A nixos-nat-pre -i t${name}+ -d ${virtualGatewayV4} -p tcp --dport 53 -j DNAT --to-destination ${cfg.routedResolverV4}
         '') vrfInterfaces
       )}
       ${lib.concatStringsSep "\n" (
@@ -637,8 +647,8 @@ in
           name: iface:
           lib.concatStringsSep "\n" (
             map (gw: ''
-              ip6tables -t nat -A nixos-nat-pre -i t${name}+ -d ${gw} -p udp --dport 53 -j DNAT --to-destination ${locationNameserverV6}
-              ip6tables -t nat -A nixos-nat-pre -i t${name}+ -d ${gw} -p tcp --dport 53 -j DNAT --to-destination ${locationNameserverV6}
+              ip6tables -t nat -A nixos-nat-pre -i t${name}+ -d ${gw} -p udp --dport 53 -j DNAT --to-destination ${cfg.routedResolverV6}
+              ip6tables -t nat -A nixos-nat-pre -i t${name}+ -d ${gw} -p tcp --dport 53 -j DNAT --to-destination ${cfg.routedResolverV6}
             '') (vrfV6Resolvers iface)
           )
         ) vrfInterfaces


### PR DESCRIPTION
This change introduces a NixOS option which allows configuration of the IP address used as the destination for DNS queries received on the virtual gateway address from layer 3 routed guest interfaces. Previously, this was hardcoded as the first of the default platform resolvers in the location, however some scenarios in the lab need extra flexibility.

PL-135138

@flyingcircusio/release-managers

## Release process

This change should be backported:

- [x] Created changelog entry using `./changelog.sh` => none, internal change.
- [x] Add `backport release-25.11` label => forward port to 26.05.

This change should only reach this branch:

- [ ] Created changelog entry using `./changelog.sh`
or
- [ ] Add a upgrade node in `doc/upgrade.md`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [ ] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - None.
- [x] Security requirements tested? (EVIDENCE)
  - Verified in the lab.
