### PR TITLE
ai-model-server: conditionally allow bridged L2 traffic on KVM hosts

### DIFF
--- a/nixos/roles/ai-model-server.nix
+++ b/nixos/roles/ai-model-server.nix
@@ -109,6 +109,13 @@ in
         services.xserver.videoDrivers = [ "nvidia" ];
         hardware.nvidia-container-toolkit.enable = true;
 
+        networking.firewall.extraCommands = lib.mkIf config.flyingcircus.roles.kvm_host.enable (
+          lib.mkAfter ''
+            # Allow bridged L2 traffic from Docker/vLLM containers on KVM hosts.
+            ip46tables -I fc-kvm-forward 1 -m physdev --physdev-is-bridged -j ACCEPT
+          ''
+        );
+
         environment.systemPackages = [
           (pkgs.writeShellScriptBin "nvtop-nvidia" ''
             exec ${pkgs.nvtopPackages.nvidia}/bin/nvtop "$@"


### PR DESCRIPTION
PL-135324

When ai-model-server and kvm_host roles are active on the same host, Docker containers (qwen3_27b, nomic15, dotsmocr) send/receive bridged L2 traffic through the physdev module. The fc-kvm-forward chain's default-refuse rule drops this traffic, breaking container networking.

Insert an ACCEPT rule at the top of fc-kvm-forward for bridged L2 packets via -m physdev --physdev-is-bridged, gated behind:
- lib.mkIf config.flyingcircus.roles.kvm_host.enable
- lib.mkAfter to ensure it runs after the fc-kvm-forward chain exists

@flyingcircusio/release-managers

## Release process

This change should be backported:

- [ ] Created changelog entry using `./changelog.sh`
- [ ] Add `backport release-25.11` label

This change should only reach this branch:

- [ ] Created changelog entry using `./changelog.sh`
or
- [ ] Add a upgrade node in `doc/upgrade.md`

## PR release workflow (internal)

- [ ] PR has internal ticket
- [ ] internal issue ID (PL-…) part of branch name
- [ ] internal issue ID mentioned in PR description text
- [ ] ticket is on Platform agile board
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [ ] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [ ] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [ ] Security requirements tested? (EVIDENCE)
