### PR TITLE
gitlab: run container registry migrations

### DIFF
--- a/changelog.d/20260402_133449_HEAD_scriv.md
+++ b/changelog.d/20260402_133449_HEAD_scriv.md
@@ -1,0 +1,26 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+<!-- Impact means "when this change is rolled out, there
+     might be interruptions/downtimes/required actions/... that
+     IMPACT THE RUNNING APPLICATION NEGATIVELY.
+
+     Having new features or changed is not an "impact". That's what
+     the main changelog (see below) is for.
+     -->
+
+### NixOS XX.XX platform
+
+- gitlab: run container registry migrations for instances that use a database as backend (PL-135270)

--- a/nixos/roles/gitlab.nix
+++ b/nixos/roles/gitlab.nix
@@ -351,6 +351,24 @@ in
         };
       };
 
+      # The container registry needs to run migrations, Nixpkgs currently does not do that because of the
+      # docker registry indirection.
+      # Can be removed as soon as this is fixed in Nixpkgs.
+      # PL-135270
+      systemd.services.docker-registry =
+        let
+          cfgRegistry = config.services.dockerRegistry;
+        in
+        (lib.mkIf cfgRegistry.extraConfig.database.enabled or false) {
+          # split the migration in two parts
+          # https://docs.gitlab.com/18.10/administration/packages/container_registry_metadata_database/#apply-database-migrations
+          preStart = ''
+            ${cfgRegistry.package}/bin/registry database migrate up ${cfgRegistry.configFile} --skip-post-deployment
+          '';
+          postStart = ''
+            ${cfgRegistry.package}/bin/registry database migrate up ${cfgRegistry.configFile}
+          '';
+        };
     })
 
     (lib.mkIf (cfg.enable && cfg.generateSecrets) {


### PR DESCRIPTION
The container registry needs to run migrations, Nixpkgs currently does not do that because of the docker registry indirection.

PL-135270

@flyingcircusio/release-managers

## Release process

This change should be backported:

- [x] Created changelog entry using `./changelog.sh`
- [x] Add `backport release-25.11` label

This change should only reach this branch:

- [ ] Created changelog entry using `./changelog.sh`
or
- [ ] Add a upgrade node in `doc/upgrade.md`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [x] ensure all checks are green
- [x] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [x] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [x] Security requirements tested? (EVIDENCE)
  - tested that this resolves the issue on the affected system