### PR TITLE
[PL-135489] loki: change the default storage backend to aws from 2026-07-01

### DIFF
--- a/changelog.d/20260604_150245_PL-135489_configure-loki-s3-storage_scriv.md
+++ b/changelog.d/20260604_150245_PL-135489_configure-loki-s3-storage_scriv.md
@@ -1,0 +1,7 @@
+### Impact
+
+-
+
+### NixOS XX.XX platform
+
+- Default to storing loki's data in the automatically configured object storage (PL-135489)

--- a/nixos/roles/loki.nix
+++ b/nixos/roles/loki.nix
@@ -60,8 +60,21 @@ in
         default = { };
         type = types.submodule {
           options = {
-            enable = mkEnableOption "storing the logs in object storage" // {
+            enable = mkOption {
+              description = ''
+                Enable additional configuration so that loki's logs can be stored in
+                object storage.
+
+                This option merely serves as a toggle for the configuration that enables
+                storing logs in object storage and does not affect the actual storage backend.
+                If you just want to store logs on disk instead you should add a fitting
+                entry to `flyingcircus.roles.loki.storageSchedule` instead.
+              '';
               default = config.flyingcircus.enc ? role_configuration.loki;
+              # role_configuration.loki is available to VMs managed via the directory with the loki role.
+              # The defaultText is adjusted here because the value above evaluates to false when
+              # evaluating the options for fc-search etc.
+              defaultText = "true";
             };
             endpoint = mkOption {
               description = "HTTP(S) endpoint of the object store";
@@ -93,10 +106,24 @@ in
                     startDate = "2024-09-10";
                     backend = "filesystem";
                   }
+                  {
+                    startDate = "2026-07-01";
+                    backend = "aws";
+                  }
                 ];
               };
               extra = mkOption {
-                description = "Additional entries to add to the log storage schedule";
+                description = ''
+                  Entries to add to the log storage schedule.
+
+                  The default policy is to store all logs in object storage starting on 2026-07-01.
+                  Object storage buckets and credentials are set up automatically for you.
+
+                  If you instead wish to store logs on the filesystem, add an entry here
+                  with `backend = "filesystem";` and a `startDate` in the future.
+
+                  See https://grafana.com/docs/loki/latest/operations/storage/schema/ for more details.
+                '';
                 type = listOf storageScheduleSubmodule;
                 default = [ ];
                 defaultText = "[]";

--- a/tests/alloy.nix
+++ b/tests/alloy.nix
@@ -18,7 +18,15 @@ import ./make-test-python.nix (
           ../nixos/roles
           (testlib.fcConfig { net.fe = false; })
         ];
-        flyingcircus.roles.loki.enable = true;
+        flyingcircus.roles.loki = {
+          enable = true;
+          storageSchedule.default = lib.mkForce [
+            {
+              startDate = "2024-09-10";
+              backend = "filesystem";
+            }
+          ];
+        };
 
         flyingcircus.encServices = [
           {

--- a/tests/k3s/default.nix
+++ b/tests/k3s/default.nix
@@ -92,7 +92,15 @@ import ../make-test-python.nix (
           config = {
             flyingcircus.encServices = encServices;
             flyingcircus.roles.k3s-server.enable = true;
-            flyingcircus.roles.loki.enable = true;
+            flyingcircus.roles.loki = {
+              enable = true;
+              storageSchedule.default = lib.mkForce [
+                {
+                  startDate = "2024-09-10";
+                  backend = "filesystem";
+                }
+              ];
+            };
             flyingcircus.kubernetes.network.enableIPv6 = enableIPv6;
             networking.domain = "fcio.net";
             networking.hostName = lib.mkForce "k3sserver";

--- a/tests/loki-relay.nix
+++ b/tests/loki-relay.nix
@@ -32,7 +32,15 @@ import ./make-test-python.nix (
           ];
 
           flyingcircus = {
-            roles.loki.enable = true;
+            roles.loki = {
+              enable = true;
+              storageSchedule.default = lib.mkForce [
+                {
+                  startDate = "2024-09-10";
+                  backend = "filesystem";
+                }
+              ];
+            };
             enc.role_configuration."statshost-master".relay_from_details = {
               loki_relay.addresses = [
                 loki_relay_v4

--- a/tests/loki.nix
+++ b/tests/loki.nix
@@ -19,7 +19,15 @@ import ./make-test-python.nix (
           ../nixos/roles
           (testlib.fcConfig { net.fe = false; })
         ];
-        flyingcircus.roles.loki.enable = true;
+        flyingcircus.roles.loki = {
+          enable = true;
+          storageSchedule.default = lib.mkForce [
+            {
+              startDate = "2024-09-10";
+              backend = "filesystem";
+            }
+          ];
+        };
 
         flyingcircus.encServices = [
           {

--- a/tests/nginx.nix
+++ b/tests/nginx.nix
@@ -260,7 +260,15 @@ import ./make-test-python.nix (
             (testlib.fcConfig { id = 7; })
           ];
 
-          flyingcircus.roles.loki.enable = true;
+          flyingcircus.roles.loki = {
+            enable = true;
+            storageSchedule.default = lib.mkForce [
+              {
+                startDate = "2024-09-10";
+                backend = "filesystem";
+              }
+            ];
+          };
           flyingcircus.roles.webgateway.enable = true;
           flyingcircus.services.nginx = {
             virtualHosts.server = {


### PR DESCRIPTION
@flyingcircusio/release-managers

PL-135489

## Release process

This change should be backported:

- [x] Created changelog entry using `./changelog.sh`
- [x] Add `backport fc-25.11-dev` label

This change should only reach this branch:

- [ ] Created changelog entry using `./changelog.sh`
or
- [ ] Add a upgrade node in `doc/upgrade.md`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [ ] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [x] Security requirements tested? (EVIDENCE)
- this pr adjusts the default storage backend for loki's data