### PR TITLE
nginx: remove informational warning of TLS checks

### DIFF
--- a/nixos/services/nginx/default.nix
+++ b/nixos/services/nginx/default.nix
@@ -443,7 +443,7 @@ in
               };
             }
           else
-            lib.warn "Informational: nginx vhost '${n}' does not declare a plain hostname. No HTTPS certificate check is added. This warning will be removed after 2 releases." acc
+            acc
         ) { } (lib.attrNames vhostsWithTLS))
         # Add certificate file checks for non-ACME hosts specified in nginx config.
         # ACME certificates in general (nginx enableACME or others) are covered in platform/acme.nix.
@@ -463,7 +463,7 @@ in
               };
             }
           else
-            lib.warn "Informational: nginx vhost '${n}' does not declare a plain hostname. No TLS certificate check is added. This warning will be removed after 2 releases." acc
+            acc
         ) { } (lib.attrNames nonAcmeVhostsWithTLS));
 
         networking.firewall.allowedTCPPorts = [


### PR DESCRIPTION
As a follow-up to PL-135244, remove the informational warning after the announced grace period.

PL-135271

@flyingcircusio/release-managers

## Release process

This change should be backported:

- [ ] Created changelog entry using `./changelog.sh`
  - no, change was already announced earlier
- [x] Add `backport release-26.05` label

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [x] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - [x] ensure that all NixOS-defined acme certs still get checked, irrespectively of the ignored vhost rules
- [x] Security requirements tested? (EVIDENCE)
  - checked acme.nix code in fc-nixos