### PR TITLE
physical: explicitly load more filesystem kernel modules

### DIFF
--- a/changelog.d/20260713_104934_HEAD_scriv.md
+++ b/changelog.d/20260713_104934_HEAD_scriv.md
@@ -1,0 +1,27 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+<!-- Impact means "when this change is rolled out, there
+     might be interruptions/downtimes/required actions/... that
+     IMPACT THE RUNNING APPLICATION NEGATIVELY.
+
+     Having new features or changed is not an "impact". That's what
+     the main changelog (see below) is for.
+     -->
+
+
+### NixOS XX.XX platform
+
+- physical hosts: explicitly load more filesystem kernel modules to fix an intermittent issue where servers would occasionally fail to recognize the boot partition during startup (PL-135585)

--- a/nixos/infrastructure/flyingcircus-physical.nix
+++ b/nixos/infrastructure/flyingcircus-physical.nix
@@ -39,6 +39,20 @@ mkIf (cfg.infrastructureModule == "flyingcircus-physical") (
           "nvme"
         ];
 
+        # We don't know generally which filesystems our machines use for their
+        # /boot partition, so we cannot set this using filesystems.<...>.fsType.
+        # We have seen issues that the filesystem could not be mounted
+        # (likely because of timing issues), so explicitly load the modules for
+        # filesystems we use.
+        supportedFilesystems = [
+          "ext4"
+          "vfat"
+        ];
+        initrd.supportedFilesystems = [
+          "ext4"
+          "vfat"
+        ];
+
         # not relevant for boot stage1
         kernelModules = [
           "dm_mirror" # LVM disk migration scenarios


### PR DESCRIPTION
PL-135585

@flyingcircusio/release-managers

## Release process

This change should only reach this branch:

- [x] Created changelog entry using `./changelog.sh`


## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [x] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [x] Security requirements tested? (EVIDENCE)
  - checked that vfat and ext4 are our boot filesystems
  - checked that vfat and ext4 appear in the initrd
<img width="866" height="169" alt="Screenshot 2026-07-13 at 11 09 00" src="https://github.com/user-attachments/assets/a33f9249-9a69-496a-b2d4-1994882f2b75" />
  - checked that the hosts reboot fine (the issue was non-reproducible before!)