### PR TITLE
frr-wait-online.service: fix timeout specification

### DIFF
--- a/changelog.d/20260821_114707_PL-135151-timeout-fixup_scriv.md
+++ b/changelog.d/20260821_114707_PL-135151-timeout-fixup_scriv.md
@@ -1,0 +1,27 @@
+<!--
+
+A new changelog entry.
+
+Delete placeholder items that do not apply. Empty sections will be removed
+automatically during release.
+
+Leave the XX.XX as is: this is a placeholder and will be automatically filled
+correctly during the release and helps when backporting over multiple platform
+branches.
+
+-->
+
+### Impact
+
+<!-- Impact means "when this change is rolled out, there
+     might be interruptions/downtimes/required actions/... that
+     IMPACT THE RUNNING APPLICATION NEGATIVELY.
+
+     Having new features or changed is not an "impact". That's what
+     the main changelog (see below) is for.
+     -->
+
+
+### NixOS XX.XX platform
+
+- frr-wait-online.service: fix typo in timeout specification (PL-135151)

--- a/nixos/platform/network.nix
+++ b/nixos/platform/network.nix
@@ -1367,7 +1367,7 @@ in
           RemainAfterExit = true;
           # Timeouts necessary to prevent switch-to-configuration from blocking.
           # Allow a very generous amount of time for routes to appear…
-          TimeoutStart = config.systemd.services.frr.startLimitIntervalSec * 2;
+          TimeoutStartSec = config.systemd.services.frr.startLimitIntervalSec * 2;
           #… but if they don't, fail for good because that is an unexpected result in need of manual investigation.
           Restart = "no";
         };


### PR DESCRIPTION
An incorrect systemd unit property was used before.

PL-135151

@flyingcircusio/release-managers

## Release process

- [x] Created changelog entry using `./changelog.sh`
or
- [ ] Add a upgrade node in `doc/upgrade.md`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [x] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - this time also test the timeout on a real machine
  - unit spec needs to be valid
- [x] Security requirements tested? (EVIDENCE)
  - [x] verified timeout behaviour on a dev machine with uplinks cut at switch side
  - [x] verified unit file using `systemd analyze verify`