### PR TITLE
[26.05] roles/kvm: support qemu-10.1 on Ceph Pacific

### DIFF
--- a/changelog.d/20260520_160517_PL-131408-kvm-qemu10-pacific_scriv.md
+++ b/changelog.d/20260520_160517_PL-131408-kvm-qemu10-pacific_scriv.md
@@ -1,0 +1,29 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+<!-- Impact means "when this change is rolled out, there
+     might be interruptions/downtimes/required actions/... that
+     IMPACT THE RUNNING APPLICATION NEGATIVELY.
+
+     Having new features or changed is not an "impact". That's what
+     the main changelog (see below) is for.
+     -->
+
+
+### NixOS XX.XX platform
+
+- roles/kvm: support Ceph Pacific and qemu-10.1 (PL-131408)
+
+  not yet enabled by default, will be manually rolled out location-wise

--- a/pkgs/fc/default.nix
+++ b/pkgs/fc/default.nix
@@ -64,19 +64,19 @@ rec {
   };
 
   qemu-pacific = callPackage ./qemu rec {
-    version = "1.7dev";
+    version = "1.8dev";
     src = pkgs.fetchFromGitHub {
       owner = "flyingcircusio";
       repo = "fc.qemu";
       # The release tooling didn't upgrade properly so we had to pick a specific
       # commit instead.
-      rev = "256964f932353a4c5375d709445afecc8f48aaaf";
-      hash = "sha256-ydEJlzio8ixFRqZEaDEwDkJFZYQ9RJ6DQhRJwTG+zik";
+      rev = "7a79807d6235eff3933c91d4d4e20c8cc2552d67";
+      hash = "sha256-d+HqB3kfGRosE3tEH9b2jiASd3OUwmwNcA04zrw5oJc=";
     };
     fc-ceph = ceph;
     qemu_ceph = pkgs.qemu-ceph-pacific;
     ceph_client = pkgs.ceph-pacific.ceph-client;
-    python3Packages = pkgs.python311Packages;
+    python3Packages = pkgs.python313Packages;
   };
 
   # Enable this temporarily during development, but DO NOT commit this as

--- a/pkgs/fc/qemu/default.nix
+++ b/pkgs/fc/qemu/default.nix
@@ -77,7 +77,6 @@ py.buildPythonPackage rec {
     util-linux
     xfsprogs
     py.requests
-    py.future
     py.colorama
     py.structlog
     py_consulate

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -71,10 +71,10 @@ in
     clientCephRelease = "nautilus";
     serverCephRelease = "pacific";
   };
-  #kvm_host_ceph-pacific-pacific = callTest ./kvm_host_ceph-nautilus.nix {
-  #  clientCephRelease = "pacific";
-  #  serverCephRelease = "pacific";
-  #};
+  kvm_host_ceph-pacific-pacific = callTest ./kvm_host_ceph-nautilus.nix {
+    clientCephRelease = "pacific";
+    serverCephRelease = "pacific";
+  };
   lampVm = callTest ./lamp/vm-test.nix { };
   lampVm72 = callTest ./lamp/vm-test.nix { version = "lamp_php72"; };
   lampVm73 = callTest ./lamp/vm-test.nix { version = "lamp_php73"; };


### PR DESCRIPTION
Setting the `flyingcircus.roles.cephRelease = "pacific"` also updates qemu from 6.0 to 10.1.

Requires https://github.com/flyingcircusio/fc-nixos/pull/2351 to have taken effect for rollout.

PL-131408

Supersedes #2382 with some test fixes.

@flyingcircusio/release-managers

## Release process

This change should only reach this branch:

- internal changes

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [x] set urgency and risk labels
- [x] ensure the merge bot has determined a merge date
-->
- [x] ensure all checks are green
- [x] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [x] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - [x] differing migration log has no semantic difference for the actual migration behaviour
- [x] Security requirements tested? (EVIDENCE)
  - [x] tests pass
