### PR TITLE
hydra: change to 26.05

### DIFF
--- a/.hydra/config.json
+++ b/.hydra/config.json
@@ -4,12 +4,12 @@
     "inputs": {
         "nixpkgs": {
             "type": "git",
-            "value": "https://github.com/flyingcircusio/nixpkgs.git nixos-25.11",
+            "value": "https://github.com/flyingcircusio/nixpkgs.git nixos-26.05",
             "emailresponsible": false
         },
         "branch": {
             "type": "string",
-            "value": "fc-25.11-dev",
+            "value": "fc-26.05-dev",
             "emailresponsible": false
         }
     }

--- a/.hydra/project.json
+++ b/.hydra/project.json
@@ -12,7 +12,7 @@
     "inputs": {
         "generator_config": {
             "type": "git",
-            "value": "https://github.com/flyingcircusio/fc-nixos.git fc-25.11-dev",
+            "value": "https://github.com/flyingcircusio/fc-nixos.git fc-26.05-dev",
             "emailresponsible": false
         },
         "inputPath": {


### PR DESCRIPTION
PL-134240

@flyingcircusio/release-managers

## Release process

This change should be backported:

- [ ] Created changelog entry using `./changelog.sh`
- [ ] Add `backport release-25.11` label

This change should only reach this branch:

- [ ] Created changelog entry using `./changelog.sh`
or
- [ ] Add a upgrade node in `doc/upgrade.md`
  No, internal

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [ ] ensure all checks are green
- [x] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [x] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [x] Security requirements tested? (EVIDENCE)
  Hydra will check this PR and we can revert as needed.
  We already run jobsets against Nixpkgs' `nixos-26.05`.