### PR TITLE
platform: improve early boot kmsg logging

### DIFF
--- a/changelog.d/20260723_205913_PL-135546-physical-kmsg-buffer-size_scriv.md
+++ b/changelog.d/20260723_205913_PL-135546-physical-kmsg-buffer-size_scriv.md
@@ -1,0 +1,21 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+
+### NixOS XX.XX platform
+
+- imporve early boot logging for physical and virtual machines (PL-135546)
+
+  adjust buffer size and rate limiting settings to get rid off `Too many messages being logged to kmsg, ignoring`

--- a/nixos/infrastructure/flyingcircus-virtual.nix
+++ b/nixos/infrastructure/flyingcircus-virtual.nix
@@ -38,7 +38,6 @@ mkIf (cfg.infrastructureModule == "flyingcircus") {
     kernelParams = [
       "console=ttyS0"
       "nosetmode"
-      "log_buf_len=8388608" # 8MiB kernel ring buffer for bootup messages
     ];
 
     kernel.sysctl = {

--- a/nixos/platform/default.nix
+++ b/nixos/platform/default.nix
@@ -295,6 +295,8 @@ in
 
         # Output management
         "systemd.log_target=kmsg"
+        "log_buf_len=8388608" # 8MiB kernel ring buffer for bootup messages
+        "systemd.log_ratelimit_kmsg=0" # disable systemd early-boot rate limiting when logging to kmsg
       ];
 
       kernel.sysctl = {


### PR DESCRIPTION
Increase the kmsg buffer to be sufficiently large for early boot message storms, now also for physical machines.
During early boot, systemd logs directly to kmsg but applies a rate limiting by default. Disable this as well.

PL-135546

@flyingcircusio/release-managers

## Release process

This change should be backported:

- [x] Created changelog entry using `./changelog.sh`
- There is no forward porting flow for 26.11 available yet

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [x] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - [x] Ensure that regular earlyboot messages without rate limiting do not overload a physical machine's console. In PL-132397 we encountered machine crashes due to message storms.
- [x] Security requirements tested? (EVIDENCE)
  - [x] tested on both virtual and phsyical machines. A previously present `Too many messages being logged to kmsg, ignoring` line in the logs has vanished after applying these changes.
  - [x] Tested on a physical host affected by PL-132397 (SOL disconnected). No crashes appeared.
