### PR TITLE
important packages: add nodejs 20 and add it to nixos test for prebuilding

### DIFF
--- a/changelog.d/20260911_155500_PL-135591-nodejs20_scriv.md
+++ b/changelog.d/20260911_155500_PL-135591-nodejs20_scriv.md
@@ -1,0 +1,3 @@
+### NixOS XX.XX platform
+
+- Prebuild `nodejs_20` on Hydra so customer VMs using the (insecure-marked, EOL) `nodejs_20` package no longer compile it locally for hours. (PL-135591)

--- a/release/important_packages.json
+++ b/release/important_packages.json
@@ -116,6 +116,7 @@
   "nginxStable",
   "nix",
   "nodejs",
+  "nodejs_20",
   "nodejs_22",
   "nodejs_24",
   "nspr",

--- a/release/package-versions.json
+++ b/release/package-versions.json
@@ -574,6 +574,11 @@
     "pname": "nodejs",
     "version": "24.18.0"
   },
+  "nodejs_20": {
+    "name": "nodejs-20.20.2",
+    "pname": "nodejs",
+    "version": "20.20.2"
+  },
   "nodejs_22": {
     "name": "nodejs-22.23.1",
     "pname": "nodejs",

--- a/tests/nodejs.nix
+++ b/tests/nodejs.nix
@@ -16,9 +16,11 @@ import ./make-test-python.nix (
 
     testScript = with pkgs; ''
       package_versions = {
+        "${nodejs-slim_20}": "20",
         "${nodejs-slim_22}": "22",
         "${nodejs-slim_24}": "24",
         "${nodejs-slim}": "24",
+        "${nodejs_20}": "20",
         "${nodejs_22}": "22",
         "${nodejs_24}": "24",
         "${nodejs}": "24",


### PR DESCRIPTION
@flyingcircusio/release-managers

For PL-135591 where customer VMs take a long time building nodejs20

nodejs 20 already marked as allowed insecure package in https://github.com/flyingcircusio/fc-nixos/commit/acb75e45673eb513ec0288e63bf2a69081e33f7e so this is just for our hydra to prebuild it

## Release process

This change should only reach this branch:

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [ ] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- nodejs20 already explicitly marked as insecure but allowed to build, now cached
- [x] Security requirements tested? (EVIDENCE)
- nixos test tested on hydra01
