### PR TITLE
ceph: lower pg_num_min for better scaling 

### DIFF
--- a/pkgs/fc/ceph/src/fc/ceph/api/pools.py
+++ b/pkgs/fc/ceph/src/fc/ceph/api/pools.py
@@ -1,4 +1,3 @@
-import json
 import random
 import time
 from subprocess import CalledProcessError
@@ -82,8 +81,9 @@ class Pool(object):
         self.name = poolname
         self.cluster = cluster
         self._images = None
-        self._pg_num = None
-        self._pgp_num = None
+        self._pg_num: int | None = None
+        self._pg_num_min: int | None = None
+        self._pgp_num: int | None = None
 
     def get(self, imagename):
         """Deprecated. Use pool[imagename] instead."""
@@ -173,6 +173,48 @@ class Pool(object):
         # XXX: Since Ceph Nautilus: as long as pgp_num and pg_num currently match, pgp_num will automatically track any pg_num changes
         # We might be able to simplfy this here. Letting Ceph itself track the pgp changes is even preferrable, as this is done in smaller steps.
         self.pgp_num = value
+
+    @property
+    def pg_num_min(self) -> int | None:
+        if self._pg_num_min:
+            return self.pg_num_min
+        try:
+            pginfo = run.json.ceph(
+                "-c",
+                self.cluster.ceph_conf,
+                "osd",
+                "pool",
+                "get",
+                self.name,
+                "pg_num_min",
+            )
+            self._pg_num_min = int(pginfo["pg_num_min"])
+        except CalledProcessError as e:
+            if e.returncode == 2 and b"is not set on pool" in e.stderr:
+                # still the default value
+                self._pg_num_min = None
+            else:
+                raise
+
+        return self._pg_num_min
+
+    @pg_num_min.setter
+    def pg_num_min(self, value: int | None):
+        """Sets the minimum number of PGs assigned by the pg_autoscaler."""
+        value_numerical = (
+            value if value else 0
+        )  # setting `0` unsets the property back to default
+        run.ceph(
+            "-c",
+            self.cluster.ceph_conf,
+            "osd",
+            "pool",
+            "set",
+            self.name,
+            "pg_num_min",
+            str(value_numerical),
+        )
+        self._pg_num_min = int(value) if value else None
 
     @property
     def pgp_num(self):

--- a/pkgs/fc/ceph/src/fc/ceph/api/pools.py
+++ b/pkgs/fc/ceph/src/fc/ceph/api/pools.py
@@ -157,9 +157,7 @@ class Pool(object):
         """Sets the number of PGs.
 
         This may take a while as pgp_num (the effective number) can only
-        be changed after the PGs have been created in the cluster. Note
-        that you can only increase the number of PGs and never decrease
-        it again. Note that this method may take a while to complete.
+        be changed after the PGs have been created in the cluster.
         """
         run.ceph(
             "-c",
@@ -172,6 +170,8 @@ class Pool(object):
             str(value),
         )
         self._pg_num = int(value)
+        # XXX: Since Ceph Nautilus: as long as pgp_num and pg_num currently match, pgp_num will automatically track any pg_num changes
+        # We might be able to simplfy this here. Letting Ceph itself track the pgp changes is even preferrable, as this is done in smaller steps.
         self.pgp_num = value
 
     @property

--- a/pkgs/fc/ceph/src/fc/ceph/api/tests/test_pools.py
+++ b/pkgs/fc/ceph/src/fc/ceph/api/tests/test_pools.py
@@ -1,5 +1,6 @@
 import time
 from subprocess import CalledProcessError
+from unittest.mock import MagicMock
 
 import pkg_resources
 import pytest
@@ -218,6 +219,60 @@ class TestPool(object):
                 "32",
             ],
         ]
+
+    def test_get_pg_num_min(self, cluster, monkeypatch):
+        monkeypatch.setattr(
+            "fc.ceph.api.pools.run.json.ceph",
+            lambda *args: {
+                "pool": "test",
+                "pool_id": 161,
+                "pg_num": 512,
+                "pg_num_min": 1,
+            },
+        )
+        assert 1 == Pool("test", cluster).pg_num_min
+
+        def raiser(*args):
+            raise CalledProcessError(
+                returncode=2,
+                cmd="ceph -c /etc/ceph/ceph.conf osd pool get test1 pg_num_min",
+                stderr=b"Error ENOENT: option 'pg_num_min' is not set on pool 'test1'",
+            )
+
+        monkeypatch.setattr("fc.ceph.api.pools.run.json.ceph", raiser)
+        assert Pool("test1", cluster).pg_num_min is None
+
+    def test_set_pg_num_min(self, cluster, monkeypatch):
+        mock_ceph = MagicMock()
+        monkeypatch.setattr("fc.ceph.api.pools.run.ceph", mock_ceph)
+
+        p = Pool("test", cluster)
+        p.pg_num_min = 1
+        mock_ceph.assert_called_with(
+            "-c",
+            cluster.ceph_conf,
+            "osd",
+            "pool",
+            "set",
+            "test",
+            "pg_num_min",
+            "1",
+        )
+        assert p._pg_num_min == 1
+
+        mock_ceph.reset_mock()
+        p.pg_num_min = None
+        mock_ceph.assert_called_with(
+            "-c",
+            cluster.ceph_conf,
+            "osd",
+            "pool",
+            "set",
+            "test",
+            "pg_num_min",
+            "0",
+        )
+        assert p._pg_num_min is None
 
     def test_get_pgp_num(self, cluster, monkeypatch):
         monkeypatch.setattr(

--- a/pkgs/fc/ceph/src/fc/ceph/maintenance/nautilus.py
+++ b/pkgs/fc/ceph/src/fc/ceph/maintenance/nautilus.py
@@ -47,6 +47,20 @@ class ResourcegroupPoolEquivalence(object):
 
         return status_code
 
+    def ensure_pools_are_balanceable(self):
+        """For all pools that have a default value of `pg_num_min`, set that
+        property to `1`.
+        We have many pools that are almost empty by design, like `rbd`. The
+        pg_autoscaler assigns at least `pg_num_min` PGs to each pool, which
+        defaults to `32` and is a waste of PGs in smaller clusters. Let's allow
+        going down to 1 PG if needed. Unfortunately there is no configurable
+        default value.
+        This behaviour *might* improve in Ceph Quincy.
+        """
+        for pool in self.pools:
+            if not pool.pg_num_min:
+                pool.pg_num_min = 1
+
 
 class VolumeDeletions(object):
     def __init__(self, directory, cluster):
@@ -216,6 +230,8 @@ class MaintenanceTasks(object):
         volume_statuscode = volumes.ensure()
         rpe = ResourcegroupPoolEquivalence(directory, ceph)
         rpe_statuscode = rpe.ensure()
+        # piggybacking this for now
+        rpe.ensure_pools_are_balanceable()
         return max(volume_statuscode, rpe_statuscode)
 
     def _ensure_maintenance_volume(self):


### PR DESCRIPTION
@flyingcircusio/release-managers

Works around an issue that even empty pools get at least 32 PGs assigned
by default.
Unless another value is set for `pg_num_min`, we explicitly allow
reducing PGs to a minimum of 1 for better pg_autoscaler results.

PL-131408

## Release process

This change should be backported:

- [ ] Created changelog entry using `./changelog.sh`
  - no, internal and affects only pg_autoscaler which is not yet used in production
- [x] Add `backport release-25.11` label

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [x] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - work around limitations in pg_autoscaler
  - needs to work on both ceph versions
- [x] Security requirements tested? (EVIDENCE)
  - expanded unit tests for lower level function
  - checked behaviour of both Ceph Nautilus and Pacific
  - tested adjustment in dev cluster