### PR TITLE
[FC-52541] opensearch 3.5

### DIFF
--- a/changelog.d/20260416_161604_FC-52541_opensearch_3_5_scriv.md
+++ b/changelog.d/20260416_161604_FC-52541_opensearch_3_5_scriv.md
@@ -1,0 +1,19 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+
+### NixOS XX.XX platform
+
+- Provide version 3.5 of the Opensearch package for use with the opensearch service and role. This is a temporary measure targeted at 25.11 until the package is updated upstream in 26.05.

--- a/nixos/services/opensearch.nix
+++ b/nixos/services/opensearch.nix
@@ -195,6 +195,9 @@ in
               ++ [
                 "${pkgs.writeShellScript "opensearch-link-jdk" "ln -sfT ${pkgs.jre_headless} ${cfgUpstream.dataDir}/jdk"}"
               ]
+              ++ (lib.optionals (lib.pathExists "${config.services.opensearch.package}/agent") [
+                "${pkgs.writeShellScript "opensearch-link-agent" "ln -sfT ${config.services.opensearch.package}/agent ${config.services.opensearch.dataDir}/agent"}"
+              ])
             );
         };
       };

--- a/pkgs/opensearch_3_5.nix
+++ b/pkgs/opensearch_3_5.nix
@@ -1,0 +1,71 @@
+{
+  coreutils,
+  fetchurl,
+  gnugrep,
+  jre_headless,
+  lib,
+  makeBinaryWrapper,
+  nixosTests,
+  stdenv,
+  stdenvNoCC,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "opensearch";
+  version = "3.5.0";
+
+  src = fetchurl {
+    url = "https://artifacts.opensearch.org/releases/bundle/opensearch/${finalAttrs.version}/opensearch-${finalAttrs.version}-linux-x64.tar.gz";
+    hash = "sha256-0d6TQU1LTE983CsYbaK4fNuC86VAx23XD2xR6y2NuHw=";
+  };
+
+  nativeBuildInputs = [
+    makeBinaryWrapper
+  ];
+
+  buildInputs = [
+    jre_headless
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out
+    cp -R bin config lib modules plugins agent $out
+
+    substituteInPlace $out/bin/opensearch \
+      --replace 'bin/opensearch-keystore' "$out/bin/opensearch-keystore"
+
+    wrapProgram $out/bin/opensearch \
+      --prefix PATH : "${
+        lib.makeBinPath [
+          gnugrep
+          coreutils
+        ]
+      }" \
+      --prefix LD_LIBRARY_PATH : "${
+        lib.makeLibraryPath [ stdenv.cc.cc ]
+      }:$out/plugins/opensearch-knn/lib/" \
+      --set JAVA_HOME "${jre_headless}"
+
+    wrapProgram $out/bin/opensearch-plugin --set JAVA_HOME "${jre_headless}"
+
+    rm $out/bin/opensearch-cli
+
+    runHook postInstall
+  '';
+
+  passthru.tests = nixosTests.opensearch;
+
+  meta = {
+    description = "Open Source, Distributed, RESTful Search Engine";
+    homepage = "https://github.com/opensearch-project/OpenSearch";
+    license = lib.licenses.asl20;
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+    sourceProvenance = with lib.sourceTypes; [
+      binaryBytecode
+      binaryNativeCode
+    ];
+  };
+})

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -591,6 +591,8 @@ builtins.mapAttrs (_: patchPhps phpLogPermissionPatch) {
 
   opensearch-dashboards = super.callPackage ./opensearch-dashboards { };
 
+  opensearch_3_5 = super.callPackage ./opensearch_3_5.nix { };
+
   percona = self.percona84;
   percona-toolkit = super.perlPackages.PerconaToolkit.overrideAttrs (oldAttrs: {
     # The script uses usr/bin/env perl and the Perl builder adds PERL5LIB to it.


### PR DESCRIPTION
provide opensearch 3.5 via fc-nixos.
the update to 3.5 has been merged into 26.05 upstream but the package is already required in some 25.11 installations

@flyingcircusio/release-managers

## Release process

This change should be backported:

- [x] Created changelog entry using `./changelog.sh`
- [x] Add `backport release-25.11` label

This change should only reach this branch:

- [ ] Created changelog entry using `./changelog.sh`
or
- [ ] Add a upgrade node in `doc/upgrade.md`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [ ] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - provides a new version of an existing package as a separate package
- [ ] Security requirements tested? (EVIDENCE)
  - yes, no security-relevant impact
