### PR TITLE
ai-model-server: include vllm-cuda in system closure for Hydra pre-build

### DIFF
--- a/release/important_packages.json
+++ b/release/important_packages.json
@@ -234,6 +234,7 @@
   "varnish",
   "varnish80",
   "vim",
+  "vllm-cuda",
   "wget",
   "wireguard-tools",
   "xfsprogs",


### PR DESCRIPTION
## Problem

Per-machine config (`/etc/local/nixos/ai-model-server.nix`) references `pkgs.vllm-cuda` for the vllm engine binaries used by the skvaider inference service. However, `vllm-cuda` is never pre-built by Hydra:

- `vllm-cuda` is defined in `pkgs/overlay.nix` as `nixpkgs-nixos-unstable-cuda.vllm` — a lazy thunk that imports a separate nixpkgs set with `cudaSupport = true`
- `getDottedPackageNames` in `release/default.nix` uses `lib.isDerivation` to filter overlay packages — lazy thunks return false and are skipped
- The Hydra test uses a **separate** `vllm-cpu` import (CPU-only, no CUDA config), so the test closure does not pull in `vllm-cuda`

This means ike02/ike03 build vllm-cuda locally on every switch instead of pulling from the Hydra cache.

## Fix

Add `vllm-cuda` to `release/important_packages.json`. The `pkgNameToHydraJobs` function uses `lib.attrByPath` to resolve the dotted name, which forces thunk evaluation. This creates an explicit Hydra job for `vllm-cuda`.