### PR TITLE
[25.05] nixpkgs: pull in backported stable kernel updates

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -168,11 +168,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1779266516,
-        "narHash": "sha256-x4C1A1RBrjM6J1PC2L8sb2AhXbLjY/vD/HPA32XrUoU=",
+        "lastModified": 1780477205,
+        "narHash": "sha256-ktdTbBIZ94ZZryPjbUAdpXN6IUFAjx3lZlA0MYInfvk=",
         "owner": "flyingcircusio",
         "repo": "nixpkgs",
-        "rev": "9f6b9265bdd050fa91117e7a2d29effe6d76ed39",
+        "rev": "5d5d32b0d23de91fcaf63f50390494e14b772a5a",
         "type": "github"
       },
       "original": {

--- a/release/package-versions.json
+++ b/release/package-versions.json
@@ -460,14 +460,14 @@
     "version": "0.2.5"
   },
   "linuxKernelStable": {
-    "name": "linux-6.12.90",
+    "name": "linux-6.12.92",
     "pname": "linux",
-    "version": "6.12.90"
+    "version": "6.12.92"
   },
   "linuxKernelVerify": {
-    "name": "linux-6.12.90",
+    "name": "linux-6.12.92",
     "pname": "linux",
-    "version": "6.12.90"
+    "version": "6.12.92"
   },
   "logrotate": {
     "name": "logrotate-3.22.0",

--- a/release/versions.json
+++ b/release/versions.json
@@ -8,10 +8,10 @@
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/"
   },
   "nixpkgs": {
-    "hash": "sha256-x4C1A1RBrjM6J1PC2L8sb2AhXbLjY/vD/HPA32XrUoU=",
+    "hash": "sha256-ktdTbBIZ94ZZryPjbUAdpXN6IUFAjx3lZlA0MYInfvk=",
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "9f6b9265bdd050fa91117e7a2d29effe6d76ed39"
+    "rev": "5d5d32b0d23de91fcaf63f50390494e14b772a5a"
   },
   "poetry2nix": {
     "hash": "sha256-nzgO/ZCSBzWjbMkYDxG+yl9Z2eGbCgQu06Oku3ir5D4=",


### PR DESCRIPTION
PL-135412

@flyingcircusio/release-managers

## Release process

This change should be backported:

- [x] Created changelog entry using `./changelog.sh`
  - package-versions.json changelog
  - 
## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [x] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - manually backport critical kernel bugfixes to otherwise unmaintained release
- [x] Security requirements tested? (EVIDENCE)
  - tests still pass