### PR TITLE
update nixpkgs lock to get gitlab container registry fixes

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -165,11 +165,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1786423102,
-        "narHash": "sha256-nwekVk/YxUgeOs9jz0HOseLx/5lir1H7SjydOfNVWqE=",
+        "lastModified": 1786615859,
+        "narHash": "sha256-dbIOl7Ze3lJnyCelQeiJjoeupxjCrP9ttWh0xmvNOa4=",
         "owner": "flyingcircusio",
         "repo": "nixpkgs",
-        "rev": "95acec9871de3e16c4222ddee618a2cc170e3181",
+        "rev": "6fb1774181bd0229367d00eabeb1a865896873bf",
         "type": "github"
       },
       "original": {

--- a/release/versions.json
+++ b/release/versions.json
@@ -8,10 +8,10 @@
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/"
   },
   "nixpkgs": {
-    "hash": "sha256-nwekVk/YxUgeOs9jz0HOseLx/5lir1H7SjydOfNVWqE=",
+    "hash": "sha256-dbIOl7Ze3lJnyCelQeiJjoeupxjCrP9ttWh0xmvNOa4=",
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "95acec9871de3e16c4222ddee618a2cc170e3181"
+    "rev": "6fb1774181bd0229367d00eabeb1a865896873bf"
   },
   "poetry2nix": {
     "hash": "sha256-nzgO/ZCSBzWjbMkYDxG+yl9Z2eGbCgQu06Oku3ir5D4=",


### PR DESCRIPTION
FC-50289

adds
- https://github.com/flyingcircusio/nixpkgs/commit/7d80ce0ed421ac2c681c5cb01d8551ca00814ceb
- https://github.com/flyingcircusio/nixpkgs/commit/6fb1774181bd0229367d00eabeb1a865896873bf

to our fork. These commits will be upstreamed to Nixpkgs

@flyingcircusio/release-managers

## Release process

This change should only reach this branch:

- [ ] Created changelog entry using `./changelog.sh`
  no, internal change
or
- [ ] Add a upgrade node in `doc/upgrade.md`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [x] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [x] Security requirements tested? (EVIDENCE)
  tested on VM