### PR TITLE
frr-wait-online.service: provide a timeout

### DIFF
--- a/changelog.d/20260817_175318_PL-135151-frr-wait-online-timeout_scriv.md
+++ b/changelog.d/20260817_175318_PL-135151-frr-wait-online-timeout_scriv.md
@@ -1,0 +1,27 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+<!-- Impact means "when this change is rolled out, there
+     might be interruptions/downtimes/required actions/... that
+     IMPACT THE RUNNING APPLICATION NEGATIVELY.
+
+     Having new features or changed is not an "impact". That's what
+     the main changelog (see below) is for.
+     -->
+
+
+### NixOS XX.XX platform
+
+- network-online.target: on physical machines, fails-stop when no FRR-based routes appear (PL-135151)

--- a/nixos/platform/network.nix
+++ b/nixos/platform/network.nix
@@ -1365,6 +1365,11 @@ in
         serviceConfig = {
           Type = "oneshot";
           RemainAfterExit = true;
+          # Timeouts necessary to prevent switch-to-configuration from blocking.
+          # Allow a very generous amount of time for routes to appear…
+          TimeoutStart = config.systemd.services.frr.startLimitIntervalSec * 2;
+          #… but if they don't, fail for good because that is an unexpected result in need of manual investigation.
+          Restart = "no";
         };
       };
     })


### PR DESCRIPTION
As a oneshot service, frr-wait-timeout.service by default had no timeout. In case of a broken state where no bgp routes appear, switch-to-configuration blocked due to this infinetly running service. Adding a timeout provides a fail-stop behaviour instead of masking the actual failure indefinitely.

PL-135151

@flyingcircusio/release-managers

## Release process

This change should only reach this branch:

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [x] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - provide a fail-stop behaviour for cases of the frr-based BGP routes not appearing
  - failure is not masked anymore, but overall system switch now fails instead of hanging indefinitley => improved visibility
- [x] Security requirements tested? (EVIDENCE)
  - [x] automated tests eval and pass
