### PR TITLE
physical hosts: explicitly load ext4 kernel module in initrd

### DIFF
--- a/changelog.d/20260805_102530_HEAD_scriv.md
+++ b/changelog.d/20260805_102530_HEAD_scriv.md
@@ -1,0 +1,26 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+<!-- Impact means "when this change is rolled out, there
+     might be interruptions/downtimes/required actions/... that
+     IMPACT THE RUNNING APPLICATION NEGATIVELY.
+
+     Having new features or changed is not an "impact". That's what
+     the main changelog (see below) is for.
+     -->
+
+### NixOS XX.XX platform
+
+- physical hosts: explicitly load ext4 kernel module in initrd (PL-135613)

--- a/nixos/infrastructure/flyingcircus-physical.nix
+++ b/nixos/infrastructure/flyingcircus-physical.nix
@@ -53,6 +53,15 @@ mkIf (cfg.infrastructureModule == "flyingcircus-physical") (
           "vfat"
         ];
 
+        # We have seen sporadic boot issues where an ext4 filesystem could not be mounted due to the kernel module not
+        # being loaded at mount time.
+        # ext4 was an available kernel module then.
+        # Until we figured out which bug this is, load ext4 by default in the initrd.
+        # PL-135613
+        initrd.kernelModules = [
+          "ext4"
+        ];
+
         # not relevant for boot stage1
         kernelModules = [
           "dm_mirror" # LVM disk migration scenarios


### PR DESCRIPTION
PL-135613

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`
or
- [ ] Add a upgrade node in `doc/upgrade.md`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [x] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [x] Security requirements tested? (EVIDENCE)
  confirmed that this does lead to ext4 being loaded by default