### PR TITLE
Router config cleanups and NAT address management

### DIFF
--- a/nixos/roles/router/default.nix
+++ b/nixos/roles/router/default.nix
@@ -126,6 +126,24 @@ in
         visible = false;
         description = "Networks considered invalid as source addresses or as forwarding destinations";
       };
+
+      dhcpResolversV4 = mkOption {
+        type = types.listOf (types.addCheck types.str fclib.isIp4);
+        # pass the system resolver configuration through to dhcp.
+        default = filter fclib.isIp4 config.networking.nameservers;
+        description = "IPv4 DNS resolvers to be advertised in DHCP";
+      };
+      dhcpResolversV6 = mkOption {
+        type = types.listOf (types.addCheck types.str fclib.isIp6);
+        default =
+          # networking.nameservers never uses IPv6 resolvers, fall
+          # back to static data.
+          if (hasAttr location config.flyingcircus.static.nameservers6) then
+            config.flyingcircus.static.nameservers6."${location}"
+          else
+            [ ];
+        description = "IPv6 DNS resolvers to be advertised in DHCPv6";
+      };
     };
   };
 

--- a/nixos/roles/router/default.nix
+++ b/nixos/roles/router/default.nix
@@ -126,20 +126,6 @@ in
         visible = false;
         description = "Networks considered invalid as source addresses or as forwarding destinations";
       };
-
-      sourceAddressV4 = mkOption {
-        type = types.nullOr (types.addCheck types.str fclib.isIp4);
-        default = null;
-        defaultText = "192.0.2.1";
-        description = "IPv4 address to prefer as source address for outgoing connections";
-      };
-      sourceAddressV6 = mkOption {
-        type = types.nullOr (types.addCheck types.str fclib.isIp6);
-        default = null;
-        defaultText = "2001:db8::1";
-        description = "IPv6 address to prefer as source address for outgoing connections";
-      };
-
     };
   };
 

--- a/nixos/roles/router/default.nix
+++ b/nixos/roles/router/default.nix
@@ -144,6 +144,20 @@ in
             [ ];
         description = "IPv6 DNS resolvers to be advertised in DHCPv6";
       };
+
+      masqueradeNetworks = mkOption {
+        type = types.listOf (types.addCheck types.str fclib.isIp4);
+        description = "List of IPv4 source networks which should get masqueraded upon egress";
+        default = [
+          "172.16.0.0/12"
+          "10.0.0.0/8"
+        ];
+      };
+      masqueradeSourceAddress = mkOption {
+        type = types.nullOr (types.addCheck types.str fclib.isIp4);
+        description = "Source address to be applied when applying masquerading rules to outgoing traffic";
+        default = null;
+      };
     };
   };
 
@@ -302,14 +316,24 @@ in
       ]
     );
 
-    networking.nat.extraCommands = ''
-      #############
-      # Masquerading rules for the uplink interfaces
-      ${lib.concatMapStringsSep "\n" (iface: ''
-        iptables -t nat -A nixos-nat-post -o ${iface} -s 172.16.0.0/12 -j MASQUERADE
-        iptables -t nat -A nixos-nat-post -o ${iface} -s 10.0.0.0/8 -j MASQUERADE
-      '') uplinkInterfaces}
-    '';
+    networking.nat.extraCommands =
+      let
+        masqueradeTarget =
+          if role.masqueradeSourceAddress != null then
+            "SNAT --to ${role.masqueradeSourceAddress}"
+          else
+            "MASQUERADE";
+      in
+      ''
+        #############
+        # Masquerading rules for the uplink interfaces
+        ${lib.concatMapStringsSep "\n" (
+          iface:
+          lib.concatMapStringsSep "\n" (
+            net: "iptables -t nat -A nixos-nat-post -o ${iface} -s ${net} -j ${masqueradeTarget}"
+          ) role.masqueradeNetworks
+        ) uplinkInterfaces}
+      '';
 
     networking.firewall.extraStopCommands = ''
       ip46tables -D FORWARD -j fc-router-forward || true

--- a/nixos/roles/router/default.nix
+++ b/nixos/roles/router/default.nix
@@ -41,8 +41,7 @@ let
     fclib.filterConfiguredNetworks role.routerUplinkNetworks
   );
 
-  # TODO: this should use routerGatewayNetworks in the future.
-  gatewayInterfaces = map (network: fclib.network."${network}") role.floatingGatewayNetworks;
+  gatewayInterfaces = map (network: fclib.network."${network}") role.routerGatewayNetworks;
 
   martianIptablesInput = (
     lib.concatMapStringsSep "\n" (

--- a/nixos/roles/router/kea.nix
+++ b/nixos/roles/router/kea.nix
@@ -20,18 +20,6 @@ let
 
   bootServer = head fclib.network.mgm.v4.defaultGateways;
 
-  resolvers4 =
-    if (hasAttr location config.flyingcircus.static.nameservers) then
-      config.flyingcircus.static.nameservers.${location}
-    else
-      [ ];
-
-  resolvers6 =
-    if (hasAttr location config.flyingcircus.static.nameservers6) then
-      config.flyingcircus.static.nameservers6.${location}
-    else
-      [ ];
-
   baseConfig = {
     dhcp-ddns = {
       enable-updates = false;
@@ -65,7 +53,7 @@ let
       }
       {
         name = "domain-name-servers";
-        data = lib.concatStringsSep ", " resolvers4;
+        data = lib.concatStringsSep ", " role.dhcpResolversV4;
       }
       # NTP options set on a per-subnet basis by fc-kea
     ];
@@ -104,7 +92,7 @@ let
     option-data = [
       {
         name = "dns-servers";
-        data = lib.concatStringsSep ", " resolvers6;
+        data = lib.concatStringsSep ", " role.dhcpResolversV6;
       }
       {
         name = "domain-search";

--- a/nixos/roles/router/radvd.nix
+++ b/nixos/roles/router/radvd.nix
@@ -17,7 +17,6 @@ let
     lib.concatStringsSep "\n" ([ (head lines) ] ++ (fclib.indentWith spaces (tail lines)));
 
   ifaces = listToAttrs (
-    # TODO: this should use routerGatewayNetworks in the future.
     filter (iface: iface.value.networkAttrs != [ ]) (
       map (
         vlan:
@@ -30,7 +29,7 @@ let
             networkAttrs = filter (attr: attr.addresses != [ ]) iface.v6.networkAttrs;
           }
         )
-      ) role.floatingGatewayNetworks
+      ) role.routerGatewayNetworks
     )
   );
 


### PR DESCRIPTION
This change makes some minor cleanups in the router role, and introduces some new options to for managing NAT for outbound connections. The source addresses which should be masqueraded upon egress and whether a specific address should be used as source address are now configurable using NixOS options.

@flyingcircusio/release-managers

## Release process

This change should be backported:

- [ ] Created changelog entry using `./changelog.sh`
- [ ] Add `backport release-25.11` label

This change should only reach this branch:

- [x] Created changelog entry using `./changelog.sh` => none, internal change.
or
- [ ] Add a upgrade node in `doc/upgrade.md`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [ ] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Removing obsolete stubs from the code.
  - Additional configuration operations for operational flexibility
- [x] Security requirements tested? (EVIDENCE)
  - Hydra tests green.
  - Config builds with no semantic diff against running system on various dev, staging, and production routers.