### PR TITLE
sensu: remove swap checks

### DIFF
--- a/doc/src/upgrade.md
+++ b/doc/src/upgrade.md
@@ -401,6 +401,8 @@ affected. You can still add gcroots manually (e.g. via `nix-store --add-root`).
 
 - The `imagemagick6` family of packages has known vulnerabilities and is not permitted by default anymore. Update your applications to work with a current version of imagemagick, or add this to `flyingcircus.permittedInsecurePackages`.
 
+- The sensu `swap` checks have been removed, as they are no longer relevant with systemd-oomd, which we introduced in fc-nixos 25.11
+
 ## Known issues
 
 None.

--- a/nixos/services/sensu/client.nix
+++ b/nixos/services/sensu/client.nix
@@ -303,18 +303,6 @@ in
           };
         };
       };
-      expectedSwap = {
-        warning = mkOption {
-          type = types.int;
-          default = 1024;
-          description = "Limit of swap usage in MiB before warning.";
-        };
-        critical = mkOption {
-          type = types.int;
-          default = 2048;
-          description = "Limit of swap usage in MiB before reaching critical.";
-        };
-      };
 
       mutedSystemdUnits = mkOption {
         type = types.listOf types.str;
@@ -470,14 +458,6 @@ in
           #     "-c ${cfg.expectedLoad.critical}";
           #   interval = 10;
           # };
-          swap = {
-            notification = "Swap usage is too high";
-            command =
-              "${fc.sensuplugins}/bin/check_swap_abs "
-              + "-w ${toString cfg.expectedSwap.warning} "
-              + "-c ${toString cfg.expectedSwap.critical}";
-            interval = 300;
-          };
           ssh = {
             notification = "SSH server is not responding properly";
             command = "check_ssh localhost";


### PR DESCRIPTION
With the systemd-oomd construct introduced in fc-nixos 25.11, we no longer have the relevancy for these checks. It manages the level of swap the machne is allowed to have.

PL-134281

@flyingcircusio/release-managers

## Release process

This change should only reach this branch:

- [ ] Created changelog entry using `./changelog.sh`
or
- [x] Add a upgrade node in `doc/upgrade.md`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [x] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [x] Security requirements tested? (EVIDENCE)
  - Swap is a required for the correct functionality of systemd-oomd and kernel OOMing. We adjusted the OOM settings to limit Swap use generally. These checks are non-actionable for our staff and for our customers. 
