### PR TITLE
update nixpkgs to fix check-meta bug

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -165,11 +165,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1779089458,
-        "narHash": "sha256-vP8J5m9TViNBrqZvKvDPaLKa27TLPq6ENL3MZ1lZ0CY=",
+        "lastModified": 1779196308,
+        "narHash": "sha256-FjlImHvKgcCnGjF+DMKRIe7n7yd7ZbBAI+eKRqFzxRc=",
         "owner": "flyingcircusio",
         "repo": "nixpkgs",
-        "rev": "702abb45008628f90e0a3d6c7015a1b980f955a9",
+        "rev": "9a043559d46cbfda4a7411b0de5a11b2b127cad0",
         "type": "github"
       },
       "original": {

--- a/release/versions.json
+++ b/release/versions.json
@@ -8,10 +8,10 @@
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/"
   },
   "nixpkgs": {
-    "hash": "sha256-vP8J5m9TViNBrqZvKvDPaLKa27TLPq6ENL3MZ1lZ0CY=",
+    "hash": "sha256-FjlImHvKgcCnGjF+DMKRIe7n7yd7ZbBAI+eKRqFzxRc=",
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "702abb45008628f90e0a3d6c7015a1b980f955a9"
+    "rev": "9a043559d46cbfda4a7411b0de5a11b2b127cad0"
   },
   "poetry2nix": {
     "hash": "sha256-nzgO/ZCSBzWjbMkYDxG+yl9Z2eGbCgQu06Oku3ir5D4=",


### PR DESCRIPTION
Already fixed in our Nixpkgs with the following commit

```diff
diff --git a/pkgs/stdenv/generic/check-meta.nix b/pkgs/stdenv/generic/check-meta.nix index 0cb6adb77f..a6df0c6ab5 100644
--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -488,7 +488,7 @@
     else if hasDeniedUnfreeLicense attrs && !(allowlist != [ ] && hasAllowlistedLicense attrs) then
       {
         reason = "unfree";
-        errormsg = "has an unfree license (‘${showLicense attrs.meta.license}’)";
+        msg = "has an unfree license (‘${showLicense attrs.meta.license}’)";
         remediation = remediate_unfree attrs;
       }
     else if blocklist != [ ] && hasBlocklistedLicense attrs then
```

This was broken by a git rebase.

@flyingcircusio/release-managers

## Release process

This change should be backported:

- [ ] Created changelog entry using `./changelog.sh`
- [ ] Add `backport release-25.11` label

This change should only reach this branch:

- [ ] Created changelog entry using `./changelog.sh`
or
- [ ] Add a upgrade node in `doc/upgrade.md`

## PR release workflow (internal)

- [ ] PR has internal ticket
  - none, follow up to #2367
- [ ] internal issue ID (PL-…) part of branch name
- [ ] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
- [x] set urgency and risk labels
- [x] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [x] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [x] Security requirements tested? (EVIDENCE)
 Tested on affected machine