### PR TITLE
fc.qemu: fix flaky tests, refactor fc-qemu.conf overrides and simplify flake-finder usage

### DIFF
--- a/pkgs/fc/default.nix
+++ b/pkgs/fc/default.nix
@@ -74,8 +74,8 @@ rec {
       repo = "fc.qemu";
       # The release tooling didn't upgrade properly so we had to pick a specific
       # commit instead.
-      rev = "63c7251a96b45b0fd4b0377df217825bbcddc36a";
-      hash = "sha256-hGntQnBuQsHVD7sS8bL6zjnxM2myzZ2/Kybt4CfFXsk=";
+      rev = "7b38ffbd3ec218c2717a1121aa4e6a5e32ba6fb4";
+      hash = "sha256-bZey7m/4HCQpb/FC19ck6grgYIKMPg6FRnwnDeOE3Qg=";
     };
     fc-ceph = ceph;
     qemu_ceph = pkgs.qemu-ceph-pacific;

--- a/pkgs/fc/qemu/default.nix
+++ b/pkgs/fc/qemu/default.nix
@@ -133,6 +133,7 @@ py.buildPythonPackage (finalAttrs: {
     nativeCheckInputs = [
       file
       openssh
+      procps # pkill
       py.pytest_patterns
       py.pytest
       py.pytest-xdist

--- a/pkgs/fc/qemu/default.nix
+++ b/pkgs/fc/qemu/default.nix
@@ -94,6 +94,11 @@ py.buildPythonPackage (finalAttrs: {
 
   name = "fc.qemu-${version}";
 
+  outputs = [
+    "out"
+    "testdata"
+  ];
+
   dontStrip = true;
 
   pyproject = true;
@@ -159,6 +164,8 @@ py.buildPythonPackage (finalAttrs: {
 
   postInstall = ''
     cp -Pr $src/share $out/share
+    mkdir $testdata
+    cp -r $src/tests/testdata/. $testdata || true  # fallback for previous revisions not providing testdata
   '';
 
   nativeCheckInputs = finalAttrs.passthru.nativeCheckInputs;

--- a/tests/kvm_host_ceph-nautilus.nix
+++ b/tests/kvm_host_ceph-nautilus.nix
@@ -64,9 +64,18 @@ import ./make-test-python.nix (
         flyingcircus.static.mtus.stb = 1500;
 
         # Override some fc-qemu.conf values to match the values expected by tests
-        flyingcircus.roles.kvm_host.settings = {
-          qemu.binary-generation = lib.mkForce 2;
-        };
+
+        flyingcircus.roles.kvm_host.settings =
+          let
+            deploymentOverride = "${testPackage.testdata}/deployment-settings-overrides.nix";
+          in
+          if builtins.pathExists deploymentOverride then
+            import deploymentOverride { inherit lib; }
+          else
+            # TODO: clean up when removing Ceph Nautilus support
+            {
+              qemu.binary-generation = lib.mkForce 2;
+            };
 
         systemd.timers.fc-ceph-load-vm-images.enable = lib.mkForce false;
         systemd.timers.fc-ceph-mon-update-client-keys.enable = lib.mkForce false;

--- a/tests/kvm_host_ceph-nautilus.nix
+++ b/tests/kvm_host_ceph-nautilus.nix
@@ -1,19 +1,24 @@
 import ./make-test-python.nix (
   {
+    lib,
     testlib,
     useCheckout ? false,
+    useFlakefinder ? false,
     testOpts ? "",
-    #testOpts ? "--flake-finder --flake-runs=10 -x --no-cov",
     # examples to specify tests
     # "-k mytest"
     # "--flake-finder --flake-runs=500 -x --no-cov"
-    # "--show-setup"  # shows which fixtures have been set up / torn down
-    clientCephRelease ? "nautilus",
-    serverCephRelease ? "nautilus",
+    # "--setup-show"  # shows which fixtures have been set up / torn down
+    clientCephRelease ? "pacific",
+    serverCephRelease ? "pacific",
     ...
   }:
   with testlib;
   let
+    flakeTestOps = "--flake-finder --flake-runs=9 -x --no-cov -k test_crashed_vm_clean_restart";
+    # use some default test opes when running with flake finder
+    testOpsToUse = if useFlakefinder && testOps == "" then flakeTestOps else testOpts;
+    testTimeout = if useFlakefinder then 25 * 60 * 60 else 40 * 60;
     getIPForVLAN = vlan: id: "192.168.${toString vlan}.${toString (5 + id)}";
     getIP6ForVLAN = vlan: id: "fd00:1234:000${toString vlan}::${toString (5 + id)}";
 
@@ -383,6 +388,7 @@ import ./make-test-python.nix (
   in
   {
     name = "kvm";
+    globalTimeout = testTimeout;
     nodes = {
       host1 = makeHostConfig { id = 1; };
       host2 = makeHostConfig { id = 2; };
@@ -446,7 +452,7 @@ import ./make-test-python.nix (
         host1.wait_for_unit("nginx", timeout=10)
 
         with subtest("Run tests"):
-          host1.succeed("run-tests ${testOpts}", timeout=30*60)
+          host1.succeed("run-tests ${testOpsToUse}", timeout=${toString testTimeout})
 
         # XXX the following tests should be migrated to fc.qemu at some point
         show(host1, "rbd rm rbd/.fc-qemu.maintenance || true")
@@ -500,8 +506,10 @@ import ./make-test-python.nix (
           result = show(host1, "fc-qemu-scrub")
           assert "I simplevm              running-ensure                 generation=0" in result, result
 
-        host1.copy_from_vm('/tmp/coverage', './')
-        host1.copy_from_vm('/tmp/fc.qemu-report.xml', './')
+        ${lib.optionalString (!useFlakefinder) ''
+          host1.copy_from_vm('/tmp/coverage', './')
+          host1.copy_from_vm('/tmp/fc.qemu-report.xml', './')
+        ''}
 
       '';
   }


### PR DESCRIPTION
@flyingcircusio/release-managers

Corresponding PR to https://github.com/flyingcircusio/fc.qemu/pull/60.

For discovering and fixing these test flakes, I ran the fc-nixos test with flake-finder. This required several adjustments to the tests, which are now easier handled by the `useFlakefinder` flag.
The fc-qemu.conf overrides are now shared with the fc.qemu batou devhost deployments and taken from a package output (taking care for backwards compatibility).

PL-134257

## Release process

- [ ] Created changelog entry using `./changelog.sh`
  - No, internals

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [x] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - n/a
- [x] Security requirements tested? (EVIDENCE)
