### PR TITLE
[25.05] Fix Nix CVE-2026-39860

### DIFF
--- a/changelog.d/20260408_130431_HEAD_scriv.md
+++ b/changelog.d/20260408_130431_HEAD_scriv.md
@@ -1,0 +1,27 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+<!-- Impact means "when this change is rolled out, there
+     might be interruptions/downtimes/required actions/... that
+     IMPACT THE RUNNING APPLICATION NEGATIVELY.
+
+     Having new features or changed is not an "impact". That's what
+     the main changelog (see below) is for.
+     -->
+
+
+### NixOS XX.XX platform
+
+- fix Nix security vulnerability CVE-2026-39860 / GHSA-g3g9-5vj6-r3gj (FC-52786)

--- a/flake.lock
+++ b/flake.lock
@@ -168,11 +168,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1769771945,
-        "narHash": "sha256-x5CNG73HOMdEvqt9sNHMaEvD6qzrIsSCTRgFyaZY8/4=",
+        "lastModified": 1775647357,
+        "narHash": "sha256-mmjdQ1nMHOhSQT9N1Qe7ORPc7dlJkGB1u5yeq5Ml5xw=",
         "owner": "flyingcircusio",
         "repo": "nixpkgs",
-        "rev": "7ebd1a5cfb836296c3d988067f89c6882a7d0e62",
+        "rev": "9d30244089af7b1851d979e4555596c4fa341e9b",
         "type": "github"
       },
       "original": {

--- a/release/package-versions.json
+++ b/release/package-versions.json
@@ -295,9 +295,9 @@
     "version": "12.0.7"
   },
   "grub2": {
-    "name": "grub-2.12",
+    "name": "grub-2.12.1",
     "pname": "grub",
-    "version": "2.12"
+    "version": "2.12.1"
   },
   "haproxy": {
     "name": "haproxy-3.1.7",
@@ -570,9 +570,9 @@
     "version": "1.28.0"
   },
   "nix": {
-    "name": "nix-2.28.5",
+    "name": "nix-2.28.6",
     "pname": "nix",
-    "version": "2.28.5"
+    "version": "2.28.6"
   },
   "nodejs": {
     "name": "nodejs-22.21.1",

--- a/release/versions.json
+++ b/release/versions.json
@@ -8,10 +8,10 @@
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/"
   },
   "nixpkgs": {
-    "hash": "sha256-x5CNG73HOMdEvqt9sNHMaEvD6qzrIsSCTRgFyaZY8/4=",
+    "hash": "sha256-mmjdQ1nMHOhSQT9N1Qe7ORPc7dlJkGB1u5yeq5Ml5xw=",
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "7ebd1a5cfb836296c3d988067f89c6882a7d0e62"
+    "rev": "9d30244089af7b1851d979e4555596c4fa341e9b"
   },
   "poetry2nix": {
     "hash": "sha256-nzgO/ZCSBzWjbMkYDxG+yl9Z2eGbCgQu06Oku3ir5D4=",


### PR DESCRIPTION
PL-135283 / FC-52786

`nixVersions.git` is marked as vulnerable as I didn't manage to get it to work and likely nobody uses it.

## Release process

- [x] Created changelog entry using `./changelog.sh`

Backport for #2287 

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [x] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  None, security improvement. Already merged in Nixpkgs for 25.11, we backport this here for 25.05. Tested by automated tests.
- [x] Security requirements tested? (EVIDENCE)
