### PR TITLE
kernel: bump linuxKernelVerify to 6.18

### DIFF
--- a/changelog.d/20260702_124219_PL-135546-linux-6.18-verify_scriv.md
+++ b/changelog.d/20260702_124219_PL-135546-linux-6.18-verify_scriv.md
@@ -1,0 +1,30 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+<!-- Impact means "when this change is rolled out, there
+     might be interruptions/downtimes/required actions/... that
+     IMPACT THE RUNNING APPLICATION NEGATIVELY.
+
+     Having new features or changed is not an "impact". That's what
+     the main changelog (see below) is for.
+     -->
+
+
+
+### NixOS XX.XX platform
+
+- linuxKernelVerify: bump to 6.18
+
+  All non-production machines, as well as all machines running in our WHQ and DEV locations, will now use a 6.18 kernel. Production RZOB machines remain at kernel 6.12 for now.

--- a/nixos/platform/kernel.nix
+++ b/nixos/platform/kernel.nix
@@ -126,7 +126,6 @@ in
       PC87413_WDT n
       NV_TCO n
       60XX_WDT n
-      CPU5_WDT n
       SMSC_SCH311X_WDT n
       SMSC37B787_WDT n
       TQMX86_WDT n
@@ -156,6 +155,9 @@ in
       {
         name = "fcio-kernel-options";
         patch = null;
+        structuredExtraConfig = with lib.kernel.whenHelpers config.boot.kernelPackages.kernel.version; {
+          CPU5_WDT = whenOlder "6.18" lib.kernel.no;
+        };
         extraConfig = config.flyingcircus.kernelOptions;
       }
     ];

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -330,7 +330,7 @@ builtins.mapAttrs (_: patchPhps phpLogPermissionPatch) {
   # The logic for enabling different kernels on prod and non-prod remains active
   # the whole time. But in the normal case, both kernels point to the same
   # stable kernel packages.
-  linuxKernelVerify = self.linux_6_12;
+  linuxKernelVerify = self.linux_6_18;
 
   linuxKernelStable = self.linux_6_12;
 

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -61,7 +61,10 @@ in
   k3s = callTest ./k3s { };
   k3s_ipv6 = callTest ./k3s { enableIPv6 = true; };
   k3s_monitoring = callTest ./k3s/monitoring.nix { };
-  kernelconfig = callTest ./kernelconfig.nix { };
+  kernelconfig = {
+    default = callTest ./kernelconfig.nix { };
+    verification = callTest ./kernelconfig-verification.nix { };
+  };
   kernelversions = callTest ./kernelversions.nix { };
   kvm_host_ceph-nautilus-nautilus = callTest ./kvm_host_ceph-nautilus.nix {
     clientCephRelease = "nautilus";

--- a/tests/kernelconfig-verification.nix
+++ b/tests/kernelconfig-verification.nix
@@ -1,0 +1,263 @@
+import ./make-test-python.nix (
+  {
+    pkgs,
+    lib,
+    testlib,
+    ...
+  }:
+
+  let
+    # Those are configured in base nixos and we want to ensure
+    # the do not get lost.
+    additionalExpectedConfig = ''
+      BLK_DEV_DM m
+      BLK_DEV_INTEGRITY y
+      BLK_DEV_LOOP m
+      BLK_DEV_NBD m
+      BLK_DEV_NVME m
+      BLK_DEV_RBD m
+      BNX2 m
+      BONDING m
+      BOOTPARAM_HARDLOCKUP_PANIC y
+      BOOTPARAM_SOFTLOCKUP_PANIC y
+      BRIDGE m
+      BRIDGE_IGMP_SNOOPING y
+      COMPACTION y
+      CONFIGFS_FS m
+      CPU_FREQ_GOV_CONSERVATIVE m
+      CPU_FREQ_GOV_ONDEMAND m
+      CPU_FREQ_GOV_PERFORMANCE y
+      CPU_FREQ_GOV_POWERSAVE m
+      CRYPTO_AES_NI_INTEL m
+      CRYPTO_CRC32C m
+      CRYPTO_SHA256 y
+      CRYPTO_SHA512 y
+      DEBUG_FS y
+      DEFAULT_SECURITY_APPARMOR y
+      DM_CRYPT m
+      DM_MIRROR m
+      DM_MULTIPATH m
+      DM_SNAPSHOT m
+      DM_THIN_PROVISIONING m
+      DM_ZERO m
+      DMIID y
+      E1000 m
+      E1000E m
+      EXT4_FS m
+      EXT4_FS_POSIX_ACL y
+      FTRACE_SYSCALLS y
+      FUNCTION_GRAPH_TRACER y
+      FUNCTION_PROFILER y
+      FUNCTION_TRACER y
+      FUSE_FS m
+      FUSION y
+      FUSION_CTL m
+      FUSION_SAS m
+      HANGCHECK_TIMER m
+      HARDLOCKUP_DETECTOR y
+      HW_RANDOM_INTEL m
+      HW_RANDOM_TIMERIOMEM m
+      I40E m
+      I40EVF m
+      IGB m
+      IKCONFIG y
+      IKCONFIG_PROC y
+      INET_DIAG m
+      INET_UDP_DIAG m
+      INTEL_IDLE y
+      INTEL_IOATDMA m
+      INTEL_IOMMU_DEFAULT_ON n
+      IP_ADVANCED_ROUTER y
+      IP_MULTICAST y
+      IP_MULTIPLE_TABLES y
+      IPMI_DEVICE_INTERFACE m
+      IPMI_HANDLER m
+      IPMI_POWEROFF m
+      IPMI_SI m
+      IPMI_WATCHDOG m
+      IPV6 y
+      IPV6_MULTIPLE_TABLES y
+      IRQ_REMAP y
+      IXGBE m
+      IXGBE_DCA y
+      IXGBE_HWMON y
+      IXGBEVF m
+      KPROBES y
+      KVM m
+      KVM_AMD m
+      KVM_INTEL m
+      MD y
+      MD_RAID0 m
+      MD_RAID1 m
+      MD_RAID456 m
+      MEGARAID_MAILBOX m
+      MEGARAID_MM m
+      MEGARAID_NEWGEN y
+      MEGARAID_SAS m
+      MICROCODE y
+      MLX5_CORE m
+      MLX5_CORE_EN y
+      MLX5_EN_ARFS y
+      MLX5_EN_RXNFC y
+      MLX5_MPFS y
+      NET_IPGRE m
+      NET_IPGRE_DEMUX m
+      NET_IPIP m
+      NET_SCH_CODEL m
+      NET_SCH_FQ m
+      NET_SCH_FQ_CODEL m
+      NET_SCH_PRIO m
+      NETFILTER_ADVANCED y
+      NETFILTER_XT_MATCH_HASHLIMIT m
+      NETFILTER_XT_MATCH_IPRANGE m
+      NETFILTER_XT_MATCH_LIMIT m
+      NETFILTER_XT_MATCH_MARK m
+      NETFILTER_XT_MATCH_MULTIPORT m
+      NETFILTER_XT_MATCH_OWNER m
+      NETFILTER_XT_MATCH_TCPMSS m
+      NETWORK_FILESYSTEMS y
+      NF_CONNTRACK m
+      NFSD m
+      NFSD_V4 y
+      NR_CPUS 384
+      OPENVSWITCH m
+      PACKET_DIAG m
+      PAGE_POOL y
+      RAID_ATTRS m
+      RELAY y
+      SCSI_DH_RDAC m
+      SCSI_LOWLEVEL y
+      SCSI_MPT3SAS m
+      SCSI_SAS_ATA y
+      SCSI_SAS_ATTRS m
+      SCSI_SAS_LIBSAS m
+      SECURITY_APPARMOR y
+      ITCO_WDT n
+      SOFTLOCKUP_DETECTOR y
+      TCP_CONG_BBR m
+      TCP_CONG_BIC m
+      TCP_CONG_HTCP m
+      TCP_CONG_ILLINOIS m
+      TCP_CONG_VEGAS m
+      TCP_CONG_WESTWOOD m
+      TCP_CONG_YEAH m
+      TRANSPARENT_HUGEPAGE y
+      TUN m
+      UNIX_DIAG m
+      USB_EHCI_HCD m
+      USB_SERIAL y
+      USB_SERIAL_FTDI_SIO m
+      USB_SERIAL_PL2303 m
+      USB_UHCI_HCD m
+      USB_XHCI_HCD m
+      VHOST_NET m
+      VLAN_8021Q m
+      VXLAN m
+      X86_ACPI_CPUFREQ m
+
+      X86_PCC_CPUFREQ m
+      XFS_FS m
+
+      ## watchdog config
+      WATCHDOG y
+      IPMI_WATCHDOG m
+      I6300ESB_WDT y
+      ITCO_WDT n
+      SP5100_TCO n
+    '';
+  in
+  rec {
+    name = "kernel-config-verification";
+    nodes.machine =
+      { config, ... }:
+      {
+        imports = [
+          (testlib.fcConfig { id = 1; })
+        ];
+        flyingcircus.useVerificationKernel = true;
+      };
+
+    testScript =
+      let
+      in
+      { nodes, ... }:
+      ''
+        def parseConfigDef(cfg):
+            cfg = cfg.split('\n')
+            opts = {}
+            for line in cfg:
+                line = line.strip()
+                if line.startswith('##'):
+                    continue
+                if line.startswith('#'):
+                    line = line[1:]
+                line = line.strip()
+                if not line:
+                    continue
+                key, value = line.split(" ", maxsplit=1)
+                opts[key] = value
+            return cfg, opts
+
+        def parseConfigFinal(cfg):
+            cfg = cfg.split('\n')
+            opts = {}
+            for line in cfg:
+                if not 'CONFIG_' in line:
+                    continue
+                if line.startswith('#'):
+                    line = line[1:]
+                line = line.strip()
+                if not line:
+                    continue
+                line = line.replace('CONFIG_', "", 1)
+                if 'is not set' in line:
+                    key = line.split(' ', maxsplit=1)[0]
+                    value = 'n'
+                else:
+                    key, value = line.split("=", maxsplit=1)
+                opts[key] = value
+            return cfg, opts
+
+        expectedRaw, expectedConfig = parseConfigDef("""${toString nodes.machine.flyingcircus.kernelOptions}\n${additionalExpectedConfig}""")
+
+        duplicateOptions = []
+        # Ensure the expected config has no double entries
+        expectedSeen = set()
+        for line in expectedConfig:
+            option = line.split()[0]
+            if option.startswith("##"):
+                continue
+            if not option.strip():
+                continue
+            if option in expectedSeen:
+                print('Duplicate option:', line)
+                duplicateOptions.append(option)
+            expectedSeen.add(option)
+        if duplicateOptions:
+            raise ValueError('{} duplicate expected options'.format(len(duplicateOptions)))
+
+        _, foundConfig = machine.execute("zcat /proc/config.gz")
+        foundRaw, foundConfig = parseConfigFinal(foundConfig)
+
+        print()
+        missingOptions = []
+        for key in expectedConfig:
+            if key not in foundConfig:
+                print('Missing: ', key)
+                missingOptions.append(key)
+            elif foundConfig[key] != expectedConfig[key]:
+                print('{} expected {} but found {}'.format(
+                    key, expectedConfig[key], foundConfig[key]))
+                missingOptions.append(key)
+        if missingOptions:
+            raise ValueError('{} wrong config options'.format(len(missingOptions)))
+
+
+        with subtest("nmi watchdog is enabled"):
+            _, output = machine.execute("cat /proc/sys/kernel/nmi_watchdog")
+            output = output.strip()
+            print(output)
+            assert output == "0", output
+      '';
+  }
+)

--- a/tests/kernelversions.nix
+++ b/tests/kernelversions.nix
@@ -221,8 +221,8 @@ import ./make-test-python.nix (
                 f"Expected: {expected}, found: {found}. uname -a: {uname_a}"
               )
 
-      assert "${stableVersion}".startswith("6.12."), "Expecting a 6.6.x kernel as stable kernel"
-      assert "${verifyVersion}".startswith("6.12."), "Expecting a 6.12.x kernel as verify kernel"
+      assert "${stableVersion}".startswith("6.12."), "Expecting a 6.12.x kernel as stable kernel"
+      assert "${verifyVersion}".startswith("6.18."), "Expecting a 6.18.x kernel as verify kernel"
       assertKernelVersion(verifyKernel, "${verifyVersion}")
       assertKernelVersion(prodKernel, "${stableVersion}")
       assertKernelVersion(rzobProdKernel, "${stableVersion}")


### PR DESCRIPTION
Partially picked from a97e5963ee0ab18e2bec43d58215f84e7ab2c9ac

PL-135546

@flyingcircusio/release-managers

## Release process

This change should only reach this branch:

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [x] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - provide the next LTS branch of the Linux kernel on non-prod and staging machines for testing its feasibility
- [x] Security requirements tested? (EVIDENCE)
  - adjusted kernelconfig test to module changes