### PR TITLE
[PL-134309] remove prometheus from the default statshost location

### DIFF
--- a/changelog.d/20260629_094700_PL-134309_remove-prometheus-from-grafana-location_scriv.md
+++ b/changelog.d/20260629_094700_PL-134309_remove-prometheus-from-grafana-location_scriv.md
@@ -1,0 +1,7 @@
+### Impact
+
+-
+
+### NixOS XX.XX platform
+
+- Remove a deprecated proxy pass to prometheus on root location of the default statshost domain that was causing a number of basic auth pop ups (PL-134309)

--- a/nixos/roles/statshost/default.nix
+++ b/nixos/roles/statshost/default.nix
@@ -506,25 +506,12 @@ in
         recommendedOptimisation = true;
         recommendedProxySettings = true;
         recommendedTlsSettings = true;
-        appendHttpConfig = ''
-          map $http_referer $redirect_referer {
-              "~^https://${cfgStats.hostName}/grafana/" 1;
-              default 0;
-          }
-        '';
         virtualHosts.${cfgStats.hostName} = {
           enableACME = cfgStats.useSSL;
           forceSSL = cfgStats.useSSL;
           locations = {
             "/".extraConfig = ''
-              if ($redirect_referer) {
-                  rewrite ^(.*)$ /grafana$1 redirect;
-              }
-
-              rewrite ^/$ /grafana/ redirect;
-              auth_basic "FCIO user";
-              auth_basic_user_file "/etc/local/htpasswd_fcio_users";
-              proxy_pass http://${prometheusListenAddress};
+              rewrite ^(.*)$ /grafana$1 redirect;
             '';
             "/grafana/" = {
               proxyPass = "http://127.0.0.1:3001/";


### PR DESCRIPTION
@flyingcircusio/release-managers

PL-134309

## Release process

This change should be backported:

- [x] Created changelog entry using `./changelog.sh`
- [x] Add `backport fc-25.11-dev` label

This change should only reach this branch:

- [ ] Created changelog entry using `./changelog.sh`
or
- [ ] Add a upgrade node in `doc/upgrade.md`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [ ] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [x] Security requirements tested? (EVIDENCE)
- removed a basic-auth protected proxy pass to prometheus