### PR TITLE
agent: fix fc-postgresql upgrade to 18 without --upgrade-now

### DIFF
--- a/changelog.d/20260528_102756_HEAD_scriv.md
+++ b/changelog.d/20260528_102756_HEAD_scriv.md
@@ -1,0 +1,29 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+<!-- Impact means "when this change is rolled out, there
+     might be interruptions/downtimes/required actions/... that
+     IMPACT THE RUNNING APPLICATION NEGATIVELY.
+
+     Having new features or changed is not an "impact". That's what
+     the main changelog (see below) is for.
+     -->
+
+- A bullet item for the Impact category.
+
+
+### NixOS XX.XX platform
+
+- agent: fix fc-postgresql upgrade to 18 without --upgrade-now (FC-54426)

--- a/pkgs/fc/agent/src/fc/manage/postgresql.py
+++ b/pkgs/fc/agent/src/fc/manage/postgresql.py
@@ -233,24 +233,21 @@ def upgrade(
     if upgrade_now:
         stop_pg(log, old_data_dir, stop)
 
-        # PostgreSQL 18 requires checksums to be enabled.
-        if int(new_version) >= 18:
-            old_version = fc.util.postgresql.get_pg_version_from_data_dir(
-                log, old_data_dir
-            )
-            old_bin_dir = fc.util.postgresql.build_pg_bin_dir(
-                log, context.pg_data_root, old_version, False, extension_names
-            )
-            fc.util.postgresql.run_pg_checksums_enable(
-                log, old_bin_dir, old_data_dir
-            )
-
         fc.util.postgresql.run_pg_upgrade(
             log,
             new_bin_dir,
             new_data_dir,
             old_data_dir,
         )
+
+        # PostgreSQL 18 typically has data checksums enabled by default.
+        # We run initdb on the new cluster without data checksums, so that
+        # pg_upgrade --check runs successfully. Therefore, enable checksums
+        # after that to get to the desired state.
+        if int(new_version) >= 18:
+            fc.util.postgresql.run_pg_checksums_enable(
+                log, new_bin_dir, new_data_dir
+            )
 
         current_pgdata = fc.util.postgresql.get_current_pgdata_from_service()
 

--- a/pkgs/fc/agent/src/fc/manage/tests/test_postgresql.py
+++ b/pkgs/fc/agent/src/fc/manage/tests/test_postgresql.py
@@ -63,7 +63,6 @@ def test_invoke_list_versions(invoke_app, monkeypatch, tmp_path):
     result = invoke_app("list-versions")
     print(result.output)
 
-
 @patch("fc.util.postgresql.run_pg_upgrade")
 @patch("fc.util.postgresql.run_pg_upgrade_check")
 @patch("fc.util.postgresql.prepare_upgrade")
@@ -81,6 +80,29 @@ def test_invoke_upgrade(
     run_pg_upgrade_check.assert_called()
     # Make sure we don't run destructive things by default.
     run_pg_upgrade.assert_not_called()
+
+
+
+@patch("fc.util.postgresql.run_pg_checksums_enable")
+@patch("fc.util.postgresql.run_pg_upgrade")
+@patch("fc.util.postgresql.run_pg_upgrade_check")
+@patch("fc.util.postgresql.prepare_upgrade")
+@patch("fc.util.postgresql.build_pg_bin_dir")
+def test_invoke_upgrade_18(
+    build_pg_bin_dir: Mock,
+    prepare_upgrade: Mock,
+    run_pg_upgrade_check: Mock,
+    run_pg_upgrade: Mock,
+    run_pg_checksums_enable: Mock,
+    invoke_app,
+):
+    invoke_app("upgrade", "--new-version", "18")
+    build_pg_bin_dir.assert_called()
+    prepare_upgrade.assert_called()
+    run_pg_upgrade_check.assert_called()
+    # Make sure we don't run destructive things by default.
+    run_pg_upgrade.assert_not_called()
+    run_pg_checksums_enable.assert_not_called()
 
 
 @patch("fc.util.postgresql.get_current_pgdata_from_service")

--- a/pkgs/fc/agent/src/fc/util/postgresql.py
+++ b/pkgs/fc/agent/src/fc/util/postgresql.py
@@ -172,6 +172,7 @@ def create_new_data_dir(
     log,
     collate,
     ctype,
+    new_version: PGVersion,
     new_bin_dir,
     new_data_dir,
     old_data_dir,
@@ -194,6 +195,15 @@ def create_new_data_dir(
         "--lc-ctype",
         ctype,
     ]
+
+    # PostgreSQL 18 has data checksums on per default. When initrd runs
+    # with data checksums enabled, pg_upgrade --check fails. So initrd
+    # the new cluster without and enable checksums after the upgrade happened.
+    if int(new_version) >= 18 and not has_cluster_checksums(
+        log, old_data_dir / "package/bin", old_data_dir
+    ):
+        initdb_cmd.append("--no-data-checksums")
+
     initdb_cmd_str = " ".join(str(e) for e in initdb_cmd)
     log.debug("upgrade-initdb-cmd", cmd=initdb_cmd_str)
     try:
@@ -402,6 +412,7 @@ def prepare_upgrade(
             log,
             collate,
             ctype,
+            new_version,
             new_bin_dir,
             new_data_dir,
             old_data_dir,
@@ -521,32 +532,39 @@ def retrieve_shared_preload_libraries_setting(
                     return line.split("=")[1].strip()
 
 
-def check_if_checksums_need_to_be_enabled(
-    log, old_bin_dir: Path, old_data_dir: Path
-) -> bool:
+def has_cluster_checksums(log, bin_dir: Path, data_dir: Path) -> bool:
     log.info("check-checksums")
     cmd = run_as_postgres(
-        [old_bin_dir / "pg_checksums", "-D", old_data_dir, "--check"],
+        [bin_dir / "pg_controldata", "-D", data_dir],
         capture_output=True,
     )
-    if cmd.returncode == 0:
-        return False
-    if "data checksums are not enabled in cluster" in cmd.stderr:
-        return True
+    for line in cmd.stdout.splitlines():
+        stripped_line = line.strip()
+        if stripped_line.startswith("Data page checksum version:"):
+            try:
+                checksum_version = int(
+                    stripped_line.split("Data page checksum version:")[
+                        1
+                    ].strip()
+                )
+            except ValueError:
+                break
+            if checksum_version == 0:
+                return False
+            else:
+                return True
     log.error("check-checksums-failed", stdout=cmd.stdout, stderr=cmd.stderr)
     raise RuntimeError("check-checksums: unclear state")
 
 
-def run_pg_checksums_enable(log, old_bin_dir: Path, old_data_dir: Path):
-    if not check_if_checksums_need_to_be_enabled(
-        log, old_bin_dir, old_data_dir
-    ):
-        log.debug("enable-checksums-skipped")
+def run_pg_checksums_enable(log, bin_dir: Path, data_dir: Path):
+    if has_cluster_checksums(log, bin_dir, data_dir):
+        log.debug("enable-checksums-no-op")
         return
     log.info("enable-checksums")
     try:
         run_as_postgres(
-            [old_bin_dir / "pg_checksums", "-D", old_data_dir, "--enable"],
+            [bin_dir / "pg_checksums", "-D", data_dir, "--enable"],
             check=True,
         )
     except CalledProcessError as e:

--- a/tests/postgresql/upgrade.nix
+++ b/tests/postgresql/upgrade.nix
@@ -155,6 +155,7 @@ import ../make-test-python.nix (
             print(machine.succeed("${fc-postgresql} list-versions"))
 
           with subtest("upgrade 17 -> 18 in one step"):
+            machine.succeed('${fc-postgresql} upgrade --expected employees --new-version 18')
             machine.succeed('${fc-postgresql} upgrade --expected employees --new-version 18 --stop --upgrade-now')
             machine.succeed("stat /srv/postgresql/17/fcio_migrated_to")
             machine.succeed("stat /srv/postgresql/18/fcio_migrated_from")


### PR DESCRIPTION
PostgreSQL 18 now has data checksums enabled by default. Previously we enabled data checksums on the old cluster in the `upgrade-now` step.

When the old PostgreSQL cluster had data checksums disabled, and the new one has them enabled, pg_upgrade --check fails, so fc-postgresql upgrade without --update-now also failed.

This change changes the behavior so that the new cluster gets created without data checksums enabled if the old cluster also has no data checksums enabled. If the new cluster version is >=18, data checksums are enabled after pg_upgrade ran.

FC-54426

@flyingcircusio/release-managers

## Release process

This change should be backported:

- [x] Created changelog entry using `./changelog.sh`
- [x] Add `backport release-25.11` label

This change should only reach this branch:

- [ ] Created changelog entry using `./changelog.sh`
or
- [ ] Add a upgrade node in `doc/upgrade.md`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [x] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - We should follow upstream's intentions and enable data checksums on the new cluster
- [x] Security requirements tested? (EVIDENCE)
  - tested on a VM that both `fc-postgresql upgrade --new-version 18` and `fc-postgresql upgrade --new-version 18 --upgrade-now` works and that the new cluster has data checksums enabled (14->18, 15->18, 14->16, 16->18, 17->18)
  - Regression testing covered by automated tests
  - New regression testing: Extended automated tests