### PR TITLE
ceph/rgw: fix maintenance hook absolute paths

### DIFF
--- a/changelog.d/20260701_155208_PL-135499-fixup-hook-paths_scriv.md
+++ b/changelog.d/20260701_155208_PL-135499-fixup-hook-paths_scriv.md
@@ -1,0 +1,27 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+<!-- Impact means "when this change is rolled out, there
+     might be interruptions/downtimes/required actions/... that
+     IMPACT THE RUNNING APPLICATION NEGATIVELY.
+
+     Having new features or changed is not an "impact". That's what
+     the main changelog (see below) is for.
+     -->
+
+
+### NixOS XX.XX platform
+
+- ceph/rgw: take separate maintenance lock for radosgw, preventing race conditions in shutdown of instances (PL-135499)

--- a/nixos/roles/ceph/rgw.nix
+++ b/nixos/roles/ceph/rgw.nix
@@ -145,8 +145,8 @@ in
       };
 
       flyingcircus.agent.maintenance.rgw = {
-        enter = "fc-ceph maintenance lock .radosgw && systemctl stop fc-ceph-rgw";
-        leave = "systemctl start fc-ceph-rgw && fc-ceph maintenance unlock .radosgw";
+        enter = "${cephPkgs.fc-ceph}/bin/fc-ceph maintenance lock .radosgw && ${config.systemd.package}/bin/systemctl stop fc-ceph-rgw";
+        leave = "${config.systemd.package}/bin/systemctl start fc-ceph-rgw && ${cephPkgs.fc-ceph}/bin/fc-ceph maintenance unlock .radosgw";
       };
 
       networking.firewall.extraStopCommands = ''


### PR DESCRIPTION
The `fc-ceph` command was not found when the hooks were run in scope of `fc-agent.service`, due to the systemd unit having a reduced PATH. This did not show up during manual testing, because interactive invocations of `fc-maintenance` copy the system-wide PATH.

Note: `systemctl` is already in PATH of the unit. But as I could not trace where this PATH addition originates, I've decided to be better explicit than implicit there and declare a full absolute path to the executable nonetheless.

PL-135499

Fixup for #2441

@flyingcircusio/release-managers

## Release process

This change should only reach this branch:

- [x] Created changelog entry using `./changelog.sh`
  - changelog was missing altogehter in original PR anyways

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [x] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - fix regression in new rgw maintenance hooks
  - identify reason why this was not caught in testing
  - ensure cleanup of stuck maintenances in staging, where this surfaced
- [x] Security requirements tested? (EVIDENCE)
  - this was not caught due to different PATH handling in maunal `fc-maintenance` invocations vs. `fc-agent.service`
  - manually ensured that `fc-agent.service` correctly invokes *leave* hook and cleans up locks
  - taking care of stuck staging servers has been noted down as a follow-up action
