### PR TITLE
fc-ceph: Add locking to internal object storage accounting to prevent race conditions

### DIFF
--- a/changelog.d/20260323_154430_HEAD_scriv.md
+++ b/changelog.d/20260323_154430_HEAD_scriv.md
@@ -1,0 +1,27 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+<!-- Impact means "when this change is rolled out, there
+     might be interruptions/downtimes/required actions/... that
+     IMPACT THE RUNNING APPLICATION NEGATIVELY.
+
+     Having new features or changed is not an "impact". That's what
+     the main changelog (see below) is for.
+     -->
+
+
+### NixOS XX.XX platform
+
+- fc-ceph: Add locking to internal object storage accounting to prevent race conditions (PL-128135)

--- a/pkgs/fc/ceph/src/fc/ceph/logs.py
+++ b/pkgs/fc/ceph/src/fc/ceph/logs.py
@@ -61,6 +61,7 @@ class LogTasks(object):
         self,
         state_file: Path,
         enc_file: Path,
+        lock_dir: Path,
         enc_services_file: Path = Path("/etc/nixos/services.json"),
     ):
         final_stats = []
@@ -82,7 +83,7 @@ class LogTasks(object):
                     internal_networks.append(IPy.IP(network))
 
             ops_log = OpsLog(
-                state_file, internal_networks, rgw_location_proxy_ips
+                state_file, lock_dir, internal_networks, rgw_location_proxy_ips
             )
 
             with ops_log.get_pending_stats_by_day() as logs:
@@ -114,5 +115,5 @@ class LogTasks(object):
                 print(f"Gathered {len(final_stats)} samples to account")
                 d.store_s3_traffic(final_stats)
 
-    def gc_s3_traffic(self, state_file: Path):
-        OpsLog(state_file).gc_log_objects()
+    def gc_s3_traffic(self, state_file: Path, lock_dir: Path):
+        OpsLog(state_file, lock_dir).gc_log_objects()

--- a/pkgs/fc/ceph/src/fc/ceph/main.py
+++ b/pkgs/fc/ceph/src/fc/ceph/main.py
@@ -343,6 +343,14 @@ def ceph(args=sys.argv[1:]):
         type=Path,
         default=Path("/etc/nixos/enc.json"),
     )
+    (
+        account_s3_traffic.add_argument(
+            "--lock-dir",
+            default="/run/lock",
+            help="Directory where the lock file for exclusive operations should be "
+            "placed.",
+        ),
+    )
     account_s3_traffic.set_defaults(action="account_s3_traffic")
 
     gc_s3_traffic = logs_sub.add_parser(
@@ -355,6 +363,14 @@ def ceph(args=sys.argv[1:]):
         "--state-file",
         help="File which contains the state of the S3 traffic accounting (i.e. last accounted days)",
         type=Path,
+    )
+    (
+        gc_s3_traffic.add_argument(
+            "--lock-dir",
+            default="/run/lock",
+            help="Directory where the lock file for exclusive operations should be "
+            "placed.",
+        ),
     )
 
     slowreq_histogram = logs_sub.add_parser(

--- a/pkgs/fc/ceph/src/fc/ceph/tests/test_logs.py
+++ b/pkgs/fc/ceph/src/fc/ceph/tests/test_logs.py
@@ -49,7 +49,7 @@ def enc_empty_services_file(tmpdir) -> Path:
 
 
 def test_account_s3_traffic_when_directory_is_unavailable(
-    state_file, enc_file, enc_empty_services_file, monkeypatch
+    state_file, enc_file, enc_empty_services_file, monkeypatch, tmpdir
 ):
     class DirectoryCMMock:
         def lookup_networks(*args, **kwargs):
@@ -102,6 +102,6 @@ def test_account_s3_traffic_when_directory_is_unavailable(
     )
 
     with pytest.raises(RuntimeError):
-        LogTasks().account_s3_traffic(state_file, enc_file, enc_empty_services_file)
+        LogTasks().account_s3_traffic(state_file, enc_file, tmpdir, enc_empty_services_file)
 
     assert json.load(state_file.open())["last_processed_datetime"] == "2025-01-01T01"

--- a/pkgs/fc/ceph/src/fc/ceph/tests/test_opslog.py
+++ b/pkgs/fc/ceph/src/fc/ceph/tests/test_opslog.py
@@ -26,20 +26,18 @@ def state_file(tmpdir) -> Path:
 
     return state_file
 
+def test_opslog_state_rw(state_file, tmpdir):
+    with OpsLogState.open_locked(state_file, tmpdir) as state:
+        assert state.last_gced_day.year == 2024
+        assert state.last_gced_day.month == 12
+        assert state.last_gced_day.day == 28
+        assert state.last_processed_datetime.year == 2025
+        assert state.last_processed_datetime.month == 1
+        assert state.last_processed_datetime.day == 1
+        assert state.last_processed_datetime.hour == 1
+        assert state.last_processed_datetime.minute == 0
 
-def test_opslog_state_rw(state_file):
-    state = OpsLogState.read_from(state_file)
-    assert state.last_gced_day.year == 2024
-    assert state.last_gced_day.month == 12
-    assert state.last_gced_day.day == 28
-    assert state.last_processed_datetime.year == 2025
-    assert state.last_processed_datetime.month == 1
-    assert state.last_processed_datetime.day == 1
-    assert state.last_processed_datetime.hour == 1
-    assert state.last_processed_datetime.minute == 0
-
-    state.last_gced_day = date(2025, 1, 2)
-    state.write_to(state_file)
+        state.last_gced_day = date(2025, 1, 2)
 
     with state_file.open("r") as f:
         raw = json.loads(f.read())
@@ -81,8 +79,8 @@ def rados_log_objects(monkeypatch):
 
 
 @freezegun.freeze_time("2025-01-03 04:00")
-def test_opslog_entries_by_day(state_file, rados_log_objects):
-    opslog = OpsLog(state_file, [], [])
+def test_opslog_entries_by_day(state_file, rados_log_objects, tmpdir):
+    opslog = OpsLog(state_file, tmpdir, [], [])
 
     with opslog.get_pending_stats_by_day() as log_objects:
         assert len(log_objects.keys()) == 3
@@ -118,8 +116,8 @@ def test_opslog_entries_by_day(state_file, rados_log_objects):
 
 
 @freezegun.freeze_time("2025-01-01 04:00")
-def test_start_end_same_day(state_file, rados_log_objects):
-    opslog = OpsLog(state_file, [], [])
+def test_start_end_same_day(state_file, rados_log_objects, tmpdir):
+    opslog = OpsLog(state_file,tmpdir, [], [])
 
     with opslog.get_pending_stats_by_day() as log_objects:
         assert len(log_objects.keys()) == 1
@@ -175,9 +173,9 @@ def rados_log_objects_day_wrap(monkeypatch):
     return mock
 
 
-def test_opslog_day_wrap(state_file, rados_log_objects_day_wrap):
+def test_opslog_day_wrap(state_file, rados_log_objects_day_wrap, tmpdir):
     rados_log_objects = rados_log_objects_day_wrap
-    opslog = OpsLog(state_file, [], [])
+    opslog = OpsLog(state_file, tmpdir, [], [])
 
     def test_log_objects(
         expected_processed_day: str, expected_processed_hour: str
@@ -259,9 +257,9 @@ def rados_log_objects_multiday(monkeypatch):
     return mock
 
 
-def test_opslog_multiday(state_file_multiday, rados_log_objects_multiday):
+def test_opslog_multiday(state_file_multiday, rados_log_objects_multiday, tmpdir):
     state_file = state_file_multiday
-    opslog = OpsLog(state_file, [], [])
+    opslog = OpsLog(state_file, tmpdir, [], [])
     rados_log_objects = rados_log_objects_multiday
 
     def test_log_objects(expected_date: datetime):
@@ -322,8 +320,8 @@ def test_opslog_multiday(state_file_multiday, rados_log_objects_multiday):
 
 
 @freezegun.freeze_time("2025-01-03 04:00")
-def test_opslog_entries_error_handling(state_file, rados_log_objects):
-    opslog = OpsLog(state_file, [], [])
+def test_opslog_entries_error_handling(state_file, rados_log_objects, tmpdir):
+    opslog = OpsLog(state_file, tmpdir, [], [])
 
     class SpecialException(Exception):
         pass
@@ -435,9 +433,9 @@ def get_object_mock(monkeypatch):
     return mock, internal_networks, rgw_location_proxy_ips
 
 
-def test_opslog_object_with_filtered_ips(get_object_mock, state_file):
+def test_opslog_object_with_filtered_ips(get_object_mock, state_file, tmpdir):
     mock, internal_networks, rgw_location_proxy_ips = get_object_mock
-    opslog = OpsLog(state_file, internal_networks, rgw_location_proxy_ips)
+    opslog = OpsLog(state_file,tmpdir, internal_networks, rgw_location_proxy_ips)
 
     result = opslog.get_object("foo")
     mock.assert_has_calls(
@@ -468,14 +466,14 @@ def test_opslog_object_with_filtered_ips(get_object_mock, state_file):
         entries[2]["http_x_headers"][0]["HTTP_X_REAL_IP"] == "2a01:4f8:f00::1"
     )
 
-def test_opslog_object_with_filtered_rgw_location_proxy(get_object_mock, state_file):
+def test_opslog_object_with_filtered_rgw_location_proxy(get_object_mock, state_file, tmpdir):
     mock, _, _ = get_object_mock
     internal_networks = []
     rgw_location_proxy_ips = [
         IPy.IP("10.0.1.2"),
         IPy.IP("fd42:23::abc")
     ]
-    opslog = OpsLog(state_file, internal_networks, rgw_location_proxy_ips)
+    opslog = OpsLog(state_file, tmpdir, internal_networks, rgw_location_proxy_ips)
 
     result = opslog.get_object("foo")
     mock.assert_has_calls(

--- a/pkgs/fc/ceph/src/fc/ceph/util/lock.py
+++ b/pkgs/fc/ceph/src/fc/ceph/util/lock.py
@@ -1,0 +1,54 @@
+import contextlib
+import fcntl
+import os
+from pathlib import Path
+
+
+@contextlib.contextmanager
+def locked(log, lockdir: Path | str, lockfile_name: str):
+    """Execute the associated with-block exclusively.
+
+    A lockfile will be created as necessary. Once the exclusive lock has
+    been acquired, the current PID is recorded to assist debugging in
+    case of need.
+    """
+
+    if not isinstance(lockdir, Path):
+        lockdir = Path(lockdir)
+    lockfile = Path(lockdir) / lockfile_name
+
+    if not lockfile.exists():
+        lockfile.touch()
+
+    with open(lockfile, "r+", buffering=1) as f:
+        try:
+            fcntl.flock(f, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError:
+            other_pid = f.read().strip() or "<unknown>"
+            log.info(
+                "lock-try",
+                lockfile=str(lockfile),
+                other_pid=other_pid,
+                _replace_msg=(
+                    "Looks like another management command is running, waiting "
+                    "for {lockfile} locked by PID {other_pid} (no timeout) ..."
+                ),
+            )
+            fcntl.flock(f, fcntl.LOCK_EX)
+
+        f.truncate(0)
+        f.seek(0)
+        print(os.getpid(), file=f)
+        log.debug(
+            "lock-locked",
+            _replace_msg="Locked {lockfile}",
+            lockfile=lockfile,
+        )
+        yield
+        f.truncate(0)
+        fcntl.flock(f, fcntl.LOCK_UN)
+        log.debug(
+            "lock-released",
+            _replace_msg="Released {lockfile} from PID {pid}",
+            lockfile=lockfile,
+        )

--- a/pkgs/fc/ceph/src/fc/ceph/util/opslog.py
+++ b/pkgs/fc/ceph/src/fc/ceph/util/opslog.py
@@ -1,4 +1,6 @@
+import contextlib
 import json
+import logging
 import re
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -6,8 +8,11 @@ from datetime import UTC, date, datetime, timedelta
 from pathlib import Path
 from typing import Generator
 
+import fc.ceph.util.lock
 import IPy
 from fc.ceph.util import run
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -16,15 +21,33 @@ class OpsLogState:
     last_gced_day: date
 
     @classmethod
-    def read_from(cls, file: Path):
-        with file.open("r") as f:
-            json_data = json.loads(f.read())
-            return OpsLogState(
-                last_gced_day=date.fromisoformat(json_data["last_gced_day"]),
-                last_processed_datetime=datetime.strptime(
-                    json_data["last_processed_datetime"], "%Y-%m-%dT%H"
-                ),
-            )
+    @contextlib.contextmanager
+    def open_locked(
+        cls, state_file: Path, lockdir: Path | str
+    ) -> Generator["OpsLogState", None, None]:
+        "Read state under an exclusive file lock, yield it, write back on success."
+        with fc.ceph.util.lock.locked(logger, lockdir, "fc-ceph-opslog.lock"):
+            if state_file.exists():
+                with state_file.open("r") as f:
+                    json_data = json.loads(f.read())
+                state = cls(
+                    last_gced_day=date.fromisoformat(
+                        json_data["last_gced_day"]
+                    ),
+                    last_processed_datetime=datetime.strptime(
+                        json_data["last_processed_datetime"],
+                        "%Y-%m-%dT%H",
+                    ),
+                )
+            else:
+                state = cls(
+                    datetime.today() - timedelta(days=1),
+                    date.today() - timedelta(days=2),
+                )
+
+            yield state
+
+            state.write_to(state_file)
 
     def write_to(self, file: Path):
         with file.open("w") as f:
@@ -44,25 +67,18 @@ class OpsLog:
     def __init__(
         self,
         state_file: Path,
+        lock_dir: Path,
         internal_networks: list[IPy.IP] | None = None,
         rgw_location_proxy_ips: list[IPy.IP] | None = None,
     ):
         self.state_file = state_file
+        self.lock_dir = lock_dir
         self.internal_networks = internal_networks
         self.rgw_location_proxy_ips = rgw_location_proxy_ips
         self.opslog_ptrn = re.compile(
             r"^[\d]{4}-[\d]{2}-[\d]{2}-[\d]{2}-[A-Za-z0-9.-]+$"
         )
         self._local_ips = {}
-
-        if not self.state_file.exists():
-            self.opslog_state = OpsLogState(
-                datetime.today() - timedelta(days=1),
-                date.today() - timedelta(days=2),
-            )
-            self.opslog_state.write_to(self.state_file)
-        else:
-            self.opslog_state = OpsLogState.read_from(self.state_file)
 
     @contextmanager
     def get_pending_stats_by_day(
@@ -77,68 +93,70 @@ class OpsLog:
         exception is thrown, the processed days won't be saved for a retry.
         """
 
-        # Logs are recorded by hour
-        max_date = datetime.now(tz=UTC).replace(
-            microsecond=0, second=0, minute=0
-        )
-        start = self.opslog_state.last_processed_datetime + timedelta(hours=1)
+        with OpsLogState.open_locked(
+            self.state_file, self.lock_dir
+        ) as opslog_state:
+            # Logs are recorded by hour
+            max_date = datetime.now(tz=UTC).replace(
+                microsecond=0, second=0, minute=0
+            )
+            start = opslog_state.last_processed_datetime + timedelta(hours=1)
 
-        stats_by_day: dict[date, list[str]] = {}
+            stats_by_day: dict[date, list[str]] = {}
 
-        start_day = start.date()
-        end_day = max_date.date()
+            start_day = start.date()
+            end_day = max_date.date()
 
-        day = start_day
-        while day <= end_day:
-            logs_by_hour: list[list[str]] = [[] for _ in range(0, 24)]
-            for entry in run.json.radosgw_admin(
-                "log", "list", f"--date={day.strftime('%Y-%m-%d')}"
-            ):
-                if self.opslog_ptrn.match(entry):
-                    logs_by_hour[int(entry[11:13])].append(entry)
+            day = start_day
+            while day <= end_day:
+                logs_by_hour: list[list[str]] = [[] for _ in range(0, 24)]
+                for entry in run.json.radosgw_admin(
+                    "log", "list", f"--date={day.strftime('%Y-%m-%d')}"
+                ):
+                    if self.opslog_ptrn.match(entry):
+                        logs_by_hour[int(entry[11:13])].append(entry)
 
-            if day == end_day:
-                logs_by_hour = logs_by_hour[: max_date.hour]
-            if day == start_day:
-                logs_by_hour = logs_by_hour[start.hour :]
+                if day == end_day:
+                    logs_by_hour = logs_by_hour[: max_date.hour]
+                if day == start_day:
+                    logs_by_hour = logs_by_hour[start.hour :]
 
-            log_list = [obj for hour in logs_by_hour for obj in hour]
+                log_list = [obj for hour in logs_by_hour for obj in hour]
 
-            if log_list:
-                try:
-                    stats_by_day[day].extend(log_list)
-                except KeyError:
-                    stats_by_day[day] = log_list
+                if log_list:
+                    try:
+                        stats_by_day[day].extend(log_list)
+                    except KeyError:
+                        stats_by_day[day] = log_list
 
-            day += timedelta(days=1)
+                day += timedelta(days=1)
 
-        self.opslog_state.last_processed_datetime = max_date - timedelta(
-            hours=1
-        )
+            opslog_state.last_processed_datetime = max_date - timedelta(hours=1)
 
-        yield stats_by_day
-
-        self.opslog_state.write_to(self.state_file)
+            yield stats_by_day
 
     def gc_log_objects(self):
-        last_date = self.opslog_state.last_processed_datetime.date()
-        assert date.today() >= last_date, (
-            f"last_processed_datetime ({self.opslog_state.last_processed_datetime} must not be in the future)"
-        )
+        with OpsLogState.open_locked(
+            self.state_file, self.lock_dir
+        ) as opslog_state:
+            last_date = opslog_state.last_processed_datetime.date()
+            assert date.today() >= last_date, (
+                f"last_processed_datetime ({opslog_state.last_processed_datetime} must not be in the future)"
+            )
 
-        day = self.opslog_state.last_gced_day + timedelta(days=1)
-        end = last_date - timedelta(days=1)
+            day = opslog_state.last_gced_day + timedelta(days=1)
+            end = last_date - timedelta(days=1)
 
-        while day < end:
-            for obj in run.json.radosgw_admin(
-                "log", "list", f"--date={day.strftime('%Y-%m-%d')}"
-            ):
-                run.radosgw_admin("log", "rm", f"--object={obj}")
+            while day < end:
+                for obj in run.json.radosgw_admin(
+                    "log", "list", f"--date={day.strftime('%Y-%m-%d')}"
+                ):
+                    run.radosgw_admin("log", "rm", f"--object={obj}")
 
-            self.opslog_state.last_gced_day = day
-            self.opslog_state.write_to(self.state_file)
+                opslog_state.last_gced_day = day
+                opslog_state.write_to(self.state_file)
 
-            day += timedelta(days=1)
+                day += timedelta(days=1)
 
     def get_object(self, name: str):
         assert self.internal_networks is not None


### PR DESCRIPTION
PL-128135

@flyingcircusio/release-managers

## Release process

This change should be backported:

- [ ] Created changelog entry using `./changelog.sh`
- [ ] Add `backport release-25.11` label

This change should only reach this branch:

- [x] Created changelog entry using `./changelog.sh`
or
- [ ] Add a upgrade node in `doc/upgrade.md`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [x] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [x] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [x] Security requirements tested? (EVIDENCE)
  - Tested that automated tests succeed
  - Didn't test in dev cluster due to rollout of new ceph version (delegate to @osnyx if necessary)  