### PR TITLE
Fix configuration of routed PUB on routers and refactor to remove dangerous idiom

### DIFF
--- a/nixos/lib/network.nix
+++ b/nixos/lib/network.nix
@@ -38,7 +38,7 @@ let
         ])
       ) encInterfaces;
       invalidLinktypesCount = length (attrNames invalidLinktypes);
-      dynamicInterfaces = lib.filterAttrs (_: value: value.linktype or null == "dynamic") encInterfaces;
+      dynamicInterfaces = lib.filterAttrs (_: value: value.linktype == "dynamic") encInterfaces;
       dynamicCount = length (attrNames dynamicInterfaces);
 
       commonConditions = [
@@ -524,6 +524,7 @@ rec {
         lo = {
           vlan = "lo";
           policy = "unmanaged";
+          linktype = "bridged";
           dualstack = {
             addresses = [
               "127.0.0.1"

--- a/nixos/roles/kvm/default.nix
+++ b/nixos/roles/kvm/default.nix
@@ -23,7 +23,7 @@ let
   virtualGatewayV4 = "169.254.83.168";
   virtualGatewayV6 = "fe80::1";
 
-  vrfInterfaces = lib.filterAttrs (_: v: (v.linktype or null) == "routed") fclib.network;
+  vrfInterfaces = lib.filterAttrs (_: v: v.linktype == "routed") fclib.network;
   vrfV6Resolvers = iface: map (net: "${net.network}1") iface.v6.networkAttrs;
 
   ubuntuUpdateScript = pkgs.writeShellApplication {

--- a/nixos/roles/router/bird2-vrf-bridge.nix
+++ b/nixos/roles/router/bird2-vrf-bridge.nix
@@ -11,7 +11,7 @@ let
   inherit (config) fclib;
   inherit (config.flyingcircus) location;
 
-  enableVrfBridge = any (net: net.routed or false) (attrValues fclib.network);
+  enableVrfBridge = any (net: net.linktype == "routed") (attrValues fclib.network);
 
   role = config.flyingcircus.roles.router;
   package = pkgs.bird2-vrf;
@@ -136,7 +136,7 @@ let
       kernel table ${toString net.vrfTable};
     }
 
-  '') (filter (n: n.routed or false) (attrValues fclib.network)));
+  '') (filter (n: n.linktype == "routed") (attrValues fclib.network)));
 
 in
 {

--- a/nixos/roles/router/default.nix
+++ b/nixos/roles/router/default.nix
@@ -71,7 +71,7 @@ let
 
   sensuSourceAddress = head (filter (i: fclib.isIp4 i) (locationSensuServer.ips));
 
-  routedVrfsEnabled = any (net: net.routed or false) (attrValues fclib.network);
+  routedVrfsEnabled = any (net: net.linktype == "routed") (attrValues fclib.network);
 in
 {
   options = {
@@ -373,7 +373,7 @@ in
           interval = 600;
           command =
             let
-              nets = filter (n: n.routed or false) (attrValues fclib.network);
+              nets = filter (n: n.linktype == "routed") (attrValues fclib.network);
             in
             "${pkgs.fc.check-vrf-default-routes}/bin/check_vrf_default_routes ${
               lib.concatMapStringsSep " " (n: n.vrfInterface) nets

--- a/tests/ipv6-autoconfig.nix
+++ b/tests/ipv6-autoconfig.nix
@@ -28,6 +28,7 @@ import ./make-test-python.nix (
               interfaces.srv.policy = "vxlan";
               interfaces.ul = {
                 policy = "underlay";
+                linktype = "bridged";
                 nics = map (link: {
                   mac = "52:54:00:12:${lib.toLower (lib.toHexString link)}:0${toString testNodeId}";
                   external_label = "phys/${toString link}";

--- a/tests/testlib.nix
+++ b/tests/testlib.nix
@@ -211,6 +211,7 @@ rec {
             interfaces = mapAttrs (name: vid: {
               mac = "52:54:00:12:0${toString vid}:0${toString test_node_id}";
               bridged = false;
+              linktype = "bridged";
               networks = {
                 "192.168.${toString vid}.0/24" = [ "192.168.${toString vid}.${toString id}" ];
                 "2001:db8:${toString vid}::/64" = [ "2001:db8:${toString vid}::${toString id}" ];


### PR DESCRIPTION
The change which introduced support for dynamic private customer L2 networks in #2471 changed the format of some internal networking data structures, removing the `routed` attrset key and replacing it with `linktype`. During development, we discovered that the KVM role would use the idiom `net.routed or false` to discover routed L3 networks in order to configure forwarding correctly – however, as this field was removed and the `or` operator masked the field access, so L3 networks stopped being configured correctly. (This problem was fixed in the KVM role before merging.)

This idiom is also present in the router role, which resulted in routed L3 networks breaking in DEV once the above PR was rolled out to the routers. This change updates the router role to use the `linktype` field, and fixes the synthesised data for the loopback interface under `fclib.network` so the usages of the `or` operator which were previously necessary can be removed.

PL-135250

@flyingcircusio/release-managers

## Release process

This change should be backported:

- [ ] Created changelog entry using `./changelog.sh`
- [ ] Add `backport release-25.11` label

This change should only reach this branch:

- [x] Created changelog entry using `./changelog.sh` => none, internal change
or
- [ ] Add a upgrade node in `doc/upgrade.md`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [ ] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - The network shouldn't silently break due to changes in internal data structures.
  - Breaking changes should fail loudly.
- [x] Security requirements tested? (EVIDENCE)
  - Currently running on the dev routers, VMs with pub interfaces are remotely accessible with this change applied.
  - Builds on a KVM host with no diff against the running system configuration.