### PR TITLE
fc-ceph: resolve radosgw maintenance race conditions

### DIFF
--- a/nixos/roles/ceph/rgw.nix
+++ b/nixos/roles/ceph/rgw.nix
@@ -145,8 +145,8 @@ in
       };
 
       flyingcircus.agent.maintenance.rgw = {
-        enter = "systemctl stop fc-ceph-rgw";
-        leave = "systemctl start fc-ceph-rgw";
+        enter = "fc-ceph maintenance lock .radosgw && systemctl stop fc-ceph-rgw";
+        leave = "systemctl start fc-ceph-rgw && fc-ceph maintenance unlock .radosgw";
       };
 
       networking.firewall.extraStopCommands = ''

--- a/pkgs/fc/ceph/src/fc/ceph/main.py
+++ b/pkgs/fc/ceph/src/fc/ceph/main.py
@@ -437,6 +437,22 @@ requests. Useful for identifying slacky OSDs.""",
     parser_leave = maint_sub.add_parser("leave", help="Leave maintenance mode.")
     parser_leave.set_defaults(action="leave")
 
+    parser_lock = maint_sub.add_parser(
+        "lock", help="Acquire a named maintenance lock."
+    )
+    parser_lock.set_defaults(action="lock")
+    parser_lock.add_argument(
+        "lock_name", help="name of the rbd lock volume to acquire"
+    )
+
+    parser_unlock = maint_sub.add_parser(
+        "unlock", help="Free a named maintenance lock."
+    )
+    parser_unlock.set_defaults(action="unlock")
+    parser_unlock.add_argument(
+        "lock_name", help="name of the rbd lock volume to acquire"
+    )
+
     check = subparsers.add_parser("check", help="Cluster checks")
     check.set_defaults(action=check.print_usage)
     check_sub = check.add_subparsers()

--- a/pkgs/fc/ceph/src/fc/ceph/maintenance/nautilus.py
+++ b/pkgs/fc/ceph/src/fc/ceph/maintenance/nautilus.py
@@ -235,22 +235,22 @@ class MaintenanceTasks(object):
         rpe.ensure_pools_are_balanceable()
         return max(volume_statuscode, rpe_statuscode)
 
-    def _ensure_maintenance_volume(self):
+    def _ensure_maintenance_volume(self, lock_name: str):
         try:
             # fmt: off
-            run.rbd_locktool("-q", "-i", "rbd/.maintenance",
+            run.rbd_locktool("-q", "-i", f"rbd/{lock_name}",
                 timeout=self.LOCKTOOL_TIMEOUT_SECS,
             )
             # fmt: on
         except subprocess.CalledProcessError:
-            run.rbd("create", "--size", "1", "rbd/.maintenance")
+            run.rbd("create", "--size", "1", f"rbd/{lock_name}")
 
-    def enter(self):
+    def lock(self, lock_name: str):
         try:
-            self._ensure_maintenance_volume()
+            self._ensure_maintenance_volume(lock_name)
             # Aquire the maintenance lock
             run.rbd_locktool(
-                "-l", "rbd/.maintenance", timeout=self.LOCKTOOL_TIMEOUT_SECS
+                "-l", f"rbd/{lock_name}", timeout=self.LOCKTOOL_TIMEOUT_SECS
             )
         # locking can block on a busy cluster, causing the whole agent (and all other
         # agent operations waiting for the global agent lock) to be stuck
@@ -263,6 +263,9 @@ class MaintenanceTasks(object):
         except subprocess.CalledProcessError:
             sys.exit(75)  # EXIT_TEMPFAIL, fc-agent might retry
 
+    def enter(self):
+        self.lock(".maintenance")
+
         # Check that the cluster is fully healhty
         cluster_status = run.json.ceph("health")
         if not self.check_cluster_maintenance(cluster_status):
@@ -271,7 +274,9 @@ class MaintenanceTasks(object):
                 f"Ceph status is {cluster_status['status']}."
             )
             # when postponing the maintenance, do not leave a stale lock around in case
-            # e.g. the machine failing before the next maintenance attempt
+            # e.g. the machine failing before the next maintenance attempt.
+            # This also sets our own OSDs `up` again, in case they might have
+            # been the culprit behind the unhealthy status.
             self.leave()
             # 69 signals to postpone the maintenance, triggering a leave in fc-agent
             sys.exit(69)
@@ -284,27 +289,18 @@ class MaintenanceTasks(object):
                 run.ceph("osd", "set-group", "noup", *sorted(osd_ids))
                 run.ceph("osd", "down", *sorted(osd_ids))
         except Exception:
+            # `leave` is necessary once we started setting OSDs noup/ down,
+            # as down OSDs will cause the next lock-time health check to fail
             self.leave()
             sys.exit(75)  # EXIT_TEMPFAIL, fc-agent might retry
 
-    def leave(self):
-        _, osd_ids = get_host_crush_buckets()
-
-        noup_osds = sorted(filter_noup_osds(osd_ids))
-        for osd_id in noup_osds:
-            # remove noup flags in a staggered fashion, to reduce peering storm
-            run.ceph("osd", "unset-group", "noup", str(osd_id))
-            time.sleep(15)
-
-        if noup_osds and noup_workaround.run() != 0:
-            raise RuntimeError("noup-workaround failed, PGs may still be stuck")
-
+    def unlock(self, lock_name: str):
         last_exc = None
         for _ in range(self.UNLOCK_MAX_RETRIES):
             try:
-                self._ensure_maintenance_volume()
+                self._ensure_maintenance_volume(lock_name)
                 # fmt: off
-                run.rbd_locktool("-q", "-u", "rbd/.maintenance",
+                run.rbd_locktool("-q", "-u", f"rbd/{lock_name}",
                     timeout=self.LOCKTOOL_TIMEOUT_SECS,
                 )
                 # fmt: on
@@ -328,3 +324,17 @@ class MaintenanceTasks(object):
                 if last_exc
                 else RuntimeError("Ceph cluster maintenance unlock failed")
             )
+
+    def leave(self):
+        _, osd_ids = get_host_crush_buckets()
+
+        noup_osds = sorted(filter_noup_osds(osd_ids))
+        for osd_id in noup_osds:
+            # remove noup flags in a staggered fashion, to reduce peering storm
+            run.ceph("osd", "unset-group", "noup", str(osd_id))
+            time.sleep(15)
+
+        if noup_osds and noup_workaround.run() != 0:
+            raise RuntimeError("noup-workaround failed, PGs may still be stuck")
+
+        self.unlock(".maintenance")

--- a/pkgs/fc/ceph/src/fc/ceph/maintenance/nautilus.py
+++ b/pkgs/fc/ceph/src/fc/ceph/maintenance/nautilus.py
@@ -279,7 +279,7 @@ class MaintenanceTasks(object):
         # Prohibit OSD traffic by marking them down and flagging them to
         # not automatically return.
         try:
-            host_buckets, osd_ids = get_host_crush_buckets()
+            _, osd_ids = get_host_crush_buckets()
             if osd_ids:
                 run.ceph("osd", "set-group", "noup", *sorted(osd_ids))
                 run.ceph("osd", "down", *sorted(osd_ids))
@@ -288,11 +288,7 @@ class MaintenanceTasks(object):
             sys.exit(75)  # EXIT_TEMPFAIL, fc-agent might retry
 
     def leave(self):
-        host_buckets, osd_ids = get_host_crush_buckets()
-        if host_buckets:
-            # PL-133952: still needed for getting hosts upgrading from the
-            # previous mechanism out of maintenance. Remove later.
-            run.ceph("osd", "unset-group", "noup", *sorted(host_buckets))
+        _, osd_ids = get_host_crush_buckets()
 
         noup_osds = sorted(filter_noup_osds(osd_ids))
         for osd_id in noup_osds:

--- a/pkgs/fc/ceph/src/fc/ceph/tests/fc-ceph/test_maintenance.py
+++ b/pkgs/fc/ceph/src/fc/ceph/tests/fc-ceph/test_maintenance.py
@@ -68,7 +68,12 @@ def ceph_calls(monkeypatch):
 
 
 def test_successful_maintenance_cycle(
-    ceph_json_calls, ceph_calls, locktoolcalls, maintenance_manager, nosleep, monkeypatch
+    ceph_json_calls,
+    ceph_calls,
+    locktoolcalls,
+    maintenance_manager,
+    nosleep,
+    monkeypatch,
 ):
     monkeypatch.setattr("fc.ceph.maintenance.noup_workaround.run", lambda: 0)
     maintenance_task = maintenance_manager.MaintenanceTasks()
@@ -119,16 +124,13 @@ def test_successful_maintenance_cycle(
     maintenance_task.leave()
 
     assert ceph_json_calls.call_count == 4
-    assert ceph_calls.call_count == 6
+    assert ceph_calls.call_count == 5
     assert locktoolcalls.call_count == 4
 
     ceph_calls.assert_has_calls(
         [
             mock.call("osd", "set-group", "noup", "13", "14", "27"),
             mock.call("osd", "down", "13", "14", "27"),
-            mock.call(
-                "osd", "unset-group", "noup", "localhost", "localhost-ssd"
-            ),
             mock.call("osd", "unset-group", "noup", "13"),
             mock.call("osd", "unset-group", "noup", "14"),
             mock.call("osd", "unset-group", "noup", "27"),
@@ -258,8 +260,9 @@ def test_tempfail_when_another_lockholder(locktoolcalls, maintenance_manager):
 
 
 def test_postpone_and_leave_when_unclean(
-    locktoolcalls, ceph_calls, ceph_json_calls, maintenance_manager
+    locktoolcalls, ceph_calls, ceph_json_calls, maintenance_manager, monkeypatch
 ):
+    monkeypatch.setattr("fc.ceph.maintenance.noup_workaround.run", lambda: 0)
     maintenance_task = maintenance_manager.MaintenanceTasks()
 
     locktoolcalls.side_effect = [
@@ -277,9 +280,18 @@ def test_postpone_and_leave_when_unclean(
     ceph_json_calls.side_effect = [
         {"status": "HEALTH_ERR"},
         # osd tree
-        {"nodes": []},
+        {
+            "nodes": [
+                {"name": "localhost", "type": "host", "children": [14]},
+                {
+                    "name": "localhost-ssd",
+                    "type": "host",
+                    "children": [27, 13],
+                },
+            ]
+        },
         # health detail
-        {},
+        CEPH_HEALTH_NOUP_DATA,
     ]
 
     with pytest.raises(SystemExit, match="69"):
@@ -292,6 +304,14 @@ def test_postpone_and_leave_when_unclean(
             mock.call("-l", "rbd/.maintenance", timeout=30),
             mock.call("-q", "-i", "rbd/.maintenance", timeout=30),
             mock.call("-q", "-u", "rbd/.maintenance", timeout=30),
+        ]
+    )
+    ceph_calls.assert_has_calls(
+        [
+            # particularly important to ensure the health warnings can clear up for the next attempt
+            mock.call("osd", "unset-group", "noup", "13"),
+            mock.call("osd", "unset-group", "noup", "14"),
+            mock.call("osd", "unset-group", "noup", "27"),
         ]
     )
 


### PR DESCRIPTION
@flyingcircusio/release-managers

The ceph_rgw role now takes its own rbd-based atomic maintenance before
executing its stateful maintenance action – shutting down the radosgw
daemon. This resolves a race condition where multiple radosgw daemons were shut
down during overlapping maintenances.

PL-135499

supersedes #2379 and #2425

Reasons why the rgw requires its own lock file and just a plain `fc-ceph
maintenance lock`:
- `fc-ceph maintenance enter` is not re-entrant on OSD hosts: Setting
  osds to `noup`/`down` causes a HEALTH_WARN that will make subsequent
  `maintenance enter` attempts fail.
  This will finally resolve and succeed as a subsequent `maintenance
  enter` attempt encountering a HEALTH_WARN will set these OSDs back up
  again, causing the health warning to resolve
- separate lock file is required to avoid the following sequence:
  1. generic ceph maintenance leave action unlocks the rbd lock
  2. rgw maintenance leave action is executed, but fails to start the
     fc-ceph-rgw.service, e.g. due to invalid config
  3. As the lock was cleared in 1., another radosgw host may enter its
     maintenance again and shut down its radosgw, resulting in
     overlapping radosgw downtimes.

## Release process

This change should only reach this branch:

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [x] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - [x] maintenance enter hooks also need to serialise and protect maintenance execution when other hooks are present
  - [x] maintenance enter failures due to remote locks need to (finally) resolve when the remote lock has been freed
  - [x] highlight load-bearing (un)lock behaviour in code for clarity
- [x] Security requirements tested? (EVIDENCE)
  - [x] extended existing tests to highlight and explicitly test load-bearing unlock behaviour at certain maintenance enter failure paths
  - [x] extensively tested maintenance execution in the face of combinations of different locking failures in development cluster
