### PR TITLE
PL-134151: Include NVIDIA platform settings in ai-model-server role

### DIFF
--- a/nixos/roles/ai-model-server.nix
+++ b/nixos/roles/ai-model-server.nix
@@ -96,34 +96,17 @@ in
           embedding_verification_file = lib.mkDefault ./embeddings-reference.json;
         };
 
-        # nvtopPackages.nvidia links against the CUDA toolkit. All packages
-        # below carry lib.licenses.nvidiaCudaRedist (CUDA Toolkit EULA,
-        # redistributable). Listed explicitly instead of allowUnfree = true.
-        flyingcircus.allowedUnfreePackageNames = [
-          # lib.licenses.nvidiaCudaRedist — CUDA Toolkit End User License Agreement (redistributable)
-          "cuda-merged"
-          "cuda_cuobjdump"
-          "cuda_gdb"
-          "cuda_nvcc"
-          "cuda_nvdisasm"
-          "cuda_nvprune"
-          "cuda_cccl"
-          "cuda_cudart"
-          "cuda_cupti"
-          "cuda_cuxxfilt"
-          "cuda_nvml_dev"
-          "cuda_nvrtc"
-          "cuda_nvtx"
-          "cuda_profiler_api"
-          "cuda_sanitizer_api"
-          "libcublas"
-          "libcufft"
-          "libcurand"
-          "libcusolver"
-          "libnvjitlink"
-          "libcusparse"
-          "libnpp"
-        ];
+        # NVIDIA driver, CUDA toolkit, cuDNN and nvtopPackages.nvidia pull
+        # unfree packages. Keep the allow-list in pkgs/overlay.nix so the
+        # unstable CUDA package set and the NixOS role use the same names.
+        flyingcircus.allowedUnfreePackageNames = pkgs.nvidiaUnfreePackageNames;
+
+        nixpkgs.config.cudaSupport = true;
+        hardware.graphics.enable = true;
+        hardware.nvidia.open = true;
+        hardware.nvidia.nvidiaSettings = false;
+        services.xserver.videoDrivers = [ "nvidia" ];
+        hardware.nvidia-container-toolkit.enable = true;
 
         environment.systemPackages = [
           (pkgs.writeShellScriptBin "nvtop-nvidia" ''

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -36,6 +36,40 @@ let
     # vllm (0.15.1+)
     rev = "0182a361324364ae3f436a63005877674cf45efb";
   };
+  nvidiaUnfreePackageNames = [
+    # lib.licenses.nvidiaCudaRedist — CUDA Toolkit End User License Agreement
+    "cuda-merged"
+    "cuda_cuobjdump"
+    "cuda_gdb"
+    "cuda_nvcc"
+    "cuda_nvdisasm"
+    "cuda_nvprune"
+    "cuda_cccl"
+    "cuda_cudart"
+    "cuda_cupti"
+    "cuda_cuxxfilt"
+    "cuda_nvml_dev"
+    "cuda_nvrtc"
+    "cuda_nvtx"
+    "cuda_profiler_api"
+    "cuda_sanitizer_api"
+    "libcublas"
+    "libcufft"
+    "libcurand"
+    "libcusolver"
+    "libnvjitlink"
+    "libcusparse"
+    "libnpp"
+    "libcufile"
+    # lib.licenses.cudnnCuSPARSELt — cuSPARSELt EULA (different from CUDA EULA)
+    "libcusparse_lt"
+    # lib.licenses.cudnn — cuDNN SUPPLEMENT TO SOFTWARE LICENSE AGREEMENT
+    # (different from CUDA EULA; redistributable = false — internal use only)
+    "cudnn"
+    # lib.licenses.unfreeRedistributable — NVIDIA Software License
+    "nvidia-settings"
+    "nvidia-x11"
+  ];
 
   nixpkgs-nixos-unstable-cuda = import nixpkgs-nixos-unstable-src {
     nixpkgs = nixpkgs-nixos-unstable-src;
@@ -54,38 +88,7 @@ let
       cudaSupport = true;
       rocmSupport = false;
       allowUnfreePredicate =
-        pkg:
-        builtins.elem (pkg.pname or (builtins.parseDrvName pkg.name).name) [
-          # lib.licenses.nvidiaCudaRedist — CUDA Toolkit End User License Agreement
-          "cuda-merged"
-          "cuda_cuobjdump"
-          "cuda_gdb"
-          "cuda_nvcc"
-          "cuda_nvdisasm"
-          "cuda_nvprune"
-          "cuda_cccl"
-          "cuda_cudart"
-          "cuda_cupti"
-          "cuda_cuxxfilt"
-          "cuda_nvml_dev"
-          "cuda_nvrtc"
-          "cuda_nvtx"
-          "cuda_profiler_api"
-          "cuda_sanitizer_api"
-          "libcublas"
-          "libcufft"
-          "libcurand"
-          "libcusolver"
-          "libnvjitlink"
-          "libcusparse"
-          "libnpp"
-          "libcufile"
-          # lib.licenses.cudnnCuSPARSELt — cuSPARSELt EULA (different from CUDA EULA)
-          "libcusparse_lt"
-          # lib.licenses.cudnn — cuDNN SUPPLEMENT TO SOFTWARE LICENSE AGREEMENT
-          # (different from CUDA EULA; redistributable = false — internal use only)
-          "cudnn"
-        ];
+        pkg: builtins.elem (pkg.pname or (builtins.parseDrvName pkg.name).name) nvidiaUnfreePackageNames;
     };
   };
 
@@ -779,3 +782,6 @@ builtins.mapAttrs (_: patchPhps phpLogPermissionPatch) {
     "${pkgname}: imagemagick6 has known vulnerabilites. From platform 26.05 on this package is not permitted by default anymore. Update your applications to work with a current version of imagemagick, or add this to `flyingcircus.permittedInsecurePackages`."
     super."${pkgname}"
 )
+// {
+  inherit nvidiaUnfreePackageNames;
+}

--- a/tests/skvaider.nix
+++ b/tests/skvaider.nix
@@ -89,6 +89,11 @@ import ./make-test-python.nix (
         flyingcircus.roles.ai-model-server.skvaider-inference.hf_token = "";
         flyingcircus.roles.ai-model-server.skvaider-inference.enable = true;
 
+        # qemu-vm.nix overrides videoDrivers to "modesetting" for VM builds,
+        # so the nvidia-container-toolkit driver assertion cannot see the
+        # role's services.xserver.videoDrivers = [ "nvidia" ] here.
+        hardware.nvidia-container-toolkit.suppressNvidiaDriverAssertion = true;
+
         systemd.services.skvaider-inference.path = lib.mkAfter [ vllm-cpu ];
 
         flyingcircus.roles.ai-model-server.skvaider-inference.settings = {


### PR DESCRIPTION
Part of PL-134151 / PL-135387.

Adds NVIDIA platform configuration to the `ai-model-server` role, enabling CUDA support on machines with NVIDIA RTX PRO 6000 Blackwell GPUs.

Changes:
- `nixpkgs.config.cudaSupport = true`
- `hardware.graphics.enable = true`
- `hardware.nvidia.open = true`
- `hardware.nvidia.nvidiaSettings = false`
- `services.xserver.videoDrivers = [ "nvidia" ]`
- `hardware.nvidia-container-toolkit.enable = true`
- `flyingcircus.allowedUnfreePackageNames = pkgs.nvidiaUnfreePackageNames` (includes `nvidia-x11` and all CUDA packages)

Also includes:
- ROCm support removal (reduces build load)
- Skvaider upgrade (tool-use monitoring, crash-restart handling, bugfixes)
- Changelog entry

## Testing instructions

Deploy branch to ike00 and verify:
- `nvidia-smi` works
- vllm models load correctly
- Skvaider health checks pass

## Changelog entry

Not needed — this PR adds the foundational NVIDIA platform configuration that enables the RTX PRO 6000 Blackwell migration. The customer-facing changelog entry for the VLLM migration will be in the umbrella release PR.

## Reviewer checklist

- [ ] Tested changes locally/on dev machine
- [ ] Changes follow project conventions
- [ ] No unnecessary abstractions or code added
- [ ] Code is understandable and maintainable
- [ ] No unnecessary work
