### PR TITLE
ai-model-server: restrict log permissions, add ACL for sudo-srv/admins

### DIFF
--- a/nixos/roles/ai-model-server.nix
+++ b/nixos/roles/ai-model-server.nix
@@ -265,10 +265,12 @@ in
         };
         systemd.tmpfiles.rules = [
           "d /var/lib/skvaider 0755 skvaider service -"
-          "d /var/log/skvaider 0755 skvaider service -"
+          "d /var/log/skvaider 0750 skvaider service -"
           "d ${cfg.skvaider-inference.settings.models_dir} 0755 skvaider service -"
           "d /var/lib/skvaider/debug 0750 skvaider service -"
           "e /var/lib/skvaider/debug 4 -" # clean up debug logs older than 4 days
+          "A /var/log/skvaider - - - - g:sudo-srv:r-x,g:admins:r-x"
+          "a /var/log/skvaider - - - - d:g:sudo-srv:r,d:g:admins:r"
         ];
 
       }


### PR DESCRIPTION
needs one time `sudo setfacl -R -m g:sudo-srv:r,g:admins:r /var/log/skvaider/` on inference hosts or wait for logrotate to set new facls

- /var/log/skvaider: 0755 -> 0750 (no world access)
- tmpfiles ACL: g:sudo-srv:r-x + g:admins:r-x on directory
- tmpfiles default ACL: g:sudo-srv:r + g:admins:r for new files

@flyingcircusio/release-managers

## Release process

This change should be backported:

- [ ] Created changelog entry using `./changelog.sh`
- [ ] Add `backport release-25.11` label

This change should only reach this branch:

- [ ] Created changelog entry using `./changelog.sh`
or
- [ ] Add a upgrade node in `doc/upgrade.md`

## PR release workflow (internal)

- [ ] PR has internal ticket
- [ ] internal issue ID (PL-…) part of branch name
- [ ] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [ ] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [ ] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [ ] Security requirements tested? (EVIDENCE)
