### PR TITLE
[PL-135131] mailserver: add an evaluation warning hinting at the new defaults for imap and smtp ports

### DIFF
--- a/changelog.d/20260505_115351_PL-135131_mailserver-ports-deprecation-warning_scriv.md
+++ b/changelog.d/20260505_115351_PL-135131_mailserver-ports-deprecation-warning_scriv.md
@@ -1,0 +1,18 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+### NixOS XX.XX platform
+
+- add an evaluation warning for the mailserver role that hints at breaking port changes for SMPT and IMAP in the next release (25.11) (PL-135131)

--- a/nixos/roles/mailserver.nix
+++ b/nixos/roles/mailserver.nix
@@ -106,7 +106,7 @@ let
     };
 
     dynamicMaps = mkOption {
-      description = '''';
+      description = "";
       type = with types; attrsOf (listOf path);
       default = { };
       example = {
@@ -304,6 +304,17 @@ in
   config = lib.mkMerge [
 
     (lib.mkIf roles.mailserver.enable {
+      warnings = lib.optionals (config.flyingcircus.platform.version == "25.05") [
+        ''
+          Be aware that in the next release the default ports and protocols for IMAP and SMTP will change to now be:
+
+          - Incoming: IMAP with SSL/TLS, mailHost port 993
+          - Outgoing: SMTP with SSL/TLS, mailHost port 465.
+
+          See also the changes in https://doc.flyingcircus.io/roles/fc-25.11-production/upgrade.html#mail-server
+        ''
+      ];
+
       flyingcircus.services.mail.enable =
         assert !roles.mailstub.enable;
         true;


### PR DESCRIPTION
@flyingcircusio/release-managers

PL-135131

## Release process

This change should be backported:

- [ ] Created changelog entry using `./changelog.sh`
- [ ] Add `backport release-25.11` label

This change should only reach this branch:

- [x] Created changelog entry using `./changelog.sh`
or
- [ ] Add a upgrade node in `doc/upgrade.md`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [ ] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [x] Security requirements tested? (EVIDENCE
- this pr adds a single evaluation warning in the 25.05 release