### PR TITLE
nix: use nix 2.34 and cleanup tarball-cache-v1

### DIFF
--- a/nixos/platform/nix.nix
+++ b/nixos/platform/nix.nix
@@ -8,7 +8,7 @@
 let
   production = lib.attrByPath [ "parameters" "production" ] "" config.flyingcircus.enc;
 
-  nixPackage = pkgs.nixVersions.nix_2_28;
+  nixPackage = pkgs.nixVersions.nix_2_34;
 in
 {
   options.flyingcircus = {
@@ -35,5 +35,29 @@ in
 
   config = {
     nix.package = nixPackage;
+
+    # Nix 2.34 switches from the `tarball-cache` directory to the
+    # `tarball-cache-v2` directory without cleaning up the first one.
+    # This could lead to disk space issues. So we clean it up.
+    # The directory could be in each users home directory while most likely
+    # it primarily exists in /root/, because the fc-agent runs there.
+    systemd.services."fc-cleanup-nix-tarball-cache-v1" =
+      let
+        tarballCacheDirectories = lib.unique (
+          lib.mapAttrsToList (_: cfg: "${cfg.home}/.cache/nix/tarball-cache") config.users.users
+        );
+      in
+      lib.mkIf (lib.versionAtLeast config.nix.package.version "2.34") {
+        wantedBy = [ "multi-user.target" ];
+        unitConfig = {
+          # The | makes this condition OR based. When one directory exists,
+          # this systemd service runs.
+          ConditionPathExists = lib.map (v: "|${v}") tarballCacheDirectories;
+        };
+        serviceConfig = {
+          User = "root";
+        };
+        script = builtins.concatStringsSep "\n" (lib.map (v: "rm -rf ${v}") tarballCacheDirectories);
+      };
   };
 }

--- a/pkgs/fc/default.nix
+++ b/pkgs/fc/default.nix
@@ -8,7 +8,7 @@ rec {
   recurseForDerivations = true;
 
   agent = callPackage ./agent {
-    nix = pkgs.nixVersions.nix_2_28;
+    nix = pkgs.nixVersions.nix_2_34;
     pyPackages = pyPackages;
   };
   # FIXME: PL-135090


### PR DESCRIPTION
Nix 2.34 is the new default in NixOS 26.05.

According to the relase notes, it now uses tarball-cache-v2, but doesn't cleanup the old directory. This change creates a systemd unit that cleans it up.

PL-135274

@flyingcircusio/release-managers

## Release process

This change should only reach this branch:

- [ ] Created changelog entry using `./changelog.sh`
or
- [ ] Add a upgrade node in `doc/upgrade.md`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [x] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [x] Security requirements tested? (EVIDENCE)
  - Tested on dev machine