### PR TITLE
KVM: workaround to fix guest tap device reattachment

### DIFF
--- a/nixos/roles/kvm/default.nix
+++ b/nixos/roles/kvm/default.nix
@@ -45,6 +45,37 @@ let
   noopScriptWithNautilusFallback =
     content: if cfg.cephRelease == "nautilus" then content else noopScript;
 
+  # XXX tap reattachment is currently not implemented in fc.qemu, need
+  # to use the old script implementations for handling reattachment.
+  nautilusIfupScript = pkgs.writeShellScriptBin "nautilus-kvm-ifup" ''
+    # Wire up Qemu tap devices to the bridge of the corresponding VLAN.
+    # Interface names are expected to be of the form `t<VLAN><ifnumber>`, for example:
+    # tsrv0, tsrv1, tfe0, ...
+    set -e
+
+    INTERFACE="$1"
+    VLAN=$(echo $INTERFACE | ${pkgs.gnused}/bin/sed 's/t\([a-zA-Z]\+\)[0-9]\+/\1/')
+    BRIDGE="br''${VLAN}"
+
+    ${pkgs.iproute2}/bin/ip link set "$INTERFACE" up
+    ${pkgs.iproute2}/bin/ip link set mtu $(< /sys/class/net/br''${VLAN}/mtu) dev "$INTERFACE"
+    ${pkgs.iproute2}/bin/ip link set "$INTERFACE" master "$BRIDGE"
+  '';
+
+  nautilusIfupVrfScript = pkgs.writeShellScriptBin "nautilus-kvm-ifup-vrf" ''
+    INTERFACE="$1"
+    VLAN=$(echo $INTERFACE | sed 's/t\([a-zA-Z]\+\)[0-9]\+/\1/')
+    VRF="vrf''${VLAN}"
+
+    ${pkgs.iproute2}/bin/ip link set $INTERFACE master $VRF
+
+    # add addresses idempotently
+    ${pkgs.iproute2}/bin/ip address replace ${virtualGatewayV4}/16 dev $INTERFACE
+    ${pkgs.iproute2}/bin/ip address replace ${virtualGatewayV6}/64 dev $INTERFACE
+
+    ${pkgs.iproute2}/bin/ip link set $INTERFACE up
+  '';
+
 in
 {
   options = {
@@ -261,21 +292,7 @@ in
     # BBB PL-135610 - Need to be kept to allow bi-directional migrations
     # with older fc-nixos incarnations.
     environment.etc."kvm/kvm-ifup" = noopScriptWithNautilusFallback {
-      text = ''
-        #!${pkgs.stdenv.shell}
-        # Wire up Qemu tap devices to the bridge of the corresponding VLAN.
-        # Interface names are expected to be of the form `t<VLAN><ifnumber>`, for example:
-        # tsrv0, tsrv1, tfe0, ...
-        set -e
-
-        INTERFACE="$1"
-        VLAN=$(echo $INTERFACE | ${pkgs.gnused}/bin/sed 's/t\([a-zA-Z]\+\)[0-9]\+/\1/')
-        BRIDGE="br''${VLAN}"
-
-        ${pkgs.iproute2}/bin/ip link set "$INTERFACE" up
-        ${pkgs.iproute2}/bin/ip link set mtu $(< /sys/class/net/br''${VLAN}/mtu) dev "$INTERFACE"
-        ${pkgs.iproute2}/bin/ip link set "$INTERFACE" master "$BRIDGE"
-      '';
+      source = lib.getExe' nautilusIfupScript "nautilus-kvm-ifup";
       mode = "0744";
     };
     environment.etc."kvm/kvm-ifdown" = noopScriptWithNautilusFallback {
@@ -292,20 +309,7 @@ in
       mode = "0744";
     };
     environment.etc."kvm/kvm-ifup-vrf" = noopScriptWithNautilusFallback {
-      text = ''
-        #!${pkgs.stdenv.shell}
-        INTERFACE="$1"
-        VLAN=$(echo $INTERFACE | sed 's/t\([a-zA-Z]\+\)[0-9]\+/\1/')
-        VRF="vrf''${VLAN}"
-
-        ${pkgs.iproute2}/bin/ip link set $INTERFACE master $VRF
-
-        # add addresses idempotently
-        ${pkgs.iproute2}/bin/ip address replace ${virtualGatewayV4}/16 dev $INTERFACE
-        ${pkgs.iproute2}/bin/ip address replace ${virtualGatewayV6}/64 dev $INTERFACE
-
-        ${pkgs.iproute2}/bin/ip link set $INTERFACE up
-      '';
+      source = lib.getExe' nautilusIfupVrfScript "nautilus-kvm-ifup-vrf";
       mode = "0744";
     };
     environment.etc."kvm/kvm-ifdown-vrf" = noopScriptWithNautilusFallback {
@@ -372,7 +376,7 @@ in
     ]);
 
     systemd.services.fc-qemu-reattach-taps = {
-      # XXX pull into fc.qemu networking as a direct helper script?
+      # XXX pull into fc.qemu networking as a direct helper script
       description = "Reattach all VM taps if needed.";
 
       path = [
@@ -383,7 +387,7 @@ in
       script = ''
         for interface in $(ip -j link show |  jq '.[] | .ifname' -r | egrep '^t(srv|fe)'); do
           echo "Ensuring attachment of $interface"
-          /etc/kvm/kvm-ifup $interface || true
+          ${lib.getExe' nautilusIfupScript "nautilus-kvm-ifup"} $interface || true
         done
       '';
 
@@ -405,7 +409,7 @@ in
     };
 
     systemd.services.fc-qemu-reattach-vrf-taps = lib.mkIf (fclib.network ? pub) {
-      # XXX pull into fc.qemu networking as a direct helper script?
+      # XXX pull into fc.qemu networking as a direct helper script
       description = "Reattach all VM taps to VRF devices if needed.";
 
       path = [
@@ -416,7 +420,7 @@ in
       script = ''
         for interface in $(ip -j link show |  jq '.[] | .ifname' -r | egrep '^tpub'); do
           echo "Ensuring attachment of $interface"
-          /etc/kvm/kvm-ifup-vrf $interface || true
+          ${lib.getExe' nautilusIfupVrfScript "nautilus-kvm-ifup-vrf"} $interface || true
         done
       '';
 


### PR DESCRIPTION
This change adds a workaround to ensure that runtime reattachment of guest interfaces in the KVM role works correctly.

With the most recent version of fc.qemu, management of guest tap interfaces has been moved out of the platform. However, the ability to reattach tap devices at runtime (should the host network configuration change) was overlooked, and is not yet implemented. The reattachment systemd units shell out to the ifup/ifdown scripts in `/etc/kvm`, however these are now no-ops and don't do anything.

This change updates the systemd units to use the old ifup/ifdown scripts (which have been kept around to preserve the Ceph Nautilus to Pacific migration path) to ensure that guest interfaces get reattached properly.

PL-135250

@flyingcircusio/release-managers

## Release process

This change should be backported:

- [ ] Created changelog entry using `./changelog.sh`
- [ ] Add `backport release-25.11` label

This change should only reach this branch:

- [x] Created changelog entry using `./changelog.sh` => none, internal change.
or
- [ ] Add a upgrade node in `doc/upgrade.md`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [ ] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - KVM host network configuration should normally not change at runtime with active guest VMs, however if this does happen then this should not negatively impact the network connectivity of the guests.
- [x] Security requirements tested? (EVIDENCE)
  - 5 minutes of testing on a KVM host in dev, does the right thing at face value.
  - Change builds with `flyingcircus.roles.kvm_host.cephRelease = "nautilus"` as a typo-finding sanity check.