### PR TITLE
Document update procedures for k3s

### DIFF
--- a/changelog.d/20260513_111556_PL-132803-k3s-upgrade-docs_scriv.md
+++ b/changelog.d/20260513_111556_PL-132803-k3s-upgrade-docs_scriv.md
@@ -1,0 +1,27 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+<!-- Impact means "when this change is rolled out, there
+     might be interruptions/downtimes/required actions/... that
+     IMPACT THE RUNNING APPLICATION NEGATIVELY.
+
+     Having new features or changed is not an "impact". That's what
+     the main changelog (see below) is for.
+     -->
+
+
+### NixOS XX.XX platform
+
+- Document upgrade procedures for k3s. (PL-132803)

--- a/doc/src/kubernetes.md
+++ b/doc/src/kubernetes.md
@@ -469,6 +469,62 @@ storage or NFS.
 We also recommend to consider using our S3-compatible API for storing object
 data.
 
+## Updates and version management
+
+We provide multiple versions of k3s within each release of our managed
+platform. Unless explicitly configured, the k3s roles will use the default
+version of k3s given at the top of this page. A different version of k3s can be
+configured by setting the `services.k3s.package` NixOS option, for example:
+
+```nix
+# /etc/local/nixos/k3s-version.nix
+{ pkgs, ... }:
+{
+
+  # Each minor version of k3s is available as a separate versioned package,
+  # e.g. k3s_1_33 provides the latest patch release of 1.33.x, k3s_1_34
+  # provides 1.34.x, etc.
+
+  services.k3s.package = pkgs.k3s_1_33;
+}
+```
+
+:::{warning}
+Outside of upgrade scenarios, all nodes in the cluster should be running the
+same version of k3s.
+:::
+
+
+### Updating k3s
+
+When upgrading a cluster to a newer version of k3s, the **server VM must always
+be updated to the new version first**. After the server VM has been updated, the
+remaining VM's in the cluster can be updated freely.
+
+Note that k3s only supports updating from one minor version to the immediately
+following minor version. This means, for example, that in order to update from
+1.32.x to 1.34.x the entire cluster must first be updated to 1.33.x as an
+intermediate step.
+
+The upstream [upgrade documentation](https://docs.k3s.io/upgrades) and release
+notes should also be checked in case there are further version-specific update
+steps required.
+
+### Platform upgrades
+
+New versions of the Flying Circus platform include different versions of
+k3s. This affects the default version of k3s used when k3s roles are enabled,
+but this also means that the default k3s version provided in the previous
+platform may no longer be available in the new platform.
+
+Before upgrading a k3s cluster to a new version of the platform, you should
+ensure that the cluster is running a version of k3s which is available in both
+the current platfrom and the new platform, updating k3s as described above if
+necessary. The desired version of k3s should also be explictly configured on the
+cluster VM's during platform upgrades to prevent the new default k3s version
+taking effect unintentionally.
+
+
 ## Known limitations
 
 - Due to our high security requirements for user passwords accessing the


### PR DESCRIPTION
This change adds some documentation on how to handle updating k3s clusters, both for k3s itself and for platform upgrades.

PL-132803

@flyingcircusio/release-managers

## Release process

This change should be backported:

- [x] Created changelog entry using `./changelog.sh`
- [x] Add `backport release-25.11` label

This change should only reach this branch:

- [ ] Created changelog entry using `./changelog.sh`
or
- [ ] Add a upgrade node in `doc/upgrade.md`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [ ] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - None, documentation change only
- [x] Security requirements tested? (EVIDENCE)
  - Nothing to test.