### PR TITLE
router: add 26.05 to ipxe

### DIFF
--- a/changelog.d/20260601_113859_HEAD_scriv.md
+++ b/changelog.d/20260601_113859_HEAD_scriv.md
@@ -1,0 +1,27 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+<!-- Impact means "when this change is rolled out, there
+     might be interruptions/downtimes/required actions/... that
+     IMPACT THE RUNNING APPLICATION NEGATIVELY.
+
+     Having new features or changed is not an "impact". That's what
+     the main changelog (see below) is for.
+     -->
+
+
+### NixOS XX.XX platform
+
+- router: add 26.05 release to IPXE (PL-134240)

--- a/nixos/roles/router/flyingcircus.ipxe
+++ b/nixos/roles/router/flyingcircus.ipxe
@@ -23,8 +23,8 @@ item local_efi              Boot machine from local disk (EFI)
 item netboot                Launch netboot.xyz (various live images and tools)
 item --gap --               --- Install ---
 item --gap --               Installer: ${installer_url}
+item install_nixos_26_05    Set installer to NixOS 26.05 install image
 item install_nixos_25_11    Set installer to NixOS 25.11 install image
-item install_nixos_25_05    Set installer to NixOS 25.05 install image
 item install_nixos_dev      Set installer to NixOS development install image
 item install_edit_url       Manually edit installer URL
 item install_start          Boot selected installer
@@ -36,12 +36,12 @@ choose --timeout ${menu-timeout} --default ${menu-default} selected || goto canc
 set menu-timeout 0
 goto ${selected}
 
-:install_nixos_25_11
-set installer_url https://hydra.flyingcircus.io/job/flyingcircus/fc-25.11-production/images.netboot/latest/download/netboot.ipxe
+:install_nixos_26_05
+set installer_url https://hydra.flyingcircus.io/job/flyingcircus/fc-26.05-production/images.netboot/latest/download/netboot.ipxe
 goto start
 
-:install_nixos_25_05
-set installer_url https://hydra.flyingcircus.io/job/flyingcircus/fc-25.05-production/images.netboot/latest/download/netboot.ipxe
+:install_nixos_25_11
+set installer_url https://hydra.flyingcircus.io/job/flyingcircus/fc-25.11-production/images.netboot/latest/download/netboot.ipxe
 goto start
 
 :install_nixos_dev


### PR DESCRIPTION
PL-134240

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`
or
- [ ] Add a upgrade node in `doc/upgrade.md`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [x] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [x] Security requirements tested? (EVIDENCE)
  - We have a second release (25.11) in the IPXE installer, this is the fallback. We will test this thoroughly when also fixing IPXE generally on 26.05. 