### PR TITLE
[PL-135488] pass s3 credentials to loki via EnvironmentFile

### DIFF
--- a/changelog.d/20260604_090314_PL-135488_loki-s3-auth-envfile_scriv.md
+++ b/changelog.d/20260604_090314_PL-135488_loki-s3-auth-envfile_scriv.md
@@ -1,0 +1,8 @@
+### Impact
+
+-
+
+
+### NixOS XX.XX platform
+
+- Fix an issue where object storage credentials were not passed to loki correctly. (PL-135488)

--- a/nixos/roles/loki.nix
+++ b/nixos/roles/loki.nix
@@ -193,9 +193,9 @@ in
             "Z '/run/loki' 0750 root lokienv - -"
           ];
 
-          systemd.services.loki = {
-            environment."AWS_SHARED_CREDENTIALS_FILE" = credentialFile;
-            serviceConfig.SupplementaryGroups = [ "lokienv" ];
+          systemd.services.loki.serviceConfig = {
+            EnvironmentFile = credentialFile;
+            SupplementaryGroups = [ "lokienv" ];
           };
 
           systemd.services.loki-s3-setup = {


### PR DESCRIPTION
@flyingcircusio/release-managers

PL-135488

## Release process

This change should be backported:

- [x] Created changelog entry using `./changelog.sh`
- [x] Add `backport fc-25.11-dev` label

This change should only reach this branch:

- [ ] Created changelog entry using `./changelog.sh`
or
- [ ] Add a upgrade node in `doc/upgrade.md`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [x] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [ ] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [x] Security requirements tested? (EVIDENCE)
- fixes a configuration issue with the loki service