### PR TITLE
fc.devhost: increase timeout for VM provisioning

### DIFF
--- a/changelog.d/20260601_114204_HEAD_scriv.md
+++ b/changelog.d/20260601_114204_HEAD_scriv.md
@@ -1,0 +1,26 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+<!-- Impact means "when this change is rolled out, there
+     might be interruptions/downtimes/required actions/... that
+     IMPACT THE RUNNING APPLICATION NEGATIVELY.
+
+     Having new features or changed is not an "impact". That's what
+     the main changelog (see below) is for.
+     -->
+
+### NixOS XX.XX platform
+
+- fc.devhost: increase timeout for VM provisioning (PL-135475)

--- a/nixos/roles/devhost/fc.devhost/src/fc/devhost/manager.py
+++ b/nixos/roles/devhost/fc.devhost/src/fc/devhost/manager.py
@@ -449,7 +449,7 @@ class Manager:
             fcntl.flock(self.lockfile, fcntl.LOCK_UN)
             # Wait for the VM to get online
             print("Waiting for VM to become pingable ...")
-            ping_timeout = TimeOut(60)
+            ping_timeout = TimeOut(120)
             while ping_timeout.tick():
                 response = os.system(f"ping -c 1 {self.cfg['srv-ip']}")
                 if response == 0:


### PR DESCRIPTION
There are some scenarios where the VM provisoning takes longer than
60 seconds, here experienced on largo00 (likely because of the slower CPU)

Related to PL-135475

@flyingcircusio/release-managers

## Release process

This change should be backported:

- [ ] Created changelog entry using `./changelog.sh`
- [ ] Add `backport release-25.11` label

This change should only reach this branch:

- [x] Created changelog entry using `./changelog.sh`
or
- [ ] Add a upgrade node in `doc/upgrade.md`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [x] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [x] Security requirements tested? (EVIDENCE)
  None