### PR TITLE
webproxy: fix vinyl-cache-http sensu check

### DIFF
--- a/nixos/roles/check-varnish-cache-http.py
+++ b/nixos/roles/check-varnish-cache-http.py
@@ -4,7 +4,7 @@ import sys
 ports = []
 
 for line in (
-    subprocess.check_output(["vinyladm", "debug.listen_address"])
+    subprocess.check_output(["varnishadm", "debug.listen_address"])
     .decode("ascii")
     .splitlines()
 ):
@@ -15,7 +15,7 @@ for line in (
     ports.append((ip, port))
 
 if not ports:
-    print("No listen_address reported by vinyladm")
+    print("No listen_address reported by varnishadm")
     sys.exit(2)
 
 STATUS = 0

--- a/nixos/roles/webproxy.nix
+++ b/nixos/roles/webproxy.nix
@@ -81,7 +81,7 @@ in
         };
         varnish_http =
           let
-            check-varnish-http = pkgs.writers.writePython3BinFromFile ./check-vinyl-cache-http.py {
+            check-varnish-http = pkgs.writers.writePython3BinFromFile ./check-varnish-cache-http.py {
               dependencies = [
                 cfg.package
                 pkgs.monitoring-plugins

--- a/tests/webproxy-legacy.nix
+++ b/tests/webproxy-legacy.nix
@@ -157,73 +157,79 @@ import ./make-test-python.nix (
         };
     };
 
-    testScript = ''
-      start_all()
+    testScript =
+      { nodes, ... }:
+      ''
+        start_all()
 
-      webproxy.wait_for_unit("varnish.service")
-      webproxy.wait_for_unit("varnishncsa.service")
-      webproxy.wait_for_unit("helloserver.service")
-
-      url = 'http://localhost:${builtins.toString varnishport}/hello.txt'
-      curl = "curl -s " + url
-
-      webproxy.wait_until_succeeds(curl)
-
-      with subtest("request should return expected output"):
-          webproxy.wait_until_succeeds(f"{curl} | grep -q 'Hello World!'")
-
-      with subtest("varnishncsa should log requests"):
-          webproxy.wait_until_succeeds(f"{curl} && grep -q 'GET {url} HTTP/' /var/log/varnish.log")
-
-      with subtest("varnish pid should be the same across small configuration changes"):
-        old_pid = webproxy.succeed("systemctl show varnish.service --property MainPID --value")
-        old_port = webproxy.succeed("varnishadm vcl.show label-test | grep \"\\.port\" | cut -d \"\\\"\" -f 2")
-        webproxy.succeed("/run/current-system/specialisation/varnish-switch-test/bin/switch-to-configuration switch")
-        new_pid = webproxy.succeed("systemctl show varnish.service --property MainPID --value")
-        new_port = webproxy.succeed("varnishadm vcl.show label-test | grep \"\\.port\" | cut -d \"\\\"\" -f 2")
-
-        assert old_pid == new_pid, f"pid is different: {old_pid} != {new_pid}"
-        assert old_port != new_port, f"port is identical: {old_port} == {new_port}"
-
-      with subtest("old varnish config should work before and after reload"):
-        webproxy_old_varnish.wait_for_unit("varnish.service")
-        webproxy_old_varnish.wait_for_unit("helloserver.service")
-        webproxy_old_varnish.wait_until_succeeds(f"{curl} | grep -q 'Hello World!'")
-        webproxy_old_varnish.systemctl("reload varnish")
-        webproxy_old_varnish.wait_until_succeeds(f"{curl} | grep -q 'Hello World!'")
-
-      with subtest("varnish reloads with cold vcl and the cold vcl is discarded"):
-        webproxy.succeed("varnishadm vcl.list | grep \"0 boot\"")
-        webproxy.succeed("varnishadm vcl.state boot cold")
-        webproxy.systemctl("reload varnish")
-        webproxy.fail("varnishadm vcl.list | grep cold")
-
-      with subtest("varnish reloads with multiple cold vcls and the cold vcls are discarded"):
-        webproxy.systemctl("restart varnish")
-        webproxy.succeed("varnishadm vcl.list | grep \"0 boot\"")
-        webproxy.succeed("varnishadm vcl.state boot cold")
-        webproxy.succeed("varnishadm vcl.load another_cold_vcl ${cold_testvcl} cold")
-        webproxy.systemctl("reload varnish")
-        webproxy.fail("varnishadm vcl.list | grep \" cold \"")
-
-      with subtest("varnish with broken config should fail to switch"):
-        # switching to a different specialisation requires a reboot, otherwise `/run/current-system/specialisation/` is empty
-        # reboot is broken since it doesn't set `booted = False` and the VM will not boot with `booted = True`
-        webproxy.shutdown()
-        webproxy.start()
         webproxy.wait_for_unit("varnish.service")
-        webproxy.fail("/run/current-system/specialisation/varnish-broken-config-test/bin/switch-to-configuration switch")
+        webproxy.wait_for_unit("varnishncsa.service")
+        webproxy.wait_for_unit("helloserver.service")
 
-      with subtest("fallback configuration for varnish works if the other conditions don't match"):
-        # verify that requests with the "Test" host header are being handled by the explicitly defined varnish backend
-        # while others are handled by the fallback backend
-        # the fallback configuration points at a working http server that serves a hello.txt while the other
-        # (explicitly configured) backend which is selected when adding the "Test" host header doesn't serve anything
-        webproxy_mixed_config.wait_for_unit("varnish.service")
-        webproxy_mixed_config.succeed("varnishadm vcl.list | grep \"localhost\"")
-        webproxy_mixed_config.succeed("varnishadm vcl.show")
-        webproxy_mixed_config.fail(f"curl --fail -H 'Host: Test' 127.0.0.1:8008/hello.txt")
-        webproxy_mixed_config.succeed(f"curl --fail 127.0.0.1:8008/hello.txt")
-    '';
+        url = 'http://localhost:${builtins.toString varnishport}/hello.txt'
+        curl = "curl -s " + url
+
+        webproxy.wait_until_succeeds(curl)
+
+        with subtest("request should return expected output"):
+            webproxy.wait_until_succeeds(f"{curl} | grep -q 'Hello World!'")
+
+        with subtest("varnishncsa should log requests"):
+            webproxy.wait_until_succeeds(f"{curl} && grep -q 'GET {url} HTTP/' /var/log/varnish.log")
+
+        with subtest("sensu checks should be successful"):
+            webproxy.succeed("${nodes.webproxy.flyingcircus.services.sensu-client.checks.varnish_http.command}")
+            webproxy.succeed("${nodes.webproxy.flyingcircus.services.sensu-client.checks.varnish_status.command}")
+
+        with subtest("varnish pid should be the same across small configuration changes"):
+          old_pid = webproxy.succeed("systemctl show varnish.service --property MainPID --value")
+          old_port = webproxy.succeed("varnishadm vcl.show label-test | grep \"\\.port\" | cut -d \"\\\"\" -f 2")
+          webproxy.succeed("/run/current-system/specialisation/varnish-switch-test/bin/switch-to-configuration switch")
+          new_pid = webproxy.succeed("systemctl show varnish.service --property MainPID --value")
+          new_port = webproxy.succeed("varnishadm vcl.show label-test | grep \"\\.port\" | cut -d \"\\\"\" -f 2")
+
+          assert old_pid == new_pid, f"pid is different: {old_pid} != {new_pid}"
+          assert old_port != new_port, f"port is identical: {old_port} == {new_port}"
+
+        with subtest("old varnish config should work before and after reload"):
+          webproxy_old_varnish.wait_for_unit("varnish.service")
+          webproxy_old_varnish.wait_for_unit("helloserver.service")
+          webproxy_old_varnish.wait_until_succeeds(f"{curl} | grep -q 'Hello World!'")
+          webproxy_old_varnish.systemctl("reload varnish")
+          webproxy_old_varnish.wait_until_succeeds(f"{curl} | grep -q 'Hello World!'")
+
+        with subtest("varnish reloads with cold vcl and the cold vcl is discarded"):
+          webproxy.succeed("varnishadm vcl.list | grep \"0 boot\"")
+          webproxy.succeed("varnishadm vcl.state boot cold")
+          webproxy.systemctl("reload varnish")
+          webproxy.fail("varnishadm vcl.list | grep cold")
+
+        with subtest("varnish reloads with multiple cold vcls and the cold vcls are discarded"):
+          webproxy.systemctl("restart varnish")
+          webproxy.succeed("varnishadm vcl.list | grep \"0 boot\"")
+          webproxy.succeed("varnishadm vcl.state boot cold")
+          webproxy.succeed("varnishadm vcl.load another_cold_vcl ${cold_testvcl} cold")
+          webproxy.systemctl("reload varnish")
+          webproxy.fail("varnishadm vcl.list | grep \" cold \"")
+
+        with subtest("varnish with broken config should fail to switch"):
+          # switching to a different specialisation requires a reboot, otherwise `/run/current-system/specialisation/` is empty
+          # reboot is broken since it doesn't set `booted = False` and the VM will not boot with `booted = True`
+          webproxy.shutdown()
+          webproxy.start()
+          webproxy.wait_for_unit("varnish.service")
+          webproxy.fail("/run/current-system/specialisation/varnish-broken-config-test/bin/switch-to-configuration switch")
+
+        with subtest("fallback configuration for varnish works if the other conditions don't match"):
+          # verify that requests with the "Test" host header are being handled by the explicitly defined varnish backend
+          # while others are handled by the fallback backend
+          # the fallback configuration points at a working http server that serves a hello.txt while the other
+          # (explicitly configured) backend which is selected when adding the "Test" host header doesn't serve anything
+          webproxy_mixed_config.wait_for_unit("varnish.service")
+          webproxy_mixed_config.succeed("varnishadm vcl.list | grep \"localhost\"")
+          webproxy_mixed_config.succeed("varnishadm vcl.show")
+          webproxy_mixed_config.fail(f"curl --fail -H 'Host: Test' 127.0.0.1:8008/hello.txt")
+          webproxy_mixed_config.succeed(f"curl --fail 127.0.0.1:8008/hello.txt")
+      '';
   }
 )

--- a/tests/webproxy.nix
+++ b/tests/webproxy.nix
@@ -214,88 +214,94 @@ import ./make-test-python.nix (
         };
     };
 
-    testScript = ''
-      start_all()
+    testScript =
+      { nodes, ... }:
+      ''
+        start_all()
 
-      webproxy.wait_for_unit("vinyl-cache.service")
-      webproxy.wait_for_unit("vinylncsa.service")
-      webproxy.wait_for_unit("helloserver.service")
-
-      url = 'http://localhost:${builtins.toString vinylport}/hello.txt'
-      curl = "curl -s " + url
-
-      webproxy.wait_until_succeeds(curl)
-
-      with subtest("request should return expected output"):
-          webproxy.wait_until_succeeds(f"{curl} | grep -q 'Hello World!'")
-
-      with subtest("vinylncsa should log requests"):
-          webproxy.wait_until_succeeds(f"{curl} && grep -q 'GET {url} HTTP/' /var/log/vinyl-cache/vinyl-cache.log")
-
-      with subtest("vinyl pid should be the same across small configuration changes"):
-        old_pid = webproxy.succeed("systemctl show vinyl-cache.service --property MainPID --value")
-        old_port = webproxy.succeed("vinyladm vcl.show label-test | grep \"\\.port\" | cut -d \"\\\"\" -f 2")
-        webproxy.succeed("/run/current-system/specialisation/vinyl-switch-test/bin/switch-to-configuration switch")
-        new_pid = webproxy.succeed("systemctl show vinyl-cache.service --property MainPID --value")
-        new_port = webproxy.succeed("vinyladm vcl.show label-test | grep \"\\.port\" | cut -d \"\\\"\" -f 2")
-
-        assert old_pid == new_pid, f"pid is different: {old_pid} != {new_pid}"
-        assert old_port != new_port, f"port is identical: {old_port} == {new_port}"
-
-      with subtest("old vinyl config should work before and after reload"):
-        webproxy_old_vinyl.wait_for_unit("vinyl-cache.service")
-        webproxy_old_vinyl.wait_for_unit("helloserver.service")
-        webproxy_old_vinyl.wait_until_succeeds(f"{curl} | grep -q 'Hello World!'")
-        webproxy_old_vinyl.systemctl("reload vinyl")
-        webproxy_old_vinyl.wait_until_succeeds(f"{curl} | grep -q 'Hello World!'")
-
-      with subtest("Vinyl should still support configuring via Varnish file"):
-        webproxy_config_varnish_namespace_file.wait_for_unit("vinyl-cache.service")
-        webproxy_config_varnish_namespace_file.wait_for_unit("helloserver.service")
-        webproxy_config_varnish_namespace_file.wait_until_succeeds(f"{curl} | grep -q 'Hello World!'")
-        webproxy_config_varnish_namespace_file.systemctl("reload vinyl")
-        webproxy_config_varnish_namespace_file.wait_until_succeeds(f"{curl} | grep -q 'Hello World!'")
-
-
-      with subtest("Vinyl should still support configuring via Varnish NixOS module"):
-        webproxy_config_varnish_namespace_module.wait_for_unit("vinyl-cache.service")
-        webproxy_config_varnish_namespace_module.wait_for_unit("helloserver.service")
-        webproxy_config_varnish_namespace_module.wait_until_succeeds(f"{curl} | grep -q 'Hello World!'")
-        webproxy_config_varnish_namespace_module.systemctl("reload vinyl")
-        webproxy_config_varnish_namespace_module.wait_until_succeeds(f"{curl} | grep -q 'Hello World!'")
-
-      with subtest("vinyl reloads with cold vcl and the cold vcl is discarded"):
-        webproxy.succeed("vinyladm vcl.list | grep \"0 boot\"")
-        webproxy.succeed("vinyladm vcl.state boot cold")
-        webproxy.systemctl("reload vinyl-cache")
-        webproxy.fail("vinyladm vcl.list | grep cold")
-
-      with subtest("vinyl reloads with multiple cold vcls and the cold vcls are discarded"):
-        webproxy.systemctl("restart vinyl-cache")
-        webproxy.succeed("vinyladm vcl.list | grep \"0 boot\"")
-        webproxy.succeed("vinyladm vcl.state boot cold")
-        webproxy.succeed("vinyladm vcl.load another_cold_vcl ${cold_testvcl} cold")
-        webproxy.systemctl("reload vinyl-cache")
-        webproxy.fail("vinyladm vcl.list | grep \" cold \"")
-
-      with subtest("vinyl with broken config should fail to switch"):
-        # switching to a different specialisation requires a reboot, otherwise `/run/current-system/specialisation/` is empty
-        # reboot is broken since it doesn't set `booted = False` and the VM will not boot with `booted = True`
-        webproxy.shutdown()
-        webproxy.start()
         webproxy.wait_for_unit("vinyl-cache.service")
-        webproxy.fail("/run/current-system/specialisation/vinyl-broken-config-test/bin/switch-to-configuration switch")
+        webproxy.wait_for_unit("vinylncsa.service")
+        webproxy.wait_for_unit("helloserver.service")
 
-      with subtest("fallback configuration for vinyl works if the other conditions don't match"):
-        # verify that requests with the "Test" host header are being handled by the explicitly defined vinyl backend
-        # while others are handled by the fallback backend
-        # the fallback configuration points at a working http server that serves a hello.txt while the other
-        # (explicitly configured) backend which is selected when adding the "Test" host header doesn't serve anything
-        webproxy_mixed_config.wait_for_unit("vinyl-cache.service")
-        webproxy_mixed_config.succeed("vinyladm vcl.list | grep \"localhost\"")
-        webproxy_mixed_config.succeed("vinyladm vcl.show")
-        webproxy_mixed_config.fail(f"curl --fail -H 'Host: Test' 127.0.0.1:8008/hello.txt")
-        webproxy_mixed_config.succeed(f"curl --fail 127.0.0.1:8008/hello.txt")
-    '';
+        url = 'http://localhost:${builtins.toString vinylport}/hello.txt'
+        curl = "curl -s " + url
+
+        webproxy.wait_until_succeeds(curl)
+
+        with subtest("request should return expected output"):
+            webproxy.wait_until_succeeds(f"{curl} | grep -q 'Hello World!'")
+
+        with subtest("vinylncsa should log requests"):
+            webproxy.wait_until_succeeds(f"{curl} && grep -q 'GET {url} HTTP/' /var/log/vinyl-cache/vinyl-cache.log")
+
+        with subtest("sensu checks should be successful"):
+            webproxy.succeed("${nodes.webproxy.flyingcircus.services.sensu-client.checks.vinyl_cache_http.command}")
+            webproxy.succeed("${nodes.webproxy.flyingcircus.services.sensu-client.checks.vinyl_cache_status.command}")
+
+        with subtest("vinyl pid should be the same across small configuration changes"):
+          old_pid = webproxy.succeed("systemctl show vinyl-cache.service --property MainPID --value")
+          old_port = webproxy.succeed("vinyladm vcl.show label-test | grep \"\\.port\" | cut -d \"\\\"\" -f 2")
+          webproxy.succeed("/run/current-system/specialisation/vinyl-switch-test/bin/switch-to-configuration switch")
+          new_pid = webproxy.succeed("systemctl show vinyl-cache.service --property MainPID --value")
+          new_port = webproxy.succeed("vinyladm vcl.show label-test | grep \"\\.port\" | cut -d \"\\\"\" -f 2")
+
+          assert old_pid == new_pid, f"pid is different: {old_pid} != {new_pid}"
+          assert old_port != new_port, f"port is identical: {old_port} == {new_port}"
+
+        with subtest("old vinyl config should work before and after reload"):
+          webproxy_old_vinyl.wait_for_unit("vinyl-cache.service")
+          webproxy_old_vinyl.wait_for_unit("helloserver.service")
+          webproxy_old_vinyl.wait_until_succeeds(f"{curl} | grep -q 'Hello World!'")
+          webproxy_old_vinyl.systemctl("reload vinyl")
+          webproxy_old_vinyl.wait_until_succeeds(f"{curl} | grep -q 'Hello World!'")
+
+        with subtest("Vinyl should still support configuring via Varnish file"):
+          webproxy_config_varnish_namespace_file.wait_for_unit("vinyl-cache.service")
+          webproxy_config_varnish_namespace_file.wait_for_unit("helloserver.service")
+          webproxy_config_varnish_namespace_file.wait_until_succeeds(f"{curl} | grep -q 'Hello World!'")
+          webproxy_config_varnish_namespace_file.systemctl("reload vinyl")
+          webproxy_config_varnish_namespace_file.wait_until_succeeds(f"{curl} | grep -q 'Hello World!'")
+
+
+        with subtest("Vinyl should still support configuring via Varnish NixOS module"):
+          webproxy_config_varnish_namespace_module.wait_for_unit("vinyl-cache.service")
+          webproxy_config_varnish_namespace_module.wait_for_unit("helloserver.service")
+          webproxy_config_varnish_namespace_module.wait_until_succeeds(f"{curl} | grep -q 'Hello World!'")
+          webproxy_config_varnish_namespace_module.systemctl("reload vinyl")
+          webproxy_config_varnish_namespace_module.wait_until_succeeds(f"{curl} | grep -q 'Hello World!'")
+
+        with subtest("vinyl reloads with cold vcl and the cold vcl is discarded"):
+          webproxy.succeed("vinyladm vcl.list | grep \"0 boot\"")
+          webproxy.succeed("vinyladm vcl.state boot cold")
+          webproxy.systemctl("reload vinyl-cache")
+          webproxy.fail("vinyladm vcl.list | grep cold")
+
+        with subtest("vinyl reloads with multiple cold vcls and the cold vcls are discarded"):
+          webproxy.systemctl("restart vinyl-cache")
+          webproxy.succeed("vinyladm vcl.list | grep \"0 boot\"")
+          webproxy.succeed("vinyladm vcl.state boot cold")
+          webproxy.succeed("vinyladm vcl.load another_cold_vcl ${cold_testvcl} cold")
+          webproxy.systemctl("reload vinyl-cache")
+          webproxy.fail("vinyladm vcl.list | grep \" cold \"")
+
+        with subtest("vinyl with broken config should fail to switch"):
+          # switching to a different specialisation requires a reboot, otherwise `/run/current-system/specialisation/` is empty
+          # reboot is broken since it doesn't set `booted = False` and the VM will not boot with `booted = True`
+          webproxy.shutdown()
+          webproxy.start()
+          webproxy.wait_for_unit("vinyl-cache.service")
+          webproxy.fail("/run/current-system/specialisation/vinyl-broken-config-test/bin/switch-to-configuration switch")
+
+        with subtest("fallback configuration for vinyl works if the other conditions don't match"):
+          # verify that requests with the "Test" host header are being handled by the explicitly defined vinyl backend
+          # while others are handled by the fallback backend
+          # the fallback configuration points at a working http server that serves a hello.txt while the other
+          # (explicitly configured) backend which is selected when adding the "Test" host header doesn't serve anything
+          webproxy_mixed_config.wait_for_unit("vinyl-cache.service")
+          webproxy_mixed_config.succeed("vinyladm vcl.list | grep \"localhost\"")
+          webproxy_mixed_config.succeed("vinyladm vcl.show")
+          webproxy_mixed_config.fail(f"curl --fail -H 'Host: Test' 127.0.0.1:8008/hello.txt")
+          webproxy_mixed_config.succeed(f"curl --fail 127.0.0.1:8008/hello.txt")
+      '';
   }
 )


### PR DESCRIPTION
PL-135368

@flyingcircusio/release-managers

## Release process

This change should be backported:

- [ ] Created changelog entry using `./changelog.sh`
- [ ] Add `backport release-25.11` label

This change should only reach this branch:

- [ ] Created changelog entry using `./changelog.sh`
or
- [ ] Add a upgrade node in `doc/upgrade.md`
  no: follow-up to broken change, not yet released
## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [x] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [x] Security requirements tested? (EVIDENCE)
  - checked vinyl case on VM
  - extended NixOS test for Vinyl and Varnish case