### PR TITLE
ceph/mon: adjustments after Pacific upgrade

### DIFF
--- a/nixos/lib/ceph-common.nix
+++ b/nixos/lib/ceph-common.nix
@@ -7,8 +7,8 @@ let
   # TODO: Once all ceph packages have a similar structure, those can be
   # generated from this list (let's wait for pacific to see if the structure holds)
   releaseOrder = [
-    "nautilus"
     "pacific"
+    "nautilus"
   ];
   cephReleaseType = types.enum releaseOrder;
   defaultRelease = "nautilus";

--- a/nixos/roles/ceph/mon.nix
+++ b/nixos/roles/ceph/mon.nix
@@ -186,6 +186,13 @@ in
             package = cephPkgs.fc-ceph;
             groups = [ "sensuclient" ];
           }
+          {
+            commands = [
+              "bin/rbd trash ls"
+            ];
+            package = cephPkgs.ceph;
+            groups = [ "sensuclient" ];
+          }
         ];
 
         flyingcircus.services.sensu-client.checks = {
@@ -200,6 +207,17 @@ in
             notification = "Ceph cluster is unhealthy";
             command = "sudo ${cephPkgs.fc-ceph}/bin/${checkClusterCmd}";
             interval = 60;
+          };
+          rbd_trash = {
+            notification = "Unexpected rbd images found in trash.";
+            command = ''
+              if [ $(sudo ${cephPkgs.ceph}/bin/rbd trash ls | ${pkgs.coreutils}/bin/wc -l) -ne 0 ]; then
+                echo '`rbd trash ls`: Unexpected rbd images found in trash.' \
+                  'We do not regularly use trash so far, contact the Infra' \
+                  'team if you see a need to do so.'
+              fi
+            '';
+            interval = 600;
           };
         };
         flyingcircus.services.ceph = {

--- a/nixos/roles/ceph/osd.nix
+++ b/nixos/roles/ceph/osd.nix
@@ -46,10 +46,7 @@ let
 
     # automatically repairing PGs at scrub mismatches is reliable due to Bluestore
     # internal checksumming…
-    # TODO: but we still keep it disabled for Nautilus because it has spurious status
-    # display issues of generally indicating a `repairing` for deep-scrubbing PGs.
-    # see PL-131662
-    osdScrubAutoRepair = false;
+    osdScrubAutoRepair = true;
     # we use the default value of max. number of automatically corrected errors
     # "osd_scrub_auto_repair_num_errors": "5",
 
@@ -291,6 +288,12 @@ in
       }
       // osdServiceDeps;
 
+    })
+    (lib.mkIf (cfg.enable && !fclib.ceph.releaseAtLeast "pacific" cfg.cephRelease) {
+      # we need to disable autorepair for Nautilus because it has spurious status
+      # display issues of generally indicating a `repairing` for deep-scrubbing PGs.
+      # see PL-131662
+      flyingcircus.services.ceph.extraSettings.osdScrubAutoRepair = false;
     })
   ];
 }


### PR DESCRIPTION
Introduces 2 useful but non-urgent changes for Ceph Pacific and more recent:

- sensu check for `rbd trash` images: Right now we do not generally use the rbd trash feature, so finding images there is unexpected and requires investigation. Does not need to be version-gated as the command already works in Nautilus.
- re-enable ceph osd autorepair at scrub time in Pacific and newer

PL-131408

@flyingcircusio/release-managers

## Release process

This change should only reach this branch:

- [ ] Created changelog entry using `./changelog.sh`
  - no, internal

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [x] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - ensure that data supposed to be deleted is not accidentally forgotten in trash
  - the spurious autorepair display issues from PL-131662 need to be gone
- [x] Security requirements tested? (EVIDENCE)
  - check ran successfully on dev machine
  - no `repair` state appeared over 3 days after temporarily enabling autorepair in 3 different clusters via injectargs