### PR TITLE
fc-update-channel: stagger execution over 2h instead of 1h

### DIFF
--- a/changelog.d/20260421_100309_FC-52891-stretch-updates_scriv.md
+++ b/changelog.d/20260421_100309_FC-52891-stretch-updates_scriv.md
@@ -1,0 +1,28 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+<!-- Impact means "when this change is rolled out, there
+     might be interruptions/downtimes/required actions/... that
+     IMPACT THE RUNNING APPLICATION NEGATIVELY.
+
+     Having new features or changed is not an "impact". That's what
+     the main changelog (see below) is for.
+     -->
+
+
+
+### NixOS XX.XX platform
+
+- stagger the fetch and build of releases over 2 hours instead of 1 hour, to reduce load (FC-52891)

--- a/nixos/platform/agent.nix
+++ b/nixos/platform/agent.nix
@@ -528,8 +528,8 @@ in
 
         timerConfig = {
           OnActiveSec = "1m";
-          OnCalendar = "hourly";
-          RandomizedDelaySec = "60m";
+          OnCalendar = "00/2:00";
+          RandomizedDelaySec = "120m";
           FixedRandomDelay = true;
           Persistent = true;
         };


### PR DESCRIPTION
When fc-update-channel encounters a new release, it immediately downloads the corresponding sources and pre-builds the package. We already staggered the individual service execution over a stretch of one hour on a cluster-wide level to reduce strain on the infrastructure.

When rolling out especially large releases, e.g. after a full rebuild due to low-level dependency changes, this strain became so high it impacted VM operations.
Stretching the rollout of such updates over twice the time, reduces load on all involved components. Judging by the metrics, the Ceph storage clusters (both WHQ, most strongly affected by the Hydra fetch) as well as RZOB (most affected due to the high number of production VMs doing updates) were able to cope. The clear bottle neck was the object storage gateway serving the build artifacts, and this gateway now also gets its load reduced.

FC-52891

@flyingcircusio/release-managers

## Release process

This change should be backported:

- [x] Created changelog entry using `./changelog.sh`
- [x] Add `backport release-25.11` label

This change should only reach this branch:

- [ ] Created changelog entry using `./changelog.sh`
or
- [ ] Add a upgrade node in `doc/upgrade.md`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [x] set urgency and risk labels
- [x] ensure the merge bot has determined a merge date
-->
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [x] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - improve availability: reduce infrastructure load during release rollout
- [x] Security requirements tested? (EVIDENCE)
  - checked whether the interval is mentioned in our documentation – did not find any mentions, no need to update the docs