### PR TITLE
nix: test new object storage gateways as binary cache for our internal dev VMs

### DIFF
--- a/changelog.d/20260413_144001_HEAD_scriv.md
+++ b/changelog.d/20260413_144001_HEAD_scriv.md
@@ -1,0 +1,26 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+<!-- Impact means "when this change is rolled out, there
+     might be interruptions/downtimes/required actions/... that
+     IMPACT THE RUNNING APPLICATION NEGATIVELY.
+
+     Having new features or changed is not an "impact". That's what
+     the main changelog (see below) is for.
+     -->
+
+### NixOS XX.XX platform
+
+- nix: test new object storage gateways as binary cache for our internal development VMs (PL-128135)

--- a/nixos/platform/default.nix
+++ b/nixos/platform/default.nix
@@ -336,11 +336,21 @@ in
       '';
 
       settings = {
-        substituters = lib.mkOverride 90 [
-          "https://cache.nixos.org"
-          "https://s3.whq.fcio.net/hydra"
-          "https://hydra.flyingcircus.io"
-        ];
+        # In absense of a specific priority in both the nix-cache-info and the URL, order matters.
+        substituters = lib.mkOverride 90 (
+          [
+            "https://cache.nixos.org"
+          ]
+          ++ lib.optionals (config.flyingcircus.location == "dev") [
+            "https://objects.whq.fcio.net/hydra"
+          ]
+          ++ lib.optionals (config.flyingcircus.location != "dev") [
+            "https://s3.whq.fcio.net/hydra"
+          ]
+          ++ [
+            "https://hydra.flyingcircus.io"
+          ]
+        );
 
         trusted-public-keys = [
           "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="


### PR DESCRIPTION
@flyingcircusio/release-managers

PL-128135

## Release process

This change should be backported:

- [x] Created changelog entry using `./changelog.sh`
- [x] Add `backport release-25.11` label

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [x] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Redundancy: better with new one
- [x] Security requirements tested? (EVIDENCE)
  - The new object storage gateway is nearly equivalent to the old one, but has redundancy
  - I tested that pulling from the cache still works and that `objects.whq.fcio.net` gets prioritized over `hydra.flyingcircus.io` (which is on it's path to deprecation).