### PR TITLE
ai-model-server: enable nvidia_smi Telegraf input for GPU metrics

### DIFF
--- a/nixos/roles/ai-model-server.nix
+++ b/nixos/roles/ai-model-server.nix
@@ -284,7 +284,7 @@ in
           }
         ];
         flyingcircus.services.telegraf.inputs.nvidia_smi = lib.mkIf cfg.skvaider-inference.enable [
-          { }
+          { bin_path = "/run/current-system/sw/bin/nvidia-smi"; }
         ];
         services.logrotate.settings.skvaider-inference = {
           create = "0640 skvaider service";

--- a/nixos/roles/ai-model-server.nix
+++ b/nixos/roles/ai-model-server.nix
@@ -283,6 +283,9 @@ in
             ];
           }
         ];
+        flyingcircus.services.telegraf.inputs.nvidia_smi = lib.mkIf cfg.skvaider-inference.enable [
+          { }
+        ];
         services.logrotate.settings.skvaider-inference = {
           create = "0640 skvaider service";
           files = [


### PR DESCRIPTION
Collect GPU utilization, temperature, power, fan speed, PCIe info, and other nvidia-smi metrics via Telegraf's built-in plugin. Required for the Skvaider AI Platform Grafana dashboard GPU row.

@flyingcircusio/release-managers

## Release process

This change should be backported:

- [ ] Created changelog entry using `./changelog.sh`
- [ ] Add `backport release-25.11` label

This change should only reach this branch:

- [ ] Created changelog entry using `./changelog.sh`
or
- [ ] Add a upgrade node in `doc/upgrade.md`

## PR release workflow (internal)

- [ ] PR has internal ticket
- [ ] internal issue ID (PL-…) part of branch name
- [ ] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [ ] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [ ] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [ ] Security requirements tested? (EVIDENCE)
