### PR TITLE
fc.qemu-ceph-pacific: pull in migration fixes

### DIFF
--- a/pkgs/fc/default.nix
+++ b/pkgs/fc/default.nix
@@ -47,21 +47,25 @@ rec {
   neighbour-cache-monitor = callPackage ./neighbour-cache-monitor { };
   ping-on-tap = callPackage ./ping-on-tap { };
 
-  qemu-nautilus = callPackage ./qemu rec {
-    version = "1.7dev";
-    src = pkgs.fetchFromGitHub {
-      owner = "flyingcircusio";
-      repo = "fc.qemu";
-      # The release tooling didn't upgrade properly so we had to pick a specific
-      # commit instead.
-      rev = "256964f932353a4c5375d709445afecc8f48aaaf";
-      hash = "sha256-ydEJlzio8ixFRqZEaDEwDkJFZYQ9RJ6DQhRJwTG+zik";
-    };
-    fc-ceph = ceph;
-    qemu_ceph = pkgs.qemu-ceph-nautilus;
-    ceph_client = pkgs.ceph-nautilus.ceph-client;
-    python3Packages = pkgs.python311Packages;
-  };
+  qemu-nautilus =
+    (callPackage ./qemu rec {
+      version = "1.7dev";
+      src = pkgs.fetchFromGitHub {
+        owner = "flyingcircusio";
+        repo = "fc.qemu";
+        # The release tooling didn't upgrade properly so we had to pick a specific
+        # commit instead.
+        rev = "256964f932353a4c5375d709445afecc8f48aaaf";
+        hash = "sha256-ydEJlzio8ixFRqZEaDEwDkJFZYQ9RJ6DQhRJwTG+zik";
+      };
+      fc-ceph = ceph;
+      qemu_ceph = pkgs.qemu-ceph-nautilus;
+      ceph_client = pkgs.ceph-nautilus.ceph-client;
+      python3Packages = pkgs.python311Packages;
+    }).overridePythonAttrs
+      (old: {
+        propagatedBuildInputs = old.propagatedBuildInputs ++ [ pkgs.procps ];
+      });
 
   qemu-pacific = callPackage ./qemu rec {
     version = "1.8dev";
@@ -70,8 +74,8 @@ rec {
       repo = "fc.qemu";
       # The release tooling didn't upgrade properly so we had to pick a specific
       # commit instead.
-      rev = "6f61942e685b9b24400908a722370b04b582e0b0";
-      hash = "sha256-/viOM98kS0rUGWl314lmhgmSM/VcxbLu3B55ppgFWeg=";
+      rev = "6f4d9d90ce63c8b82069ab1e27af13cc1093feee";
+      hash = "sha256-y+F2rTp6Mao0jZRe5V7VNCtZpOJqU6BdhVlBz7accac=";
     };
     fc-ceph = ceph;
     qemu_ceph = pkgs.qemu-ceph-pacific;
@@ -85,7 +89,7 @@ rec {
   #
   # qemu-dev-pacific = qemu-pacific.overrideAttrs (old: {
   #   # for tests and development checkouts on kvm hosts:
-  #   src = ../../../../../fc.qemu/.;
+  #   src = ../../../fc.qemu/.;
   #   # for nix-shell . -A fc.qemu-dev-pacific
   #   # src = ../../../fc.qemu/.;
   # });

--- a/pkgs/fc/qemu/default.nix
+++ b/pkgs/fc/qemu/default.nix
@@ -55,7 +55,7 @@ let
 in
 # We use buildPythonPackage instead of buildPythonApplication
 # to assist using this in a mixed buildEnv for external unit testing.
-py.buildPythonPackage rec {
+py.buildPythonPackage (finalAttrs: {
   inherit version src;
 
   name = "fc.qemu-${version}";
@@ -71,7 +71,6 @@ py.buildPythonPackage rec {
     gptfdisk
     iproute2
     parted
-    procps
     qemu_ceph
     systemd
     util-linux
@@ -88,49 +87,51 @@ py.buildPythonPackage rec {
   ];
 
   passthru = {
-    inherit py nativeCheckInputs;
+    inherit py;
+    # need to be defined here to keep them overridable *and* consistent,
+    # because `buildPythonPackages` messes with `nativeCheckInputs`,
+    nativeCheckInputs = [
+      file
+      openssh
+      py.pytest_patterns
+      py.pytest
+      py.pytest-xdist
+      py.pytest-cov
+      py.pytest-timeout
+      py.mock
+      fc-ceph
+      # Allow passing through to pytest in the NixOS test.
+      (py.buildPythonPackage rec {
+        pname = "pytest-flakefinder";
+        version = "1.1.0";
+
+        src = py.fetchPypi {
+          inherit pname version;
+          hash = "sha256-4kEqGSC9uOeQh4OyCz1X6drVkMw5qT6Flv/dSTtAPg4=";
+        };
+
+        pyproject = true;
+        build-system = [ py.setuptools ];
+        propagatedBuildInputs = [ py.pytest ];
+
+        meta = {
+          description = "Runs tests multiple times to expose flakiness.";
+          homepage = "https://github.com/dropbox/pytest-flakefinder";
+        };
+      })
+    ];
   };
 
   postInstall = ''
     cp -Pr $src/share $out/share
   '';
 
-  nativeCheckInputs = [
-    file
-    openssh
-    py.pytest_patterns
-    py.pytest
-    py.pytest-xdist
-    py.pytest-cov
-    py.pytest-timeout
-    py.mock
-    fc-ceph
-    # Allow passing through to pytest in the NixOS test.
-    (py.buildPythonPackage rec {
-      pname = "pytest-flakefinder";
-      version = "1.1.0";
-
-      src = py.fetchPypi {
-        inherit pname version;
-        hash = "sha256-4kEqGSC9uOeQh4OyCz1X6drVkMw5qT6Flv/dSTtAPg4=";
-      };
-
-      pyproject = true;
-      build-system = [ py.setuptools ];
-      propagatedBuildInputs = [ py.pytest ];
-
-      meta = with lib; {
-        description = "Runs tests multiple times to expose flakiness.";
-        homepage = "https://github.com/dropbox/pytest-flakefinder";
-      };
-    })
-  ];
-
+  nativeCheckInputs = finalAttrs.passthru.nativeCheckInputs;
   doCheck = true;
   checkPhase = ''
     runHook preCheck
-    PATH="${lib.makeBinPath propagatedBuildInputs}:$PATH" pytest -vv -m "unit"
+    PATH="${lib.makeBinPath finalAttrs.propagatedBuildInputs}:$PATH" pytest -vv -m "unit"
     runHook postCheck
   '';
 
-}
+})


### PR DESCRIPTION
@flyingcircusio/release-managers

PL-135486

## Release process

This change should be backported:

- [ ] Created changelog entry using `./changelog.sh`
  - no, qemu-ceph-pacific has not been rolled out to production yet
- [x] Add `backport release-25.11` label

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [x] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - needs to work with both qemu-6 and qemu-10 processes
- [x] Security requirements tested? (EVIDENCE)
  - [x] NixOS tests pass
  - [x] entering maintenance works in dev cluster
  - [x] extended live integration suite with a smoke test that surfaces changes in the qemu process signature
  - [x] unit tests are based on process signatures of both qemu-6 and qemu10