### PR TITLE
sensu: prevent invalid check names, allow disabling checks

### DIFF
--- a/changelog.d/20260402_125054_PL-135244-sanitise-sensu-check-names_scriv.md
+++ b/changelog.d/20260402_125054_PL-135244-sanitise-sensu-check-names_scriv.md
@@ -1,0 +1,32 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+<!-- Impact means "when this change is rolled out, there
+     might be interruptions/downtimes/required actions/... that
+     IMPACT THE RUNNING APPLICATION NEGATIVELY.
+
+     Having new features or changed is not an "impact". That's what
+     the main changelog (see below) is for.
+     -->
+
+- webgateway: TLS- or ACME-enabled vhosts that do not define a single valid hostname do not receive an automatic certificate check anymore (PL-135244)
+
+  An evaluation warning informs about that behaviour change. The warning will be removed after 2 releases.
+
+
+### NixOS XX.XX platform
+
+- webgateway: Only generate certificate checks for vhosts defining a single valid hostname (PL-135244)
+- `flyingcircus.services.sensu-client.checks`: Prevent illegal check names that would crash the client service (PL-135244)

--- a/changelog.d/20260402_125054_PL-135244-sanitise-sensu-check-names_scriv.md
+++ b/changelog.d/20260402_125054_PL-135244-sanitise-sensu-check-names_scriv.md
@@ -30,3 +30,4 @@ branches.
 
 - webgateway: Only generate certificate checks for vhosts defining a single valid hostname (PL-135244)
 - `flyingcircus.services.sensu-client.checks`: Prevent illegal check names that would crash the client service (PL-135244)
+- `flyingcircus.services.sensu-client.checks.enable`: introduce new option to explicitly disable checks

--- a/nixos/lib/network.nix
+++ b/nixos/lib/network.nix
@@ -564,4 +564,5 @@ rec {
           externalLabel = l.external_label;
         }) links;
       };
+
 }

--- a/nixos/lib/utils.nix
+++ b/nixos/lib/utils.nix
@@ -104,6 +104,15 @@ rec {
     }:
     "install -d -o ${user} -g ${group} -m ${permissions} ${dir}";
 
+  /*
+    basic plausibility check whether something is a valid hostname. Might not enforce
+    all restrictions (like total length), due to limits of ERE syntax.
+  */
+  isHostname =
+    str:
+    builtins.match "^([[:alnum:]]([[:alnum:]-]{0,61}[[:alnum:]])?\.)*[[:alnum:]]([[:alnum:]-]{0,61}[[:alnum:]])?$" str
+    != null;
+
   # Allow overrides with default priority (100)
   mkPlatform = lib.mkOverride 900;
   # Allow overrides with default priority (100) but override mkPlatform

--- a/nixos/services/nginx/default.nix
+++ b/nixos/services/nginx/default.nix
@@ -421,36 +421,50 @@ in
             interval = 60;
           };
         }
-        // (lib.mapAttrs' (
-          n: vhost:
+        // (lib.foldl' (
+          acc: n:
           let
+            vhost = vhostsWithTLS.${n};
             host = if vhost.serverName != null then vhost.serverName else n;
           in
-          lib.nameValuePair "nginx_https_${n}" {
-            notification = "HTTPS certificate check failed for vhost ${n}";
-            # We're using a timeout of 15 seconds because 10 seconds is the timeout
-            # that will trigger if DNS issues occur and giving the check a higher
-            # timeout allows us to see those. Otherwise they get hidden behind
-            # a generic timeout message.
-            # Note that we assume that the certificate is reachable via port 443.
-            # Other configurations might need overrides for the sensu check command.
-            command = "check_http -p 443 -S --sni -C 25,14 -H ${host} -t 15";
-            interval = 600;
-          }
-        ) vhostsWithTLS)
+          if fclib.utils.isHostname host then
+            acc
+            // {
+              "nginx_https_${n}" = {
+                notification = "HTTPS certificate check failed for vhost ${n}";
+                # We're using a timeout of 15 seconds because 10 seconds is the timeout
+                # that will trigger if DNS issues occur and giving the check a higher
+                # timeout allows us to see those. Otherwise they get hidden behind
+                # a generic timeout message.
+                # Note that we assume that the certificate is reachable via port 443.
+                # Other configurations might need overrides for the sensu check command.
+                command = "check_http -p 443 -S --sni -C 25,14 -H ${host} -t 15";
+                interval = 600;
+              };
+            }
+          else
+            lib.warn "Informational: nginx vhost '${n}' does not declare a plain hostname. No HTTPS certificate check is added. This warning will be removed after 2 releases." acc
+        ) { } (lib.attrNames vhostsWithTLS))
         # Add certificate file checks for non-ACME hosts specified in nginx config.
         # ACME certificates in general (nginx enableACME or others) are covered in platform/acme.nix.
-        // (lib.mapAttrs' (
-          n: vhost:
+        // (lib.foldl' (
+          acc: n:
           let
+            vhost = nonAcmeVhostsWithTLS.${n};
             host = if vhost.serverName != null then vhost.serverName else n;
           in
-          lib.nameValuePair "ssl_cert_nginx_${n}" {
-            notification = "SSL certificate for non-ACME nginx vhost ${n} is invalid or will expire soon";
-            command = "sudo ${checkCert} ${vhost.sslCertificate} ${host}";
-            interval = 3600;
-          }
-        ) nonAcmeVhostsWithTLS);
+          if fclib.utils.isHostname host then
+            acc
+            // {
+              "ssl_cert_nginx_${n}" = {
+                notification = "SSL certificate for non-ACME nginx vhost ${n} is invalid or will expire soon";
+                command = "sudo ${checkCert} ${vhost.sslCertificate} ${host}";
+                interval = 3600;
+              };
+            }
+          else
+            lib.warn "Informational: nginx vhost '${n}' does not declare a plain hostname. No TLS certificate check is added. This warning will be removed after 2 releases." acc
+        ) { } (lib.attrNames nonAcmeVhostsWithTLS));
 
         networking.firewall.allowedTCPPorts = [
           80

--- a/nixos/services/sensu/client.nix
+++ b/nixos/services/sensu/client.nix
@@ -126,6 +126,12 @@ let
     paths = cfg.checkEnvPackages;
   };
 
+  /*
+    > Validated with Ruby regex /^[\w\.-]+$/.match("check-name")
+    https://github.com/sensu/sensu-docs/blob/3a7a04dc7c5b7c96d4e94e806b29d5ce0b47cd22/content/sensu-core/1.9/reference/checks.md#check-naming-check-names
+  */
+  isValidSensuCheckname = str: (builtins.match "[-[:alnum:]._]+" str) != null;
+
 in
 {
   options = {
@@ -581,6 +587,17 @@ in
     {
       # Config that should always be available to allow deployments to
       # succeed even if no real sensu environment is available.
+
+      assertions =
+        let
+          invalidNames = lib.filter (name: !isValidSensuCheckname name) (lib.attrNames cfg.checks);
+        in
+        [
+          {
+            assertion = invalidNames == [ ];
+            message = "Invalid sensu check names (must match regex ^[\\w.-]+$): ${lib.concatStringsSep ", " invalidNames}";
+          }
+        ];
 
       environment.etc."local/sensu-client/README.txt".text = ''
         Put local sensu checks here.

--- a/nixos/services/sensu/client.nix
+++ b/nixos/services/sensu/client.nix
@@ -56,7 +56,10 @@ let
       },
       "checks": ${
         builtins.toJSON (
-          mapAttrs (name: value: filterAttrs (name: value: name != "_module") value) cfg.checks
+          lib.pipe cfg.checks [
+            (filterAttrs (_: v: v.enable))
+            (mapAttrs (name: value: filterAttrs (name: value: name != "_module") value))
+          ]
         )
       }
     }
@@ -76,6 +79,12 @@ let
 
   checkOptions = {
     options = {
+      enable = lib.mkOption {
+        type = types.bool;
+        default = true;
+        description = "While enabled by default, checks can be explicitly disabled, removing them from the sensu config file as well.";
+      };
+
       notification = mkOption {
         type = types.str;
         description = "The notification on events.";


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

This change should be backported:

- [x] Created changelog entry using `./changelog.sh`
- [x] Add `backport release-26.05` label

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [x] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - [x] provide informational warnings on breaking changes
  - [x] prevent invalid config from being activated
  - [x] test with config that caused the issue in the wild
- [x] Security requirements tested? (EVIDENCE)
  - [x] automated tests pass
  - [x] created follow-up ticket to clean up the warnings
  - [x] manually tested on dev vm:
    - non-hostname vhost definition does not generate a sensu check, but causes eval warning
    - assertion catches invalid sensu check names
    - checks can be disabled
  - [x] creating automated tests for *positive* assertions is too complicated 
