### PR TITLE
nixos/kernel: disable rxrpc module

### DIFF
--- a/changelog.d/20260512_164742_PL-135378-disable-rxrpc_scriv.md
+++ b/changelog.d/20260512_164742_PL-135378-disable-rxrpc_scriv.md
@@ -1,0 +1,27 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+<!-- Impact means "when this change is rolled out, there
+     might be interruptions/downtimes/required actions/... that
+     IMPACT THE RUNNING APPLICATION NEGATIVELY.
+
+     Having new features or changed is not an "impact". That's what
+     the main changelog (see below) is for.
+     -->
+
+
+### NixOS XX.XX platform
+
+- linux kernel: mitigate "dirty frag" vulnerabilities (CVE-2026-43500, CVE-2026-4328)

--- a/nixos/platform/kernel.nix
+++ b/nixos/platform/kernel.nix
@@ -159,5 +159,6 @@ in
         extraConfig = config.flyingcircus.kernelOptions;
       }
     ];
+    boot.blacklistedKernelModules = [ "rxrpc" ]; # PL-135378, CVE-2026-43500 and unecessary module (AFS)
   };
 }


### PR DESCRIPTION
The rxrpc module is one of the vectors for the "dirty frag" vulnerability. It is a niche module just used for the "Andrew File System" not part of our infrastructure, hence it can be disabled.

PL-135378

@flyingcircusio/release-managers

## Release process

This change should only reach this branch:
Will be fixed in the 26.05 kernel before release

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [x] ensure all checks are green
- [x] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [x] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - work around an unpatched vulnerability by disabling the unused kernel module entry vector
  - investigated fix state of the affected CVEs in the differen linux stable branches
- [x] Security requirements tested? (EVIDENCE)
  - tests pass