### PR TITLE
platform/dhparams: fix typo

### DIFF
--- a/doc/src/upgrade.md
+++ b/doc/src/upgrade.md
@@ -462,7 +462,7 @@ suggest migration paths tailored to the VMs' specific situation.
 
 - `services.dovecot2.extraConfig` was removed. Migrate configuration to `services.dovecot2.settings`.
 
-- `services.dhparams` has been deprecated. Remove any uses of DHE and migrate to ECDHE (RFC 8422, 2018) and Hybrid PQ (draft-ietf-tls-ecdhe-mlkem, 2026) key exchange algorithms. `services.dhparams` will be removed in fc-nixos 26.11
+- `security.dhparams` has been deprecated. Remove any uses of DHE and migrate to ECDHE (RFC 8422, 2018) and Hybrid PQ (draft-ietf-tls-ecdhe-mlkem, 2026) key exchange algorithms. `security.dhparams` will be removed in fc-nixos 26.11
 
 ## Known issues
 

--- a/nixos/platform/dhparams.nix
+++ b/nixos/platform/dhparams.nix
@@ -5,7 +5,7 @@
     assertions = [
       {
         assertion = (config.security.dhparams.params != { }) -> config.security.dhparams.enable;
-        message = "Generation of dhparams requested with 'security.dhparams.params' (params: ${lib.concatStringsSep ", " (builtins.attrNames config.security.dhparams.params)}) but 'security.dhparams.enable = false'. Set 'security.dhparams.enable = true' or remove the params. 'services.dhparams' is deprecated and will be removed in fc-nixos 26.11 in favor of ECDHE and Hybrid PQ key exchange algorithms.";
+        message = "Generation of dhparams requested with 'security.dhparams.params' (params: ${lib.concatStringsSep ", " (builtins.attrNames config.security.dhparams.params)}) but 'security.dhparams.enable = false'. Set 'security.dhparams.enable = true' or remove the params. 'security.dhparams' is deprecated and will be removed in fc-nixos 26.11 in favor of ECDHE and Hybrid PQ key exchange algorithms.";
       }
     ];
   };


### PR DESCRIPTION
PL-135358

@flyingcircusio/release-managers

## Release process

This change should be backported:

- [ ] Created changelog entry using `./changelog.sh`
- [ ] Add `backport release-25.11` label

This change should only reach this branch:

- [ ] Created changelog entry using `./changelog.sh`
or
- [ ] Add a upgrade node in `doc/upgrade.md`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [ ] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [x] Security requirements tested? (EVIDENCE)
  NOne