### PR TITLE
platform: remove dhparams by default

### DIFF
--- a/doc/src/upgrade.md
+++ b/doc/src/upgrade.md
@@ -462,6 +462,8 @@ suggest migration paths tailored to the VMs' specific situation.
 
 - `services.dovecot2.extraConfig` was removed. Migrate configuration to `services.dovecot2.settings`.
 
+- `services.dhparams` has been deprecated. Remove any uses of DHE and migrate to ECDHE (RFC 8422, 2018) and Hybrid PQ (draft-ietf-tls-ecdhe-mlkem, 2026) key exchange algorithms. `services.dhparams` will be removed in fc-nixos 26.11
+
 ## Known issues
 
 None.

--- a/doc/src/webgateway.md
+++ b/doc/src/webgateway.md
@@ -8,8 +8,8 @@ failover support.
 
 ## Versions
 
-- HAProxy: 3.2.x
-- Nginx: 1.28.x
+- HAProxy: 3.3.x
+- Nginx: 1.30.x
 
 ## Role architecture
 
@@ -210,7 +210,12 @@ To use a custom certificate, set the certificate options and set `"enableACME" =
 
 #### SSL ciphers
 
+
 With default settings, the following ciphers are available:
+
+<!--
+We use IANA names for the ciphers here.
+-->
 
 TLS 1.3:
 
@@ -224,15 +229,30 @@ TLS 1.2:
 - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
 - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
 
+with the
+
+- X25519MLKEM768
+- X25519
+- P-256
+- P-384
+
+TLS groups.
+
 To use ciphers based on RSA for legacy clients, an RSA key must be
 used for the certificates. Note that this disables the ciphers listed above
-and reduces performance with newer clients.
+and reduces performance. Please avoid using RSA certificates!
 
 Overriding the key type can be done per certificate:
 
 ```nix
-security.acme.certs."test.fcio.net".keyType = "rsa2048";
+security.acme.certs."test.fcio.net".keyType = "rsa4096";
 ```
+
+When an RSA server certificate is in use the following ciphers are activated:
+
+- `TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256`
+- `TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384`
+- `TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256`
 
 Using two certificates to support both kinds of ciphers is possible with Nginx
 but needs manual configuration.
@@ -240,19 +260,24 @@ but needs manual configuration.
 For ciphers using DHE, an RSA certificate must be used. *dhparams* must be generated and set:
 
 ```nix
+security.dhparams.enable = true;
 security.dhparams.params.nginx = {};
 services.nginx.sslDhparam = config.security.dhparams.params.nginx.path;
 ```
 
-This enables the following TLS 1.2 ciphers:
+DHE TLS ciphers are deprecated and will be removed in fc-nixos 26.11 together with the `services.dhparams` module.
+Please migrate to ECDHE (RFC 8422, 2018) and Hybrid PQ (draft-ietf-tls-ecdhe-mlkem, 2026) key exchange algorithms.
 
-- TLS_DHE_RSA_WITH_AES_128_GCM_SHA256
-- TLS_DHE_RSA_WITH_AES_256_GCM_SHA384
+This enables the following TLS ciphers:
 
-The DH param file is located at /var/lib/dhparams/nginx.pem.
+- `TLS_DHE_RSA_WITH_AES_128_GCM_SHA256`
+- `TLS_DHE_RSA_WITH_AES_256_GCM_SHA384`
+- `TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256`
+
+The DH param file is located at `/var/lib/dhparams/nginx.pem`.
 This path can be referenced from Nix code by `security.dhparams.params.nginx.path` as shown in the config example above.
 
-The [services.nginx.sslCiphers](https://search.flyingcircus.io/search/options?q=services.nginx.sslCiphers&channel=fc-25.05-dev#services.nginx.sslCiphers)
+The [services.nginx.sslCiphers](https://search.flyingcircus.io/search/options?q=services.nginx.sslCiphers&channel=fc-26.05-dev#services.nginx.sslCiphers)
 option can be used to change the cipher list.
 
 If you enable weaker ciphers, you should also set `services.nginx.legacyTlsSettings` to true

--- a/nixos/platform/default.nix
+++ b/nixos/platform/default.nix
@@ -30,6 +30,7 @@ in
     ./alloy.nix
     ./audit.nix
     ./auditbeat.nix
+    ./dhparams.nix
     ./go-audit.nix
     ./beats.nix
     ./filebeat.nix

--- a/nixos/platform/default.nix
+++ b/nixos/platform/default.nix
@@ -416,8 +416,6 @@ in
       // (filterAttrs (n: v: n != "commands" && n != "package") e)
     ) cfg.passwordlessSudoPackages;
 
-    security.dhparams.enable = true;
-
     services = {
       # upstream uses cron.enable = mkDefault ... (prio 1000), mkPlatform
       # overrides it

--- a/nixos/platform/default.nix
+++ b/nixos/platform/default.nix
@@ -449,6 +449,8 @@ in
         KbdInteractiveAuthentication = false;
         PasswordAuthentication = false;
         KexAlgorithms = [
+          "mlkem768x25519-sha256"
+          "sntrup761x25519-sha512"
           "sntrup761x25519-sha512@openssh.com"
           "curve25519-sha256"
           "curve25519-sha256@libssh.org"

--- a/nixos/platform/dhparams.nix
+++ b/nixos/platform/dhparams.nix
@@ -1,0 +1,12 @@
+{ lib, config, ... }:
+{
+  # Can be removed with fc-nixos 26.11
+  config = {
+    assertions = [
+      {
+        assertion = (config.security.dhparams.params != { }) -> config.security.dhparams.enable;
+        message = "Generation of dhparams requested with 'security.dhparams.params' (params: ${lib.concatStringsSep ", " (builtins.attrNames config.security.dhparams.params)}) but 'security.dhparams.enable = false'. Set 'security.dhparams.enable = true' or remove the params. 'services.dhparams' is deprecated and will be removed in fc-nixos 26.11 in favor of ECDHE and Hybrid PQ key exchange algorithms.";
+      }
+    ];
+  };
+}

--- a/nixos/roles/external_net/openvpn.nix
+++ b/nixos/roles/external_net/openvpn.nix
@@ -62,10 +62,11 @@ let
     "TLS-DHE-RSA-WITH-AES-256-CBC-SHA256"
   ];
 
+  # https://openvpn.net/as-docs/tutorials/tutorial--change-encryption-cipher.html
   allowedCiphers = [
     "AES-256-GCM"
-    # for 2.3.x clients
     "AES-256-CBC"
+    "CHACHA20-POLY1305"
   ];
 
   #

--- a/nixos/services/nginx/README.txt
+++ b/nixos/services/nginx/README.txt
@@ -121,40 +121,64 @@ To use a custom certificate, set the certificate options and set `"enableACME" =
 
 ### SSL ciphers
 
+
 With default settings, the following ciphers are available:
+
+<!--
+We use IANA names for the ciphers here.
+-->
 
 TLS 1.3:
 
-TLS_AES_128_GCM_SHA256
-TLS_AES_256_GCM_SHA384
-TLS_CHACHA20_POLY1305_SHA256
+- TLS_AES_128_GCM_SHA256
+- TLS_AES_256_GCM_SHA384
+- TLS_CHACHA20_POLY1305_SHA256
 
 TLS 1.2:
 
-TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
-TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
-TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
+- TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+- TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+- TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
+
+with the
+
+- X25519MLKEM768
+- X25519
+- P-256
+- P-384
+
+TLS groups.
 
 To use ciphers based on RSA for legacy clients, an RSA key must be
 used for the certificates. Note that this disables the ciphers listed above
-and reduces performance with newer clients.
+and reduces performance. Please avoid using RSA certificates!
 
 Overriding the key type can be done per certificate:
 
-security.acme.certs."test.fcio.net".keyType = "rsa2048";
+security.acme.certs."test.fcio.net".keyType = "rsa4096";
+
+When an RSA server certificate is in use the following ciphers are activated:
+
+- TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+- TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+- TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
 
 Using two certificates to support both kinds of ciphers is possible with Nginx
 but needs manual configuration.
 
 For ciphers using DHE, an RSA certificate must be used. *dhparams* must be generated and set:
 
+security.dhparams.enable = true;
 security.dhparams.params.nginx = {};
-services.nginx.sslDhparam = config.security.dhparams.params.nginx.path;
+services.nginx.sslDhparam = config.security.dhparams.params.nginx.path;i
 
-This enables the following TLS 1.2 ciphers:
+DHE TLS ciphers are deprecated and will be removed in fc-nixos 26.11 together with the `services.dhparams` module. Please migrate to ECDHE (RFC 8422, 2018) and Hybrid PQ (draft-ietf-tls-ecdhe-mlkem, 2026) key exchange algorithms.
 
-* TLS_DHE_RSA_WITH_AES_128_GCM_SHA256
-* TLS_DHE_RSA_WITH_AES_256_GCM_SHA384
+This enables the following TLS ciphers:
+
+- TLS_DHE_RSA_WITH_AES_128_GCM_SHA256
+- TLS_DHE_RSA_WITH_AES_256_GCM_SHA384
+- TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256
 
 The DH param file is located at /var/lib/dhparams/nginx.pem.
 This path can be referenced from Nix code by `security.dhparams.params.nginx.path` as shown in the config example above.

--- a/tests/mail/default.nix
+++ b/tests/mail/default.nix
@@ -81,21 +81,6 @@ import ../make-test-python.nix (
                 };
               };
 
-              # avoid time-consuming generation
-              systemd.services.dhparams-gen-dovecot2.script = lib.mkForce ''
-                mkdir -p /var/lib/dhparams
-                cat > /var/lib/dhparams/dovecot2.pem <<_EOT_
-                -----BEGIN DH PARAMETERS-----
-                MIIBCAKCAQEA46Obr4INGWek+Ngo+f3Pew34jsXHMPI5gaLwf901wbm18FGgp0Nu
-                f91t6beKYJrc+2E63R3E6E26+jY8fo6R4hh7wXtMEb94MyAJ8+fdyNpOGgNko2gf
-                c+kuTqgw/wGXZo2k9Zbd/vqTUS1rFR6GuqL6Urb6VAqi2aSFiJfbuE5XJrne9SP4
-                j+zSYwtr9mJZHikes6wOs1v5Fkt/ZvKEvlUEfn/nWNnr9xVqBQp7amZullkEHh4r
-                F5V/qvJRsppwxaWQWWhcTP/u7GnJBrpQXaQKgDwH9uOwy/hleuRGtfhgIADuWDma
-                GT0F+r7c94IjRNKnMd5PdJybaH3xAj+aSwIBAg==
-                -----END DH PARAMETERS-----
-                _EOT_
-              '';
-
               systemd.services.mailserver-selfsigned-certificate = {
                 after = [ "local-fs.target" ];
                 wantedBy = [ "multi-user.target" ];


### PR DESCRIPTION
dhparams is deprecated. We should move to DHE and Hybrid PQ Kex
PL-135358

@flyingcircusio/release-managers

## Release process

This change should be backported:

- [ ] Created changelog entry using `./changelog.sh`
- [ ] Add `backport release-25.11` label

This change should only reach this branch:

- [ ] Created changelog entry using `./changelog.sh`
or
- [x] Add a upgrade node in `doc/upgrade.md`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [x] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Secure algorithms
  - Client compatibility
  - Upgrade path ensured
- [x] Security requirements tested? (EVIDENCE)
  - Validated algorithms to recommendations:
    - OpenVPN: https://openvpn.net/as-docs/tutorials/tutorial--change-encryption-cipher.html#recommended-values
    - nginx: default behavior of Nixpkgs
    - openssh: Combination of PL-135358 and defaults of OpenSSH https://github.com/openssh/openssh-portable/blob/V_10_3_P1/sshd_config.5
      - I currently decided to not remove the DHE Kex. I started a discussion within Nixpkgs where we decided to do this in the next release cycle as people weren't sure if curve25519+sntrup+mlkem is enough. 
    - We're going forward with Hybrid PQ algorithms where possible, this is NGINX and openssh here.
  - Upgrade path: Added assertion that prevents specified dhparams while the `security.dhparams` module is disabled. 