### PR TITLE
ai-api-gateway: add tmpfiles rules for skvaider directories and log cleanup

### DIFF
--- a/nixos/roles/ai-api-gateway.nix
+++ b/nixos/roles/ai-api-gateway.nix
@@ -150,7 +150,7 @@ in
       };
     };
     systemd.tmpfiles.rules = [
-      "d /var/lib/skvaider 0755 skvaider service -"
+      "d /var/lib/skvaider 0750 skvaider service -"
       "d /var/log/skvaider 0750 skvaider service -"
       "A /var/log/skvaider - - - - g:sudo-srv:r-x,g:admins:r-x"
       "a /var/log/skvaider - - - - d:g:sudo-srv:r,d:g:admins:r"

--- a/nixos/roles/ai-api-gateway.nix
+++ b/nixos/roles/ai-api-gateway.nix
@@ -149,6 +149,15 @@ in
         isSystemUser = true;
       };
     };
+    systemd.tmpfiles.rules = [
+      "d /var/lib/skvaider 0755 skvaider service -"
+      "d /var/log/skvaider 0750 skvaider service -"
+      "A /var/log/skvaider - - - - g:sudo-srv:r-x,g:admins:r-x"
+      "a /var/log/skvaider - - - - d:g:sudo-srv:r,d:g:admins:r"
+      "d /var/lib/skvaider/debug 0750 skvaider service -"
+      "e /var/lib/skvaider/debug 4 -" # clean up debug logs after 4 days
+      "e /var/log/skvaider 4 -" # clean up old logs after 4 days
+    ];
     services.logrotate.settings.skvaider = {
       create = "0640 skvaider service";
       files = [ "/var/log/skvaider/*.log" ];


### PR DESCRIPTION

- /var/lib/skvaider: 0755 skvaider service
- /var/log/skvaider: 0750 skvaider service (no world access)
- ACLs for sudo-srv and admins groups (read + execute)
- /var/lib/skvaider/debug: 0750, cleaned after 24h
- /var/log/skvaider: cleaned after 4 days

Mirrors the permissions fix already applied to ai-model-server (PL-135413) but for the gateway role.

@flyingcircusio/release-managers

## Release process

This change should be backported:

- [ ] Created changelog entry using `./changelog.sh`
- [ ] Add `backport release-25.11` label

This change should only reach this branch:

- [ ] Created changelog entry using `./changelog.sh`
or
- [ ] Add a upgrade node in `doc/upgrade.md`

## PR release workflow (internal)

- [ ] PR has internal ticket
- [ ] internal issue ID (PL-…) part of branch name
- [ ] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [ ] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [ ] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [ ] Security requirements tested? (EVIDENCE)
