### PR TITLE
k3s release notes for 26.05

### DIFF
--- a/doc/src/kubernetes.md
+++ b/doc/src/kubernetes.md
@@ -429,27 +429,35 @@ on your requirements there are a few more options available:
 
 ### IPv6 support
 
-By default, Kubernetes clusters in our environment are configured with
-single-stack IPv4-only networking. This means that pods are only assigned a single
-IPv4 address, and cannot access external IPv6-only hosts.
+By default, new Kubernetes clusters in our environment are configured with
+dual-stack networking enabled. This means that pods are assigned both an IPv4
+and an IPv6 address, and can access external hosts over both address families.
 
-However, we provide the option to enable dual-stack networking when the cluster is
-first created, so that pods can be assigned both IPv4 and IPv6
-addresses. Dual-stack networking can be enabled by setting the
-`flyingcircus.kubernetes.network.enableIPv6` NixOS option to `true` in the host
-configuration on each node in the cluster, **before** any k3s roles are added to
-the node.
+Dual-stack networking can be disabled when the cluster is first created by
+setting the `flyingcircus.kubernetes.network.enableIPv6` NixOS option to `false`
+in the host configuration in each node in the cluster before any k3s roles are
+assigned. In this case, pods will only receive a single IPv4 address. However,
+single-stack networking in Kubernetes is **not recommended**.
 
 :::{warning}
 It is not possible to change the value of the
 `flyingcircus.kubernetes.network.enableIPv6` option after the cluster is
-created. Changing this value after cluster creation (after the k3s daemon has been
-started for the first time) has the potential to irrecoverably break the cluster,
-and is explicitly not supported.
+created. Changing this value after cluster creation (after the k3s daemon has
+been started for the first time) has the potential to irrecoverably break the
+cluster, and is explicitly not supported.
 
-Migrating an existing cluster with single-stack networking to dual-stack
-networking requires the cluster to be destroyed and recreated.
+Changing between single-stack networking and dual-stack networking (and vice
+versa) requires the cluster to be destroyed and recreated.
 :::
+
+Note that clusters which were originally created on platfrom versions 25.11 and
+older do not have dual-stack networking enabled unless explicitly configured. As
+dual-stack networking is now enabled by default in 26.05 and later, care must be
+taken when adding new agent VM's to clusters upgraded from older versions, to
+ensure that the networking configuration is consistent across the entire
+cluster. In this case, it's recommended to explicitly set the
+`flyingcircus.kubernetes.network.enableIPv6` option on all the cluster VM's to
+match the configuration with which the cluster was originally created.
 
 ## Storage
 

--- a/doc/src/kubernetes.md
+++ b/doc/src/kubernetes.md
@@ -427,6 +427,8 @@ on your requirements there are a few more options available:
 }
 ```
 
+(nixos-k3s-ipv6)=
+
 ### IPv6 support
 
 By default, new Kubernetes clusters in our environment are configured with
@@ -502,6 +504,7 @@ Outside of upgrade scenarios, all nodes in the cluster should be running the
 same version of k3s.
 :::
 
+(nixos-k3s-update-versions)=
 
 ### Updating k3s
 

--- a/doc/src/upgrade.md
+++ b/doc/src/upgrade.md
@@ -28,6 +28,7 @@ Contact our [support](/platform/index.html#support) for upgrade assistance.
   - {ref}`opensearch <nixos-upgrade-opensearch>`
   - {ref}`slurm <nixos-upgrade-slurm>`
   - {ref}`webproxy <nixos-upgrade-webproxy>`
+  - {ref}`k3s <nixos-upgrade-k3s>`
 - Removed significant packages:
   - `python310`
   - `k3s_1_32`
@@ -499,13 +500,30 @@ We support this migration with NixOS warnings, which you can review using the co
 After migrating to fc-nixos 26.05, this command will highlight any deprecated behaviour and
 suggest migration paths tailored to the VMs' specific situation.
 
+(nixos-upgrade-k3s)=
+
+### k3s
+
+The default network configuration for new Kubernetes clusters has changed, and
+dual-stack networking is now enabled by default. Existing clusters are not
+affected by this change, so the existing configuration will be preserved when
+upgrading to 26.05.
+
+However, adding new agent VM's to clusters upgraded from older platform versions
+may require extra configuration due to the change in defaults. See the
+{ref}`role documentation <nixos-k3s-ipv6>` for IPv6 support in k3s for further
+information.
+
+The default `k3s` package has also been bumped to 1.33. Existing clusters may
+need to be updated to this version before upgrading cluster VM's to the 26.05
+platform. See the role documentation for {ref}`cluster version updates
+<nixos-k3s-update-versions>`.
+
 ## Other notable changes
 
 - The `imagemagick6` family of packages has known vulnerabilities and has been removed. Please upgrade to `imagemagick`, which is version 7.
 
 - The sensu `swap` checks have been removed, as they are no longer relevant with systemd-oomd, which we introduced in fc-nixos 25.11
-
-- The default `k3s` package has been bumped to 1.33
 
 - `services.dovecot2.extraConfig` was removed. Migrate configuration to `services.dovecot2.settings`.
 

--- a/release/important_packages.json
+++ b/release/important_packages.json
@@ -77,6 +77,8 @@
   "k3s",
   "k3s_1_33",
   "k3s_1_34",
+  "k3s_1_35",
+  "k3s_1_36",
   "keycloak",
   "kubernetes-helm",
   "libffi",

--- a/release/package-versions.json
+++ b/release/package-versions.json
@@ -384,6 +384,16 @@
     "pname": "k3s",
     "version": "1.34.7+k3s1"
   },
+  "k3s_1_35": {
+    "name": "k3s-1.35.4+k3s1",
+    "pname": "k3s",
+    "version": "1.35.4+k3s1"
+  },
+  "k3s_1_36": {
+    "name": "k3s-1.36.0+k3s1",
+    "pname": "k3s",
+    "version": "1.36.0+k3s1"
+  },
   "keycloak": {
     "name": "keycloak-26.6.2",
     "pname": "keycloak",


### PR DESCRIPTION
This change adds release notes for the k3s roles in 26.05, including the change in defaults for dual stack networking which affect new clusters.

I've additionally added newer k3s versions available in 26.05 to the important packages.

PL-135129

@flyingcircusio/release-managers

## Release process

This change should be backported:

- [ ] Created changelog entry using `./changelog.sh`
- [ ] Add `backport release-25.11` label

This change should only reach this branch:

- [ ] Created changelog entry using `./changelog.sh`
or
- [x] Add a upgrade node in `doc/upgrade.md`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [x] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Prevent users from breaking their k3s clusters due to interactions between defaults derived from different NixOS stateVersions.
- [x] Security requirements tested? (EVIDENCE)
  - Release notes.