### PR TITLE
Revert "[PL-135231] alloy configuration for k3s logs"

### DIFF
--- a/changelog.d/20260311_133045_PL-135231_k3s_logs_scriv.md
+++ b/changelog.d/20260311_133045_PL-135231_k3s_logs_scriv.md
@@ -1,8 +1,0 @@
-### Impact
-
--
-
-
-### NixOS XX.XX platform
-
-- Provide a new alloy configuration snippet that exports the running pod's journal to a loki instance (PL-135231)

--- a/nixos/platform/alloy.nix
+++ b/nixos/platform/alloy.nix
@@ -9,15 +9,14 @@ let
   # collector process.
 
   prometheusServer = fclib.findOneService "statshost-master-collector";
-  prometheusHost = builtins.head prometheusServer.ips;
+  prometheusHost = lib.replaceStrings [ "gocept.net" ] [ "fcio.net" ] prometheusServer.address;
   prometheusPort = 9090;
 
   lokiServer = fclib.findOneService "loki-collector";
-  lokiHost = builtins.head lokiServer.ips;
+  tempoServer = fclib.findOneService "tempo-collector";
   lokiPort = 3100;
 
-  tempoServer = fclib.findOneService "tempo-collector";
-  tempoHost = builtins.head tempoServer.ips;
+  tempoHost = lib.replaceStrings [ "gocept.net" ] [ "fcio.net" ] tempoServer.address;
   tempoPort = 4317;
 in
 {
@@ -43,7 +42,7 @@ in
       environment.etc."alloy/loki.alloy".text = ''
         loki.write "fcio_rg_loki" {
           endpoint {
-            url = "http://${lokiHost}:${toString lokiPort}/loki/api/v1/push"
+            url = "http://${lokiServer.address}:${toString lokiPort}/loki/api/v1/push"
           }
 
           // there are server side limits to how many labels loki

--- a/nixos/roles/k3s/default.nix
+++ b/nixos/roles/k3s/default.nix
@@ -11,8 +11,6 @@
 }:
 let
   inherit (config.flyingcircus.kubernetes.network) enableIPv6;
-  location = lib.attrByPath [ "parameters" "location" ] "standalone" config.flyingcircus.enc;
-  lokiServer = config.fclib.findOneService "loki-collector";
 in
 {
   imports = with lib; [
@@ -136,87 +134,6 @@ in
             ];
           }
         ];
-      })
-
-      (lib.mkIf (server && (!builtins.isNull lokiServer)) {
-        systemd.services.alloy = lib.mkIf config.services.alloy.enable {
-          requires = [ "k3s.service" ];
-          after = [ "k3s.service" ];
-
-          serviceConfig.LoadCredential = "bearer_token_file:/var/lib/k3s/tokens/alloy";
-          environment.BEARER_TOKEN_FILE = "%d/bearer_token_file";
-          environment.API_SERVER = "https://127.0.0.1:6443";
-          environment.CLUSTER_LOCATION = location;
-          reloadTriggers = [
-            config.environment.etc."alloy/k3s_events.alloy".source
-            config.environment.etc."alloy/pod_logs.alloy".source
-          ];
-        };
-
-        environment.etc."alloy/pod_logs.alloy".text = ''
-          discovery.kubernetes "pods" {
-            role = "pod"
-            selectors {
-              role = "pod"
-            }
-            api_server = sys.env("API_SERVER")
-            bearer_token_file = sys.env("BEARER_TOKEN_FILE")
-            tls_config {
-              insecure_skip_verify = true
-            }
-          }
-
-          discovery.relabel "pods" {
-            targets = discovery.kubernetes.pods.targets
-
-            rule {
-              source_labels = ["__meta_kubernetes_pod_container_name"]
-              action = "replace"
-              target_label = "container"
-            }
-
-            rule {
-              source_labels = ["__meta_kubernetes_pod_phase"]
-              action = "replace"
-              target_label = "phase"
-            }
-          }
-
-          loki.source.kubernetes "pod_logs" {
-            targets    = discovery.relabel.pods.output
-            forward_to = [loki.process.pod_logs.receiver]
-            client {
-              api_server = sys.env("API_SERVER")
-              bearer_token_file = sys.env("BEARER_TOKEN_FILE")
-              tls_config {
-                insecure_skip_verify = true
-              }
-            }
-          }
-
-          loki.process "pod_logs" {
-            stage.static_labels {
-                values = {
-                  cluster = sys.env("CLUSTER_LOCATION"),
-                }
-            }
-
-            forward_to = [loki.write.fcio_rg_loki.receiver]
-          }
-        '';
-
-        environment.etc."alloy/k3s_events.alloy".text = ''
-          loki.source.kubernetes_events "k3s_events" {
-            forward_to = [loki.write.fcio_rg_loki.receiver]
-            client {
-              api_server = sys.env("API_SERVER")
-              bearer_token_file = sys.env("BEARER_TOKEN_FILE")
-              tls_config {
-                insecure_skip_verify = true
-              }
-            }
-          }
-        '';
       })
     ];
 }

--- a/nixos/roles/k3s/server.nix
+++ b/nixos/roles/k3s/server.nix
@@ -15,6 +15,7 @@ let
 
   location = lib.attrByPath [ "parameters" "location" ] "standalone" config.flyingcircus.enc;
   srvFQDN = "${config.networking.hostName}.fcio.net";
+
   lokiServer = fclib.findOneService "loki-collector";
 
   # We allow frontend access to the dashboard at the moment
@@ -231,43 +232,7 @@ let
             }
           ];
         })
-      ]
-      ++ (lib.optionals (!builtins.isNull lokiServer) [
-        (serviceAccount "alloy")
-        (serviceAccountSecret "alloy")
-        (clusterRole {
-          metadata.name = "flyingcircus:alloy";
-          rules = [
-            {
-              apiGroups = [ "" ];
-              resources = [
-                "pods"
-                "pods/log"
-              ];
-              verbs = [
-                "get"
-                "list"
-                "watch"
-              ];
-            }
-          ];
-        })
-        (clusterRoleBinding {
-          metadata.name = "flyingcircus:alloy:viewer";
-          roleRef = {
-            apiGroup = "rbac.authorization.k8s.io";
-            kind = "ClusterRole";
-            name = "flyingcircus:alloy";
-          };
-          subjects = [
-            {
-              kind = "ServiceAccount";
-              name = "io.flyingcircus.service.alloy";
-              namespace = "kube-system";
-            }
-          ];
-        })
-      ]);
+      ];
       renderedManifests = lib.concatStringsSep "\n" (
         lib.flatten (
           map (m: [
@@ -286,18 +251,26 @@ let
   authTokenScript = pkgs.writeShellScriptBin "kubernetes-write-auth-token" ''
     set -o pipefail
 
-    tokenname="$1"
+    user="$1"
     secretname="$2"
-    user="$3"
-    group="$4"
 
     tokendir=/var/lib/k3s/tokens
     export KUBECONFIG=${defaultKubeconfig}
 
+    if [ -z "$secretname" ]; then
+      echo 'missing kubernetes secret name' 2>&1
+      exit 1
+    fi
+
+    if [ -z "$user" ]; then
+      echo 'missing service account name' 2>&1
+      exit 1
+    fi
+
     mkdir -p "$tokendir"
-    install -o "$user" -g "$group" -m 600 /dev/null "$tokendir/$tokenname.b64"
-    install -o "$user" -g "$group" -m 600 /dev/null "$tokendir/$tokenname.tmp"
-    install -o "$user" -g "$group" -m 600 /dev/null "$tokendir/$tokenname.cfg.tmp"
+    install -o "$user" -g "$user" -m 600 /dev/null "$tokendir/$user.b64"
+    install -o "$user" -g "$user" -m 600 /dev/null "$tokendir/$user.tmp"
+    install -o "$user" -g "$user" -m 600 /dev/null "$tokendir/$user.cfg.tmp"
 
     # this service may race with k3s loading and processing the vendor
     # manifests from disk -- they are not present on first run, and k3s only
@@ -308,8 +281,8 @@ let
     rc=0
     for i in 1 2 3 4 5 6 7 8 9 10; do
       kubectl get -n kube-system -o jsonpath='{.data.token}' \
-        secret "$secretname" > "$tokendir/$tokenname.b64" && \
-        test -s "$tokendir/$tokenname.b64"
+        secret "$secretname" > "$tokendir/$user.b64" && \
+        test -s "$tokendir/$user.b64"
       rc="$?"
 
       if [ "$rc" = 0 ]; then
@@ -323,56 +296,49 @@ let
       exit 1
     fi
 
-    base64 -d "$tokendir/$tokenname.b64" > "$tokendir/$tokenname.tmp"
+    base64 -d "$tokendir/$user.b64" > "$tokendir/$user.tmp"
     if [ "$?" != 0 ]; then
       echo 'could not decode secret token' 2>&1
       exit 1
     fi
 
     remarshal "$KUBECONFIG" -if yaml -of json | \
-      jq --rawfile token "$tokendir/$tokenname.tmp" \
+      jq --rawfile token "$tokendir/$user.tmp" \
       '.users[0].user |= (del(."client-key-data", ."client-certificate-data") | .token = $token)' \
-      > "$tokendir/$tokenname.cfg.tmp"
+      > "$tokendir/$user.cfg.tmp"
     if [ "$?" != 0 ]; then
       echo 'could not generate kubeconfig from token' 2>&1
       exit 1
     fi
 
-    mv "$tokendir/$tokenname.tmp" "$tokendir/$tokenname"
-    mv "$tokendir/$tokenname.cfg.tmp" "$tokendir/$tokenname.cfg"
-    echo "Successfully initialised token with name \"$tokenname\" for secret \"$secretname\" for user \"$user\" in group \"$group\"."
-    rm -f "$tokendir/$tokennname.b64"
+    mv "$tokendir/$user.tmp" "$tokendir/$user"
+    mv "$tokendir/$user.cfg.tmp" "$tokendir/$user.cfg"
+    echo "Successfully initialised token for secret \"$secretname\" for user \"$user\"."
+    rm -f "$tokendir/$user.b64"
   '';
 
-  makeAuthTokenService =
-    {
-      user,
-      secret,
-      group ? user,
-      tokenname ? user,
-    }:
-    {
-      wantedBy = [ "multi-user.target" ];
-      requires = [
-        "k3s.service"
-      ];
-      after = [
-        "k3s.service"
-      ];
-      path = with pkgs; [
-        coreutils
-        kubectl
-        remarshal
-        jq
-      ];
-      serviceConfig = {
-        RemainAfterExit = true;
-        Type = "oneshot";
-        Restart = "on-failure";
-        RestartSec = 10;
-        ExecStart = "${authTokenScript}/bin/kubernetes-write-auth-token '${tokenname}' '${secret}' '${user}' '${group}'";
-      };
+  makeAuthTokenService = user: secret: {
+    wantedBy = [ "multi-user.target" ];
+    requires = [
+      "k3s.service"
+    ];
+    after = [
+      "k3s.service"
+    ];
+    path = with pkgs; [
+      coreutils
+      kubectl
+      remarshal
+      jq
+    ];
+    serviceConfig = {
+      RemainAfterExit = true;
+      Type = "oneshot";
+      Restart = "on-failure";
+      RestartSec = 10;
+      ExecStart = "${authTokenScript}/bin/kubernetes-write-auth-token ${user} ${secret}";
     };
+  };
 
   podPendingScript = pkgs.writeScriptBin "check-kube-pending-pods" ''
     set -euo pipefail
@@ -630,24 +596,10 @@ in
           "L+ /var/lib/k3s/server/manifests/flyingcircus/flyingcircus.yaml - - - - ${additionalManifests}/flyingcircus.yaml"
         ];
 
-        systemd.services.fc-k3s-token-telegraf = makeAuthTokenService {
-          user = "telegraf";
-          secret = "io.flyingcircus.service-token.telegraf";
-        };
-        systemd.services.fc-k3s-token-sensuclient = makeAuthTokenService {
-          user = "sensuclient";
-          secret = "io.flyingcircus.service-token.sensu-client";
-        };
-        systemd.services.fc-k3s-token-alloy = lib.mkIf (!builtins.isNull lokiServer) (makeAuthTokenService {
-          user = "root";
-          tokenname = "alloy";
-          secret = "io.flyingcircus.service-token.alloy";
-        });
+        systemd.services.fc-k3s-token-telegraf = makeAuthTokenService "telegraf" "io.flyingcircus.service-token.telegraf";
+        systemd.services.fc-k3s-token-sensuclient = makeAuthTokenService "sensuclient" "io.flyingcircus.service-token.sensu-client";
         systemd.services.telegraf.after = [ "fc-k3s-token-telegraf.service" ];
         systemd.services.sensu-client.after = [ "fc-k3s-token-sensuclient.service" ];
-        systemd.services.alloy.after = lib.optionals (!builtins.isNull lokiServer) [
-          "fc-k3s-token-alloy.service"
-        ];
 
         ### Dashboard
         flyingcircus.services.nginx.enable = true;
@@ -751,6 +703,18 @@ in
           "ip_vs_sh"
         ];
       }
+
+      (lib.mkIf (!builtins.isNull lokiServer) {
+        systemd.services.alloy = lib.mkIf config.services.alloy.enable {
+          reloadTriggers = [ config.environment.etc."alloy/k3s_events.alloy".source ];
+        };
+
+        environment.etc."alloy/k3s_events.alloy".text = ''
+          loki.source.kubernetes_events "k3s_events" {
+            forward_to = [loki.write.fcio_rg_loki.receiver]
+          }
+        '';
+      })
     ]
   );
 }

--- a/tests/k3s/default.nix
+++ b/tests/k3s/default.nix
@@ -51,14 +51,6 @@ import ../make-test-python.nix (
         ];
         service = "k3s-frontend";
       }
-      {
-        address = "k3sserver.fcio.net";
-        ips = [
-          masterSrv4
-          masterSrv6
-        ];
-        service = "loki-collector";
-      }
     ];
 
     # synthetic default routes are required so that connections to the
@@ -77,6 +69,7 @@ import ../make-test-python.nix (
   {
 
     name = "k3s";
+
     nodes = {
 
       master =
@@ -92,7 +85,6 @@ import ../make-test-python.nix (
           config = {
             flyingcircus.encServices = encServices;
             flyingcircus.roles.k3s-server.enable = true;
-            flyingcircus.roles.loki.enable = true;
             flyingcircus.kubernetes.network.enableIPv6 = enableIPv6;
             networking.domain = "fcio.net";
             networking.hostName = lib.mkForce "k3sserver";
@@ -102,9 +94,6 @@ import ../make-test-python.nix (
               6443
             ];
             networking.firewall.allowedUDPPorts = [ 53 ];
-
-            environment.variables.LOKI_ADDR = "http://127.0.0.1:3100";
-            environment.systemPackages = [ pkgs.grafana-loki ];
 
             services.nginx.virtualHosts."kubernetes.test.fcio.net" = {
               enableACME = false;
@@ -237,9 +226,6 @@ import ../make-test-python.nix (
       { nodes, ... }:
       let
         masterSensuCheck = testlib.sensuCheckCmd nodes.master;
-        testscript = pkgs.writeShellScript "test-podlog-in-loki.sh" ''
-          test $(logcli -q query '{container="redis"} |= `Redis is starting`' | wc -l) -gt 0
-        '';
       in
       ''
         import time
@@ -311,9 +297,6 @@ import ../make-test-python.nix (
 
         with subtest("frontend should be able to ping redis pods"):
           frontend.wait_until_succeeds("redis-cli ping | grep PONG")
-
-        with subtest("redis logs are shipped to loki"):
-          k3sserver.succeed('${testscript}')
 
         with subtest("dashboard sensu check should be red after shutting down dashboard"):
           k3sserver.systemctl("stop kube-dashboard")


### PR DESCRIPTION
Reverts flyingcircusio/fc-nixos#2235

I missed that this causes eval failures, @PhilTaken 

```
       … while evaluating the attribute 'drvPath'
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/customisation.nix:429:7:
          428|     // {
          429|       drvPath =
             |       ^
          430|         assert condition;

       … while calling the 'derivationStrict' builtin
         at <nix/derivation-internal.nix>:37:12:
           36|
           37|   strict = derivationStrict drvAttrs;
             |            ^
           38|

       … while evaluating derivation 'vm-test-run-nginx'
         whose name attribute is located at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/pkgs/stdenv/generic/make-derivation.nix:541:13

       … while evaluating attribute 'buildCommand' of derivation 'vm-test-run-nginx'
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/nixos/lib/testing/run.nix:107:9:
          106|
          107|         buildCommand = ''
             |         ^
          108|           mkdir -p $out

       … while calling the 'getAttr' builtin
         at <nix/derivation-internal.nix>:50:17:
           49|     value = commonAttrs // {
           50|       outPath = builtins.getAttr outputName strict;
             |                 ^
           51|       drvPath = strict.drvPath;

       … while calling the 'derivationStrict' builtin
         at <nix/derivation-internal.nix>:37:12:
           36|
           37|   strict = derivationStrict drvAttrs;
             |            ^
           38|

       … while evaluating derivation 'nixos-test-driver-nginx'
         whose name attribute is located at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/pkgs/stdenv/generic/make-derivation.nix:541:13

       … while evaluating attribute 'buildCommand' of derivation 'nixos-test-driver-nginx'
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/pkgs/build-support/trivial-builders/default.nix:80:17:
           79|         enableParallelBuilding = true;
           80|         inherit buildCommand name;
             |                 ^
           81|         passAsFile = [ "buildCommand" ] ++ (derivationArgs.passAsFile or [ ]);

       … while calling the 'toString' builtin
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/nixos/lib/testing/driver.nix:65:38:
           64|
           65|         vmStartScripts=($(for i in ${toString vms}; do echo $i/bin/run-*-vm; done))
             |                                      ^
           66|

       … while evaluating the first argument passed to builtins.toString

       … while calling the 'getAttr' builtin
         at <nix/derivation-internal.nix>:50:17:
           49|     value = commonAttrs // {
           50|       outPath = builtins.getAttr outputName strict;
             |                 ^
           51|       drvPath = strict.drvPath;

       … while calling the 'derivationStrict' builtin
         at <nix/derivation-internal.nix>:37:12:
           36|
           37|   strict = derivationStrict drvAttrs;
             |            ^
           38|

       … while evaluating derivation 'nixos-vm'
         whose name attribute is located at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/pkgs/stdenv/generic/make-derivation.nix:541:13

       … while evaluating attribute 'buildCommand' of derivation 'nixos-vm'
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/pkgs/build-support/trivial-builders/default.nix:80:17:
           79|         enableParallelBuilding = true;
           80|         inherit buildCommand name;
             |                 ^
           81|         passAsFile = [ "buildCommand" ] ++ (derivationArgs.passAsFile or [ ]);

       … from call site
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/nixos/modules/virtualisation/qemu-vm.nix:1455:19:
         1454|           mkdir -p $out/bin
         1455|           ln -s ${config.system.build.toplevel} $out/system
             |                   ^
         1456|           ln -s ${hostPkgs.writeScript "run-nixos-vm" startVM} $out/bin/run-${config.system.name}-vm

       … while calling anonymous lambda
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/attrsets.nix:1691:14:
         1690|         zipAttrsWith (
         1691|           n: values:
             |              ^
         1692|           let

       … while calling the 'head' builtin
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/attrsets.nix:1696:13:
         1695|           if length values == 1 || pred here (elemAt values 1) (head values) then
         1696|             head values
             |             ^
         1697|           else

       … while calling anonymous lambda
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/attrsets.nix:1188:17:
         1187|         mapAttrs (
         1188|           name: value:
             |                 ^
         1189|           if isAttrs value && cond value then recurse (path ++ [ name ]) value else f (path ++ [ name ]) value

       … from call site
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/attrsets.nix:1189:85:
         1188|           name: value:
         1189|           if isAttrs value && cond value then recurse (path ++ [ name ]) value else f (path ++ [ name ]) value
             |                                                                                     ^
         1190|         );

       … while calling anonymous lambda
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/modules.nix:275:71:
          274|           # For definitions that have an associated option
          275|           declaredConfig = mapAttrsRecursiveCond (v: !isOption v) (_: v: v.value) options;
             |                                                                       ^
          276|

       … while evaluating the attribute 'value'
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/modules.nix:1118:7:
         1117|     // {
         1118|       value = addErrorContext "while evaluating the option `${showOption loc}':" value;
             |       ^
         1119|       inherit (res.defsFinal') highestPrio;

       … while evaluating the option `nodes.server7.system.build.toplevel':

       … while evaluating the attribute 'mergedValue'
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/modules.nix:1192:5:
         1191|     # Type-check the remaining definitions, and merge them. Or throw if no definitions.
         1192|     mergedValue =
             |     ^
         1193|       if isDefined then

       … while evaluating a branch condition
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/modules.nix:1193:7:
         1192|     mergedValue =
         1193|       if isDefined then
             |       ^
         1194|         if type.merge ? v2 then

       … while evaluating the attribute 'values'
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/modules.nix:1186:9:
         1185|       {
         1186|         values = defsSorted;
             |         ^
         1187|         inherit (defsFiltered) highestPrio;

       … while evaluating a branch condition
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/modules.nix:1180:11:
         1179|           # Avoid sorting if we don't have to.
         1180|           if any (def: def.value._type or "" == "order") defsFiltered.values then
             |           ^
         1181|             sortProperties defsFiltered.values

       … while calling the 'any' builtin
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/modules.nix:1180:14:
         1179|           # Avoid sorting if we don't have to.
         1180|           if any (def: def.value._type or "" == "order") defsFiltered.values then
             |              ^
         1181|             sortProperties defsFiltered.values

       … while evaluating the attribute 'values'
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/modules.nix:1360:7:
         1359|     {
         1360|       values = concatMap (def: if getPrio def == highestPrio then [ (strip def) ] else [ ]) defs;
             |       ^
         1361|       inherit highestPrio;

       … while calling the 'concatMap' builtin
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/modules.nix:1360:16:
         1359|     {
         1360|       values = concatMap (def: if getPrio def == highestPrio then [ (strip def) ] else [ ]) defs;
             |                ^
         1361|       inherit highestPrio;

       … while calling the 'concatMap' builtin
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/modules.nix:1160:26:
         1159|         # Process mkMerge and mkIf properties.
         1160|         defsNormalized = concatMap (
             |                          ^
         1161|           m:

       … while calling anonymous lambda
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/modules.nix:1161:11:
         1160|         defsNormalized = concatMap (
         1161|           m:
             |           ^
         1162|           map (

       … while calling the 'map' builtin
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/modules.nix:1162:11:
         1161|           m:
         1162|           map (
             |           ^
         1163|             value:

       … while evaluating definitions from `/nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/nixos/modules/system/activation/top-level.nix':

       … from call site
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/modules.nix:1171:80:
         1170|               }
         1171|           ) (addErrorContext "while evaluating definitions from `${m.file}':" (dischargeProperties m.value))
             |                                                                                ^
         1172|         ) defs;

       … while calling 'dischargeProperties'
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/modules.nix:1311:5:
         1310|   dischargeProperties =
         1311|     def:
             |     ^
         1312|     if def._type or "" == "merge" then

       … while evaluating a branch condition
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/modules.nix:1312:5:
         1311|     def:
         1312|     if def._type or "" == "merge" then
             |     ^
         1313|       concatMap dischargeProperties def.contents

       … while evaluating the attribute 'value'
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/modules.nix:805:21:
          804|             inherit (module) file;
          805|             inherit value;
             |                     ^
          806|           }) module.config

       … from call site
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/nixos/modules/system/activation/top-level.nix:81:26:
           80|   # Handle assertions and warnings
           81|   baseSystemAssertWarn = lib.asserts.checkAssertWarn config.assertions config.warnings baseSystem;
             |                          ^
           82|

       … while calling 'checkAssertWarn'
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/asserts.nix:193:27:
          192|   checkAssertWarn =
          193|     assertions: warnings: val:
             |                           ^
          194|     let

       … from call site
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/asserts.nix:200:7:
          199|     else
          200|       showWarnings warnings val;
             |       ^
          201|

       … while calling 'showWarnings'
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/trivial.nix:982:28:
          981|
          982|   showWarnings = warnings: res: lib.foldr (w: x: warn w x) res warnings;
             |                            ^
          983|

       … from call site
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/trivial.nix:982:33:
          981|
          982|   showWarnings = warnings: res: lib.foldr (w: x: warn w x) res warnings;
             |                                 ^
          983|

       … while calling 'foldr'
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/lists.nix:139:14:
          138|   foldr =
          139|     op: nul: list:
             |              ^
          140|     let

       … from call site
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/lists.nix:144:5:
          143|     in
          144|     fold' 0;
             |     ^
          145|

       … while calling 'fold''
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/lists.nix:142:15:
          141|       len = length list;
          142|       fold' = n: if n == len then nul else op (elemAt list n) (fold' (n + 1));
             |               ^
          143|     in

       … from call site
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/nixos/modules/system/activation/top-level.nix:63:16:
           62|   # makes it bootable. See `activatable-system.nix`.
           63|   baseSystem = pkgs.stdenvNoCC.mkDerivation (
             |                ^
           64|     {

       … while calling 'mkDerivation'
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/pkgs/stdenv/generic/make-derivation.nix:66:18:
           65|   */
           66|   mkDerivation = fnOrAttrs: makeDerivationExtensible (toFunction fnOrAttrs);
             |                  ^
           67|

       … from call site
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/pkgs/stdenv/generic/make-derivation.nix:66:29:
           65|   */
           66|   mkDerivation = fnOrAttrs: makeDerivationExtensible (toFunction fnOrAttrs);
             |                             ^
           67|

       … while calling 'makeDerivationExtensible'
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/pkgs/stdenv/generic/make-derivation.nix:77:5:
           76|   makeDerivationExtensible =
           77|     rattrs:
             |     ^
           78|     let

       … from call site
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/pkgs/stdenv/generic/make-derivation.nix:139:22:
          138|
          139|       finalPackage = mkDerivationSimple overrideAttrs args;
             |                      ^
          140|

       … from call site
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/pkgs/stdenv/generic/make-derivation.nix:66:55:
           65|   */
           66|   mkDerivation = fnOrAttrs: makeDerivationExtensible (toFunction fnOrAttrs);
             |                                                       ^
           67|

       … while calling 'toFunction'
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/trivial.nix:1120:16:
         1119|   */
         1120|   toFunction = v: if isFunction v then v else k: v;
             |                ^
         1121|

       … while evaluating a branch condition
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/trivial.nix:1120:19:
         1119|   */
         1120|   toFunction = v: if isFunction v then v else k: v;
             |                   ^
         1121|

       … from call site
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/trivial.nix:1120:22:
         1119|   */
         1120|   toFunction = v: if isFunction v then v else k: v;
             |                      ^
         1121|

       … while calling 'isFunction'
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/trivial.nix:1043:16:
         1042|   */
         1043|   isFunction = f: builtins.isFunction f || (f ? __functor && isFunction (f.__functor f));
             |                ^
         1044|

       … in the left operand of the OR (||) operator
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/trivial.nix:1043:41:
         1042|   */
         1043|   isFunction = f: builtins.isFunction f || (f ? __functor && isFunction (f.__functor f));
             |                                         ^
         1044|

       … while calling the 'isFunction' builtin
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/trivial.nix:1043:19:
         1042|   */
         1043|   isFunction = f: builtins.isFunction f || (f ? __functor && isFunction (f.__functor f));
             |                   ^
         1044|

       … in the right operand of the update (//) operator
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/nixos/modules/system/activation/top-level.nix:77:5:
           76|     }
           77|     // config.system.systemBuilderArgs
             |     ^
           78|   );

       … from call site
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/nixos/modules/system/activation/top-level.nix:77:8:
           76|     }
           77|     // config.system.systemBuilderArgs
             |        ^
           78|   );

       … while calling anonymous lambda
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/attrsets.nix:1188:17:
         1187|         mapAttrs (
         1188|           name: value:
             |                 ^
         1189|           if isAttrs value && cond value then recurse (path ++ [ name ]) value else f (path ++ [ name ]) value

       … from call site
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/attrsets.nix:1189:85:
         1188|           name: value:
         1189|           if isAttrs value && cond value then recurse (path ++ [ name ]) value else f (path ++ [ name ]) value
             |                                                                                     ^
         1190|         );

       … while calling anonymous lambda
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/modules.nix:275:71:
          274|           # For definitions that have an associated option
          275|           declaredConfig = mapAttrsRecursiveCond (v: !isOption v) (_: v: v.value) options;
             |                                                                       ^
          276|

       … while evaluating the attribute 'value'
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/modules.nix:1118:7:
         1117|     // {
         1118|       value = addErrorContext "while evaluating the option `${showOption loc}':" value;
             |       ^
         1119|       inherit (res.defsFinal') highestPrio;

       … while evaluating the option `nodes.server7.system.systemBuilderArgs':

       … while evaluating the attribute 'mergedValue'
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/modules.nix:1192:5:
         1191|     # Type-check the remaining definitions, and merge them. Or throw if no definitions.
         1192|     mergedValue =
             |     ^
         1193|       if isDefined then

       … while evaluating the attribute 'value'
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/types.nix:878:17:
          877|                 headError = checkDefsForError check loc defs;
          878|                 value = mapAttrs (
             |                 ^
          879|                   n: v:

       … while calling the 'mapAttrs' builtin
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/types.nix:878:25:
          877|                 headError = checkDefsForError check loc defs;
          878|                 value = mapAttrs (
             |                         ^
          879|                   n: v:

       … from call site
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/types.nix:872:21:
          871|                     # Meaning it is less lazy
          872|                     filterAttrs (n: v: v.optionalValue ? value) (
             |                     ^
          873|                       zipAttrsWith (name: defs: mergeDefinitions (loc ++ [ name ]) elemType defs) (pushPositions defs)

       … while calling 'filterAttrs'
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/attrsets.nix:663:23:
          662|   */
          663|   filterAttrs = pred: set: removeAttrs set (filter (name: !pred name set.${name}) (attrNames set));
             |                       ^
          664|

       … while calling the 'removeAttrs' builtin
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/attrsets.nix:663:28:
          662|   */
          663|   filterAttrs = pred: set: removeAttrs set (filter (name: !pred name set.${name}) (attrNames set));
             |                            ^
          664|

       … while calling the 'filter' builtin
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/attrsets.nix:663:45:
          662|   */
          663|   filterAttrs = pred: set: removeAttrs set (filter (name: !pred name set.${name}) (attrNames set));
             |                                             ^
          664|

       … while calling anonymous lambda
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/attrsets.nix:663:53:
          662|   */
          663|   filterAttrs = pred: set: removeAttrs set (filter (name: !pred name set.${name}) (attrNames set));
             |                                                     ^
          664|

       … in the argument of the not operator
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/attrsets.nix:663:60:
          662|   */
          663|   filterAttrs = pred: set: removeAttrs set (filter (name: !pred name set.${name}) (attrNames set));
             |                                                            ^
          664|

       … from call site
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/attrsets.nix:663:60:
          662|   */
          663|   filterAttrs = pred: set: removeAttrs set (filter (name: !pred name set.${name}) (attrNames set));
             |                                                            ^
          664|

       … while calling anonymous lambda
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/types.nix:872:37:
          871|                     # Meaning it is less lazy
          872|                     filterAttrs (n: v: v.optionalValue ? value) (
             |                                     ^
          873|                       zipAttrsWith (name: defs: mergeDefinitions (loc ++ [ name ]) elemType defs) (pushPositions defs)

       … while evaluating the attribute 'optionalValue'
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/modules.nix:1256:5:
         1255|
         1256|     optionalValue = if isDefined then { value = mergedValue; } else { };
             |     ^
         1257|   };

       … while evaluating a branch condition
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/modules.nix:1256:21:
         1255|
         1256|     optionalValue = if isDefined then { value = mergedValue; } else { };
             |                     ^
         1257|   };

       (8 duplicate frames omitted)

       … while evaluating definitions from `/nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/nixos/modules/system/activation/activatable-system.nix':

       … from call site
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/modules.nix:1171:80:
         1170|               }
         1171|           ) (addErrorContext "while evaluating definitions from `${m.file}':" (dischargeProperties m.value))
             |                                                                                ^
         1172|         ) defs;

       … while calling 'dischargeProperties'
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/modules.nix:1311:5:
         1310|   dischargeProperties =
         1311|     def:
             |     ^
         1312|     if def._type or "" == "merge" then

       … while evaluating a branch condition
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/modules.nix:1312:5:
         1311|     def:
         1312|     if def._type or "" == "merge" then
             |     ^
         1313|       concatMap dischargeProperties def.contents

       … while evaluating the attribute 'value'
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/types.nix:819:15:
          818|               inherit (def) file;
          819|               value = v;
             |               ^
          820|             }) def.value

       … while evaluating the attribute 'system.activationScripts.script'
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/nixos/modules/system/activation/activation-script.nix:172:11:
          171|         // {
          172|           script = systemActivationScript set false;
             |           ^
          173|         };

       … from call site
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/nixos/modules/system/activation/activation-script.nix:172:20:
          171|         // {
          172|           script = systemActivationScript set false;
             |                    ^
          173|         };

       … while calling 'systemActivationScript'
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/nixos/modules/system/activation/activation-script.nix:30:10:
           29|   systemActivationScript =
           30|     set: onlyDry:
             |          ^
           31|     let

       … from call site
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/nixos/modules/system/activation/activation-script.nix:71:9:
           70|
           71|       ${textClosureMap id withDrySnippets (attrNames withDrySnippets)}
             |         ^
           72|

       … while calling 'textClosureMap'
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/strings-with-deps.nix:168:20:
          167|   textClosureMap =
          168|     f: predefined: names:
             |                    ^
          169|     concatStringsSep "\n" (map f (textClosureList predefined names));

       … while calling the 'concatStringsSep' builtin
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/strings-with-deps.nix:169:5:
          168|     f: predefined: names:
          169|     concatStringsSep "\n" (map f (textClosureList predefined names));
             |     ^
          170|

       … while calling 'id'
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/trivial.nix:40:8:
           39|   */
           40|   id = x: x;
             |        ^
           41|

       … while evaluating the attribute 'text'
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/nixos/modules/system/activation/activation-script.nix:17:7:
           16|     // {
           17|       text = ''
             |       ^
           18|         #### Activation script snippet ${a}:

       … from call site
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/nixos/modules/system/activation/activation-script.nix:20:11:
           19|         _localstatus=0
           20|         ${v.text}
             |           ^
           21|

       … while calling anonymous lambda
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/attrsets.nix:1188:17:
         1187|         mapAttrs (
         1188|           name: value:
             |                 ^
         1189|           if isAttrs value && cond value then recurse (path ++ [ name ]) value else f (path ++ [ name ]) value

       … from call site
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/attrsets.nix:1189:85:
         1188|           name: value:
         1189|           if isAttrs value && cond value then recurse (path ++ [ name ]) value else f (path ++ [ name ]) value
             |                                                                                     ^
         1190|         );

       … while calling anonymous lambda
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/modules.nix:275:71:
          274|           # For definitions that have an associated option
          275|           declaredConfig = mapAttrsRecursiveCond (v: !isOption v) (_: v: v.value) options;
             |                                                                       ^
          276|

       … while evaluating the attribute 'value'
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/modules.nix:1118:7:
         1117|     // {
         1118|       value = addErrorContext "while evaluating the option `${showOption loc}':" value;
             |       ^
         1119|       inherit (res.defsFinal') highestPrio;

       … while evaluating the option `nodes.server7.system.activationScripts.etc.text':

       (10 duplicate frames omitted)

       … while evaluating definitions from `/nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/nixos/modules/system/etc/etc-activation.nix':

       … from call site
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/modules.nix:1171:80:
         1170|               }
         1171|           ) (addErrorContext "while evaluating definitions from `${m.file}':" (dischargeProperties m.value))
             |                                                                                ^
         1172|         ) defs;

       … while calling 'dischargeProperties'
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/modules.nix:1311:5:
         1310|   dischargeProperties =
         1311|     def:
             |     ^
         1312|     if def._type or "" == "merge" then

       … while evaluating a branch condition
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/modules.nix:1312:5:
         1311|     def:
         1312|     if def._type or "" == "merge" then
             |     ^
         1313|       concatMap dischargeProperties def.contents

       … while evaluating the attribute 'value'
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/modules.nix:805:21:
          804|             inherit (module) file;
          805|             inherit value;
             |                     ^
          806|           }) module.config

       … from call site
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/nixos/modules/system/etc/etc-activation.nix:19:9:
           18|         "specialfs"
           19|       ] config.system.build.etcActivationCommands;
             |         ^
           20|     }

       … while calling anonymous lambda
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/attrsets.nix:1691:14:
         1690|         zipAttrsWith (
         1691|           n: values:
             |              ^
         1692|           let

       … while calling the 'head' builtin
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/attrsets.nix:1696:13:
         1695|           if length values == 1 || pred here (elemAt values 1) (head values) then
         1696|             head values
             |             ^
         1697|           else

       … while calling anonymous lambda
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/types.nix:879:22:
          878|                 value = mapAttrs (
          879|                   n: v:
             |                      ^
          880|                   if lazy then

       … while evaluating the attribute 'optionalValue.value'
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/modules.nix:1256:5:
         1255|
         1256|     optionalValue = if isDefined then { value = mergedValue; } else { };
             |     ^
         1257|   };

       (9 duplicate frames omitted)

       … while evaluating definitions from `/nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/nixos/modules/system/etc/etc.nix':

       … from call site
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/modules.nix:1171:80:
         1170|               }
         1171|           ) (addErrorContext "while evaluating definitions from `${m.file}':" (dischargeProperties m.value))
             |                                                                                ^
         1172|         ) defs;

       … while calling 'dischargeProperties'
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/modules.nix:1311:5:
         1310|   dischargeProperties =
         1311|     def:
             |     ^
         1312|     if def._type or "" == "merge" then

       … while evaluating a branch condition
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/modules.nix:1312:5:
         1311|     def:
         1312|     if def._type or "" == "merge" then
             |     ^
         1313|       concatMap dischargeProperties def.contents

       … while evaluating the attribute 'value'
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/types.nix:819:15:
          818|               inherit (def) file;
          819|               value = v;
             |               ^
          820|             }) def.value

       … from call site
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/attrsets.nix:289:73:
          288|       len = length attrPath;
          289|       atDepth = n: if n == len then value else { ${elemAt attrPath n} = atDepth (n + 1); };
             |                                                                         ^
          290|     in

       … while calling 'atDepth'
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/attrsets.nix:289:17:
          288|       len = length attrPath;
          289|       atDepth = n: if n == len then value else { ${elemAt attrPath n} = atDepth (n + 1); };
             |                 ^
          290|     in

       … while evaluating the attribute 'value'
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/modules.nix:805:21:
          804|             inherit (module) file;
          805|             inherit value;
             |                     ^
          806|           }) module.config

       … while calling the 'getAttr' builtin
         at <nix/derivation-internal.nix>:50:17:
           49|     value = commonAttrs // {
           50|       outPath = builtins.getAttr outputName strict;
             |                 ^
           51|       drvPath = strict.drvPath;

       … while calling the 'derivationStrict' builtin
         at <nix/derivation-internal.nix>:37:12:
           36|
           37|   strict = derivationStrict drvAttrs;
             |            ^
           38|

       … while evaluating derivation 'etc'
         whose name attribute is located at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/pkgs/stdenv/generic/make-derivation.nix:541:13

       … while evaluating attribute 'buildCommand' of derivation 'etc'
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/pkgs/build-support/trivial-builders/default.nix:80:17:
           79|         enableParallelBuilding = true;
           80|         inherit buildCommand name;
             |                 ^
           81|         passAsFile = [ "buildCommand" ] ++ (derivationArgs.passAsFile or [ ]);

       … from call site
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/nixos/modules/system/etc/etc.nix:56:11:
           55|         mkdir -p "$out/etc"
           56|         ${lib.concatMapStringsSep "\n" (
             |           ^
           57|           etcEntry:

       … while calling 'concatMapStringsSep'
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/strings.nix:261:13:
          260|   concatMapStringsSep =
          261|     sep: f: list:
             |             ^
          262|     concatStringsSep sep (map f list);

       … while calling the 'concatStringsSep' builtin
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/strings.nix:262:5:
          261|     sep: f: list:
          262|     concatStringsSep sep (map f list);
             |     ^
          263|

       … while calling anonymous lambda
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/nixos/modules/system/etc/etc.nix:57:11:
           56|         ${lib.concatMapStringsSep "\n" (
           57|           etcEntry:
             |           ^
           58|           lib.escapeShellArgs [

       … from call site
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/nixos/modules/system/etc/etc.nix:58:11:
           57|           etcEntry:
           58|           lib.escapeShellArgs [
             |           ^
           59|             "makeEtcEntry"

       … while calling 'concatMapStringsSep'
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/strings.nix:261:13:
          260|   concatMapStringsSep =
          261|     sep: f: list:
             |             ^
          262|     concatStringsSep sep (map f list);

       … while calling the 'concatStringsSep' builtin
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/strings.nix:262:5:
          261|     sep: f: list:
          262|     concatStringsSep sep (map f list);
             |     ^
          263|

       … while calling 'escapeShellArg'
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/strings.nix:1201:5:
         1200|   escapeShellArg =
         1201|     arg:
             |     ^
         1202|     let

       … while evaluating a branch condition
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/strings.nix:1205:5:
         1204|     in
         1205|     if match "[[:alnum:],._+:@%/-]+" string == null then
             |     ^
         1206|       "'${replaceString "'" "'\\''" string}'"

       … while calling the 'match' builtin
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/strings.nix:1205:8:
         1204|     in
         1205|     if match "[[:alnum:],._+:@%/-]+" string == null then
             |        ^
         1206|       "'${replaceString "'" "'\\''" string}'"

       … while evaluating the second argument passed to builtins.match

       … while calling the 'toString' builtin
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/strings.nix:1203:16:
         1202|     let
         1203|       string = toString arg;
             |                ^
         1204|     in

       … from call site
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/nixos/modules/system/etc/etc.nix:61:16:
           60|             # Force local source paths to be added to the store
           61|             "${etcEntry.source}"
             |                ^
           62|             etcEntry.target

       … while calling anonymous lambda
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/attrsets.nix:1188:17:
         1187|         mapAttrs (
         1188|           name: value:
             |                 ^
         1189|           if isAttrs value && cond value then recurse (path ++ [ name ]) value else f (path ++ [ name ]) value

       … from call site
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/attrsets.nix:1189:85:
         1188|           name: value:
         1189|           if isAttrs value && cond value then recurse (path ++ [ name ]) value else f (path ++ [ name ]) value
             |                                                                                     ^
         1190|         );

       … while calling anonymous lambda
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/modules.nix:275:71:
          274|           # For definitions that have an associated option
          275|           declaredConfig = mapAttrsRecursiveCond (v: !isOption v) (_: v: v.value) options;
             |                                                                       ^
          276|

       … while evaluating the attribute 'value'
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/modules.nix:1118:7:
         1117|     // {
         1118|       value = addErrorContext "while evaluating the option `${showOption loc}':" value;
             |       ^
         1119|       inherit (res.defsFinal') highestPrio;

       … while evaluating the option `nodes.server7.environment.etc."alloy/loki.alloy".source':

       (13 duplicate frames omitted)

       … while evaluating a branch condition
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/modules.nix:1315:7:
         1314|     else if def._type or "" == "if" then
         1315|       if isBool def.condition then
             |       ^
         1316|         if def.condition then dischargeProperties def.content else [ ]

       … while calling the 'isBool' builtin
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/modules.nix:1315:10:
         1314|     else if def._type or "" == "if" then
         1315|       if isBool def.condition then
             |          ^
         1316|         if def.condition then dischargeProperties def.content else [ ]

       … while evaluating the attribute 'condition'
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/modules.nix:1471:13:
         1470|     _type = "if";
         1471|     inherit condition content;
             |             ^
         1472|   };

       … from call site
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/nixos/modules/system/etc/etc.nix:225:36:
          224|                 target = lib.mkDefault name;
          225|                 source = lib.mkIf (config.text != null) (
             |                                    ^
          226|                   let

       … while calling anonymous lambda
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/attrsets.nix:1188:17:
         1187|         mapAttrs (
         1188|           name: value:
             |                 ^
         1189|           if isAttrs value && cond value then recurse (path ++ [ name ]) value else f (path ++ [ name ]) value

       … from call site
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/attrsets.nix:1189:85:
         1188|           name: value:
         1189|           if isAttrs value && cond value then recurse (path ++ [ name ]) value else f (path ++ [ name ]) value
             |                                                                                     ^
         1190|         );

       … while calling anonymous lambda
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/modules.nix:275:71:
          274|           # For definitions that have an associated option
          275|           declaredConfig = mapAttrsRecursiveCond (v: !isOption v) (_: v: v.value) options;
             |                                                                       ^
          276|

       … while evaluating the attribute 'value'
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/modules.nix:1118:7:
         1117|     // {
         1118|       value = addErrorContext "while evaluating the option `${showOption loc}':" value;
             |       ^
         1119|       inherit (res.defsFinal') highestPrio;

       … while evaluating the option `nodes.server7.environment.etc."alloy/loki.alloy".text':

       (10 duplicate frames omitted)

       … while evaluating definitions from `/home/os/fc-nixos/nixos/platform/alloy.nix':

       … from call site
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/modules.nix:1171:80:
         1170|               }
         1171|           ) (addErrorContext "while evaluating definitions from `${m.file}':" (dischargeProperties m.value))
             |                                                                                ^
         1172|         ) defs;

       … while calling 'dischargeProperties'
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/modules.nix:1311:5:
         1310|   dischargeProperties =
         1311|     def:
             |     ^
         1312|     if def._type or "" == "merge" then

       … while evaluating a branch condition
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/modules.nix:1312:5:
         1311|     def:
         1312|     if def._type or "" == "merge" then
             |     ^
         1313|       concatMap dischargeProperties def.contents

       … while evaluating the attribute 'value'
         at /nix/store/59kdqccisflarvc9s5nm05vp970sdmbr-nixpkgs-48df8af4841/lib/modules.nix:805:21:
          804|             inherit (module) file;
          805|             inherit value;
             |                     ^
          806|           }) module.config

       … while calling the 'head' builtin
         at /home/os/fc-nixos/nixos/platform/alloy.nix:16:14:
           15|   lokiServer = fclib.findOneService "loki-collector";
           16|   lokiHost = builtins.head lokiServer.ips;
             |              ^
           17|   lokiPort = 3100;

       error: attribute 'ips' missing
       at /home/os/fc-nixos/nixos/platform/alloy.nix:16:28:
           15|   lokiServer = fclib.findOneService "loki-collector";
           16|   lokiHost = builtins.head lokiServer.ips;
             |                            ^
           17|   lokiPort = 3100;
```