### PR TITLE
fc-luks: adjust memory lock test to MAP_DROPPABLE

### DIFF
--- a/pkgs/fc/ceph/src/fc/ceph/tests/fc-ceph/test_main.py
+++ b/pkgs/fc/ceph/src/fc/ceph/tests/fc-ceph/test_main.py
@@ -1,4 +1,5 @@
 import os
+import re
 from pathlib import Path
 from sys import argv
 
@@ -42,24 +43,46 @@ def test_main_subcommand_usage(capsys):
 
 
 def test_main_locks_memory(capsys):
-    """An overview of subcommand actions is shown when providing no action."""
+    """All mapped memory regions are locked, except [vdso] and MAP_DROPPABLE regions."""
+    # smaps header format: <addr_start>-<addr_end> <perms> <offset> <dev> <inode> [name]
+    # e.g.: 75be8cb90000-75be8cb92000 r-xp 00000000 00:00 0  [vdso]
+    smaps_header = re.compile(
+        r"^[0-9a-f]+-[0-9a-f]+ \S+ \S+ \S+ \d+\s*(?P<path>.*)"
+    )
+
     with pytest.raises(SystemExit):
         fc.ceph.main.ceph([])
+
     pid = os.getpid()
-    file, size, locked = None, 0, -1
-    with open(f"/proc/{pid}/smaps", "r") as f:
+    path = None
+    pss = locked = "0 kB"
+
+    with open(f"/proc/{pid}/smaps") as f:
         for line in f:
             print(line)
-            if "-" in line:
-                if file not in ["[vdso]", None]:
-                    assert (
-                        size == locked
-                    ), f"{file}, locked={locked}, size={size}"
-                    print(file, size, locked)
-                file = line.split()[-1]
-                size = locked = 0
-                print(file)
+            if mapping_header := smaps_header.match(line):
+                # path is optional, e.g. for anonymous mappings, but even then
+                # we take it as a string to signal we're in a segment now
+                path = mapping_header.group("path").strip()
+                pss = locked = "0 kB"
+            assert path is not None, (
+                "Invalid segment rollover - expected `path` to be set - missing segment header?"
+            )
             if line.startswith("Pss:"):
-                size = line.split(":")[1].strip()
-            if line.startswith("Locked:"):
+                pss = line.split(":")[1].strip()
+            elif line.startswith("Locked:"):
                 locked = line.split(":")[1].strip()
+            elif line.startswith("VmFlags:"):
+                vm_flags = line.split()[1:]
+                if "dp" in vm_flags:
+                    pass
+                    # "dp" means MAP_DROPPABLE: pages are dropped rather than paged out,
+                    # and do not count as mlocked.
+                elif path == "[vdso]":
+                    # kernel-owned memory space is safe, too.
+                    pass
+                else:
+                    assert pss == locked, (
+                        f"{path!r}: pss={pss}, locked={locked}"
+                    )
+                path = None


### PR DESCRIPTION
Since glibc-2.41 [^1], glibc utilises the MAP_DROPPABLE mmap flag for certain getrandom specific state. An updated glibc in the NixOS 26.05 release thus enables this behaviour.
Droppable pages are also never written to swap, but do not officially count as memlocked. Instead, they may be dropped to retain memory.

The flag exists since linux-6.11 [^2] but is still not documented in the kernel man pages. But the glibc docs [^3] mention the `MAP_DROPPABLE` flag.

[^1]: https://inbox.sourceware.org/libc-alpha/6975370.R56niFO833@pinacolada/T/#u
[^2]: https://lwn.net/Articles/983186/
[^3]: https://sourceware.org/glibc/manual/latest/html_node/Memory_002dmapped-I_002fO.html

Necessary for PL-134240 (channel blocker)

@flyingcircusio/release-managers

## Release process

This change should only reach this branch:

- [ ] Created changelog entry using `./changelog.sh`
  - no, internal test change sufficiently documented in the surrounding code (comments)

## PR release workflow (internal)

- [ ] PR has internal ticket
- [ ] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [ ] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - unblock test
  - research in documentation that droppable pages have the same security characteristics (not swapping) as memlocked pages before
- [x] Security requirements tested? (EVIDENCE)
  - fc-ceph tests pass again