### PR TITLE
[PL-135105] improve slurm reliability

### DIFF
--- a/changelog.d/20260417_110136_PL-135105_slurm-scope-monitoring_scriv.md
+++ b/changelog.d/20260417_110136_PL-135105_slurm-scope-monitoring_scriv.md
@@ -1,0 +1,21 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+-
+
+
+### NixOS XX.XX platform
+
+- Slurm: Add a workaround for a rare bug which causes new jobs to fail on startup. (PL-135105)

--- a/nixos/roles/slurm/default.nix
+++ b/nixos/roles/slurm/default.nix
@@ -437,6 +437,20 @@ in
           '';
         };
       };
+
+      systemd.services.ensure_slurmstepd_scope_active = {
+        script = ''
+          if systemctl is-active --quiet slurmd && ! systemctl is-active --quiet slurmstepd.scope; then
+            echo "ERROR: The slurmstepd scope is inactive! Restarting slurmd to restore functionality."
+            systemctl restart slurmd
+          fi
+        '';
+        serviceConfig = {
+          Type = "oneshot";
+          User = "root";
+        };
+        startAt = "*:0/2";
+      };
     })
 
     # We need at least one compute node or the controller will crash on startup.


### PR DESCRIPTION
With cgroups v2, the slurm daemon sets up a persistent scope for submitted jobs.
The current version of slurm on nixos 25.11 and older has a bug where systemd can sometimes lose track of the daemon PID and disable this scope causing new jobs to fail on startup.j
This usually occurs during communication when a job finishes and requires a restart of the slurmd service.

https://github.com/SchedMD/slurm/commit/9c6d56279dca1f8dd547896c422a096b6f0c3705

@flyingcircusio/release-managers

## Release process

This change should be backported:

- [x] Created changelog entry using `./changelog.sh`
- [x] Add `backport release-25.11` label

This change should only reach this branch:

- [ ] Created changelog entry using `./changelog.sh`
or
- [ ] Add a upgrade node in `doc/upgrade.md`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [ ] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - adds a systemd timer that ensures service availability
- [ ] Security requirements tested? (EVIDENCE)
  - Not relevant