### PR TITLE
pkgs: re-enable discourse build

### DIFF
--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -261,22 +261,19 @@ builtins.mapAttrs (_: patchPhps phpLogPermissionPatch) {
 
   docsplit = super.callPackage ./docsplit { };
 
-  # Heavy build, required to not OOM the customer machine
-  # Currently disabled because it fails to build in Nixpkgs and I (leona - maintainer in Nixpkgs)
-  # don't know the solution.
-  # discourseWithNixosPlugins = super.discourse.override {
-  #   plugins = (
-  #     with super.discourse.plugins;
-  #     [
-  #       discourse-bbcode-color
-  #       discourse-docs
-  #       discourse-events
-  #       discourse-prometheus
-  #       discourse-saved-searches
-  #       discourse-yearly-review
-  #     ]
-  #   );
-  # };
+  discourseWithNixosPlugins = super.discourse.override {
+    plugins = (
+      with super.discourse.plugins;
+      [
+        discourse-bbcode-color
+        discourse-docs
+        discourse-events
+        discourse-prometheus
+        discourse-saved-searches
+        discourse-yearly-review
+      ]
+    );
+  };
 
   dool = super.dool.overrideAttrs (old: {
     patches = old.patches or [ ] ++ [ ./dool-interface-altnames.patch ];


### PR DESCRIPTION
fixed in Nixpkgs.

no ticket, as temporary fix

@flyingcircusio/release-managers

## Release process

This change should only reach this branch:

- [ ] Created changelog entry using `./changelog.sh`
  no: internal

## PR release workflow (internal)

- [ ] PR has internal ticket
- [ ] internal issue ID (PL-…) part of branch name
- [ ] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [x] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [x] Security requirements tested? (EVIDENCE)
