### PR TITLE
[26.11] Update Nixpkgs to 6c59dde8 (2026-08-14)

### DIFF
--- a/doc/src/upgrade.md
+++ b/doc/src/upgrade.md
@@ -128,7 +128,8 @@ instead of the `docker-registry` user. This behavior can be modified with the `s
 ## Other notable changes
 
 - The `security.dhparams` module has been removed. Remove any uses of DHE and migrate to ECDHE (RFC 8422, 2018) and Hybrid PQ (draft-ietf-tls-ecdhe-mlkem, 2026) key exchange algorithms.
-- The `python2` and `python27` package has been removed.
+- The `python2` and `python27` packages has been removed.
+- The `openssl_1_1` package has been removed.
 
 ## Known issues
 

--- a/flake.lock
+++ b/flake.lock
@@ -165,11 +165,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1786024030,
-        "narHash": "sha256-Tt/ygVYNtc4cQluWOgmpNAmuaoNm47BRz80gO7MdKJg=",
+        "lastModified": 1786683707,
+        "narHash": "sha256-u7Kghr9eQkVNUbUImDBZmyBk0ftPH5ZctL8uAgpe+mo=",
         "owner": "flyingcircusio",
         "repo": "nixpkgs",
-        "rev": "7a7e3612d14d40ba4d4ace6afda55ac3574a5c6c",
+        "rev": "6c59dde860cd6a5d0812ed9e02002c4dd753bae6",
         "type": "github"
       },
       "original": {

--- a/nix-phps/pkgs/build-support/php/builders/v2/build-composer-project.nix
+++ b/nix-phps/pkgs/build-support/php/builders/v2/build-composer-project.nix
@@ -111,7 +111,7 @@ let
       };
 
       meta = meta // {
-        platforms = lib.platforms.all;
+        platforms = meta.platforms or lib.platforms.all;
       };
     };
 in

--- a/nix-phps/pkgs/development/interpreters/php/default.nix
+++ b/nix-phps/pkgs/development/interpreters/php/default.nix
@@ -69,19 +69,19 @@ let
 in
 {
   php82 = mkPhp {
-    version = "8.2.31";
-    hash = "sha256-lIGD+gTPJhybk2PAL0KJd7nd+MC/3/jo4fuoFu1XCAM=";
+    version = "8.2.33";
+    hash = "sha256-U2Lyp6DnFoznIv6gBIsaHSjg98wmXEF99nDGVnBpUBg=";
   };
   php83 = mkPhp {
-    version = "8.3.31";
-    hash = "sha256-5phrH9N+slQCEn/kpyeKPgO3+QJbt6S9KSonG9+TD7k=";
+    version = "8.3.33";
+    hash = "sha256-+cn00M12ksbj2jY81MpyqCakmuGPXtQwtvyue8KIHhg=";
   };
   php84 = mkPhp {
-    version = "8.4.22";
-    hash = "sha256-Sxbn4sOEziXgfSjrlJhVxLT+DRt7nsnI7r0F0M+pxTI=";
+    version = "8.4.24";
+    hash = "sha256-KGiQRHWIUQ3xEO3p6c4J8etPmFZjC0f9xA7OcOIDc88=";
   };
   php85 = mkPhp {
-    version = "8.5.7";
-    hash = "sha256-Tvk1X3hNSzIBUes/McWUHA2ilwJe7bl/KDiyznPdWb8=";
+    version = "8.5.9";
+    hash = "sha256-cDwIKtnSlGrGR/NZaBIwDSxis2DS8xqZkCFpKps5R2w=";
   };
 }

--- a/nix-phps/pkgs/development/php-packages/composer/default.nix
+++ b/nix-phps/pkgs/development/php-packages/composer/default.nix
@@ -13,14 +13,14 @@
 }:
 php.buildComposerProject2 (finalAttrs: {
   pname = "composer";
-  version = "2.10.1";
+  version = "2.10.2";
   __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "composer";
     repo = "composer";
     tag = finalAttrs.version;
-    hash = "sha256-0EeELI4jCSgG6S5sR6tQbwgcqdhe0JTcObvE5x49v1A=";
+    hash = "sha256-LKC4ogBHArE1wceY5hClVC2H9J8Hx98hlaV8GZEdt8c=";
   };
 
   nativeBuildInputs = [
@@ -34,7 +34,7 @@ php.buildComposerProject2 (finalAttrs: {
     inherit (finalAttrs.passthru) pharHash;
   };
 
-  vendorHash = "sha256-58l07Gt0j4g412rJfsRNSIAQ6Yd3ADpiQ9LXN+pHKNg=";
+  vendorHash = "sha256-0reKbGJEFJTQ2XnfsGij7nWICURLEHWJxjsYzanHpgs=";
 
   postInstall = ''
     wrapProgram $out/bin/composer \
@@ -56,7 +56,7 @@ php.buildComposerProject2 (finalAttrs: {
   # use together with the version from this package to keep the
   # bootstrap phar file up-to-date together with the end user composer
   # package.
-  passthru.pharHash = "sha256-NFucapjaXDDcvUsNmfyHEL8K6Yo4mO6hj3sq2d7JPwY=";
+  passthru.pharHash = "sha256-XucSX4owo00kbO/cC8hbing7KPKuyWiZQRhRI1DSgCc=";
 
   meta = {
     changelog = "https://github.com/composer/composer/releases/tag/${finalAttrs.version}";

--- a/nix-phps/pkgs/development/php-packages/maxminddb/default.nix
+++ b/nix-phps/pkgs/development/php-packages/maxminddb/default.nix
@@ -26,7 +26,7 @@ buildPecl {
 
   meta = {
     description = "C extension that is a drop-in replacement for MaxMind\\Db\\Reader";
-    license = with lib.licenses; [ asl20 ];
+    license = lib.licenses.asl20;
     homepage = "https://github.com/maxmind/MaxMind-DB-Reader-php";
     maintainers = with lib.maintainers; [
       das_j

--- a/nix-phps/pkgs/development/php-packages/pdlib/default.nix
+++ b/nix-phps/pkgs/development/php-packages/pdlib/default.nix
@@ -24,7 +24,7 @@ buildPecl {
 
   meta = {
     description = "PHP extension for Dlib";
-    license = with lib.licenses; [ mit ];
+    license = lib.licenses.mit;
     homepage = "https://github.com/goodspb/pdlib";
     teams = [ lib.teams.php ];
   };

--- a/nix-phps/pkgs/development/php-packages/relay/default.nix
+++ b/nix-phps/pkgs/development/php-packages/relay/default.nix
@@ -16,36 +16,36 @@
 }:
 
 let
-  version = "0.30.0";
+  version = "0.40.0";
   hashes = {
     "aarch64-darwin" = {
       platform = "darwin-arm64";
       hash = {
-        "8.1" = "sha256-71TLrF9HvuocMLei89bGIibJIC1sD59RB9Vb6FBS49U=";
-        "8.2" = "sha256-WFrJ0+gun1qs77s3URFTha/tZA8gSeqlGLT26twnjko=";
-        "8.3" = "fiduW1NKScDDY3k3lvw98r8KqaD0jPR4En8dNvdglFA=";
-        "8.4" = "sha256-SQ9+/zD6n49e2/9nH6hotyIJ/xsQMX5A78hFTPK4/hg=";
-        "8.5" = "+n+fE5soEbruH+L35B+bapU/Z7rSjjOD/4BgRmr3MVc=";
+        "8.1" = "sha256-pwqus2P17DirEGqwbe5CqlIZ+InPrIHbUUbcgLli8rc=";
+        "8.2" = "sha256-IeoOYVnp0sWD+Ww/d8DwDemqXv/6neEWE3g2txHEuEg=";
+        "8.3" = "OQAErtNtCIpNmz2YbfhLJ9ueH7mhZa6j1YtcuH00Ob8=";
+        "8.4" = "sha256-WP283JJfXQTnfbnyLfs0j8IIcdDGflCFtV0WxBV/JLU=";
+        "8.5" = "0zH1RD2Uq5uG4TnUsYzsYgUdUshsKNU0kzbdNG77sd8=";
       };
     };
     "aarch64-linux" = {
       platform = "debian-aarch64+libssl3";
       hash = {
-        "8.1" = "sha256-hetG8fEmMJccYWMQwPb3hml5thNeY2L6Y4gCDQmbDlo=";
-        "8.2" = "sha256-HufvcT4QSkuoxDcaCWD+hmG1fORyTUBh1Vsfnv7krng=";
-        "8.3" = "sha256-LV4coud7YNqB+s1sHoKXNVLAUrLjDMDpulS9fGVXDsg=";
-        "8.4" = "em1nZgGD1fAtvMxVeJBU4RZaA71/qMVLi0KCRAbilpM=";
-        "8.5" = "d0f3PzvZZn1KmXy1Gm0gm5f3f58kt+/LTc3yWZqto2I=";
+        "8.1" = "sha256-r6rV05ZLsi2SvFqONtYk2IIrkdbTZqsClruTMpcOOas=";
+        "8.2" = "sha256-SsHqRS3Bq4N10c06zEoVZXTv5+bfkcDgCRdntcoyD/k=";
+        "8.3" = "sha256-yQunez9xOyhGYqFKHKWtdK8BiGPz3JIyDnsfqGthIYs=";
+        "8.4" = "bC/67qQxe/Zy027r8c7tWr6S6Seeh+lbjYEl+cE7HNw=";
+        "8.5" = "3KWlZxbO8u5hpN/PsKzgCbNUhWHb56SqgNwTL8iHtSs=";
       };
     };
     "x86_64-linux" = {
       platform = "debian-x86-64+libssl3";
       hash = {
-        "8.1" = "sha256-La/TQDnQ0hqNhPMtLlwfw5cKtXCpjxBMTd6yvZM2O2M=";
-        "8.2" = "sha256-+FavbnliF071lWFU55rhFNq6X2wpW9mHSstwQQTbnwQ=";
-        "8.3" = "sha256-G6nfKMObVMtY45J7DaKg0LdHwV+lfCUa1Pkfp66+apY=";
-        "8.4" = "x9YXGxtqN3EL1lWCqAkIKKrO0b40BFalO6GExhF3p4c=";
-        "8.5" = "8hU5Ft9i3L6pf2XY7rRLmSbQmZ3z1wjI+7sjiq/GHUU=";
+        "8.1" = "sha256-KgyAPCLLtmeMa5X3Akuf0nR51aSQS6+RpNYO3U4Zdp0=";
+        "8.2" = "sha256-zSl141iQ3Vfb5JmeRacFZhBcfEKQuW9rld9O2c8HRvU=";
+        "8.3" = "sha256-kdd4k6xdbbNuIk/DBTufxqH8j+4Z2xgzG4Z/c7PfKFs=";
+        "8.4" = "jteJPpdxFSBljS81Jn9x6cLLn3iLVpqeGb3qecWFw4c=";
+        "8.5" = "uFZj/cDsd6LhIeaj3IdB3Kl9btnkS/eEVfLdYhh4Mus=";
       };
     };
   };
@@ -98,52 +98,28 @@ stdenv.mkDerivation (finalAttrs: {
   ''
   + (
     if stdenv.hostPlatform.isDarwin then
-      let
-        args =
-          lib.concatMapStrings
-            (
-              v:
-              let
-                targetName = if v ? to then v.to else builtins.baseNameOf v.from;
-              in
-              " -change ${v.from} ${lib.strings.makeLibraryPath [ v.pkg ]}/${targetName}"
-            )
-            [
-              {
-                from = "/opt/homebrew/opt/concurrencykit/lib/libck.0.dylib";
-                pkg = libck;
-              }
-              {
-                from = "/opt/homebrew/opt/openssl@3/lib/libssl.3.dylib";
-                pkg = openssl;
-              }
-              {
-                from = "/opt/homebrew/opt/openssl@3/lib/libcrypto.3.dylib";
-                pkg = openssl;
-              }
-              {
-                from = "/opt/homebrew/opt/zstd/lib/libzstd.1.dylib";
-                pkg = zstd;
-              }
-              {
-                from = "/opt/homebrew/opt/lz4/lib/liblz4.1.dylib";
-                pkg = lz4;
-              }
-              {
-                from = "/opt/homebrew/opt/hiredis/lib/libhiredis.1.3.0.dylib";
-                pkg = hiredis;
-                to = "libhiredis.1.1.0.dylib";
-              }
-              {
-                from = "/opt/homebrew/opt/hiredis/lib/libhiredis_ssl.1.3.0.dylib";
-                pkg = hiredis;
-                to = "libhiredis_ssl.dylib.1.1.0";
-              }
-            ];
-      in
-      # fixDarwinDylibNames can't be used here because we need to completely remap .dylibs, not just add absolute paths
+      # fixDarwinDylibNames can't be used here because we need to completely remap .dylibs, not just add
+      # absolute paths. Rather than hardcoding the Homebrew paths and versions relay.so happens to be
+      # linked against (which silently goes stale whenever relay or one of these libraries updates),
+      # discover the actual references via otool and remap them by matching their basename.
       ''
-        install_name_tool${args} $out/lib/php/extensions/relay.so
+        for dylib in $(otool -L $out/lib/php/extensions/relay.so | tail -n +2 | awk '{print $1}' | grep '^/opt/homebrew/'); do
+          base=$(basename "$dylib")
+          case "$base" in
+            libhiredis_ssl.*) dir="${lib.makeLibraryPath [ hiredis ]}" ;;
+            libhiredis.*) dir="${lib.makeLibraryPath [ hiredis ]}" ;;
+            libssl.*) dir="${lib.makeLibraryPath [ openssl ]}" ;;
+            libcrypto.*) dir="${lib.makeLibraryPath [ openssl ]}" ;;
+            libzstd.*) dir="${lib.makeLibraryPath [ zstd ]}" ;;
+            liblz4.*) dir="${lib.makeLibraryPath [ lz4 ]}" ;;
+            libck.*) dir="${lib.makeLibraryPath [ libck ]}" ;;
+            *)
+              echo "relay.so references unrecognized Homebrew library $dylib; add a mapping for it" >&2
+              exit 1
+              ;;
+          esac
+          install_name_tool -change "$dylib" "$dir/$base" $out/lib/php/extensions/relay.so
+        done
       ''
     else
       ""
@@ -220,7 +196,6 @@ stdenv.mkDerivation (finalAttrs: {
     platforms = [
       "x86_64-linux"
       "aarch64-linux"
-      "x86_64-darwin"
       "aarch64-darwin"
     ];
   };

--- a/nix-phps/pkgs/package-overrides.nix
+++ b/nix-phps/pkgs/package-overrides.nix
@@ -768,30 +768,26 @@ in
         let
           upstreamPatches = attrs.patches or [ ];
 
-          ourPatches = lib.optionals (lib.versionOlder prev.php.version "7.0") [
-            # PHP ≤ 5.6 requires openssl 1.0.
-            # https://github.com/php-build/php-build/pull/609
-            # https://github.com/oerdnj/deb.sury.org/issues/566
-            (pkgs.fetchurl {
-              url = "https://github.com/php-build/php-build/raw/43c8e02689bc29d48daa338b73bcd4f2bbd8def1/share/php-build/patches/php-5.6-support-openssl-1.1.0.patch";
-              sha256 = "UHu3SyYSMozfXlm5ZGRaSdD5NnrdAB7NaY4P0NREVCE=";
-            })
-          ];
+          ourPatches =
+            lib.optionals (lib.versionOlder prev.php.version "7.0") [
+              # PHP ≤ 5.6 requires openssl 1.0.
+              # https://github.com/php-build/php-build/pull/609
+              # https://github.com/oerdnj/deb.sury.org/issues/566
+              (pkgs.fetchurl {
+                url = "https://github.com/php-build/php-build/raw/43c8e02689bc29d48daa338b73bcd4f2bbd8def1/share/php-build/patches/php-5.6-support-openssl-1.1.0.patch";
+                sha256 = "UHu3SyYSMozfXlm5ZGRaSdD5NnrdAB7NaY4P0NREVCE=";
+              })
+            ]
+            ++ lib.optionals (lib.versionOlder prev.php.version "8.1") [
+              # Support OpenSSL 3 on PHP ≤ 8.1
+              # https://github.com/php-build/php-build/pull/758
+              (pkgs.fetchurl {
+                url = "https://github.com/php-build/php-build/raw/4dcf8a0b94f13dd6eff3da985dab2cffa45331f7/share/php-build/patches/php-8.0-support-openssl-3.patch";
+                hash = "sha256-NL5CZfx1FESsTVCZzK2V1XEgmH0NNM35hyCC/rsQVIM=";
+              })
+            ];
         in
         ourPatches ++ upstreamPatches;
-
-      buildInputs =
-        let
-          replaceOpenssl =
-            pkg:
-            if pkg.pname == "openssl" && lib.versionOlder prev.php.version "8.1" then
-              pkgs.openssl_1_1.overrideAttrs (old: {
-                meta = builtins.removeAttrs old.meta [ "knownVulnerabilities" ];
-              })
-            else
-              pkg;
-        in
-        builtins.map replaceOpenssl attrs.buildInputs;
     });
 
     openswoole =

--- a/nix-phps/pkgs/top-level/php-packages.nix
+++ b/nix-phps/pkgs/top-level/php-packages.nix
@@ -559,7 +559,7 @@ lib.makeScope pkgs.newScope (
               # The configure script doesn't correctly add library link
               # flags, so we add them to the variable used by the Makefile
               # when linking.
-              MYSQLND_SHARED_LIBADD = "-lz -lssl -lcrypto";
+              env.MYSQLND_SHARED_LIBADD = "-lz -lssl -lcrypto";
               # The configure script builds a config.h which is never
               # included. Let's include it in the main header file
               # included by all .c-files.

--- a/release/important_packages.json
+++ b/release/important_packages.json
@@ -128,7 +128,6 @@
   "opensearch-dashboards",
   "openssh",
   "openssl",
-  "openssl_1_1",
   "openssl_3",
   "openvpn",
   "pciutils",

--- a/release/package-versions.json
+++ b/release/package-versions.json
@@ -65,9 +65,9 @@
     "version": "3.126"
   },
   "calibre": {
-    "name": "calibre-9.11.0",
+    "name": "calibre-9.13.0",
     "pname": "calibre",
-    "version": "9.11.0"
+    "version": "9.13.0"
   },
   "ceph": {
     "name": "ceph-14.2.22",
@@ -90,14 +90,14 @@
     "version": "16.2.15"
   },
   "chromedriver": {
-    "name": "chromedriver-unwrapped-151.0.7922.75",
+    "name": "chromedriver-unwrapped-151.0.7922.137",
     "pname": "chromedriver-unwrapped",
-    "version": "151.0.7922.75"
+    "version": "151.0.7922.137"
   },
   "chromium": {
-    "name": "chromium-151.0.7922.75",
+    "name": "chromium-151.0.7922.137",
     "pname": "chromium",
-    "version": "151.0.7922.75"
+    "version": "151.0.7922.137"
   },
   "cifs-utils": {
     "name": "cifs-utils-7.5",
@@ -160,9 +160,9 @@
     "version": "2.93"
   },
   "docker": {
-    "name": "docker-29.6.2",
+    "name": "docker-29.7.2",
     "pname": "docker",
-    "version": "29.6.2"
+    "version": "29.7.2"
   },
   "docker-compose": {
     "name": "docker-compose-5.4.0",
@@ -195,9 +195,9 @@
     "version": "6.6.6"
   },
   "ffmpeg": {
-    "name": "ffmpeg-8.1.2",
+    "name": "ffmpeg-9.0",
     "pname": "ffmpeg",
-    "version": "8.1.2"
+    "version": "9.0"
   },
   "file": {
     "name": "file-5.48",
@@ -210,9 +210,9 @@
     "version": "7.17.27"
   },
   "firefox": {
-    "name": "firefox-153.0.3",
+    "name": "firefox-153.0.4",
     "pname": "firefox",
-    "version": "153.0.3"
+    "version": "153.0.4"
   },
   "gcc": {
     "name": "gcc-wrapper-15.3.0",
@@ -240,9 +240,9 @@
     "version": "19.0.4"
   },
   "github-runner": {
-    "name": "github-runner-2.335.1",
+    "name": "github-runner-2.336.0",
     "pname": "github-runner",
-    "version": "2.335.1"
+    "version": "2.336.0"
   },
   "gitlab": {
     "name": "gitlab-19.0.4",
@@ -295,9 +295,9 @@
     "version": "1.26.5"
   },
   "grafana": {
-    "name": "grafana-13.1.1",
+    "name": "grafana-13.1.3",
     "pname": "grafana",
-    "version": "13.1.1"
+    "version": "13.1.3"
   },
   "grub2": {
     "name": "grub-2.12",
@@ -370,34 +370,34 @@
     "version": "21.0.12+8"
   },
   "k3s": {
-    "name": "k3s-1.35.6+k3s1",
+    "name": "k3s-1.35.7+k3s1",
     "pname": "k3s",
-    "version": "1.35.6+k3s1"
+    "version": "1.35.7+k3s1"
   },
   "k3s_1_33": {
-    "name": "k3s-1.33.13+k3s1",
+    "name": "k3s-1.33.13+k3s2",
     "pname": "k3s",
-    "version": "1.33.13+k3s1"
+    "version": "1.33.13+k3s2"
   },
   "k3s_1_34": {
-    "name": "k3s-1.34.9+k3s1",
+    "name": "k3s-1.34.10+k3s1",
     "pname": "k3s",
-    "version": "1.34.9+k3s1"
+    "version": "1.34.10+k3s1"
   },
   "k3s_1_35": {
-    "name": "k3s-1.35.6+k3s1",
+    "name": "k3s-1.35.7+k3s1",
     "pname": "k3s",
-    "version": "1.35.6+k3s1"
+    "version": "1.35.7+k3s1"
   },
   "k3s_1_36": {
-    "name": "k3s-1.36.2+k3s1",
+    "name": "k3s-1.36.3+k3s1",
     "pname": "k3s",
-    "version": "1.36.2+k3s1"
+    "version": "1.36.3+k3s1"
   },
   "keycloak": {
-    "name": "keycloak-26.7.0",
+    "name": "keycloak-26.7.1",
     "pname": "keycloak",
-    "version": "26.7.0"
+    "version": "26.7.1"
   },
   "kubernetes-helm": {
     "name": "kubernetes-helm-4.2.3",
@@ -465,14 +465,14 @@
     "version": "0.2.5"
   },
   "linuxKernelStable": {
-    "name": "linux-6.12.101",
+    "name": "linux-6.12.103",
     "pname": "linux",
-    "version": "6.12.101"
+    "version": "6.12.103"
   },
   "linuxKernelVerify": {
-    "name": "linux-6.12.101",
+    "name": "linux-6.12.103",
     "pname": "linux",
-    "version": "6.12.101"
+    "version": "6.12.103"
   },
   "logrotate": {
     "name": "logrotate-3.22.0",
@@ -500,9 +500,9 @@
     "version": "3.3.5"
   },
   "mastodon": {
-    "name": "mastodon-4.6.4",
+    "name": "mastodon-4.6.5",
     "pname": "mastodon",
-    "version": "4.6.4"
+    "version": "4.6.5"
   },
   "matomo": {
     "name": "matomo-5.12.0",
@@ -510,9 +510,9 @@
     "version": "5.12.0"
   },
   "matrix-synapse": {
-    "name": "matrix-synapse-1.157.2",
+    "name": "matrix-synapse-1.158.0",
     "pname": "matrix-synapse",
-    "version": "1.157.2"
+    "version": "1.158.0"
   },
   "mcpp": {
     "name": "mcpp-2.7.2.3",
@@ -525,9 +525,9 @@
     "version": "1.6.42"
   },
   "mongodb": {
-    "name": "mongodb-7.0.37",
+    "name": "mongodb-7.0.39",
     "pname": "mongodb",
-    "version": "7.0.37"
+    "version": "7.0.39"
   },
   "monitoring-plugins": {
     "name": "monitoring-plugins-2.4.0",
@@ -570,9 +570,9 @@
     "version": "2.34.8"
   },
   "nodejs": {
-    "name": "nodejs-24.18.1",
+    "name": "nodejs-24.19.0",
     "pname": "nodejs",
-    "version": "24.18.1"
+    "version": "24.19.0"
   },
   "nodejs_22": {
     "name": "nodejs-22.23.2",
@@ -580,9 +580,9 @@
     "version": "22.23.2"
   },
   "nodejs_24": {
-    "name": "nodejs-24.18.1",
+    "name": "nodejs-24.19.0",
     "pname": "nodejs",
-    "version": "24.18.1"
+    "version": "24.19.0"
   },
   "nspr": {
     "name": "nspr-4.39",
@@ -634,11 +634,6 @@
     "pname": "openssl",
     "version": "3.6.3"
   },
-  "openssl_1_1": {
-    "name": "openssl-1.1.1w",
-    "pname": "openssl",
-    "version": "1.1.1w"
-  },
   "openssl_3": {
     "name": "openssl-3.0.21",
     "pname": "openssl",
@@ -665,9 +660,9 @@
     "version": "10.47"
   },
   "pdns": {
-    "name": "pdns-5.1.3",
+    "name": "pdns-5.1.4",
     "pname": "pdns",
-    "version": "5.1.3"
+    "version": "5.1.4"
   },
   "percona-server": {
     "name": "percona-server-8.4.10-10",
@@ -750,9 +745,9 @@
     "version": "127"
   },
   "postfix": {
-    "name": "postfix-3.11.5",
+    "name": "postfix-3.11.6",
     "pname": "postfix",
-    "version": "3.11.5"
+    "version": "3.11.6"
   },
   "postgresql": {
     "name": "postgresql-18.4",
@@ -855,9 +850,9 @@
     "version": "13.0.6"
   },
   "python3": {
-    "name": "python3-3.14.6",
+    "name": "python3-3.14.7",
     "pname": "python3",
-    "version": "3.14.6"
+    "version": "3.14.7"
   },
   "python311": {
     "name": "python3-3.11.15",
@@ -945,9 +940,9 @@
     "version": "6.0.0"
   },
   "qemu-ceph-pacific": {
-    "name": "qemu-11.0.2",
+    "name": "qemu-11.0.3",
     "pname": "qemu",
-    "version": "11.0.2"
+    "version": "11.0.3"
   },
   "rabbitmq-server": {
     "name": "rabbitmq-server-4.2.5",
@@ -1060,9 +1055,9 @@
     "version": "4.99.6"
   },
   "telegraf": {
-    "name": "telegraf-1.39.2",
+    "name": "telegraf-1.39.3",
     "pname": "telegraf",
-    "version": "1.39.2"
+    "version": "1.39.3"
   },
   "tmux": {
     "name": "tmux-3.7b",
@@ -1080,9 +1075,9 @@
     "version": "9.0.120"
   },
   "unifi": {
-    "name": "unifi-controller-10.5.54",
+    "name": "unifi-controller-10.5.67",
     "pname": "unifi-controller",
-    "version": "10.5.54"
+    "version": "10.5.67"
   },
   "unzip": {
     "name": "unzip-6.0",
@@ -1100,9 +1095,9 @@
     "version": "2.42.2"
   },
   "uv": {
-    "name": "uv-0.12.1",
+    "name": "uv-0.12.3",
     "pname": "uv",
-    "version": "0.12.1"
+    "version": "0.12.3"
   },
   "varnish": {
     "name": "varnish-8.0.2",

--- a/release/versions.json
+++ b/release/versions.json
@@ -8,10 +8,10 @@
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/"
   },
   "nixpkgs": {
-    "hash": "sha256-Tt/ygVYNtc4cQluWOgmpNAmuaoNm47BRz80gO7MdKJg=",
+    "hash": "sha256-u7Kghr9eQkVNUbUImDBZmyBk0ftPH5ZctL8uAgpe+mo=",
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "7a7e3612d14d40ba4d4ace6afda55ac3574a5c6c"
+    "rev": "6c59dde860cd6a5d0812ed9e02002c4dd753bae6"
   },
   "poetry2nix": {
     "hash": "sha256-nzgO/ZCSBzWjbMkYDxG+yl9Z2eGbCgQu06Oku3ir5D4=",


### PR DESCRIPTION
@flyingcircusio/release-managers

View nixpkgs update branch: [nixpkgs-auto-update/fc-26.05-dev/2026-08-14](https://github.com/flyingcircusio/nixpkgs/tree/nixpkgs-auto-update/fc-26.05-dev/2026-08-14)

Review Checklist:

- [x] Hydra is green
- [x] Package update versions look reasonable

**Manual changes:**
- removed `openssl_1_1` from important packages as it was dropped in Nixpkgs
- updated nix-phps to fix build with removed `openssl_1_1`