### PR TITLE
[25.05] nixpkgs: update kernel and nix

### DIFF
--- a/changelog.d/20260506_160159_PL-135348-2505-backports_scriv.md
+++ b/changelog.d/20260506_160159_PL-135348-2505-backports_scriv.md
@@ -1,0 +1,30 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+<!-- Impact means "when this change is rolled out, there
+     might be interruptions/downtimes/required actions/... that
+     IMPACT THE RUNNING APPLICATION NEGATIVELY.
+
+     Having new features or changed is not an "impact". That's what
+     the main changelog (see below) is for.
+     -->
+
+- Machines will reboot to enable a changed kernel.
+
+
+### NixOS XX.XX platform
+
+- linux kernel: fix copy.fail kernel vulnerability (CVE-2026-31431) (PL-135348)
+- nix: fix privilege escalation (GHSA-vh5x-56v6-4368) (PL-135360)

--- a/flake.lock
+++ b/flake.lock
@@ -168,11 +168,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1775647357,
-        "narHash": "sha256-mmjdQ1nMHOhSQT9N1Qe7ORPc7dlJkGB1u5yeq5Ml5xw=",
+        "lastModified": 1778075488,
+        "narHash": "sha256-TYlFJ+OBpFO1XKBTbXL1pmZcMSjP3fajAT9GMVSkxxA=",
         "owner": "flyingcircusio",
         "repo": "nixpkgs",
-        "rev": "9d30244089af7b1851d979e4555596c4fa341e9b",
+        "rev": "703e4e6ee1f12eb0843f955eb94ce43cd9092948",
         "type": "github"
       },
       "original": {

--- a/nixos/platform/kernel.nix
+++ b/nixos/platform/kernel.nix
@@ -77,7 +77,6 @@ in
       VLAN_8021Q_GVRP y
       XFS_POSIX_ACL y
       XFS_QUOTA y
-      WARN_ALL_UNSEEDED_RANDOM n
       ## Crash-debugging related options
       IPMI_PANIC_EVENT y
       IPMI_PANIC_STRING y

--- a/release/package-versions.json
+++ b/release/package-versions.json
@@ -460,14 +460,14 @@
     "version": "0.2.5"
   },
   "linuxKernelStable": {
-    "name": "linux-6.12.63",
+    "name": "linux-6.12.85",
     "pname": "linux",
-    "version": "6.12.63"
+    "version": "6.12.85"
   },
   "linuxKernelVerify": {
-    "name": "linux-6.12.63",
+    "name": "linux-6.12.85",
     "pname": "linux",
-    "version": "6.12.63"
+    "version": "6.12.85"
   },
   "logrotate": {
     "name": "logrotate-3.22.0",
@@ -570,9 +570,9 @@
     "version": "1.28.0"
   },
   "nix": {
-    "name": "nix-2.28.6",
+    "name": "nix-2.28.7",
     "pname": "nix",
-    "version": "2.28.6"
+    "version": "2.28.7"
   },
   "nodejs": {
     "name": "nodejs-22.21.1",

--- a/release/versions.json
+++ b/release/versions.json
@@ -8,10 +8,10 @@
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/"
   },
   "nixpkgs": {
-    "hash": "sha256-mmjdQ1nMHOhSQT9N1Qe7ORPc7dlJkGB1u5yeq5Ml5xw=",
+    "hash": "sha256-TYlFJ+OBpFO1XKBTbXL1pmZcMSjP3fajAT9GMVSkxxA=",
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "9d30244089af7b1851d979e4555596c4fa341e9b"
+    "rev": "703e4e6ee1f12eb0843f955eb94ce43cd9092948"
   },
   "poetry2nix": {
     "hash": "sha256-nzgO/ZCSBzWjbMkYDxG+yl9Z2eGbCgQu06Oku3ir5D4=",

--- a/tests/kernelconfig.nix
+++ b/tests/kernelconfig.nix
@@ -153,7 +153,6 @@ import ./make-test-python.nix (
       VHOST_NET m
       VLAN_8021Q m
       VXLAN m
-      WARN_ALL_UNSEEDED_RANDOM n
       X86_ACPI_CPUFREQ m
 
       X86_PCC_CPUFREQ m


### PR DESCRIPTION
Pull in an updated nixpks with backport fixes for:
- copy.fail kernel vulnerability (CVE-2026-31431) (PL-135348)
- nix privilege escalation (GHSA-vh5x-56v6-4368) (PL-135360)

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [x] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - selectively backport vulnerability fixes for high-impact vulnerabilities, even for releases that are out of support
- [x] Security requirements tested? (EVIDENCE)
  - system evaluates
  - desired updated package versions build