### PR TITLE
ceph: double the interval before down OSDs are out

### DIFF
--- a/nixos/services/ceph/client.nix
+++ b/nixos/services/ceph/client.nix
@@ -47,7 +47,7 @@ let
 
     monCompactOnStart = true; # Keep mondb small
     monHost = mons;
-    monOsdDownOutInterval = 900; # Allow 15 min for reboots to happen without backfilling.
+    monOsdDownOutInterval = 1800; # Allow 30 min for reboots to happen without backfilling.
     monOsdNearfullRatio = 0.9;
 
     monData = "/srv/ceph/mon/$cluster-$id";


### PR DESCRIPTION
To account for a host with reboot problems, causing it to take up to 30min to reboot, we allow OSDs to be down for up to 30min before causing the cluster to rebalance.

PL-135546

@flyingcircusio/release-managers

## Release process

- [ ] Created changelog entry using `./changelog.sh`
  - internal, not relevant for customers 

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [x] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - adjust out period to expected host downtimes
- [x] Security requirements tested? (EVIDENCE)
  - no regressions, tests pass
