### PR TITLE
flyingcircus-physical/grub: make boot loader visible in SOL

### DIFF
--- a/changelog.d/20260324_143442_PL-130728-grub-physical_scriv.md
+++ b/changelog.d/20260324_143442_PL-130728-grub-physical_scriv.md
@@ -1,0 +1,28 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+<!-- Impact means "when this change is rolled out, there
+     might be interruptions/downtimes/required actions/... that
+     IMPACT THE RUNNING APPLICATION NEGATIVELY.
+
+     Having new features or changed is not an "impact". That's what
+     the main changelog (see below) is for.
+     -->
+
+
+
+### NixOS XX.XX platform
+
+- flyingcircus-physical: show grub-bios bootloader menu over serial console as well (PL-130728)

--- a/nixos/infrastructure/flyingcircus-physical.nix
+++ b/nixos/infrastructure/flyingcircus-physical.nix
@@ -215,7 +215,13 @@ mkIf (cfg.infrastructureModule == "flyingcircus-physical") (
       boot.loader.grub = {
         device = fclib.mkPlatform "/dev/sda";
         fsIdentifier = "provided";
-        gfxmodeBios = "text";
+        extraConfig = ''
+          # `console` output is sufficiently forwarded through IPMI SOL and even
+          # shows up on the graphics output as well.
+          # No need to configure the `serial` grub IO
+          terminal_output console
+          terminal_input console
+        '';
       };
     })
 


### PR DESCRIPTION
PL-130728

@flyingcircusio/release-managers

## Release process

This change should be backported:

- [x] Created changelog entry using `./changelog.sh`
- [x] Add `backport release-25.11` label

This change should only reach this branch:

- [ ] Created changelog entry using `./changelog.sh`
or
- [ ] Add a upgrade node in `doc/upgrade.md`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [ ] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - improve operability of physical machines via SOL 
- [x] Security requirements tested? (EVIDENCE)
  - tested on physical host