### PR TITLE
roles/kvm: support qemu-10.1 on Ceph Pacific

### DIFF
--- a/changelog.d/20260520_160517_PL-131408-kvm-qemu10-pacific_scriv.md
+++ b/changelog.d/20260520_160517_PL-131408-kvm-qemu10-pacific_scriv.md
@@ -1,0 +1,29 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+<!-- Impact means "when this change is rolled out, there
+     might be interruptions/downtimes/required actions/... that
+     IMPACT THE RUNNING APPLICATION NEGATIVELY.
+
+     Having new features or changed is not an "impact". That's what
+     the main changelog (see below) is for.
+     -->
+
+
+### NixOS XX.XX platform
+
+- roles/kvm: support Ceph Pacific and qemu-10.1 (PL-131408)
+
+  not yet enabled by default, will be manually rolled out location-wise

--- a/nixos/roles/kvm/default.nix
+++ b/nixos/roles/kvm/default.nix
@@ -194,12 +194,6 @@ in
           vm-expected-overhead = 512;
         };
 
-        # compatibility section, can be thrown out once fc.qemu has been updated
-        "qemu-throttle-by-pool" = {
-          "rbd.hdd" = 250;
-          "rbd.ssd" = 10000;
-        };
-
         "block-throttle-rbd.hdd" = {
           iops = 250;
           # 250 mib/s

--- a/nixos/roles/kvm/default.nix
+++ b/nixos/roles/kvm/default.nix
@@ -165,8 +165,8 @@ in
       ''
         [qemu]
         accelerator = kvm
-        ; qemu 4.1 compatibility
-        machine-type = pc-i440fx-4.1
+        ; qemu 6.0 compatibility
+        machine-type = pc-i440fx-6.0
         vhost = true
         ; The 127.0.0.1 is important. Turning this to "localhost" confuses Qemu's
         ; VNC ACL because it gets mixed up with ::1.
@@ -177,8 +177,8 @@ in
         migration-ctl-address = ${migration_ctl_address}:0
         migration-bandwidth = ${toString cfg.migrationBandwidth}
         max-downtime = 4.0
-        ; generation 2 = #23965 upgrade to 2.7 due to security issues
-        binary-generation = 2
+        ; generation 3 = #PL-135374 in preparation for qemu-10.1 upgrade
+        binary-generation = 3
         vm-max-total-memory = ${toString enc.parameters.kvm_net_memory}
         vm-expected-overhead = 512
 

--- a/nixos/roles/kvm/default.nix
+++ b/nixos/roles/kvm/default.nix
@@ -15,6 +15,8 @@ let
 
   cephPkgs = fclib.ceph.mkPkgs cfg.cephRelease;
 
+  fcQemuConfFormat = pkgs.formats.ini { };
+
   # virtual ipv4 gateway address selected by 254-169=85, with each
   # octet +85 mod 256 the preceding octet
   virtualGatewayV4 = "169.254.83.168";
@@ -101,6 +103,17 @@ in
                     If VMs are remaining after this time, the maintenance fails temporarily.'';
       };
 
+      settings = lib.mkOption {
+        type = lib.types.submodule {
+          freeformType = fcQemuConfFormat.type;
+        };
+        description = ''
+          fc-qemu configuration as a structured attrset.
+          Populated with sensible default platform values, but certain settings
+          may be fine-grained overriden here, i.e. for tests.
+        '';
+      };
+
     };
   };
 
@@ -150,7 +163,7 @@ in
     environment.etc."iproute2/rt_protos.d/fc-qemu.conf".source =
       "${cfg.package}/share/iproute2/rt_protos";
 
-    environment.etc."qemu/fc-qemu.conf".text =
+    flyingcircus.roles.kvm_host.settings =
       let
         hostname = config.networking.hostName;
         migration_address = fclib.fqdn {
@@ -162,62 +175,69 @@ in
           domain = "gocept.net";
         };
       in
-      ''
-        [qemu]
-        accelerator = kvm
-        ; qemu 6.0 compatibility
-        machine-type = pc-i440fx-6.0
-        vhost = true
-        ; The 127.0.0.1 is important. Turning this to "localhost" confuses Qemu's
-        ; VNC ACL because it gets mixed up with ::1.
-        vnc = 127.0.0.1:{id}
-        timeout-graceful = 120
-        maintenance-evacuation-timeout = ${toString cfg.maintenanceEvacuationTimeout}
-        migration-address = tcp:${migration_address}:{id}
-        migration-ctl-address = ${migration_ctl_address}:0
-        migration-bandwidth = ${toString cfg.migrationBandwidth}
-        max-downtime = 4.0
-        ; generation 3 = #PL-135374 in preparation for qemu-10.1 upgrade
-        binary-generation = 3
-        vm-max-total-memory = ${toString enc.parameters.kvm_net_memory}
-        vm-expected-overhead = 512
+      {
+        qemu = {
+          accelerator = "kvm";
+          machine-type = "pc-i440fx-6.0";
+          vhost = true;
+          # The 127.0.0.1 is important. Turning this to "localhost" confuses
+          # Qemu's VNC ACL because it gets mixed up with ::1.
+          vnc = "127.0.0.1:{id}";
+          timeout-graceful = 120;
+          maintenance-evacuation-timeout = cfg.maintenanceEvacuationTimeout;
+          migration-address = "tcp:${migration_address}:{id}";
+          migration-ctl-address = "${migration_ctl_address}:0";
+          migration-bandwidth = cfg.migrationBandwidth;
+          max-downtime = "4.0";
+          binary-generation = 3;
+          vm-max-total-memory = enc.parameters.kvm_net_memory;
+          vm-expected-overhead = 512;
+        };
 
-        [qemu-throttle-by-pool]
-        ; compatibility section, can be thrown out once fc.qemu has been updated
-        rbd.hdd = 250
-        rbd.ssd = 10000
+        # compatibility section, can be thrown out once fc.qemu has been updated
+        "qemu-throttle-by-pool" = {
+          "rbd.hdd" = 250;
+          "rbd.ssd" = 10000;
+        };
 
-        [block-throttle-rbd.hdd]
-        iops = 250
-        ; 250 mib/s
-        bps = 262144000
-        burst-factor = 10
+        "block-throttle-rbd.hdd" = {
+          iops = 250;
+          # 250 mib/s
+          bps = 262144000;
+          burst-factor = 10;
+        };
 
-        [block-throttle-rbd.ssd]
-        iops = 10000
-        ; 500 mib/s
-        bps = 524288000
-        burst-factor = 2
+        "block-throttle-rbd.ssd" = {
+          iops = 10000;
+          # 500 mib/s
+          bps = 524288000;
+          burst-factor = 2;
+        };
 
-        [network]
-        tap-ifup-bridge = /etc/kvm/kvm-ifup
-        tap-ifdown-bridge = /etc/kvm/kvm-ifdown
-        tap-ifup-vrf = /etc/kvm/kvm-ifup-vrf
-        tap-ifdown-vrf = /etc/kvm/kvm-ifdown-vrf
+        network = {
+          tap-ifup-bridge = "/etc/kvm/kvm-ifup";
+          tap-ifdown-bridge = "/etc/kvm/kvm-ifdown";
+          tap-ifup-vrf = "/etc/kvm/kvm-ifup-vrf";
+          tap-ifdown-vrf = "/etc/kvm/kvm-ifdown-vrf";
+        };
 
-        [consul]
-        access-token = ${enc.parameters.secrets."consul/master_token"}
-        event-threads = 10
+        consul = {
+          access-token = enc.parameters.secrets."consul/master_token";
+          event-threads = 10;
+        };
 
-        [ceph]
-        client-id = ${hostname}
-        cluster = ceph
-        lock_host = ${hostname}
-        create-vm = ${pkgs.fc.agent}/bin/fc-create-vm -I {name}
-      ''
-      + lib.optionalString (cfg.mkfsXfsFlags != null) ''
-        mkfs-xfs = ${cfg.mkfsXfsFlags}
-      '';
+        ceph = {
+          client-id = hostname;
+          cluster = "ceph";
+          lock_host = hostname;
+          create-vm = "${pkgs.fc.agent}/bin/fc-create-vm -I {name}";
+        }
+        // lib.optionalAttrs (cfg.mkfsXfsFlags != null) {
+          mkfs-xfs = cfg.mkfsXfsFlags;
+        };
+      };
+
+    environment.etc."qemu/fc-qemu.conf".source = fcQemuConfFormat.generate "fc-qemu.conf" cfg.settings;
 
     # This needs to stay as is because the path is kept alive during live
     # migration.

--- a/pkgs/fc/default.nix
+++ b/pkgs/fc/default.nix
@@ -68,19 +68,19 @@ rec {
   };
 
   qemu-pacific = callPackage ./qemu rec {
-    version = "1.7dev";
+    version = "1.8dev";
     src = pkgs.fetchFromGitHub {
       owner = "flyingcircusio";
       repo = "fc.qemu";
       # The release tooling didn't upgrade properly so we had to pick a specific
       # commit instead.
-      rev = "256964f932353a4c5375d709445afecc8f48aaaf";
-      hash = "sha256-ydEJlzio8ixFRqZEaDEwDkJFZYQ9RJ6DQhRJwTG+zik";
+      rev = "850a43bccbd4f586ba11e6c6326d6f7f1dd1126b";
+      hash = "sha256-gUC4+AydcZ/BkUqaX1/rKoOLk0G0lm63hHdj/zOYwD4=";
     };
     fc-ceph = ceph;
     qemu_ceph = pkgs.qemu-ceph-pacific;
     ceph_client = pkgs.ceph-pacific.ceph-client;
-    python3Packages = pkgs.python311Packages;
+    python3Packages = pkgs.python313Packages;
   };
 
   # Enable this temporarily during development, but DO NOT commit this as

--- a/pkgs/fc/qemu/default.nix
+++ b/pkgs/fc/qemu/default.nix
@@ -77,7 +77,6 @@ py.buildPythonPackage rec {
     util-linux
     xfsprogs
     py.requests
-    py.future
     py.colorama
     py.structlog
     py_consulate

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -71,10 +71,10 @@ in
     clientCephRelease = "nautilus";
     serverCephRelease = "pacific";
   };
-  #kvm_host_ceph-pacific-pacific = callTest ./kvm_host_ceph-nautilus.nix {
-  #  clientCephRelease = "pacific";
-  #  serverCephRelease = "pacific";
-  #};
+  kvm_host_ceph-pacific-pacific = callTest ./kvm_host_ceph-nautilus.nix {
+    clientCephRelease = "pacific";
+    serverCephRelease = "pacific";
+  };
   lampVm = callTest ./lamp/vm-test.nix { };
   lampVm72 = callTest ./lamp/vm-test.nix { version = "lamp_php72"; };
   lampVm73 = callTest ./lamp/vm-test.nix { version = "lamp_php73"; };

--- a/tests/kvm_host_ceph-nautilus.nix
+++ b/tests/kvm_host_ceph-nautilus.nix
@@ -63,6 +63,11 @@ import ./make-test-python.nix (
         flyingcircus.static.mtus.sto = 1500;
         flyingcircus.static.mtus.stb = 1500;
 
+        # Override some fc-qemu.conf values to match the values expected by tests
+        flyingcircus.roles.kvm_host.settings = {
+          qemu.binary-generation = lib.mkForce 2;
+        };
+
         systemd.timers.fc-ceph-load-vm-images.enable = lib.mkForce false;
         systemd.timers.fc-ceph-mon-update-client-keys.enable = lib.mkForce false;
         systemd.timers.fc-ceph-clean-deleted-vms.enable = lib.mkForce false;


### PR DESCRIPTION
@flyingcircusio/release-managers

## Release process

This change should be backported:

- [x] Created changelog entry using `./changelog.sh`
- [x] Add `backport release-26.05` label
pgrade.md`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [x] ensure all checks are green
- [x] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
  - feature-gated behind `flyingcircus.roles.kvm_host.cephRelease`
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [x] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - feature-gating shall work, rollout of the PR itself does not break qemu-6.0 + ceph-client nautilus hosts
  - test suite needs to adapt to qemu changes
- [x] Security requirements tested? (EVIDENCE)
  - [x] re-enabled `kvm_host_ceph-pacific-pacific` test, it passes
  - [x] verified feature-gating on dev cluster host
