### PR TITLE
slurm: support slurm 25.11 and make fc-agent compatible with pyslurm 25.11

### DIFF
--- a/changelog.d/20260424_145908_HEAD_scriv.md
+++ b/changelog.d/20260424_145908_HEAD_scriv.md
@@ -1,0 +1,28 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+<!-- Impact means "when this change is rolled out, there
+     might be interruptions/downtimes/required actions/... that
+     IMPACT THE RUNNING APPLICATION NEGATIVELY.
+
+     Having new features or changed is not an "impact". That's what
+     the main changelog (see below) is for.
+     -->
+
+### NixOS XX.XX platform
+
+- slurm: add slurm 25.11 package and make fc-agent compatible with pyslurm 25.11 (PL-135105)
+
+  The default slurm version for the NixOS 25.11 platform is still 25.05. This change allows it, to move customers to slurm 25.11.

--- a/nixos/roles/slurm/default.nix
+++ b/nixos/roles/slurm/default.nix
@@ -308,7 +308,11 @@ in
         '')
       ];
 
-      flyingcircus.agent.package = pkgs.fc.agentWithSlurm;
+      flyingcircus.agent.package =
+        if (lib.versions.majorMinor config.services.slurm.package.version == "25.11") then
+          pkgs.fc.agentWithSlurm-25_11
+        else
+          pkgs.fc.agentWithSlurm;
 
       flyingcircus.passwordlessSudoRules = [
         {
@@ -433,7 +437,7 @@ in
           notification = "Slurm is unable to process jobs.";
           interval = 10;
           command = ''
-            sudo -u slurm ${pkgs.fc.agentWithSlurm}/bin/fc-slurm check
+            sudo -u slurm ${config.flyingcircus.agent.package}/bin/fc-slurm check
           '';
         };
       };

--- a/pkgs/fc/agent/default.nix
+++ b/pkgs/fc/agent/default.nix
@@ -14,6 +14,7 @@
   util-linux,
   xfsprogs,
   enableSlurm ? false,
+  slurmVersion ? "25.05",
 }:
 
 let
@@ -106,8 +107,11 @@ pyPackages.buildPythonPackage rec {
     pyPackages.systemd-python
     xfsprogs
   ]
-  ++ lib.optionals enableSlurm [
+  ++ lib.optionals (enableSlurm && slurmVersion == "25.05") [
     pyPackages.pyslurm
+  ]
+  ++ lib.optionals (enableSlurm && slurmVersion == "25.11") [
+    pyPackages.pyslurm-25_11
   ];
   dontStrip = true;
   doCheck = true;

--- a/pkgs/fc/agent/src/fc/util/slurm.py
+++ b/pkgs/fc/agent/src/fc/util/slurm.py
@@ -587,7 +587,7 @@ def check_controller(log, hostname):
     warnings = []
 
     try:
-        pyslurm.slurm_ping(0)
+        pyslurm.slurmctld.ping_primary()
     except ValueError as e:
         log.error("slurm-controller-ping-failed", exc_info=True)
         errors.append(f"Failed - {e.args[0]}")
@@ -655,13 +655,13 @@ def check_controller(log, hostname):
             + "."
         )
 
-    stats = pyslurm.statistics().get()
+    stats = pyslurm.slurmctld.diag()
 
     info = [
         f"All {num_nodes} nodes are operational.",
-        f"Running jobs: {stats['jobs_running']}.",
-        f"Pending jobs: {stats['jobs_pending']}.",
-        f"Total started jobs: {stats['jobs_started']}.",
+        f"Running jobs: {stats.jobs_running}.",
+        f"Pending jobs: {stats.jobs_pending}.",
+        f"Total started jobs: {stats.jobs_started}.",
         f"Slurm version: {pyslurm.version.__version__}",
     ]
 
@@ -818,41 +818,41 @@ def get_node_metrics(nodes) -> dict:
 
 
 def get_queue_metrics(jobs) -> dict:
-    state_counter = Counter(j["job_state"].lower() for j in jobs)
+    state_counter = Counter(j.state.lower() for j in jobs)
     return {"name": "slurm_queue", **state_counter}
 
 
 def get_scheduler_metrics(stats) -> dict:
-    sched_count = stats["schedule_cycle_counter"]
-    bf_count = stats["bf_cycle_counter"]
+    sched_count = stats.schedule_cycle_counter
+    bf_count = stats.backfill_cycle_counter
     mean_cycle = (
-        stats["schedule_cycle_sum"] / sched_count if sched_count > 0 else 0
+        stats.schedule_cycle_sum / sched_count if sched_count > 0 else 0
     )
     backfill_mean_cycle = (
-        stats["bf_cycle_sum"] / bf_count if bf_count > 0 else 0
+        stats.backfill_cycle_sum / bf_count if bf_count > 0 else 0
     )
     backfill_depth_mean = (
-        stats["bf_depth_sum"] / bf_count if bf_count > 0 else 0
+        stats.backfill_depth_sum / bf_count if bf_count > 0 else 0
     )
 
     return {
         "name": "slurm_scheduler",
-        "threads": stats["server_thread_count"],
-        "queue_size": stats["schedule_queue_len"],
-        "last_cycle": stats["schedule_cycle_last"],
+        "threads": stats.server_thread_count,
+        "queue_size": stats.schedule_queue_length,
+        "last_cycle": stats.schedule_cycle_last,
         "mean_cycle": mean_cycle,
-        "backfill_last_cycle": stats["bf_cycle_last"],
+        "backfill_last_cycle": stats.backfill_cycle_last,
         "backfill_mean_cycle": backfill_mean_cycle,
         "backfill_depth_mean": backfill_depth_mean,
-        "backfilled_jobs_since_start_total": stats["bf_backfilled_jobs"],
-        "backfilled_jobs_since_cycle_total": stats["bf_last_backfilled_jobs"],
+        "backfilled_jobs_since_start_total": stats.backfilled_jobs,
+        "backfilled_jobs_since_cycle_total": stats.last_backfilled_jobs,
     }
 
 
 def get_metrics(log) -> list[dict]:
-    stats = pyslurm.statistics().get()
+    stats = pyslurm.slurmctld.diag()
     nodes = pyslurm.Nodes.load().values()
-    jobs = pyslurm.job().get().values()
+    jobs = pyslurm.Jobs.load()
 
     return [
         *get_accounts_metrics(log, jobs),

--- a/pkgs/fc/agent/src/fc/util/tests/test_slurm.py
+++ b/pkgs/fc/agent/src/fc/util/tests/test_slurm.py
@@ -27,6 +27,10 @@ class Node:
     def modify(self, *args):
         pass
 
+class Statistics:
+    def __init__(self, **kwargs):
+        self.__dict__.update(**kwargs)
+
 # We cannot import pyslurm, as it just exits with error 1 when it has no slurm cluster
 pyslurm = type(sys)("pyslurm")
 pyslurm.Nodes = MagicMock()
@@ -35,13 +39,15 @@ pyslurm.get_controllers = MagicMock()
 pyslurm.NODE_STATE_DRAIN = 1
 pyslurm.NODE_STATE_DOWN = 2
 pyslurm.NODE_RESUME = 3
-pyslurm.slurm_ping = MagicMock()
-pyslurm.statistics = MagicMock()
-pyslurm.statistics.return_value.get.return_value = {
-    "jobs_running": 1,
-    "jobs_pending": 2,
-    "jobs_started": 3,
-}
+pyslurm.slurmctld = type(sys)(name="pyslurm.slurmctld")
+pyslurm.slurmctld.ping_primary = MagicMock()
+pyslurm.slurmctld.Statistics = Statistics
+pyslurm.slurmctld.diag = MagicMock()
+pyslurm.slurmctld.diag.return_value = Statistics(
+    jobs_running=1,
+    jobs_pending=2,
+    jobs_started=3
+)
 pyslurm.version = type(sys)("pyslurm.version")
 pyslurm.version.__version__ = "24.11.0"
 sys.modules["pyslurm"] = pyslurm

--- a/pkgs/fc/default.nix
+++ b/pkgs/fc/default.nix
@@ -12,6 +12,10 @@ rec {
     pyPackages = pyPackages;
   };
   agentWithSlurm = agent.override { enableSlurm = true; };
+  agentWithSlurm-25_11 = agent.override {
+    enableSlurm = true;
+    slurmVersion = "25.11";
+  };
 
   blockdev = callPackage ./blockdev { };
 

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -115,6 +115,19 @@ builtins.mapAttrs (_: patchPhps phpLogPermissionPatch) {
           hash = "sha256-4i1s9YAs0JtnTDB8yeA4cLjDfFA+vsPSW4byzoxTXcc=";
         };
       });
+      pyslurm-25_11 =
+        (python-super.pyslurm.override {
+          slurm = self.slurm-25_11;
+        }).overridePythonAttrs
+          (old: rec {
+            version = "25.11.1";
+            src = self.fetchFromGitHub {
+              repo = "pyslurm";
+              owner = "PySlurm";
+              tag = "v${version}";
+              hash = "sha256-0VQ/f6ppUIt4j94CFsRB+kBUrFPAjqXPqwzIaK4StfA=";
+            };
+          });
     })
   ];
 
@@ -645,6 +658,8 @@ builtins.mapAttrs (_: patchPhps phpLogPermissionPatch) {
   sensu-plugins-postgres = getClosureFromStore /nix/store/mzlxvlfwn8bga044vdabpzdcqwjjblr1-sensu-plugins-postgres-4.2.0;
   sensu-plugins-rabbitmq = getClosureFromStore /nix/store/lcvrxlakcxiqzvwq7g284nhzqfc5gvjv-sensu-plugins-rabbitmq-8.1.0;
   sensu-plugins-redis = getClosureFromStore /nix/store/qbqnynpw5mzx98nz8lx89gpjw91wyd5b-sensu-plugins-redis-4.1.0;
+
+  slurm-25_11 = super.callPackage ./slurm-25_11 { };
 
   solr = super.callPackage ./solr { };
 

--- a/pkgs/slurm-25_11/default.nix
+++ b/pkgs/slurm-25_11/default.nix
@@ -1,0 +1,191 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  runCommand,
+  config,
+  pkg-config,
+  libtool,
+  curl,
+  python3,
+  munge,
+  perl,
+  pam,
+  shadow,
+  coreutils,
+  dbus,
+  libbpf,
+  ncurses,
+  libmysqlclient,
+  lua,
+  hwloc,
+  numactl,
+  readline,
+  freeipmi,
+  xauth,
+  lz4,
+  rdma-core,
+  nixosTests,
+  pmix,
+  libjwt,
+  libyaml,
+  json_c,
+  http-parser,
+  # enable internal X11 support via libssh2
+  enableX11 ? true,
+  enablePAM ? true,
+  enableNVML ? config.cudaSupport,
+  cudaPackages,
+  symlinkJoin,
+  s2n-tls,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "slurm";
+  version = "25-11-5-1";
+
+  # N.B. We use github release tags instead of https://www.schedmd.com/downloads.php
+  # because the latter does not keep older releases.
+  src = fetchFromGitHub {
+    owner = "SchedMD";
+    repo = "slurm";
+    # The release tags use - instead of .
+    rev = "slurm-${builtins.replaceStrings [ "." ] [ "-" ] finalAttrs.version}";
+    hash = "sha256-YGENCN4Ge8wftpSNSA9zw2xV0Ltd0wJMROY+fwOREE8=";
+  };
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  prePatch = ''
+    substituteInPlace src/common/env.c \
+        --replace-fail "/bin/echo" "${lib.getExe' coreutils "echo"}"
+
+    # Autoconf does not support split packages for pmix (libs and headers).
+    # Fix the path to the pmix libraries, so dlopen can find it.
+    substituteInPlace src/plugins/mpi/pmix/mpi_pmix.c \
+        --replace-fail 'xstrfmtcat(full_path, "%s/", PMIXP_LIBPATH)' \
+                       'xstrfmtcat(full_path, "${lib.getLib pmix}/lib/")'
+
+  ''
+  + (lib.optionalString enableX11 ''
+    substituteInPlace src/common/x11_util.c \
+        --replace-fail '"/usr/bin/xauth"' '"${lib.getExe xauth}"'
+  '');
+
+  # nixos test fails to start slurmd with 'undefined symbol: slurm_job_preempt_mode'
+  # https://groups.google.com/forum/#!topic/slurm-devel/QHOajQ84_Es
+  # this doesn't fix tests completely at least makes slurmd to launch
+  hardeningDisable = [ "bindnow" ];
+
+  nativeBuildInputs = [
+    pkg-config
+    libtool
+    python3
+    perl
+  ];
+  buildInputs = [
+    curl
+    python3
+    munge
+    pam
+    libmysqlclient
+    ncurses
+    lz4
+    rdma-core
+    lua
+    hwloc
+    numactl
+    readline
+    freeipmi
+    shadow.su
+    pmix
+    json_c
+    libjwt
+    libyaml
+    dbus
+    libbpf
+    http-parser
+    s2n-tls
+  ]
+  ++ lib.optionals enableX11 [ xauth ]
+  ++ lib.optionals enableNVML [
+    (runCommand "collect-nvml" { } ''
+      mkdir $out
+      ln -s ${lib.getOutput "include" cudaPackages.cuda_nvml_dev}/include $out/include
+      ln -s ${lib.getOutput "stubs" cudaPackages.cuda_nvml_dev}/lib/stubs $out/lib
+    '')
+  ];
+
+  configureFlags = [
+    "--with-freeipmi=${freeipmi}"
+    "--with-http-parser=${http-parser}"
+    "--with-hwloc=${lib.getDev hwloc}"
+    "--with-json=${lib.getDev json_c}"
+    "--with-jwt=${libjwt}"
+    "--with-lz4=${lib.getDev lz4}"
+    "--with-munge=${munge}"
+    "--with-yaml=${lib.getDev libyaml}"
+    "--with-ofed=${lib.getDev rdma-core}"
+    "--sysconfdir=/etc/slurm"
+    "--with-pmix=${lib.getDev pmix}"
+    "--with-bpf=${libbpf}"
+    "--with-s2n=${
+      symlinkJoin {
+        name = s2n-tls.name;
+        paths = [
+          s2n-tls
+          (lib.getDev s2n-tls)
+        ];
+      }
+    }"
+    "--without-rpath" # Required for configure to pick up the right dlopen path
+  ]
+  ++ (lib.optional (!enableX11) "--disable-x11")
+  ++ (lib.optional enableNVML "--with-nvml")
+  ++ (lib.optional enablePAM "--enable-pam --with-pam_dir=${placeholder "out"}/lib/security");
+
+  preConfigure = ''
+    patchShebangs ./doc/html/shtml2html.py
+    patchShebangs ./doc/man/man2html.py
+  ''
+  + (lib.optionalString enablePAM ''
+    mkdir -p $out/lib/security
+  '');
+  postConfigure = lib.optionalString enablePAM ''
+    rm -rf $out
+  '';
+
+  postBuild = lib.optionalString enablePAM ''
+    make -C contribs/pam
+    make -C contribs/pam_slurm_adopt
+  '';
+
+  postInstall =
+    (lib.optionalString enablePAM ''
+      export LIBRARY_PATH="$PWD/src/api/.libs:''${LIBRARY_PATH:+:$LIBRARY_PATH}"
+      mkdir -p $out/lib/security
+      make -C contribs/pam install
+      make -C contribs/pam_slurm_adopt install
+    '')
+    + ''
+      rm -f $out/lib/*.la $out/lib/slurm/*.la $out/lib/security/*.la
+    '';
+
+  enableParallelBuilding = true;
+
+  passthru.tests.slurm = nixosTests.slurm;
+
+  meta = {
+    homepage = "http://www.schedmd.com/";
+    description = "Simple Linux Utility for Resource Management";
+    platforms = lib.platforms.linux;
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [
+      markuskowa
+      edwtjo
+    ];
+  };
+})


### PR DESCRIPTION

@flyingcircusio/release-managers

PL-135105

## Release process

This change should be backported:

- [x] Created changelog entry using `./changelog.sh`
- [ ] Add `backport release-25.11` label
  there will be a manual forwardport to 26.05 for the agent changes and an additional alias in the overlay for upgradeability.

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [x] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [x] Security requirements tested? (EVIDENCE)
  - Tested that fc-agent still works with slurm 25.05 on test machine: tested that all commands of `fc-slurm` run
  - Tested that fc-agent works with slurm 25.11 on test machine: tested that all commands of `fc-slurm` run