### PR TITLE
fc.agent: abort at first failing maintenance enter hook

### DIFF
--- a/changelog.d/20260609_174402_PL-135499-rgw-maintenance-race_scriv.md
+++ b/changelog.d/20260609_174402_PL-135499-rgw-maintenance-race_scriv.md
@@ -1,0 +1,29 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+<!-- Impact means "when this change is rolled out, there
+     might be interruptions/downtimes/required actions/... that
+     IMPACT THE RUNNING APPLICATION NEGATIVELY.
+
+     Having new features or changed is not an "impact". That's what
+     the main changelog (see below) is for.
+     -->
+
+
+### NixOS XX.XX platform
+
+- fc-maintenance: stop execution of maintenance enter hooks at failure of individual hook (PL-135499)
+
+  This resolves a possible race condition of multiple Ceph radosgw nodes being shut down in parallel.

--- a/nixos/roles/ceph/rgw.nix
+++ b/nixos/roles/ceph/rgw.nix
@@ -144,7 +144,10 @@ in
         };
       };
 
+      # FIXME: This only happens to work properly in relation to the `ceph` maintenance hook due to alphabetical ordered execution of maintenance hooks, see PL-135507.
+      # Otherwise there is the danger of RGWs being shut down preemptively, with the host then failing to acquire the atomic rbd maintenance locks while keeping the RGWs down.
       flyingcircus.agent.maintenance.rgw = {
+        # avoid RGW issues related to temporary network reconfigurations during system switch
         enter = "systemctl stop fc-ceph-rgw";
         leave = "systemctl start fc-ceph-rgw";
       };

--- a/pkgs/fc/agent/src/fc/maintenance/reqmanager.py
+++ b/pkgs/fc/agent/src/fc/maintenance/reqmanager.py
@@ -69,17 +69,10 @@ class RequestsNotLoaded(Exception):
         )
 
 
-class PostponeMaintenance(Exception):
-    pass
-
-
-class TempfailMaintenance(Exception):
-    pass
-
-
 class HandleEnterExceptionResult(NamedTuple):
     exit: bool = False
     postpone: bool = False
+    temporary: bool = False
 
 
 class ReqManager:
@@ -553,7 +546,9 @@ class ReqManager:
                 )
                 due_dt = max(utcnow(), request.next_due + delta)
 
-    def _enter_maintenance(self, online: bool, timeout: int):
+    def _enter_maintenance(
+        self, online: bool, timeout: int, run_all_now: bool, force_run: bool
+    ) -> HandleEnterExceptionResult:
         """Enters maintenance mode which tells the directory to mark the machine
         as 'not in service'. The main reason is to avoid false alarms during expected
         service interruptions as the machine reboots or services are restarted.
@@ -578,8 +573,6 @@ class ReqManager:
             )
         else:
             self.maintenance_marker_path.write_text(utcnow().isoformat())
-        postpone_seen = False
-        tempfail_seen = False
         for name, command in self.config["maintenance-enter"].items():
             if not command.strip():
                 continue
@@ -611,6 +604,8 @@ class ReqManager:
             stdout = "".join(stdout_lines)
             proc.wait()
 
+            enter_result = HandleEnterExceptionResult()
+
             match proc.returncode:
                 case 0:
                     log.debug("enter-maintenance-cmd-success")
@@ -624,7 +619,13 @@ class ReqManager:
                         ),
                     )
                     log.debug("enter-maintenance-postpone-out", stdout=stdout)
-                    postpone_seen = True
+                    # XXX: dispatching the effects of `--run-all-now` and `--force-run`
+                    # flags needs to be done here, to decide whether to abort
+                    # after a single enter failure
+
+                    enter_result = self._handle_enter_postpone(
+                        run_all_now, force_run
+                    )
                 case state.EXIT_TEMPFAIL:
                     log.info(
                         "enter-maintenance-tempfail",
@@ -635,7 +636,9 @@ class ReqManager:
                         ),
                     )
                     log.debug("enter-maintenance-tempfail-out", stdout=stdout)
-                    tempfail_seen = True
+                    enter_result = self._handle_enter_tempfail(
+                        run_all_now, force_run
+                    )
                 case error:
                     log.error(
                         "enter-maintenance-fail",
@@ -644,11 +647,10 @@ class ReqManager:
                     )
                     raise subprocess.CalledProcessError(error, command, stdout)
 
-        if postpone_seen:
-            raise PostponeMaintenance()
+            if enter_result.exit:
+                break
 
-        if tempfail_seen:
-            raise TempfailMaintenance()
+        return enter_result
 
     @require_directory
     def _mark_directory_service_status(
@@ -801,7 +803,7 @@ class ReqManager:
                 "execute-requests-tempfail",
             )
             # We stay in maintenance and try again on the next run.
-            return HandleEnterExceptionResult(exit=True)
+            return HandleEnterExceptionResult(exit=True, temporary=True)
 
         if run_all_now and not force_run:
             self.log.info(
@@ -812,7 +814,7 @@ class ReqManager:
                     "Doing nothing unless --force-run is given, too."
                 ),
             )
-            return HandleEnterExceptionResult(exit=True)
+            return HandleEnterExceptionResult(exit=True, temporary=True)
 
         if not run_all_now and force_run:
             self.log.warn(
@@ -822,7 +824,7 @@ class ReqManager:
                     "(temporary) failure of a maintenance enter command."
                 ),
             )
-            return HandleEnterExceptionResult()
+            return HandleEnterExceptionResult(temporary=True)
 
         if run_all_now and force_run:
             self.log.warn(
@@ -833,7 +835,7 @@ class ReqManager:
                     "(temporary) failure of a maintenance enter command."
                 ),
             )
-            return HandleEnterExceptionResult()
+            return HandleEnterExceptionResult(temporary=True)
 
     def _write_stats_for_execute(
         self,
@@ -935,38 +937,33 @@ class ReqManager:
 
         prepare_dt = utcnow()
         try:
-            self._enter_maintenance(online, timeout)
-        except PostponeMaintenance:
-            res = self._handle_enter_postpone(run_all_now, force_run)
-            if res.postpone:
-                for req in runnable_requests:
-                    self.log.debug("execute-requests-postpone", request=req.id)
-                    req.state = State.postpone
-            if res.exit:
-                self._leave_maintenance(online)
-                self._write_stats_for_execute()
-                return
-
-        except TempfailMaintenance:
-            res = self._handle_enter_tempfail(run_all_now, force_run)
-            if res.exit:
-                # Stay in maintenance mode as we expect the temporary failure
-                # to go away on the next agent run.
-                self._write_stats_for_execute()
-                return
+            enter_result = self._enter_maintenance(
+                online, timeout, run_all_now, force_run
+            )
 
         except Exception:
             # Other exceptions are similar to tempfail, just with additional
-            # logging. Could an error from a enter command, from the directory
+            # logging. Could be an error from a enter command, from the directory
             # or an internal one.
+            # Might already be in maintenance or not, depending on where
+            # _enter_maintenance failed. That's ok, the next agent
+            # run can continue in either case.
             self.log.error("execute-enter-maintenance-failed", exc_info=True)
-            res = self._handle_enter_tempfail(run_all_now, force_run)
-            if res.exit:
-                # Might already be in maintenance or not, depending on where
-                # _enter_maintenance failed. That's ok, the next agent
-                # run can continue in either case.
-                self._write_stats_for_execute()
-                return
+            enter_result = self._handle_enter_tempfail(run_all_now, force_run)
+
+        if enter_result.temporary and enter_result.exit:
+            # Stay in maintenance mode as we expect the temporary failure
+            # to go away on the next agent run.
+            self._write_stats_for_execute()
+            return
+        if enter_result.postpone:
+            for req in runnable_requests:
+                self.log.debug("execute-requests-postpone", request=req.id)
+                req.state = State.postpone
+        if enter_result.exit:
+            self._leave_maintenance(online)
+            self._write_stats_for_execute()
+            return
 
         # We are now in maintenance mode, start the action.
         requested_reboots = set()

--- a/pkgs/fc/agent/src/fc/maintenance/tests/test_reqmanager.py
+++ b/pkgs/fc/agent/src/fc/maintenance/tests/test_reqmanager.py
@@ -13,11 +13,7 @@ from rich.console import Console
 
 from fc.maintenance.activity import Activity, RebootType
 from fc.maintenance.estimate import Estimate
-from fc.maintenance.reqmanager import (
-    PostponeMaintenance,
-    ReqManager,
-    TempfailMaintenance,
-)
+from fc.maintenance.reqmanager import ReqManager, HandleEnterExceptionResult
 from fc.maintenance.request import Attempt, Request
 from fc.maintenance.state import ARCHIVE, EXIT_POSTPONE, State
 from fc.maintenance.tests import MergeableActivity
@@ -232,7 +228,7 @@ def test_enter_maintenance(log, reqmanager, monkeypatch):
     )
     monkeypatch.setattr("socket.gethostname", lambda: "host")
 
-    reqmanager._enter_maintenance(True, 10)
+    reqmanager._enter_maintenance(True, 10, False, False)
 
     assert log.has("enter-maintenance")
     assert log.has(
@@ -259,8 +255,8 @@ def test_enter_maintenance_postpone(log, reqmanager, monkeypatch):
     # monkeypatch.setattr("subprocess.run", run_mock := MagicMock())
     reqmanager.config["maintenance-enter"]["postpone"] = "exit 69"
 
-    with pytest.raises(PostponeMaintenance):
-        reqmanager._enter_maintenance(True, 10)
+    enter_result = reqmanager._enter_maintenance(True, 10, False, False)
+    assert enter_result == HandleEnterExceptionResult(postpone=True, exit=True)
 
     assert reqmanager.maintenance_marker_path.exists()
 
@@ -272,10 +268,51 @@ def test_enter_maintenance_tempfail(log, reqmanager, monkeypatch):
     # monkeypatch.setattr("subprocess.run", run_mock := MagicMock())
     reqmanager.config["maintenance-enter"]["tempfail"] = "exit 75"
 
-    with pytest.raises(TempfailMaintenance):
-        reqmanager._enter_maintenance(True, 10)
+    enter_result = reqmanager._enter_maintenance(True, 10, False, False)
+    assert enter_result == HandleEnterExceptionResult(temporary=True, exit=True)
 
     assert reqmanager.maintenance_marker_path.exists()
+
+
+def test_enter_maintenance_stops_at_first_failure(log, reqmanager, monkeypatch):
+    """Without --force_run, a failing hook aborts the loop. later hooks
+    must not be executed."""
+    monkeypatch.setattr(
+        "fc.util.directory.connect", connect_mock := MagicMock()
+    )
+    reqmanager.config["maintenance-enter"]["first"] = "exit 75"
+    reqmanager.config["maintenance-enter"]["second"] = 'echo "second"'
+
+    enter_result = reqmanager._enter_maintenance(
+        True, 10, run_all_now=False, force_run=False
+    )
+
+    assert enter_result == HandleEnterExceptionResult(temporary=True, exit=True)
+    assert log.has("enter-maintenance-cmd", subsystem="first")
+    assert not log.has("enter-maintenance-cmd", subsystem="second")
+
+
+def test_enter_maintenance_force_continues_after_failure(
+    log, reqmanager, monkeypatch
+):
+    """With --force_run, a failing hook is tolerated and later hooks
+    still execute."""
+    monkeypatch.setattr(
+        "fc.util.directory.connect", connect_mock := MagicMock()
+    )
+    reqmanager.config["maintenance-enter"]["first"] = "exit 75"
+    reqmanager.config["maintenance-enter"]["second"] = 'echo "second"'
+
+    enter_result = reqmanager._enter_maintenance(
+        True, 10, run_all_now=False, force_run=True
+    )
+
+    # The succeeding second hook resets enter_result on its iteration,
+    # so the tempfail signal is (intentionally) swallowed under --force-run.
+    assert enter_result == HandleEnterExceptionResult()
+    assert log.has("enter-maintenance-cmd", subsystem="first")
+    assert log.has("enter-maintenance-cmd", subsystem="second")
+    assert log.has("enter-maintenance-cmd-success", subsystem="second")
 
 
 def test_execute_postpone(log, reqmanager):
@@ -283,8 +320,10 @@ def test_execute_postpone(log, reqmanager):
     req.state = State.due
     req.execute = Mock()
 
-    def enter_maintenance_postpone(online: bool, timeout: int):
-        raise PostponeMaintenance()
+    def enter_maintenance_postpone(
+        online: bool, timeout: int, run_all_now: bool, force_run: bool
+    ):
+        return HandleEnterExceptionResult(postpone=True, exit=True)
 
     reqmanager._runnable = lambda run_all_now, force_run: [req]
     reqmanager._enter_maintenance = enter_maintenance_postpone
@@ -302,8 +341,10 @@ def test_execute_tempfail(log, reqmanager):
     req.state = State.due
     req.execute = Mock()
 
-    def enter_maintenance_tempfail(online: bool, timeout: int):
-        raise TempfailMaintenance()
+    def enter_maintenance_tempfail(
+        online: bool, timeout: int, run_all_now: bool, force_run: bool
+    ):
+        return HandleEnterExceptionResult(temporary=True, exit=True)
 
     reqmanager._runnable = lambda run_all_now, force_run: [req]
     reqmanager._enter_maintenance = enter_maintenance_tempfail
@@ -320,6 +361,7 @@ def test_execute_activity_no_reboot(reqmanager, log):
     req = reqmanager.add(Request(Activity(), 1))
     reqmanager._runnable = lambda run_all_now, force_run: [req]
     reqmanager._enter_maintenance = Mock()
+    reqmanager._enter_maintenance.return_value = HandleEnterExceptionResult()
     reqmanager._leave_maintenance = Mock()
 
     reqmanager.execute()
@@ -333,6 +375,7 @@ def test_execute_activity_with_reboot(reqmanager, log, monkeypatch):
     monkeypatch.setattr("time.sleep", sleep := Mock())
     monkeypatch.setattr("subprocess.run", run := Mock())
     reqmanager._enter_maintenance = Mock()
+    reqmanager._enter_maintenance.return_value = HandleEnterExceptionResult()
     reqmanager._leave_maintenance = Mock()
 
     activity = Activity()


### PR DESCRIPTION
When multiple `fc.agent.maintenance.<name>.enter` hooks are defined, a failing enter hook aborts execution of hooks and later hooks are not executed. `--force-run` overrides this behavior and executes all enter hooks nonetheless.

This is a quick fix for PL-135499, as the `ceph` maintenance enter hook being the first hook executed now acts as a guardian hook for later enter hooks like `rgw`.
A better modelling of maintenance hooks is still mandated, see PL-135507.

@flyingcircusio/release-managers

## Release process

This change should be backported:

- [x] Created changelog entry using `./changelog.sh`
- [x] Add `backport release-25.11` label

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [x] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - behaviour change of not executing all maintenance enter hooks in the face of failures must not change behaviour of the hooks we ship in the platform
  - failing `ceph` maintenance enter hook serves as guardian hook and prevents shutdown of rgw when failing
- [x] Security requirements tested? (EVIDENCE)
  - [x] inspected all maintenance enter hooks defined in the platform
  - [x] extended unit tests pass
  - [x] tested interaction of ceph and rgw hooks in dev cluster
