### PR TITLE
fc-ceph/maintenance: clean up deprecated migration code

### DIFF
--- a/pkgs/fc/ceph/src/fc/ceph/maintenance/nautilus.py
+++ b/pkgs/fc/ceph/src/fc/ceph/maintenance/nautilus.py
@@ -124,26 +124,22 @@ class VolumeDeletions(object):
         return status_code
 
 
-def get_host_crush_buckets() -> tuple[set[str], set[str]]:
-    """Return  the names of the crush buckets that correspond with the
-    host entries of this host as well as their associated OSD IDs.
-    """
+def get_host_osds() -> set[str]:
+    """Return the OSD IDs assigned to crush entries of this host."""
     hostname = socket.gethostname()
     osd_tree = run.json.ceph("osd", "tree")
 
     osds: set[str] = set()
 
     # Find the host entries in the crush map associated with this host
-    host_map_entries = set()
     for node in osd_tree["nodes"]:
         if node["type"] != "host":
             continue
         if node["name"].split("-")[0] != hostname:
             continue
-        host_map_entries.add(node["name"])
         osds.update(map(str, node["children"]))
 
-    return host_map_entries, osds
+    return osds
 
 
 def filter_noup_osds(osd_ids: set[str]) -> set[str]:
@@ -278,7 +274,7 @@ class MaintenanceTasks(object):
         # Prohibit OSD traffic by marking them down and flagging them to
         # not automatically return.
         try:
-            host_buckets, osd_ids = get_host_crush_buckets()
+            osd_ids = get_host_osds()
             if osd_ids:
                 run.ceph("osd", "set-group", "noup", *sorted(osd_ids))
                 run.ceph("osd", "down", *sorted(osd_ids))
@@ -287,11 +283,7 @@ class MaintenanceTasks(object):
             sys.exit(75)  # EXIT_TEMPFAIL, fc-agent might retry
 
     def leave(self):
-        host_buckets, osd_ids = get_host_crush_buckets()
-        if host_buckets:
-            # PL-133952: still needed for getting hosts upgrading from the
-            # previous mechanism out of maintenance. Remove later.
-            run.ceph("osd", "unset-group", "noup", *sorted(host_buckets))
+        osd_ids = get_host_osds()
 
         for osd_id in sorted(filter_noup_osds(osd_ids)):
             # remove noup flags in a staggered fashion, to reduce peering storm

--- a/pkgs/fc/ceph/src/fc/ceph/tests/fc-ceph/test_maintenance.py
+++ b/pkgs/fc/ceph/src/fc/ceph/tests/fc-ceph/test_maintenance.py
@@ -118,16 +118,13 @@ def test_successful_maintenance_cycle(
     maintenance_task.leave()
 
     assert ceph_json_calls.call_count == 4
-    assert ceph_calls.call_count == 6
+    assert ceph_calls.call_count == 5
     assert locktoolcalls.call_count == 4
 
     ceph_calls.assert_has_calls(
         [
             mock.call("osd", "set-group", "noup", "13", "14", "27"),
             mock.call("osd", "down", "13", "14", "27"),
-            mock.call(
-                "osd", "unset-group", "noup", "localhost", "localhost-ssd"
-            ),
             mock.call("osd", "unset-group", "noup", "13"),
             mock.call("osd", "unset-group", "noup", "14"),
             mock.call("osd", "unset-group", "noup", "27"),


### PR DESCRIPTION
Remove the code that was still there to allow transition from the previous non-staggered maintenance leave mechanism.

PL-133952

@flyingcircusio/release-managers

## Release process

This change should be backported:

- [ ] Created changelog entry using `./changelog.sh`
  - no, internal cleanup
- [ ] Add `backport release-26.05` label

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [x] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [x] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - adjust unit tests
  - works in actual development cluster
  - clean up legacy transition code
- [x] Security requirements tested? (EVIDENCE)
  - [x] successfully tested in dev cluster
  - [x] tests pass
