### PR TITLE
[FC-53263] reduce output noise for the k3s pending pods sensu check

### DIFF
--- a/changelog.d/20260722_144925_FC-53263_denoise-pod-monitoring-output_scriv.md
+++ b/changelog.d/20260722_144925_FC-53263_denoise-pod-monitoring-output_scriv.md
@@ -1,0 +1,8 @@
+
+### Impact
+
+-
+
+### NixOS XX.XX platform
+
+- Reduce output noise for the pending pods monitoring check (FC-53263)

--- a/nixos/roles/k3s/server.nix
+++ b/nixos/roles/k3s/server.nix
@@ -391,7 +391,8 @@ let
             "ns": .metadata.namespace,
             "phase": .status.phase,
             "since": .status.conditions[].lastTransitionTime,
-            "message": .status.conditions[].message}') || ret=$?
+            "message": .status.conditions[].message}
+          | select(.message != null)' | ${jqBin} -s "unique") || ret=$?
 
     if [ "$ret" -eq "4" ]; then
         # no output, good.


### PR DESCRIPTION
@flyingcircusio/release-managers

FC-53263

## Release process

This change should be backported:

- [ ] Created changelog entry using `./changelog.sh`
- [ ] Add `backport release-25.11` label

This change should only reach this branch:

- [x] Created changelog entry using `./changelog.sh`
or
- [ ] Add a upgrade node in `doc/upgrade.md`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [ ] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [x] Security requirements tested? (EVIDENCE)
- no security impact