### PR TITLE
important_packages: add php85

### DIFF
--- a/release/important_packages.json
+++ b/release/important_packages.json
@@ -146,6 +146,7 @@
   "php82",
   "php83",
   "php84",
+  "php85",
   "phpPackages.composer",
   "pkg-config",
   "podman",


### PR DESCRIPTION
Follow-up to #2201

Adding the package there ensures it is listed in the nixpkgs update package version diffs.

@flyingcircusio/release-managers

## Release process

This change should be backported:

- [ ] Created changelog entry using `./changelog.sh`
  - not user visible
- [x] Add `backport release-25.11` label

## PR release workflow (internal)

- [ ] PR has internal ticket
- [ ] internal issue ID (PL-…) part of branch name
- [ ] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [x] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - ensure visibility of package updates 
- [x] Security requirements tested? (EVIDENCE)
