### PR TITLE
kernel: update to our patched nixpkgs to fix januscape

### DIFF
--- a/changelog.d/20260707_081519_PL-135580-januscape_scriv.md
+++ b/changelog.d/20260707_081519_PL-135580-januscape_scriv.md
@@ -1,0 +1,29 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+<!-- Impact means "when this change is rolled out, there
+     might be interruptions/downtimes/required actions/... that
+     IMPACT THE RUNNING APPLICATION NEGATIVELY.
+
+     Having new features or changed is not an "impact". That's what
+     the main changelog (see below) is for.
+     -->
+
+- A bullet item for the Impact category.
+
+
+### NixOS XX.XX platform
+
+- Fast track kernel updated to 6.12.95 and 6.18.38 to fix Januscape (PL-135580, CVE-2026-53359)

--- a/flake.lock
+++ b/flake.lock
@@ -165,11 +165,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1782975192,
-        "narHash": "sha256-wcUqVYIxQl0M2vbb8D2XvyMfZim+SJ6CUZoCNv6TqKk=",
+        "lastModified": 1783404640,
+        "narHash": "sha256-pjT+Nu0tYd9tFhRhuofiOSbKMMeQwldagGhtL9VJMZc=",
         "owner": "flyingcircusio",
         "repo": "nixpkgs",
-        "rev": "450f050708317375156bdda9f733b6516600ebfd",
+        "rev": "558616077edd7fb40a08107adc03dff0da12e1ff",
         "type": "github"
       },
       "original": {

--- a/release/package-versions.json
+++ b/release/package-versions.json
@@ -465,14 +465,14 @@
     "version": "0.2.5"
   },
   "linuxKernelStable": {
-    "name": "linux-6.12.94",
+    "name": "linux-6.12.95",
     "pname": "linux",
-    "version": "6.12.94"
+    "version": "6.12.95"
   },
   "linuxKernelVerify": {
-    "name": "linux-6.12.94",
+    "name": "linux-6.18.38",
     "pname": "linux",
-    "version": "6.12.94"
+    "version": "6.18.38"
   },
   "logrotate": {
     "name": "logrotate-3.22.0",

--- a/release/versions.json
+++ b/release/versions.json
@@ -8,10 +8,10 @@
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/"
   },
   "nixpkgs": {
-    "hash": "sha256-wcUqVYIxQl0M2vbb8D2XvyMfZim+SJ6CUZoCNv6TqKk=",
+    "hash": "sha256-pjT+Nu0tYd9tFhRhuofiOSbKMMeQwldagGhtL9VJMZc=",
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "450f050708317375156bdda9f733b6516600ebfd"
+    "rev": "558616077edd7fb40a08107adc03dff0da12e1ff"
   },
   "poetry2nix": {
     "hash": "sha256-nzgO/ZCSBzWjbMkYDxG+yl9Z2eGbCgQu06Oku3ir5D4=",


### PR DESCRIPTION
PL-135580

@flyingcircusio/release-managers

## Release process

This change should only reach this branch:

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [x] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

fix security issues :p

- [x] Security requirements tested? (EVIDENCE)

verified the relevant commit is in the kernel releases