### PR TITLE
sensu-client: reduce keepalive thresholds for KVM hosts

### DIFF
--- a/changelog.d/20260818_135533_PL-135552-keepalive-alerting-speedup_scriv.md
+++ b/changelog.d/20260818_135533_PL-135552-keepalive-alerting-speedup_scriv.md
@@ -1,0 +1,29 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+<!-- Impact means "when this change is rolled out, there
+     might be interruptions/downtimes/required actions/... that
+     IMPACT THE RUNNING APPLICATION NEGATIVELY.
+
+     Having new features or changed is not an "impact". That's what
+     the main changelog (see below) is for.
+     -->
+
+
+### NixOS XX.XX platform
+
+- KVM hosts: reduce keepalive check's critical threshold (PL-135533)
+
+  This speeds up visibility of KVM host crashes in our alerting.

--- a/nixos/services/sensu/client.nix
+++ b/nixos/services/sensu/client.nix
@@ -46,6 +46,11 @@ let
         "name": "${config.networking.hostName}",
         "address": "${config.networking.hostName}",
         "subscriptions": ["default"],
+        ${
+          # default keepalive beacon interval is 20s. Overall additional delay throughout out alerting pipeline is about 110s.
+          lib.optionalString config.flyingcircus.roles.kvm_host.enable
+            ''"keepalive": {"thresholds": { "warning": 40, "critical": 80 }},''
+        }
         "signature": "${cfg.password}"
       },
       "rabbitmq": {


### PR DESCRIPTION
sensu-client sends keepalive beacons to the server each ~20s, where the lack of receiving such a beacon is translated to a `keepalive` check failure after the defined thresholds are exceeded. From observation I can say that this is only evaluated each 30s. The default thresholds are 120s (warning) and 180s (critical).

To avoid false alerts, we need to take into account how machine maintenances suppress keepalive alerts: A directory async job adds a Sensu silence for that node. That job has the following worst-case timings:
request timeout: 30s
retry period: 60s
+ some additional jobqueue delay Setting the Critical threshold to 130s allows 1 timeout processing failure.

Our alerting pipeline that processes the keepalive failure signal adds some additional delays, dampening false alerts but also delaying true alerts:
- 20s keepalive beacon message interval
- 30s evaluation interval on sensu server
- 60s sensubpi.timer interval (fc.support) + script runtime => adding up to ~110s in worst case.

Reducing the Critical threshold to 130s allows us to maintain an expected alerting delay of <5min after a KVM host crash, even when accounting for processing delays.
The Warn state of keepalive is not processed anywhere in our alerting infrastructure, so setting it low is no issue.

PL-135552

@flyingcircusio/release-managers

## Release process

This change should only reach this branch:

- [x] Created changelog entry using `./changelog.sh`
or
- [ ] Add a upgrade node in `doc/upgrade.md`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [x] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - availability: speed up visibility of crashed KVM hosts
  - detailed overview of involved timings and considerations of selected value
- [x] Security requirements tested? (EVIDENCE)
  - [x] tested on a dev KVM host
  - [x] verified that changed thresholds are picked up by sensu server
