### PR TITLE
[25.05] nixpkgs: pull in backported stable kernel updates

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -168,11 +168,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1778596490,
-        "narHash": "sha256-1zNvbKYz5ByftjkpGamDbr5QWvhEHI8L62gCbPz+mI0=",
+        "lastModified": 1779266516,
+        "narHash": "sha256-x4C1A1RBrjM6J1PC2L8sb2AhXbLjY/vD/HPA32XrUoU=",
         "owner": "flyingcircusio",
         "repo": "nixpkgs",
-        "rev": "0fdad067f131fe1f86243a3bab8fcad283e4898d",
+        "rev": "9f6b9265bdd050fa91117e7a2d29effe6d76ed39",
         "type": "github"
       },
       "original": {

--- a/nixos/platform/kernel.nix
+++ b/nixos/platform/kernel.nix
@@ -159,6 +159,9 @@ in
         extraConfig = config.flyingcircus.kernelOptions;
       }
     ];
-    boot.blacklistedKernelModules = [ "rxrpc" ]; # PL-135378, CVE-2026-43500 and unecessary module (AFS)
+    boot.blacklistedKernelModules = [
+      "rxrpc" # PL-135378, CVE-2026-43500 and unecessary module (AFS)
+      "rds" # PL-135412, "pintheft"
+    ];
   };
 }

--- a/release/package-versions.json
+++ b/release/package-versions.json
@@ -460,14 +460,14 @@
     "version": "0.2.5"
   },
   "linuxKernelStable": {
-    "name": "linux-6.12.87",
+    "name": "linux-6.12.90",
     "pname": "linux",
-    "version": "6.12.87"
+    "version": "6.12.90"
   },
   "linuxKernelVerify": {
-    "name": "linux-6.12.87",
+    "name": "linux-6.12.90",
     "pname": "linux",
-    "version": "6.12.87"
+    "version": "6.12.90"
   },
   "logrotate": {
     "name": "logrotate-3.22.0",

--- a/release/versions.json
+++ b/release/versions.json
@@ -8,10 +8,10 @@
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/"
   },
   "nixpkgs": {
-    "hash": "sha256-1zNvbKYz5ByftjkpGamDbr5QWvhEHI8L62gCbPz+mI0=",
+    "hash": "sha256-x4C1A1RBrjM6J1PC2L8sb2AhXbLjY/vD/HPA32XrUoU=",
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "0fdad067f131fe1f86243a3bab8fcad283e4898d"
+    "rev": "9f6b9265bdd050fa91117e7a2d29effe6d76ed39"
   },
   "poetry2nix": {
     "hash": "sha256-nzgO/ZCSBzWjbMkYDxG+yl9Z2eGbCgQu06Oku3ir5D4=",


### PR DESCRIPTION
PL-135412

@flyingcircusio/release-managers

## Release process

- [ ] Created changelog entry using `./changelog.sh`
  - nixpkgs-update changelog

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [x] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - backport kernel fixes
  - disable a module with a known entry vulnerability that is unused in our platform
- [ ] Security requirements tested? (EVIDENCE)
  - all tests succeed