### PR TITLE
PL-135151 fix interface specific sysctls

### DIFF
--- a/changelog.d/20260427_170935_PL-135152-sysctl_scriv.md
+++ b/changelog.d/20260427_170935_PL-135152-sysctl_scriv.md
@@ -1,0 +1,28 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+<!-- Impact means "when this change is rolled out, there
+     might be interruptions/downtimes/required actions/... that
+     IMPACT THE RUNNING APPLICATION NEGATIVELY.
+
+     Having new features or changed is not an "impact". That's what
+     the main changelog (see below) is for.
+     -->
+
+
+
+### NixOS XX.XX platform
+
+- Fix interface specific sysctls. (PL-135152)

--- a/nixos/platform/network.nix
+++ b/nixos/platform/network.nix
@@ -120,6 +120,36 @@ let
   concatMapLinesIndent = concatFuncWithIndent lib.concatMapStringsSep;
   concatMapLines = lib.concatMapStringsSep "\n";
 
+  extractSysctlInterface =
+    sysctl:
+    lib.pipe
+      [
+        ''net\.ipv[46]\.conf\.([/[:alnum:]]+)\..+''
+        "net/ipv[46]/conf/([.[:alnum:]]+)/.+"
+        ''net\.ipv[46]\.neigh\.([/[:alnum:]]+)\..+''
+        "net/ipv[46]/neigh/([.[:alnum:]]+)/.+"
+      ]
+      [
+        (lib.map (re: lib.match re sysctl))
+        (lib.findFirst lib.isList [ null ])
+        lib.head
+        (lib.mapNullable (replaceStrings [ "/" ] [ "." ]))
+      ];
+
+  interfaceSysctls = lib.pipe config.boot.kernel.sysctl [
+    lib.attrsToList
+    (map (e: e // { iface = extractSysctlInterface e.name; }))
+    (lib.filter (
+      { value, iface, ... }:
+      value != null
+      && !elem iface [
+        null
+        "default"
+        "all"
+        "*"
+      ]
+    ))
+  ];
 in
 {
 
@@ -148,6 +178,28 @@ in
 
   config = lib.mkMerge [
     {
+      assertions =
+        let
+          invalidSysctls = lib.filter (
+            { iface, ... }: !lib.elem iface (lib.mapAttrsToList (n: v: v.name) config.networking.interfaces)
+          ) interfaceSysctls;
+        in
+        [
+          {
+            assertion = lib.length invalidSysctls == 0;
+            message = ''
+              The following sysctls refer to interfaces that are not managed through networking.interfaces:
+              ${lib.concatMapStringsSep ", " ({ name, iface, ... }: "${name} (${iface})") invalidSysctls}
+              Applying sysctls to these interfaces won't work automatically. Add a systemd unit that sets the sysctls
+              and depends on the unit that brings up the interface. Then remove these entries from boot.kernel.sysctl to
+              clear this error.
+            '';
+          }
+        ];
+
+      environment.etc."sysctl.d/90-nixos-overwrite.conf".text = # Do not log error and keep excluded from glob patterns
+        lib.concatMapStrings ({ name, ... }: "-${name}\n") interfaceSysctls;
+
       environment.etc."host.conf".text = ''
         order hosts, bind
         multi on
@@ -731,6 +783,36 @@ in
               (map (link: lib.nameValuePair (unitName link) (unitTemplate link false)) virtualLinks)
               ++ (map (link: lib.nameValuePair (unitName link.link) (unitTemplate link.link true)) ethernetLinks)
             )
+          ++ (
+            let
+              sysctlFile =
+                link:
+                pkgs.writeText "sysctl-${link}" (
+                  lib.concatMapStrings (
+                    { name, value, ... }: "${name}=${if value == false then "0" else toString value}\n"
+                  ) (filter ({ iface, ... }: link == iface) interfaceSysctls)
+                );
+              unitName = link: "network-sysctl-${link}";
+              unitTemplate = link: rec {
+                description = "Apply Sysctls for link ${link}";
+                wantedBy = [ "network-addresses-${link}.service" ];
+                before = wantedBy;
+                requires = [ "${link}-netdev.service" ];
+                bindsTo = requires;
+                after = requires;
+                script = ''
+                  ${pkgs.systemd}/lib/systemd/systemd-sysctl ${sysctlFile link}
+                '';
+                serviceConfig = {
+                  Type = "oneshot";
+                  RemainAfterExit = true;
+                };
+              };
+            in
+            (lib.mapAttrsToList (
+              n: v: lib.nameValuePair (unitName v.name) (unitTemplate v.name)
+            ) config.networking.interfaces)
+          )
           ++
 
             (lib.optionals (!isNull fclib.underlay)

--- a/tests/network/default.nix
+++ b/tests/network/default.nix
@@ -111,6 +111,65 @@ import ../make-test-python.nix (
         '';
       };
 
+      sysctl = {
+        name = "sysctl";
+        nodes.machine =
+          { config, lib, ... }:
+          {
+            imports = [
+              (testlib.fcConfig { id = 1; })
+            ];
+
+            environment.systemPackages = [ pkgs.procps ];
+
+            networking.interfaces = lib.mapAttrs (_: v: { name = v.name; }) config.virtualisation.interfaces;
+
+            boot.kernel.sysctl = {
+              "net.ipv4.conf.ethfe.forwarding" = true;
+              "net/ipv6/neigh/ethfe/proxy_delay" = 20;
+            };
+
+            specialisation.changed.configuration = {
+              boot.kernel.sysctl = {
+                "net.ipv4.conf.ethfe.forwarding" = lib.mkForce false;
+                "net/ipv6/neigh/ethfe/proxy_delay" = lib.mkForce 40;
+                "net.ipv4.conf.ethfe.invalid" = false;
+              };
+            };
+          };
+
+        testScript = ''
+          def assertSysctl(sysctl, expected):
+            value = machine.succeed(f'sysctl -nb "{sysctl}"')
+            t.assertEqual(value, str(expected))
+
+          def testBoot():
+            machine.wait_for_unit("network.target")
+            assertSysctl("net.ipv4.conf.ethfe.forwarding", 1)
+            assertSysctl("net.ipv6.neigh.ethfe.proxy_delay", 20)
+            unitStatus = machine.succeed(f"systemctl status network-sysctl-ethfe.service")
+            t.assertNotIn("Couldn't write '0' to 'net/ipv4/conf/ethfe/invalid'", unitStatus)
+
+          def testSpecialisation():
+            assertSysctl("net.ipv4.conf.ethfe.forwarding", 0)
+            assertSysctl("net.ipv6.neigh.ethfe.proxy_delay", 40)
+            unitStatus = machine.succeed(f"systemctl status network-sysctl-ethfe.service")
+            t.assertIn("Couldn't write '0' to 'net/ipv4/conf/ethfe/invalid'", unitStatus)
+
+          with subtest("after boot"):
+            testBoot()
+
+          with subtest("after switch"):
+            machine.succeed("/run/current-system/specialisation/changed/bin/switch-to-configuration test")
+            testSpecialisation()
+
+          with subtest("after reboot"):
+            machine.shutdown()
+            machine.start()
+            testBoot()
+        '';
+      };
+
       wireguard = {
         name = "wireguard";
         nodes.machine = {


### PR DESCRIPTION
@flyingcircusio/release-managers
PL-135151

## Release process

This change should be backported:

- [x] Created changelog entry using `./changelog.sh`
- [x] Add `backport release-25.11` label

This change should only reach this branch:

- [ ] Created changelog entry using `./changelog.sh`
or
- [ ] Add a upgrade node in `doc/upgrade.md`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [x] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [ ] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - fix bug
- [x] Security requirements tested? (EVIDENCE)
  - automated test
  - manually tested on test vm
