### PR TITLE
[25.11] Fix Nix CVE-2026-39860

### DIFF
--- a/changelog.d/20260408_100623_HEAD_scriv.md
+++ b/changelog.d/20260408_100623_HEAD_scriv.md
@@ -1,0 +1,27 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+<!-- Impact means "when this change is rolled out, there
+     might be interruptions/downtimes/required actions/... that
+     IMPACT THE RUNNING APPLICATION NEGATIVELY.
+
+     Having new features or changed is not an "impact". That's what
+     the main changelog (see below) is for.
+     -->
+
+
+### NixOS XX.XX platform
+
+- fix Nix security vulnerability CVE-2026-39860 / GHSA-g3g9-5vj6-r3gj (FC-52786)

--- a/flake.lock
+++ b/flake.lock
@@ -168,11 +168,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1775539252,
-        "narHash": "sha256-ImQzt6KCJtWK+OxAkGokHOttgVuYwPbiLrJ6swkkCBQ=",
+        "lastModified": 1775634044,
+        "narHash": "sha256-WqRbhsrqS7LEO7YnqbRIRflHhXmvVs1BjZP+/Xzi4aY=",
         "owner": "flyingcircusio",
         "repo": "nixpkgs",
-        "rev": "b1b835b2501844103c89a1a9b73ce81367f30013",
+        "rev": "9fb20de9878156f234a28ece30f91f71458222a1",
         "type": "github"
       },
       "original": {

--- a/release/package-versions.json
+++ b/release/package-versions.json
@@ -550,9 +550,9 @@
     "version": "1.28.3"
   },
   "nix": {
-    "name": "nix-2.31.3",
+    "name": "nix-2.31.4",
     "pname": "nix",
-    "version": "2.31.3"
+    "version": "2.31.4"
   },
   "nodejs": {
     "name": "nodejs-22.22.2",

--- a/release/versions.json
+++ b/release/versions.json
@@ -8,10 +8,10 @@
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/"
   },
   "nixpkgs": {
-    "hash": "sha256-ImQzt6KCJtWK+OxAkGokHOttgVuYwPbiLrJ6swkkCBQ=",
+    "hash": "sha256-WqRbhsrqS7LEO7YnqbRIRflHhXmvVs1BjZP+/Xzi4aY=",
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "b1b835b2501844103c89a1a9b73ce81367f30013"
+    "rev": "9fb20de9878156f234a28ece30f91f71458222a1"
   },
   "poetry2nix": {
     "hash": "sha256-nzgO/ZCSBzWjbMkYDxG+yl9Z2eGbCgQu06Oku3ir5D4=",


### PR DESCRIPTION
FC-52786

@flyingcircusio/release-managers

## Release process

This change should be backported:

- [ ] Created changelog entry using `./changelog.sh`
- [ ] Add `backport release-25.11` label

This change should only reach this branch:

- [x] Created changelog entry using `./changelog.sh`
or
- [ ] Add a upgrade node in `doc/upgrade.md`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [x] ensure all checks are green
- [x] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [x] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [x] Security requirements tested? (EVIDENCE)
  - None, security improvement. Already merged in Nixpkgs, we just shorten the cycle. Tested by automated tests.