### PR TITLE
Pl 135543 cron restart

### DIFF
--- a/changelog.d/20260729_135543_PL-135543-cron-restart_scriv.md
+++ b/changelog.d/20260729_135543_PL-135543-cron-restart_scriv.md
@@ -1,0 +1,6 @@
+### Impact
+
+
+### NixOS XX.XX platform
+
+- cron: restart the daemon after unexpected termination (PL-135543)

--- a/nixos/platform/default.nix
+++ b/nixos/platform/default.nix
@@ -417,11 +417,15 @@ in
       // (filterAttrs (n: v: n != "commands" && n != "package") e)
     ) cfg.passwordlessSudoPackages;
 
-    services = {
-      # upstream uses cron.enable = mkDefault ... (prio 1000), mkPlatform
-      # overrides it
-      cron.enable = fclib.mkPlatform true;
+    # Upstream cron.service sets no Restart=, so an OOM kill (SIGKILL by
+    # systemd-oomd) leaves the daemon dead. Enable cron and restart it on
+    # termination. mkPlatform overrides upstream's mkDefault (prio 1000).
+    services.cron.enable = fclib.mkPlatform true;
+    systemd.services.cron = lib.mkIf config.services.cron.enable {
+      serviceConfig.Restart = fclib.mkPlatform "always";
+    };
 
+    services = {
       fail2ban = {
         enable = fclib.mkPlatform true;
         maxretry = fclib.mkPlatform 5;
@@ -467,11 +471,6 @@ in
           loc = attrByPath [ "parameters" "location" ] "" cfg.enc;
         in
         attrByPath [ "static" "ntpServers" loc ] [ "pool.ntp.org" ] cfg;
-    };
-
-    # Restart cron when it is terminated, e.g. by systemd-oomd.
-    systemd.services.cron = lib.mkIf config.services.cron.enable {
-      serviceConfig.Restart = fclib.mkPlatform "always";
     };
 
     system.activationScripts =

--- a/nixos/platform/default.nix
+++ b/nixos/platform/default.nix
@@ -419,7 +419,9 @@ in
 
     # Upstream cron.service sets no Restart=, so an OOM kill (SIGKILL by
     # systemd-oomd) leaves the daemon dead. Enable cron and restart it on
-    # termination. mkPlatform overrides upstream's mkDefault (prio 1000).
+    # termination.
+    # upstream uses cron.enable = mkDefault ... (prio 1000), mkPlatform
+    # overrides it
     services.cron.enable = fclib.mkPlatform true;
     systemd.services.cron = lib.mkIf config.services.cron.enable {
       serviceConfig.Restart = fclib.mkPlatform "always";

--- a/nixos/platform/default.nix
+++ b/nixos/platform/default.nix
@@ -469,6 +469,11 @@ in
         attrByPath [ "static" "ntpServers" loc ] [ "pool.ntp.org" ] cfg;
     };
 
+    # Restart cron when it is terminated, e.g. by systemd-oomd.
+    systemd.services.cron = lib.mkIf config.services.cron.enable {
+      serviceConfig.Restart = fclib.mkPlatform "always";
+    };
+
     system.activationScripts =
       let
         cfgDirs = cfg.localConfigDirs;

--- a/tests/cron.nix
+++ b/tests/cron.nix
@@ -1,0 +1,14 @@
+import ./make-test-python.nix (
+  { testlib, ... }:
+  {
+    name = "cron";
+
+    nodes.machine = {
+      imports = [ (testlib.fcConfig { }) ];
+    };
+
+    testScript = ''
+      machine.succeed("test \"$(systemctl show --property=Restart --value cron.service)\" = always")
+    '';
+  }
+)

--- a/tests/cron.nix
+++ b/tests/cron.nix
@@ -8,7 +8,26 @@ import ./make-test-python.nix (
     };
 
     testScript = ''
+      machine.wait_for_unit("cron.service")
+
+      # Confirm the restart policy is in place.
       machine.succeed("test \"$(systemctl show --property=Restart --value cron.service)\" = always")
+
+      old_pid = machine.succeed(
+          "systemctl show --property=MainPID --value cron.service"
+      ).strip()
+
+      # Simulate an OOM kill: SIGKILL the cron daemon without a clean shutdown.
+      machine.succeed("kill -9 " + old_pid)
+
+      # With Restart=always systemd must respawn the unit and it becomes active
+      # again, with a fresh main PID.
+      machine.wait_until_succeeds(
+          "test \"$(systemctl show --property=MainPID --value cron.service)\" != "
+          + old_pid
+      )
+      machine.wait_for_unit("cron.service")
+      machine.succeed("systemctl is-active cron.service")
     '';
   }
 )

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -42,6 +42,7 @@ in
   ceph-nautilus = callTest ./ceph-nautilus.nix { };
   ceph-pacific = callTest ./ceph-pacific.nix { };
   coturn = callTest ./coturn.nix { };
+  cron = callTest ./cron.nix { };
   docker = callTest ./docker.nix { };
   fcagent = callTest ./fcagent.nix { };
   fde-tooling = callTest ./fde-tooling.nix { };


### PR DESCRIPTION
@flyingcircusio/release-managers
Pl-135543 cron restart - configure cron systemd service to restart if oom killed/crashed

## Release process

This change should be backported:

- [ ] Created changelog entry using `./changelog.sh`
- [ ] Add `backport release-25.11` label

This change should only reach this branch:

- [x] Created changelog entry using `./changelog.sh`
or
- [ ] Add a upgrade node in `doc/upgrade.md`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [ ] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- No new third party code or exotic behaviours
- [x] Security requirements tested? (EVIDENCE)
- behaviour run within nixos test
