### PR TITLE
Fix FRR reloading on 26.05

### DIFF
--- a/pkgs/frr/0001-Don-t-throw-error-when-log-directory-already-exists.patch
+++ b/pkgs/frr/0001-Don-t-throw-error-when-log-directory-already-exists.patch
@@ -1,7 +1,7 @@
 From 86890af444c1655c3bb9e38fb26c44fa796821e1 Mon Sep 17 00:00:00 2001
 From: Molly Miller <mm@flyingcircus.io>
 Date: Wed, 26 Jun 2024 17:08:15 +0200
-Subject: [PATCH 1/3] Don't throw error when log directory already exists
+Subject: [PATCH 1/4] Don't throw error when log directory already exists
 
 Co-authored-by: Christian Theune <ct@flyingcircus.io>
 ---

--- a/pkgs/frr/0002-zebra-dplane-sleep-after-writing-batches-to-netlink.patch
+++ b/pkgs/frr/0002-zebra-dplane-sleep-after-writing-batches-to-netlink.patch
@@ -1,7 +1,7 @@
 From f5a9f37c6ebeaff916b708401e7c190a7ecb33e7 Mon Sep 17 00:00:00 2001
 From: Molly Miller <mm@flyingcircus.io>
 Date: Tue, 29 Apr 2025 16:12:01 +0200
-Subject: [PATCH 2/3] zebra-dplane: sleep after writing batches to netlink
+Subject: [PATCH 2/4] zebra-dplane: sleep after writing batches to netlink
 
 When synchronising the RIB for an L2-VNI into the kernel (e.g. bgpd is
 learning the initial EVPN RIB from a peer, a new VNI interface has

--- a/pkgs/frr/0003-netlink-don-t-manage-kernel-neighbour-table-entries-.patch
+++ b/pkgs/frr/0003-netlink-don-t-manage-kernel-neighbour-table-entries-.patch
@@ -1,7 +1,7 @@
 From 82e37721b57cf96efe812a6aa831316f75632e38 Mon Sep 17 00:00:00 2001
 From: Molly Miller <mm@flyingcircus.io>
 Date: Tue, 1 Jul 2025 16:11:41 +0200
-Subject: [PATCH 3/3] netlink: don't manage kernel neighbour table entries for
+Subject: [PATCH 3/4] netlink: don't manage kernel neighbour table entries for
  L2-VNI
 
 From experience, zebra's tracking of MAC-IP mappings for SVI

--- a/pkgs/frr/0004-watchfrr-don-t-admit-to-systemd-that-we-restart.patch
+++ b/pkgs/frr/0004-watchfrr-don-t-admit-to-systemd-that-we-restart.patch
@@ -1,0 +1,100 @@
+From 8c503289335b86818f9cecc55da7d53d72c66d36 Mon Sep 17 00:00:00 2001
+From: David 'equinox' Lamparter <equinox@opensourcerouting.org>
+Date: Thu, 20 Aug 2026 18:00:12 +0200
+Subject: [PATCH 4/4] watchfrr: don't admit to systemd that we restart
+
+As of systemd 259 (98734ac74d16), once you're telling it that you're
+stopping, you're _stopping_, full stop.  systemd will make sure of it.
+
+So, I guess we just shouldn't admit to systemd that we're restarting.
+Use `SIGUSR1` for reload instead, so it just gives systemd a bit of text
+instead.
+
+(cherry picked from commit 34a9f14d6f846f67c5dfdf80dee5a69d2e8e4028)
+[conflict fixed]
+Fixes: #20430
+References: https://github.com/systemd/systemd/commit/98734ac74d16862302c490e2a5bbc60539b7e6a4
+Signed-off-by: David 'equinox' Lamparter <equinox@opensourcerouting.org>
+---
+ tools/frrcommon.sh.in | 13 +++++++++++--
+ tools/frrinit.sh.in   |  2 +-
+ watchfrr/watchfrr.c   | 11 +++++++++++
+ 3 files changed, 23 insertions(+), 3 deletions(-)
+
+diff --git a/tools/frrcommon.sh.in b/tools/frrcommon.sh.in
+index 44355f8895..a0946b317a 100755
+--- a/tools/frrcommon.sh.in
++++ b/tools/frrcommon.sh.in
+@@ -201,7 +201,10 @@ daemon_stop() {
+ 	is_user_root || exit 1
+ 
+ 	all=false
++	sig=INT
++	# these can't be used at the same time anyway
+ 	[ "$2" = "--reallyall" ] && all=true
++	[ "$2" = "--reload" ] && sig=USR1
+ 
+ 	pidfile="$V_PATH/$daemon${inst:+-$inst}.pid"
+ 	vtyfile="$V_PATH/$daemon${inst:+-$inst}.vty"
+@@ -217,8 +220,14 @@ daemon_stop() {
+ 		return 1
+ 	fi
+ 
+-	debug "kill -2 $pid"
+-	kill -2 "$pid"
++	if [ "$FRR_COLLECT_CORE" = "1" ]; then
++		debug "kill -6 $pid"
++		kill -6 "$pid"
++	else
++		debug "kill -$sig $pid"
++		kill -$sig "$pid"
++	fi
++
+ 	cnt=1200
+ 	while kill -0 "$pid" 2>/dev/null; do
+ 		sleep .1
+diff --git a/tools/frrinit.sh.in b/tools/frrinit.sh.in
+index 178d18d437..c311d4dce9 100644
+--- a/tools/frrinit.sh.in
++++ b/tools/frrinit.sh.in
+@@ -89,7 +89,7 @@ reload)
+ 	# NB: This will NOT cause the other daemons to be restarted.
+ 	daemon_list enabled_daemons disabled_daemons
+ 	watchfrr_options="$watchfrr_options $enabled_daemons"
+-	daemon_stop watchfrr && \
++	daemon_stop watchfrr --reload && \
+ 		daemon_start watchfrr
+ 
+ 	# If we disable an arbitrary daemon and do reload,
+diff --git a/watchfrr/watchfrr.c b/watchfrr/watchfrr.c
+index 559514d342..ad7b0338d3 100644
+--- a/watchfrr/watchfrr.c
++++ b/watchfrr/watchfrr.c
+@@ -1097,6 +1097,13 @@ static FRR_NORETURN void sigint(void)
+ 	exit(0);
+ }
+ 
++static FRR_NORETURN void sigusr1(void)
++{
++	zlog_notice("Terminating to handle reload (SIGUSR1)");
++	systemd_send_status("watchfrr restarting to handle changes in daemons");
++	exit(0);
++}
++
+ static int valid_command(const char *cmd)
+ {
+ 	char *p;
+@@ -1352,6 +1359,10 @@ static struct frr_signal_t watchfrr_signals[] = {
+ 		.signal = SIGCHLD,
+ 		.handler = sigchild,
+ 	},
++	{
++		.signal = SIGUSR1,
++		.handler = sigusr1,
++	},
+ };
+ 
+ /* clang-format off */
+-- 
+2.50.1 (Apple Git-155)
+

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -292,6 +292,7 @@ builtins.mapAttrs (_: patchPhps phpLogPermissionPatch) {
       ./frr/0001-Don-t-throw-error-when-log-directory-already-exists.patch
       ./frr/0002-zebra-dplane-sleep-after-writing-batches-to-netlink.patch
       ./frr/0003-netlink-don-t-manage-kernel-neighbour-table-entries-.patch
+      ./frr/0004-watchfrr-don-t-admit-to-systemd-that-we-restart.patch
     ];
   });
 

--- a/tests/frr.nix
+++ b/tests/frr.nix
@@ -356,6 +356,9 @@ import ./make-test-python.nix (
               host1.succeed("ip route show 192.168.42.3 | grep -F fe80::5054:ff:fe12:203")
               host1.succeed("ip route show 192.168.42.3 | grep -F fe80::5054:ff:fe12:104")
 
+          with subtest("check that config reload works correctly"):
+              # https://github.com/FRRouting/frr/issues/20430
+              host1.succeed("systemctl reload frr")
         '';
       };
       evpn = {


### PR DESCRIPTION
systemd version 259 changed the handling of sd_notify messages sent by supervised processes, which breaks FRR's runtime reload procedure. Reloads triggered through systemd result in FRR being killed and restarted, which can cause disruptions to network connectivity. NixOS 26.05 ships with systemd version 260, which includes this behaviour. Further details are in FRRouting/frr#20430.

This change pulls in the upstream FRR patch which fixes the reload process to be compatible with the new systemd behaviour in order to avoid this issue.

PL-135549

@flyingcircusio/release-managers

## Release process

This change should be backported:

- [ ] Created changelog entry using `./changelog.sh`
- [ ] Add `backport release-25.11` label

This change should only reach this branch:

- [x] Created changelog entry using `./changelog.sh` => none, internal change.
or
- [ ] Add a upgrade node in `doc/upgrade.md`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [ ] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Integration and compatibility – reloads should be non-disruptive and not cause connectivity outages.
- [x] Security requirements tested? (EVIDENCE)
  - Tested on a lab machine.