### PR TITLE
varnish77: remove eval warnings

### DIFF
--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -654,9 +654,6 @@ builtins.mapAttrs (_: patchPhps phpLogPermissionPatch) {
         pname = "tcpdump-vxlan";
       });
 
-  varnish = lib.warn "varnish-7.x is end-of-life and still default for the `webproxy` role but has known vulnerabilities. Consider updating to varnish-8.0 by setting `services.varnish.package = varnish80;`. Note the breaking changes in https://vinyl-cache.org/docs/8.0/whats-new/upgrading-8.0.html" super.varnish;
-  varnish77 = lib.warn "varnish-7.x is end-of-life and still default for the `webproxy` role but has known vulnerabilities. Consider updating to varnish-8.0 by setting `services.varnish.package = varnish80;`. Note the breaking changes in https://vinyl-cache.org/docs/8.0/whats-new/upgrading-8.0.html" super.varnish77;
-
   xtrabackup = lib.warn "The `xtrabackup` package has been renamed to `percona-xtrabackup`." self.percona-xtrabackup;
 }
 // lib.genAttrs [ "imagemagick6" "imagemagick6Big" "imagemagick6_light" ] (


### PR DESCRIPTION
After all, we have decided that the EOL varnish package alone does not mandate an eval warning, given we've mitigated the actual vulnerability with config.

If additional vulnarabilities come up, we might consider updating the default package to varnish80 for the whole platform.

@flyingcircusio/release-managers

## Release process

This change should be backported:

- [ ] Created changelog entry using `./changelog.sh`
- [ ] Add `backport release-25.11` label

This change should only reach this branch:

- [ ] Created changelog entry using `./changelog.sh`
or
- [ ] Add a upgrade node in `doc/upgrade.md`

## PR release workflow (internal)

- [ ] PR has internal ticket
- [ ] internal issue ID (PL-…) part of branch name
- [ ] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [ ] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - reduce warnings that are not mandated, to avoid confusion and alert fatigue 
- [x] Security requirements tested? (EVIDENCE)
