### PR TITLE
mailserver: resolve warnings, update dovecot to 2.4

### DIFF
--- a/doc/src/mailserver.md
+++ b/doc/src/mailserver.md
@@ -406,10 +406,6 @@ sieveScript
 : Additional aliases which are not mentioned in users.json. Expected to be a
   dict with the alias as key and the receiving address as value.
 
-/etc/local/mail/main.cf
-
-: Additional Postfix {manpage}`postconf(5)` settings.
-
 /etc/local/mail/dns.zone
 
 : Copy-and-paste DNS records for inclusion in zone files. Adapt if necessary.

--- a/doc/src/mailstub.md
+++ b/doc/src/mailstub.md
@@ -4,17 +4,22 @@
 
 The `mailstub` role provides a minimal Postfix which is mostly usable to locally collect and queue mails to hand them off to another mail server for actual delivery (relay). Sending email directly will not work well due to spam protection measures on the receiving side. Notably the mail stub does not configure DKIM signing – use {ref}`nixos-mailserver`.
 
+Configuring Postfix is possible in NixOS configuration in the `services.postfix` module.
+
 ## Configuring as relay
 
 This is an example configuration to collect mails locally and send them all to smtp.example.com:
 
-{file}`/etc/local/postfix/main.cf`
-```
-relayhost = [smtp.example.com]:587
-smtp_sasl_auth_enable = yes
-smtp_sasl_password_maps = hash:/etc/local/postfix/sasl_passwd
-smtp_sasl_security_options = noanonymous
-smtp_use_tls = yes
+```nix
+services.postfix.settings.main = {
+  relayhost = [
+    "[smtp.example.com]:587"
+  ];
+  smtp_sasl_auth_enable = true;
+  smtp_sasl_password_maps = "hash:/etc/local/postfix/sasl_passwd";
+  smtp_sasl_security_options = "noanonymous";
+  smtp_use_tls = true;
+};
 ```
 
 {file}`/etc/local/postfix/sasl_passwd`

--- a/doc/src/upgrade.md
+++ b/doc/src/upgrade.md
@@ -114,8 +114,8 @@ for more information about the upgrade.
 The NixOS option `services.dovecot2.extraConfig` has been removed.
 Configuration for dovecot in NixOS now works via `services.dovecot2.settings`.
 
-Configuring postfix via `services.postfix.extraConfig` or `/etc/local/postfix/main.cf`
-is not allowed anymore.
+Configuring postfix via `services.postfix.extraConfig`, `/etc/local/mail/main.cf`,
+`/etc/local/postfix/main.cf` is not allowed anymore.
 Please migrate to structured config with `services.postfix.settings.main`.
 
 SMTP with STARTTLS over port 587 is no longer allowed. Please use SMTP with SSL/TLS over port 465.i

--- a/doc/src/upgrade.md
+++ b/doc/src/upgrade.md
@@ -108,6 +108,12 @@ time-window.
 
 ### Mailserver / Mailstub
 
+Dovecot was updated from 2.3 to 2.4. This update contains a full rewrite of the configuration.
+Please read the [dovecot upgrade documentation](https://doc.dovecot.org/2.4.3/installation/upgrade/2.3-to-2.4.html)
+for more information about the upgrade.
+The NixOS option `services.dovecot2.extraConfig` has been removed.
+Configuration for dovecot in NixOS now works via `services.dovecot2.settings`.
+
 Configuring postfix via `services.postfix.extraConfig` or `/etc/local/postfix/main.cf`
 is not allowed anymore.
 Please migrate to structured config with `services.postfix.settings.main`.

--- a/flake.lock
+++ b/flake.lock
@@ -81,11 +81,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1774959120,
-        "narHash": "sha256-Pzk6UbueeWy9WFiDY6iA1aHid+2AMzkS6gg2x2cSkz4=",
+        "lastModified": 1775585728,
+        "narHash": "sha256-8Psjt+TWvE4thRKktJsXfR6PA/fWWsZ04DVaY6PUhr4=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "c06f90f1eb6569bdaf6a4a10cb7e66db4454ac2a",
+        "rev": "580633fa3fe5fc0379905986543fd7495481913d",
         "type": "github"
       },
       "original": {
@@ -148,11 +148,11 @@
       },
       "locked": {
         "host": "gitlab.flyingcircus.io",
-        "lastModified": 1776350529,
-        "narHash": "sha256-1kbYCGp/neP+CTCqfqLILxiDMAsqondFFsiIBSK9fJg=",
+        "lastModified": 1777372307,
+        "narHash": "sha256-sod7JTzpLPEcfHEyBT+r2PKh2Uvw0Zc0d1s5RFUw+cU=",
         "owner": "flyingcircus",
         "repo": "nixos-mailserver",
-        "rev": "88e8c8066304be5e010c403c32a9ba9d38abb556",
+        "rev": "07bac55316468a372e120bedae9a38c5f8715dd8",
         "type": "gitlab"
       },
       "original": {

--- a/nixos/services/mail/README
+++ b/nixos/services/mail/README
@@ -57,4 +57,3 @@ Further Configuration Files
 
 - dns.zone: Copy-and-paste DNS records for inclusion in zone files.
 - local_valiases.json: Additional aliases which are not mentioned in users.json.
-- main.cf: Additional Postfix postconf(5) settings.

--- a/nixos/services/mail/default.nix
+++ b/nixos/services/mail/default.nix
@@ -239,8 +239,8 @@ in
                 (if lib.versionOlder config.system.stateVersion "25.11" then 1 else 3);
             inherit domains;
             fqdn = role.mailHost;
-            loginAccounts = fclib.jsonFromFile "/etc/local/mail/users.json" "{}";
-            extraVirtualAliases = fclib.jsonFromFile "/etc/local/mail/local_valiases.json" "{}";
+            accounts = fclib.jsonFromFile "/etc/local/mail/users.json" "{}";
+            aliases = fclib.jsonFromFile "/etc/local/mail/local_valiases.json" "{}";
             x509.useACMEHost = role.mailHost;
             enableImapSsl = true;
             enableManageSieve = true;
@@ -248,7 +248,6 @@ in
             # platform, so a bland unconfigured kresd is counterproductive.
             localDnsResolver = false;
             lmtpSaveToDetailMailbox = "no";
-            mailDirectory = vmailDir;
             mailboxes = {
               "Trash" = {
                 auto = "create";
@@ -271,8 +270,11 @@ in
                 special_use = "\\Archive";
               };
             };
-            vmailGroupName = "vmail";
-            vmailUserName = "vmail";
+            storage = {
+              path = vmailDir;
+              owner = "vmail";
+              group = "vmail";
+            };
             srs.enable = true;
           };
 

--- a/nixos/services/mail/default.nix
+++ b/nixos/services/mail/default.nix
@@ -442,7 +442,6 @@ in
             "d /etc/local/mail 02775 postfix service"
             "f /etc/local/mail/local_valiases.json 0664 postfix service - {}"
             "f /etc/local/mail/users.json 0664 postfix service - {}"
-            "f /etc/local/mail/main.cf 0664 postfix service"
           ];
 
           systemd.services.mailserver-update-stateversion = lib.mkIf (config.mailserver.stateVersion < 3) {

--- a/nixos/services/mail/default.nix
+++ b/nixos/services/mail/default.nix
@@ -291,14 +291,6 @@ in
                 passwd_file_path = role.passwdFile;
               }
             ];
-
-            plugin = {
-              mail_plugins = "$mail_plugins expire";
-              expire = "Trash";
-              expire2 = "Trash/*";
-              expire3 = "Junk";
-              expire_cache = "yes";
-            };
           };
 
           services.nginx.virtualHosts =

--- a/nixos/services/mail/default.nix
+++ b/nixos/services/mail/default.nix
@@ -285,10 +285,10 @@ in
           systemd.services.rspamd.restartTriggers = [ config.mailserver.localDnsResolver ];
 
           services.dovecot2.settings = {
-            passdb = [
+            "passdb imperative" = [
               {
                 driver = "passwd-file";
-                args = role.passwdFile;
+                passwd_file_path = role.passwdFile;
               }
             ];
 

--- a/nixos/services/mail/stub.nix
+++ b/nixos/services/mail/stub.nix
@@ -22,10 +22,10 @@ let
   readme = ''
     Mail server stub is a minimally pre-configured Postfix instance.
 
-    Put local Postfix configuration into this directory.
+    Put local Postfix files into this directory, configuration is possible in Nix configuration files.
+    It's possible to configure Postfix `master.cf` here:
 
-    - Postfix configuration statements should go into `main.cf`
-    - Postfix service definitions should go into `master.cf`
+    - Postfix service definitions should go into the `master.cf` file
 
     If you need to send mails to the outside world, this role needs quite an
     amount of manual configuration. Consider switching to the more
@@ -49,6 +49,13 @@ in
 
   config = (
     lib.mkIf config.flyingcircus.services.postfix.enable {
+      warnings = lib.optionals (builtins.pathExists "/etc/local/postfix/master.cf") [
+        ''
+          Configuring postfix via /etc/local/postfix/master.cf is deprecated.
+          Please migrate to structured config with services.postfix.settings.master.
+          This option of configuring Postfix will be removed with fc-nixos 26.11.
+        ''
+      ];
       services.postfix = {
         enable = true;
         enableSubmission = true;

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -351,8 +351,8 @@ builtins.mapAttrs (_: patchPhps phpLogPermissionPatch) {
     libxcrypt = self.libxcrypt-legacy;
   };
 
-  dovecot_2_3 =
-    (super.dovecot_2_3.override {
+  dovecot =
+    (super.dovecot.override {
       cyrus_sasl = self.cyrus_sasl-legacyCrypt;
     }).overrideAttrs
       (old: {

--- a/release/versions.json
+++ b/release/versions.json
@@ -2,9 +2,9 @@
   "nixos-mailserver": {
     "deepClone": false,
     "fetchSubmodules": false,
-    "hash": "sha256-1kbYCGp/neP+CTCqfqLILxiDMAsqondFFsiIBSK9fJg=",
+    "hash": "sha256-sod7JTzpLPEcfHEyBT+r2PKh2Uvw0Zc0d1s5RFUw+cU=",
     "leaveDotGit": false,
-    "rev": "88e8c8066304be5e010c403c32a9ba9d38abb556",
+    "rev": "07bac55316468a372e120bedae9a38c5f8715dd8",
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/"
   },
   "nixpkgs": {


### PR DESCRIPTION
This is achieved through multiple parts:
- update nixos mailserver to get dovecot 2.4 (as dovecot 2.3 is deprecated and therefore throws a eval warning)
  This also requires us to update custom config to dovecot 2.4
  - mailserver: explicitly deactive expire plugin
    It doesn't work for quite some time, as it was removed in dovecot 2.3.14. We should explicitly think about what our customers expect before just adding it.
    see PL-135343
- rename options that nixos-mailserver renamed (also threw warnings)

Additionally this PR contains a commit that updates the documentation after the removal of the configuration of Postfix via a `main.cf` file.

PL-135344

@flyingcircusio/release-managers

## Release process

This change should only reach this branch:

- [ ] Created changelog entry using `./changelog.sh`
or
- [x] Add a upgrade node in `doc/upgrade.md`
 
## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [x] ensure all checks are green
- [x] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [x] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [x] Security requirements tested? (EVIDENCE)
  - Tested mail functionality on dev vm.