### PR TITLE
fc-luks: improve detection of encrypted volumes to find unopened ones

### DIFF
--- a/changelog.d/20260411_014408_PL-133176-improve-luks-detection_scriv.md
+++ b/changelog.d/20260411_014408_PL-133176-improve-luks-detection_scriv.md
@@ -1,0 +1,27 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+<!-- Impact means "when this change is rolled out, there
+     might be interruptions/downtimes/required actions/... that
+     IMPACT THE RUNNING APPLICATION NEGATIVELY.
+
+     Having new features or changed is not an "impact". That's what
+     the main changelog (see below) is for.
+     -->
+
+
+### NixOS XX.XX platform
+
+- fc-luks: improve detection of LUKS volumes to cover those not opened currently as well (PL-133176)

--- a/pkgs/fc/ceph/src/fc/ceph/luks/manage.py
+++ b/pkgs/fc/ceph/src/fc/ceph/luks/manage.py
@@ -19,27 +19,67 @@ from fc.ceph.util import console, run
 
 class LuksDevice(NamedTuple):
     base_blockdev: str  # path of the underlying block device
-    name: str  # the LUKS name of the device
+    base_blockdev_name: str  # name of the underlying block device
+    luks_name: Optional[str] = None  # the LUKS name of the device
     # required for external header discovery, which we only utilise for backy
-    mountpoint: Optional[str]
+    mountpoint: Optional[str] = None
     header: Optional[str] = None
 
+    @property
+    def name(self) -> str:
+        """Often we just need *any* name to filter on or display, let's take
+        the best we can get."""
+        return self.luks_name if self.luks_name else self.base_blockdev_name
+
     @classmethod
-    def lsblk_to_cryptdevices(cls, lsblk_blockdevs: list) -> list["LuksDevice"]:
-        """parses the output of lsblk -Js -o NAME,PATH,TYPE,MOUNTPOINT"""
-        return [
-            cls(
-                base_blockdev=dev["children"][0]["path"],
-                name=dev["name"],
-                mountpoint=dev["mountpoint"],
-            )
-            for dev in lsblk_blockdevs
-            if dev["type"] == "crypt"
-        ]
+    def detect_cryptdevices(
+        cls, lsblk_blockdevs: list, only_active: bool
+    ) -> list["LuksDevice"]:
+        """Detects crypt devices from lsblk -Js -o NAME,PATH,TYPE,MOUNTPOINT output.
+
+        When only_active is False, also probes LVM volumes via
+        `cryptsetup isLuks` to find inactive LUKS devices."""
+
+        devs = []
+        for dev in lsblk_blockdevs:
+            # In the json output, we are only interested in the top-level list entries.
+            # These represent the leaf-node devices, meaning the most concrete
+            # device subsystem possible.
+            if dev["type"] == "crypt":
+                devs.append(
+                    cls(
+                        base_blockdev=dev["children"][0]["path"],
+                        base_blockdev_name=dev["children"][0]["name"],
+                        luks_name=dev["name"],
+                        mountpoint=dev["mountpoint"],
+                    )
+                )
+                # crypt devices' base blockdevs only show up in their children,
+                # not again in the top-level list. We're done here.
+                continue
+            if dev["type"] == "lvm" and not only_active:
+                try:
+                    run.cryptsetup("isLuks", dev["path"], check=True)
+                except CalledProcessError as e:
+                    if e.returncode == 1:
+                        # not a luks device
+                        continue
+                    else:
+                        raise
+                else:
+                    # is a luks device
+                    devs.append(
+                        cls(
+                            base_blockdev=dev["path"],
+                            base_blockdev_name=dev["name"],
+                        )
+                    )
+
+        return devs
 
     @classmethod
     def filter_cryptvolumes(
-        cls, name_glob: str, header: Optional[str]
+        cls, name_glob: str, only_active: bool, header: Optional[str]
     ) -> list["LuksDevice"]:
         """Retrieves visible crypt volumes via `lsblk`, filters their name to
         match `name_glob`.
@@ -48,8 +88,9 @@ class LuksDevice(NamedTuple):
         auto-discovery based on looking for a corresponding header file named
         <mountpoint>.luks and passes an Optional[str].
         """
-        candidates = cls.lsblk_to_cryptdevices(
-            run.json.lsblk("-s", "-o", "NAME,PATH,TYPE,MOUNTPOINT")
+        candidates = cls.detect_cryptdevices(
+            run.json.lsblk("-s", "-o", "NAME,PATH,TYPE,MOUNTPOINT"),
+            only_active=only_active,
         )
 
         matching_devs = []
@@ -136,6 +177,7 @@ class LUKSKeyStoreManager(object):
     def rekey(
         self,
         name_glob: str,
+        only_active: bool,
         header: Optional[str],
         slot="local",
     ):
@@ -156,7 +198,9 @@ class LUKSKeyStoreManager(object):
         else:
             raise ValueError(f"slot={slot}")
 
-        for dev in LuksDevice.filter_cryptvolumes(name_glob, header=header):
+        for dev in LuksDevice.filter_cryptvolumes(
+            name_glob, only_active=only_active, header=header
+        ):
             console.print(f"Rekeying {dev.name}")
             self._do_rekey(slot, device=dev.base_blockdev, header=dev.header)
 
@@ -205,8 +249,12 @@ class LUKSKeyStoreManager(object):
             self._KEYSTORE.backup_external_header(Path(header))
 
     @staticmethod
-    def check_luks(name_glob: str, header: Optional[str]) -> int:
-        devices = LuksDevice.filter_cryptvolumes(name_glob, header=header)
+    def check_luks(
+        name_glob: str, only_active: bool, header: Optional[str]
+    ) -> int:
+        devices = LuksDevice.filter_cryptvolumes(
+            name_glob, only_active=only_active, header=header
+        )
         if not devices:
             console.print(f"Note: The glob `{name_glob}` matches no volume.")
             # Do not fail as hosts may be prepared for encryption without having
@@ -233,11 +281,15 @@ class LUKSKeyStoreManager(object):
 
         return 1 if errors else 0
 
-    def test_open(self, name_glob: str, header: Optional[str]) -> int:
+    def test_open(
+        self, name_glob: str, only_active: bool, header: Optional[str]
+    ) -> int:
         # Ensure to request the admin key early on.
         self._KEYSTORE.admin_key_for_input()
 
-        devices = LuksDevice.filter_cryptvolumes(name_glob, header=header)
+        devices = LuksDevice.filter_cryptvolumes(
+            name_glob, only_active=only_active, header=header
+        )
         if not devices:
             console.print(
                 f"Warning: The glob `{name_glob}` matches no volume.",

--- a/pkgs/fc/ceph/src/fc/ceph/main.py
+++ b/pkgs/fc/ceph/src/fc/ceph/main.py
@@ -592,6 +592,11 @@ def luks(args=sys.argv[1:]):
         help="Names of LUKS volumes to check (globbing allowed), e.g. '*osd-*', 'backy'.",
     )
     parser_check.add_argument(
+        "--only-active",
+        help="Only consider LUKS volumes that are already opened.",
+        action="store_true",
+    )
+    parser_check.add_argument(
         "--header",
         help="When using an external LUKS header file, provide a path to it here."
         "\nDefaults to autodetecting and using a file called ${mountpoint}.luks",
@@ -627,6 +632,11 @@ def luks(args=sys.argv[1:]):
         help="Names of LUKS volumes to update (globbing allowed), e.g. '*osd-*', 'backy'.",
     )
     parser_rekey.add_argument(
+        "--only-active",
+        help="Only consider LUKS volumes that are already opened.",
+        action="store_true",
+    )
+    parser_rekey.add_argument(
         "--header",
         help="When using an external LUKS header file, provide a path to it here."
         "\nDefaults to autodetecting and using a file called ${mountpoint}.luks",
@@ -646,6 +656,11 @@ def luks(args=sys.argv[1:]):
     parser_test.add_argument(
         "name_glob",
         help="Names of LUKS volumes to check (globbing allowed), e.g. '*osd-*', 'backy'.",
+    )
+    parser_test.add_argument(
+        "--only-active",
+        help="Only consider LUKS volumes that are already opened.",
+        action="store_true",
     )
     parser_test.add_argument(
         "--header",

--- a/pkgs/fc/ceph/src/fc/ceph/tests/fc-luks/test_luks.py
+++ b/pkgs/fc/ceph/src/fc/ceph/tests/fc-luks/test_luks.py
@@ -3,6 +3,7 @@ import pathlib
 from io import StringIO
 from textwrap import dedent
 from unittest import mock
+from subprocess import CalledProcessError
 
 import fc.ceph.luks
 import pytest
@@ -95,7 +96,7 @@ LV_DUMMY_DATA = [
     },
 ]
 
-LSBLK_PATTY_JSON = """
+LSBLK_JSON = """
 [
   {
     "name": "sda1",
@@ -204,6 +205,28 @@ LSBLK_PATTY_JSON = """
           {
             "name": "sda",
             "path": "/dev/sda",
+            "type": "disk",
+            "mountpoint": null
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "vgosd--5-ceph--osd--5--wal--backup--crypted",
+    "path": "/dev/mapper/vgosd--5-ceph--osd--5--wal--backup--crypted",
+    "type": "lvm",
+    "mountpoint": null,
+    "children": [
+      {
+        "name": "sdb1",
+        "path": "/dev/sdb1",
+        "type": "part",
+        "mountpoint": null,
+        "children": [
+          {
+            "name": "sdb",
+            "path": "/dev/sdb",
             "type": "disk",
             "mountpoint": null
           }
@@ -321,45 +344,87 @@ def mock_LUKSKeyStoreManager(monkeypatch, tmpdir):
     return keyman
 
 
-def test_lsblk_to_cryptdevices():
+@pytest.fixture
+def mock_cryptsetup_isLuks(monkeypatch):
+    class CryptsetupIsLuksMock:
+        known_luks_devices: set
+        illegal_devices: set
+
+        def __init__(self):
+            self.known_luks_devices = set()
+            self.illegal_devices = set()
+
+        def __call__(self, *args, **kwargs):
+            assert args[0] == "isLuks", (
+                f"only isLuks is properly mocked by this object; args {args}, kwargs {kwargs}"
+            )
+
+            assert kwargs["check"], (
+                "isLuks only makes sense when checking the return code"
+            )
+            if (dev := args[1]) in self.illegal_devices:
+                raise CalledProcessError(
+                    returncode=4,
+                    cmd=f"cryptsetup isLuks {dev}",
+                    output=f"Device {dev} does not exist or access denied.",
+                )
+            if (dev := args[1]) in self.known_luks_devices:
+                return ""
+            else:
+                raise CalledProcessError(
+                    returncode=1, cmd=f"cryptestup isLuks {dev}", output=""
+                )
+
+    c_mock = CryptsetupIsLuksMock()
+    monkeypatch.setattr("fc.ceph.util.run.cryptsetup", c_mock)
+    return c_mock
+
+
+def test_detect_cryptdevices_only_active():
     import json
 
     from fc.ceph.luks import manage
 
     assert set(
-        manage.LuksDevice.lsblk_to_cryptdevices(json.loads(LSBLK_PATTY_JSON))
+        manage.LuksDevice.detect_cryptdevices(
+            json.loads(LSBLK_JSON), only_active=True
+        )
     ) == set(
         (
             manage.LuksDevice(
                 base_blockdev="/dev/mapper/vgsys-ceph--mon--crypted",
-                name="ceph-mon",
+                base_blockdev_name="vgsys-ceph--mon--crypted",
+                luks_name="ceph-mon",
                 mountpoint="/srv/ceph/mon/ceph-patty",
                 header=None,
             ),
             manage.LuksDevice(
                 base_blockdev="/dev/sdb1",
-                name="backy",
+                base_blockdev_name="sdb1",
+                luks_name="backy",
                 mountpoint="/srv/backy",
                 header=None,
             ),
             manage.LuksDevice(
                 base_blockdev="/dev/mapper/vgsys-ceph--mgr--crypted",
-                name="ceph-mgr",
+                base_blockdev_name="vgsys-ceph--mgr--crypted",
+                luks_name="ceph-mgr",
                 mountpoint="/srv/ceph/mgr/ceph-patty",
                 header=None,
             ),
         )
     )
-    assert manage.LuksDevice.lsblk_to_cryptdevices([]) == []
+    assert manage.LuksDevice.detect_cryptdevices([], only_active=True) == []
     # disks, but no crypt and no children
     assert (
-        manage.LuksDevice.lsblk_to_cryptdevices(
-            [{"name": "sdb", "path": "/dev/sda", "type": "disk"}]
+        manage.LuksDevice.detect_cryptdevices(
+            [{"name": "sdb", "path": "/dev/sda", "type": "disk"}],
+            only_active=True,
         )
         == []
     )
     # disks with mountpoint = null
-    assert manage.LuksDevice.lsblk_to_cryptdevices(
+    assert manage.LuksDevice.detect_cryptdevices(
         [
             {
                 "name": "ceph-osd3-block",
@@ -391,21 +456,122 @@ def test_lsblk_to_cryptdevices():
                     }
                 ],
             }
-        ]
+        ],
+        only_active=True,
     ) == [
         manage.LuksDevice(
-            name="ceph-osd3-block",
+            luks_name="ceph-osd3-block",
             base_blockdev="/dev/mapper/vgosd3-ceph--osd3--block--crypted",
+            base_blockdev_name="vgosd3-ceph--osd3--block--crypted",
             mountpoint=None,
         )
     ]
 
 
+def test_detect_cryptdevices_all_volumes(mock_cryptsetup_isLuks):
+    import json
+
+    from fc.ceph.luks import manage
+
+    # isLuks does not detect any additional devices: same as with `only_active=True`
+    assert set(
+        manage.LuksDevice.detect_cryptdevices(
+            json.loads(LSBLK_JSON), only_active=False
+        )
+    ) == set(
+        (
+            manage.LuksDevice(
+                base_blockdev="/dev/mapper/vgsys-ceph--mon--crypted",
+                base_blockdev_name="vgsys-ceph--mon--crypted",
+                luks_name="ceph-mon",
+                mountpoint="/srv/ceph/mon/ceph-patty",
+                header=None,
+            ),
+            manage.LuksDevice(
+                base_blockdev="/dev/sdb1",
+                base_blockdev_name="sdb1",
+                luks_name="backy",
+                mountpoint="/srv/backy",
+                header=None,
+            ),
+            manage.LuksDevice(
+                base_blockdev="/dev/mapper/vgsys-ceph--mgr--crypted",
+                base_blockdev_name="vgsys-ceph--mgr--crypted",
+                luks_name="ceph-mgr",
+                mountpoint="/srv/ceph/mgr/ceph-patty",
+                header=None,
+            ),
+        )
+    )
+
+    # additional device is detected
+    mock_cryptsetup_isLuks.known_luks_devices.add(
+        "/dev/mapper/vgosd--5-ceph--osd--5--wal--backup--crypted"
+    )
+    assert set(
+        manage.LuksDevice.detect_cryptdevices(
+            json.loads(LSBLK_JSON), only_active=False
+        )
+    ) == set(
+        (
+            manage.LuksDevice(
+                base_blockdev="/dev/mapper/vgsys-ceph--mon--crypted",
+                base_blockdev_name="vgsys-ceph--mon--crypted",
+                luks_name="ceph-mon",
+                mountpoint="/srv/ceph/mon/ceph-patty",
+                header=None,
+            ),
+            manage.LuksDevice(
+                base_blockdev="/dev/sdb1",
+                base_blockdev_name="sdb1",
+                luks_name="backy",
+                mountpoint="/srv/backy",
+                header=None,
+            ),
+            manage.LuksDevice(
+                base_blockdev="/dev/mapper/vgsys-ceph--mgr--crypted",
+                base_blockdev_name="vgsys-ceph--mgr--crypted",
+                luks_name="ceph-mgr",
+                mountpoint="/srv/ceph/mgr/ceph-patty",
+                header=None,
+            ),
+            manage.LuksDevice(
+                base_blockdev="/dev/mapper/vgosd--5-ceph--osd--5--wal--backup--crypted",
+                base_blockdev_name="vgosd--5-ceph--osd--5--wal--backup--crypted",
+                luks_name=None,
+                mountpoint=None,
+                header=None,
+            ),
+        )
+    )
+
+    # other errors of isLuks still bubble up
+    mock_cryptsetup_isLuks.known_luks_devices = {}
+    mock_cryptsetup_isLuks.illegal_devices.add(
+        "/dev/mapper/vgosd--5-ceph--osd--5--wal--backup--crypted"
+    )
+    with pytest.raises(CalledProcessError):
+        manage.LuksDevice.detect_cryptdevices(
+            json.loads(LSBLK_JSON), only_active=False
+        )
+
+
 def test_keystore_rekey_argument_calls(mock_LUKSKeyStoreManager):
     keyman = mock_LUKSKeyStoreManager
-    keyman.rekey(name_glob="*", header=None)
-    keyman.rekey(name_glob="backy", slot="local", header="/srv/foo.luks")
-    keyman.rekey(name_glob="ceph*", slot="admin", header="/srv/foo.luks")
+    # testing with `only_active` is easier, no need to mock cryptsetup
+    keyman.rekey(name_glob="*", only_active=True, header=None)
+    keyman.rekey(
+        name_glob="backy",
+        only_active=True,
+        slot="local",
+        header="/srv/foo.luks",
+    )
+    keyman.rekey(
+        name_glob="ceph*",
+        only_active=True,
+        slot="admin",
+        header="/srv/foo.luks",
+    )
 
 
 @pytest.fixture
@@ -474,8 +640,7 @@ def test_keystore_admin_key_fingerprint_init(
     # If this was a multiline string, pre-commit would be eating the trailing spaces :\
     pe.optional("Warning: Password input may be echoed.")
     pe.in_order(
-        "LUKS admin key for this location: \n"
-        "LUKS admin key for this location: "
+        "LUKS admin key for this location: \nLUKS admin key for this location: "
     )
     assert pe == captured.err
 
@@ -659,21 +824,15 @@ def test_luks_fingerprint_verify(
     inputs_mock.seek(0)
 
     # no fingerprint file
-    assert (
-        mock_LUKSKeyStoreManager.fingerprint(confirm=False, verify=True) == 1
-    )
+    assert mock_LUKSKeyStoreManager.fingerprint(confirm=False, verify=True) == 1
 
     # mismatching fingerprint file
     persist_fingerprint(b"notfoo", tmpdir)
-    assert (
-        mock_LUKSKeyStoreManager.fingerprint(confirm=False, verify=True) == 1
-    )
+    assert mock_LUKSKeyStoreManager.fingerprint(confirm=False, verify=True) == 1
 
     # matching fingerprint file
     persist_fingerprint(b"foo", tmpdir)
-    assert (
-        mock_LUKSKeyStoreManager.fingerprint(confirm=False, verify=True) == 0
-    )
+    assert mock_LUKSKeyStoreManager.fingerprint(confirm=False, verify=True) == 0
 
     captured = capsys.readouterr()
 

--- a/pkgs/fc/ceph/src/fc/ceph/tests/fc-luks/test_luks_dump.py
+++ b/pkgs/fc/ceph/src/fc/ceph/tests/fc-luks/test_luks_dump.py
@@ -239,12 +239,14 @@ def test_check_integration_ok(monkeypatch, capsys):
         return_value=[
             LuksDevice(
                 base_blockdev="/dev/mapper/foo",
-                name="testdev1",
+                luks_name="testdev1",
+                base_blockdev_name="foo--mapper1",
                 mountpoint="/mnt/foo",
             ),
             LuksDevice(
                 base_blockdev="/dev/vgbar/holygrail",
-                name="testdev2",
+                luks_name="testdev2",
+                base_blockdev_name="foo--mapper2",
                 mountpoint="/mnt/bar",
             ),
         ]
@@ -256,7 +258,9 @@ def test_check_integration_ok(monkeypatch, capsys):
         MagicMock(return_value=data_correct.encode("utf-8")),
     )
 
-    assert LUKSKeyStoreManager.check_luks("*", header=None) == 0
+    assert (
+        LUKSKeyStoreManager.check_luks("*", only_active=True, header=None) == 0
+    )
 
     captured = capsys.readouterr()
     assert captured.out == textwrap.dedent(
@@ -285,13 +289,15 @@ def test_check_integration_error(monkeypatch, capsys):
         return_value=[
             LuksDevice(
                 base_blockdev="/dev/mapper/foo",
-                name="testdev1",
+                luks_name="testdev1",
+                base_blockdev_name="foo--mapper1",
                 mountpoint="/mnt/foo",
                 header="/mnt/foo.luks",
             ),
             LuksDevice(
                 base_blockdev="/dev/vgbar/holygrail",
-                name="testdev2",
+                luks_name="testdev2",
+                base_blockdev_name="foo--mapper2",
                 mountpoint="/mnt/bar",
                 header="/mnt/bar.luks",
             ),
@@ -308,7 +314,9 @@ def test_check_integration_error(monkeypatch, capsys):
 
     monkeypatch.setattr("fc.ceph.luks.Cryptsetup.cryptsetup", DumpMock())
 
-    assert LUKSKeyStoreManager.check_luks("*", header=None) == 1
+    assert (
+        LUKSKeyStoreManager.check_luks("*", only_active=True, header=None) == 1
+    )
 
     captured = capsys.readouterr()
     assert captured.out == textwrap.dedent(


### PR DESCRIPTION
In most cases, we want *all* LUKS volumes of the system to be discovered, even if they are not currently opened. That helps
- with rekeying volumes when the keystore failed and they could not be openend in the first place
- avoiding stale keys for e.g. backup volumes

PL-133176

@flyingcircusio/release-managers

## Release process

This change should be backported:

- [x] Created changelog entry using `./changelog.sh`
- [x] Add `backport release-25.11` label

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [x] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - prevent stale volumes from getting out of sync after rekeying
  - improve operability of hosts with a failed keystore
- [x] Security requirements tested? (EVIDENCE)
  - extended unit tests to cover new scenarios
  - manually tested in dev cluster (on the Ceph pacific dev branch though)