### PR TITLE
[FC-52533] add configuration to varnish to mitigate VSV00018

### DIFF
--- a/changelog.d/20260326_145909_fc-26.05-dev_scriv.md
+++ b/changelog.d/20260326_145909_fc-26.05-dev_scriv.md
@@ -1,0 +1,7 @@
+### Impact
+
+-
+
+### NixOS XX.XX platform
+
+- Add extra configuration to Varnish's default VCL that mitigates VSV00018 (FC-52533)

--- a/nixos/services/varnish/default.nix
+++ b/nixos/services/varnish/default.nix
@@ -63,7 +63,21 @@ let
       .port = "80";
     }
 
+    # https://vinyl-cache.org/security/VSV00018.html
+    # mitigate a deficiency in http 1.1 request parsing
+    sub vsv18 {
+      if (req.url == "*" && req.method == "OPTIONS") {
+        return;
+      }
+      # NB: we do not allow connect by default (see vcl_req_method)
+      if (req.url !~ "^/" && req.method != "CONNECT") {
+        return (synth(400));
+      }
+    }
+
     sub vcl_recv {
+      call vsv18;
+
       ${virtualHostSelection}
 
       return (synth(503, "Internal Error"));


### PR DESCRIPTION
@flyingcircusio/release-managers

We have to upgrade the version of Varnish/Vinyl that is being used anyways, but adding this extra configuration snippet from the official security disclosure (https://vinyl-cache.org/security/VSV00018.html) will mitigate the vulnerability for now so that we can deal with any breaking changes that an upgrade to a more recent version would entail. 

## Release process

FC-52533

This change should be backported:

- [x] Created changelog entry using `./changelog.sh`
- [x] Add `backport release-25.11` label

This change should only reach this branch:

- [ ] Created changelog entry using `./changelog.sh`
or
- [ ] Add a upgrade node in `doc/upgrade.md`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [ ] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- adds configurtions that mitigates a vulnerability in varnish's http 1.1 request parsing logic -> https://vinyl-cache.org/security/VSV00018.html
- [x] Security requirements tested? (EVIDENCE)