### PR TITLE
[PL-135168] cross-rg loki- and statshost-relay

### DIFF
--- a/changelog.d/20260519_154628_PL-135168_cross-rg-loki_scriv.md
+++ b/changelog.d/20260519_154628_PL-135168_cross-rg-loki_scriv.md
@@ -1,0 +1,8 @@
+### Impact
+
+-
+
+
+### NixOS XX.XX platform
+
+- add the loki-relay role that enables cross-rg log shipping (PL-135168)

--- a/doc/src/statshost.md
+++ b/doc/src/statshost.md
@@ -10,6 +10,11 @@ In order to configure this stack, you just need to add the `statshost-master` ro
 and optionally the `loki` role if you want to ingest, store and visualize logs like the system journal
 or other logfiles on your VMs.
 
+If you wish to also ingest logs from other RGs, you can add the `loki-relay` role to one of the VMs in each RG.
+This will add a new configuration option in the role section of that VM's overview on [my.flyingcircus.io](https://my.flyingcircus.io) where
+you can pick a destination for the logs of all of the VMs in that VM's RG from a list of VMs with the
+statshost-master role in other RGs that belong to the same customer.
+
 ## Configuration
 
 To make our stack fit your application, you can of course configure them to suit your use-case.

--- a/doc/src/statshost.md
+++ b/doc/src/statshost.md
@@ -10,10 +10,14 @@ In order to configure this stack, you just need to add the `statshost-master` ro
 and optionally the `loki` role if you want to ingest, store and visualize logs like the system journal
 or other logfiles on your VMs.
 
-If you wish to also ingest logs from other RGs, you can add the `loki-relay` role to one of the VMs in each RG.
-This will add a new configuration option in the role section of that VM's overview on [my.flyingcircus.io](https://my.flyingcircus.io) where
-you can pick a destination for the logs of all of the VMs in that VM's RG from a list of VMs with the
-statshost-master role in other RGs that belong to the same customer.
+If you wish to also ingest metrics and logs from other RGs, you can add the `loki-relay` and `statshost-relay`
+roles to one of the VMs in each RG.
+This will enable role configuration for the stasthost-master role in the role section of that VM's overview
+on [my.flyingcircus.io](https://my.flyingcircus.io) where you can pick a `statshost-master` for logs and
+metrics from that VM's RG.
+You can choose between all VMs with the `statshost-master` role in other RGs that belong to the same customer.
+We currently only support sending logs and metrics to one remote target.
+
 
 ## Configuration
 

--- a/nixos/roles/default.nix
+++ b/nixos/roles/default.nix
@@ -30,6 +30,7 @@ in
     ./lamp.nix
     ./loghost.nix
     ./loki.nix
+    ./loki-relay.nix
     ./mailout.nix
     ./mailserver.nix
     ./mariadb.nix

--- a/nixos/roles/loki-relay.nix
+++ b/nixos/roles/loki-relay.nix
@@ -1,0 +1,68 @@
+{ config, lib, ... }:
+let
+  cfg = config.flyingcircus.roles.loki-relay;
+  fclib = config.fclib;
+  enc = config.flyingcircus.enc;
+  lokiPort = 3100;
+in
+{
+  options = {
+    flyingcircus.roles.loki-relay = {
+      enable = lib.mkEnableOption "the Flying Circus Grafana Loki relay";
+    };
+  };
+
+  config = lib.mkMerge [
+    (
+      # open ports for incoming logs from specific VMs in other RGs
+      let
+        roleConfig = enc.role_configuration."statshost-master";
+        relayFrom = roleConfig.relay_from_details;
+        makeRule =
+          addr:
+          "${fclib.iptables addr} -A nixos-fw -i ethsrv -s ${addr} -p tcp --dport ${builtins.toString lokiPort} -j nixos-fw-accept";
+
+        makeHostBlock =
+          name: value:
+          lib.concatStringsSep "\n" ([ "# loki-relay from \"${name}\"" ] ++ (map makeRule value.addresses));
+      in
+      lib.mkIf (config.flyingcircus.roles.loki.enable && enc ? "role_configuration"."statshost-master") {
+        networking.firewall.extraCommands = lib.concatStringsSep "\n\n" (
+          lib.mapAttrsToList makeHostBlock relayFrom
+        );
+      }
+    )
+    (
+      # open a relay for other VMs in this RG to route all logs to another RG (see above)
+      # functionally this is identical to the single-RG loki-collector but instead of passing
+      # the logs to a local loki instance this forwards the logs to another RG
+      # this will eventually be replaced with a similar configuration for alloy that supports
+      # sending logs out to multiple endpoints e.g. a global statshost
+      let
+        roleConfig = enc.role_configuration."statshost-relay";
+        lokiHost = builtins.head roleConfig.relay_to;
+      in
+      lib.mkIf cfg.enable {
+        flyingcircus.services.nginx = {
+          enable = true;
+
+          virtualHosts.loki = {
+            serverName = config.networking.hostName;
+            serverAliases = [
+              (fclib.fqdn { vlan = "srv"; })
+              "${config.networking.hostName}.${config.networking.domain}"
+            ];
+            listen = builtins.map (addr: {
+              inherit addr;
+              port = lokiPort;
+            }) fclib.network.srv.dualstack.addressesQuoted;
+            locations."/" = {
+              proxyPass = "http://${lokiHost}:${toString lokiPort}";
+              proxyWebsockets = true;
+            };
+          };
+        };
+      }
+    )
+  ];
+}

--- a/nixos/roles/statshost/default.nix
+++ b/nixos/roles/statshost/default.nix
@@ -14,6 +14,9 @@ with builtins;
 
 let
   fclib = config.fclib;
+  enc = config.flyingcircus.enc;
+  roleConfig = enc.role_configuration."statshost-relay";
+  prometheusHosts = roleConfig.relay_from_details;
 
   localDir = "/etc/local/statshost";
 
@@ -45,7 +48,12 @@ let
 
   prometheusMetricRelabel = cfgStats.prometheusMetricRelabel ++ customRelabelConfig;
 
-  relayRGNodes = fclib.jsonFromFile "${localDir}/relays.json" "[]";
+  relayRGNodes =
+    (lib.mapAttrsToList (n: _: {
+      job_name = n;
+      proxy_url = "http://${n}.fcio.net:9090";
+    }) prometheusHosts)
+    ++ (fclib.jsonFromFile "${localDir}/relays.json" "[]");
 
   relayLocationNodes = map (
     proxy:

--- a/nixos/roles/statshost/rg-relay.nix
+++ b/nixos/roles/statshost/rg-relay.nix
@@ -3,14 +3,30 @@
 {
   config,
   lib,
-  pkgs,
   ...
 }:
-
-with lib;
-
 {
-  config = mkIf config.flyingcircus.roles.statshost-relay.enable {
+  config = lib.mkIf config.flyingcircus.roles.statshost-relay.enable {
+    # open ports for incoming logs from specific VMs in other RGs
+    networking.firewall.extraCommands =
+      let
+        enc = config.flyingcircus.enc;
+        fclib = config.fclib;
+        roleConfig = enc.role_configuration."statshost-relay";
+        prometheusHosts = roleConfig.relay_to_details;
+        promPort = 9090;
+
+        makeRule =
+          addr:
+          "${fclib.iptables addr} -A nixos-fw -i ethsrv -s ${addr} -p tcp --dport ${builtins.toString promPort} -j nixos-fw-accept";
+
+        makeHostBlock =
+          name: value:
+          lib.concatStringsSep "\n" (
+            [ "# statshost-relay to \"${name}\"" ] ++ (map makeRule value.addresses)
+          );
+      in
+      lib.concatStringsSep "\n\n" (lib.mapAttrsToList makeHostBlock prometheusHosts);
 
     flyingcircus.services.nginx.enable = true;
     services.nginx.appendHttpConfig = ''
@@ -24,12 +40,11 @@ with lib;
         }
 
         location / {
-            resolver ${concatStringsSep " " config.networking.nameservers};
+            resolver ${builtins.concatStringsSep " " config.networking.nameservers};
             proxy_pass http://$host:9126$request_uri$is_args$args;
             limit_except GET { deny all; }
         }
       }
     '';
-
   };
 }

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -88,6 +88,7 @@ in
 
   locale = callTest ./locale.nix { };
   loki = callTest ./loki.nix { };
+  loki-relay = callTest ./loki-relay.nix { };
   loghost = callTest ./loghost.nix { };
   login = callTest ./login.nix { };
   logrotate = callTest ./logrotate.nix { };

--- a/tests/loki-relay.nix
+++ b/tests/loki-relay.nix
@@ -1,0 +1,147 @@
+import ./make-test-python.nix (
+  {
+    testlib,
+    pkgs,
+    ...
+  }:
+  let
+    loki_collector_v4 = testlib.fcIP.srv4 1;
+    loki_collector_v6 = testlib.fcIP.srv6 1;
+    loki_relay_v4 = testlib.fcIP.srv4 2;
+    loki_relay_v6 = testlib.fcIP.srv6 2;
+  in
+  {
+    name = "loki-relay";
+
+    nodes = {
+      loki_collector =
+        {
+          lib,
+          pkgs,
+          ...
+        }:
+        {
+          imports = [
+            ../nixos
+            ../nixos/roles
+            (testlib.fcConfig {
+              id = 1;
+              net.fe = false;
+              resource_group = "test2";
+            })
+          ];
+
+          flyingcircus = {
+            roles.loki.enable = true;
+            enc.role_configuration."statshost-master".relay_from_details = {
+              loki_relay.addresses = [
+                loki_relay_v4
+                loki_relay_v6
+              ];
+            };
+          };
+
+          environment.variables.LOKI_ADDR = "http://127.0.0.1:3100";
+          environment.systemPackages = [ pkgs.grafana-loki ];
+        };
+
+      loki_relay =
+        {
+          lib,
+          pkgs,
+          ...
+        }:
+        {
+          imports = [
+            ../nixos
+            ../nixos/roles
+            (testlib.fcConfig {
+              id = 2;
+              net.fe = false;
+              resource_group = "test";
+            })
+          ];
+          networking.firewall.enable = false;
+
+          flyingcircus.roles.loki-relay.enable = true;
+          flyingcircus.enc.role_configuration."statshost-relay" = {
+            relay_to = [ "loki_collector" ];
+            relay_to_details = {
+              loki_collector.addresses = [
+                loki_collector_v4
+                loki_collector_v6
+              ];
+            };
+          };
+        };
+
+      testvm =
+        { lib, pkgs, ... }:
+        {
+          imports = [
+            ../nixos
+            ../nixos/roles
+            (testlib.fcConfig {
+              id = 3;
+              net.fe = false;
+              resource_group = "test";
+            })
+          ];
+
+          flyingcircus.encServices = [
+            {
+              address = "loki_relay";
+              service = "loki-collector";
+              ips = [
+                loki_relay_v4
+                loki_relay_v6
+              ];
+            }
+          ];
+
+          # test service to spam something easily greppable into syslog
+          systemd.services.testservice = {
+            enable = true;
+            wantedBy = [ "multi-user.target" ];
+            after = [
+              "network.target"
+              "alloy.service"
+            ];
+
+            serviceConfig.ExecStart = pkgs.writeShellScript "testservice.sh" ''
+              while true; do
+                echo "test message"
+                sleep 1
+              done
+            '';
+          };
+        };
+    };
+
+    testScript =
+      { nodes, ... }:
+      let
+        testscript = pkgs.writeShellScript "test-syslog-in-loki.sh" ''
+          test $(logcli -q query '{systemd_unit="testservice.service"} |= `test message`' | wc -l) -gt 0
+        '';
+      in
+      ''
+        loki_collector.wait_for_unit("loki.service")
+        loki_collector.wait_for_unit("nginx.service")
+
+        loki_collector.wait_for_unit("network.target")
+        loki_relay.wait_for_unit("network.target")
+        testvm.wait_for_unit("network.target")
+
+        testvm.wait_for_unit("testservice.service")
+
+        loki_relay.sleep(5)
+        loki_collector.sleep(5)
+        testvm.sleep(5)
+
+        testvm.succeed("curl http://loki_relay:3100")
+        loki_relay.succeed("curl http://loki_collector:3100")
+        loki_collector.succeed('${testscript}')
+      '';
+  }
+)

--- a/tests/statshost/rg-relay.nix
+++ b/tests/statshost/rg-relay.nix
@@ -2,6 +2,11 @@ import ../make-test-python.nix (
   { pkgs, testlib, ... }:
   let
     inherit (testlib) fcConfig fcIP;
+
+    relay_v4 = fcIP.srv4 1;
+    relay_v6 = fcIP.srv6 1;
+    stats_host_v4 = fcIP.srv4 3;
+    stats_host_v6 = fcIP.srv6 3;
   in
   {
     name = "rg-relay";
@@ -10,6 +15,16 @@ import ../make-test-python.nix (
         imports = [ (fcConfig { id = 1; }) ];
 
         flyingcircus.roles.statshost-relay.enable = true;
+
+        networking.firewall.enable = false;
+
+        flyingcircus.enc.role_configuration."statshost-relay" = {
+          relay_to_details.statshost.addresses = [
+            stats_host_v4
+            stats_host_v6
+          ];
+        };
+
         environment.etc."local/statshost/scrape-rg.json".text = ''
           [
             {"targets":["statsSource:9126"]}
@@ -21,7 +36,6 @@ import ../make-test-python.nix (
           ${fcIP.srv6 2} statsSource
         '';
 
-        networking.firewall.allowedTCPPorts = [ 9090 ];
         # Nginx wants to talk to DNS, so we set up a dnsmasq that serves /etc/hosts.
         services.dnsmasq = {
           enable = true;
@@ -35,14 +49,19 @@ import ../make-test-python.nix (
 
       statsSource = {
         imports = [ (fcConfig { id = 2; }) ];
-
-        networking.firewall.allowedTCPPorts = [ 9126 ];
+        networking.firewall.enable = false;
       };
 
       statshost = {
         imports = [ (fcConfig { id = 3; }) ];
-
         environment.systemPackages = [ pkgs.curl ];
+
+        flyingcircus.enc.role_configuration."statshost-relay" = {
+          relay_from_details.relay.addresses = [
+            relay_v4
+            relay_v6
+          ];
+        };
       };
     };
 


### PR DESCRIPTION
This role configures cross-rg logshipping via specific firewall rules and an nginx reverse proxy

cc @zagy 

PL-135168

@flyingcircusio/release-managers

## Release process

This change should be backported:

- [ ] Created changelog entry using `./changelog.sh`
- [ ] Add `backport release-25.11` label

This change should only reach this branch:

- [x] Created changelog entry using `./changelog.sh`
or
- [ ] Add a upgrade node in `doc/upgrade.md`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [ ] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [x] Security requirements tested? (EVIDENCE)
- extra firewall rules are limited to specific IPs on the ethsrv interface