### PR TITLE
[PL-135503] increase loki grpc limits

### DIFF
--- a/changelog.d/20260608_160255_PL-135503_increase-loki-query-limits_scriv.md
+++ b/changelog.d/20260608_160255_PL-135503_increase-loki-query-limits_scriv.md
@@ -1,0 +1,6 @@
+### Impact
+
+
+### NixOS XX.XX platform
+
+- Increase loki's internal grpc message size limit to enable larger queries against log lines (PL-135503)

--- a/nixos/roles/loki.nix
+++ b/nixos/roles/loki.nix
@@ -117,7 +117,15 @@ in
         services.loki = {
           enable = true;
           configuration = {
-            server.http_listen_address = "127.0.0.1";
+            server = {
+              http_listen_address = "127.0.0.1";
+              grpc_server_max_recv_msg_size = 104857600;
+              grpc_server_max_send_msg_size = 104857600;
+            };
+            frontend.grpc_client_config = {
+              max_recv_msg_size = 104857600;
+              max_send_msg_size = 104857600;
+            };
 
             auth_enabled = false;
 


### PR DESCRIPTION
PL-135503

Increase the internal GRPC message limit for loki.

@flyingcircusio/release-managers

## Release process

This change should be backported:

- [ ] Created changelog entry using `./changelog.sh`
- [ ] Add `backport release-25.11` label

This change should only reach this branch:

- [x] Created changelog entry using `./changelog.sh`
or
- [ ] Add a upgrade node in `doc/upgrade.md`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [x] Provide warnings in previous platform version and upgrade notes when introducing a breaking change
- this adjusts the size limit of internal grpc queries

## Security implications

- [ ] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [ ] Security requirements tested? (EVIDENCE)
