### PR TITLE
Refactor platform networking configuration for upstream changes in 26.05

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -165,11 +165,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1788081141,
-        "narHash": "sha256-T9K0UY3vyU/Th4xDotkHJaAtX+jA9F5Z2ppnqhZPqVc=",
+        "lastModified": 1788500865,
+        "narHash": "sha256-yRo2lE7B6yJDYaHp+omYqD507aoY8VhagUiQsVIVZzA=",
         "owner": "flyingcircusio",
         "repo": "nixpkgs",
-        "rev": "e9b71398db012ea7058200bdc863a422fa8d514e",
+        "rev": "2ed77808d696a487d6d8e939fb46f06beae1d484",
         "type": "github"
       },
       "original": {

--- a/nixos/platform/network.nix
+++ b/nixos/platform/network.nix
@@ -111,6 +111,8 @@ let
 
   quoteLabel = replaceStrings [ "/" ] [ "-" ];
 
+  subsystemDevice = interface: "sys-subsystem-net-devices-${interface}.device";
+
   concatFuncWithIndent =
     func: indent:
     let
@@ -583,23 +585,26 @@ in
         ];
       }
       //
-
-        # These units performing network interface setup must be
-        # explicitly wanted by the multi-user target, otherwise they
-        # will not get initially added as the individual address units
-        # won't get restarted because triggering multi-user.target alone
-        # does not propagate to the network target, etc etc.
+        # Units performing network interface setup must be wanted by
+        # network.target (which is itself wanted by multi-user.target),
+        # and be partOf networking-scripted.target (the upstream
+        # scripted networking reset button).
         (listToAttrs (
-
           (map (
             iface:
             (lib.nameValuePair "${iface.link}-netdev" rec {
               description = "Ensure network device settings for ${iface.link}";
               wantedBy = [
-                "network-setup.service"
-                "multi-user.target"
+                "network.target"
+                (subsystemDevice iface.link)
               ];
-              requires = [ "network-setup.service" ];
+              partOf = [
+                "network.target"
+                "networking-scripted.target"
+              ];
+              after = [ "network-pre.target" ];
+              before = [ "network.target" ];
+              stopIfChanged = false;
               path = [
                 pkgs.nettools
                 pkgs.ethtool
@@ -608,7 +613,6 @@ in
                 pkgs.jq
                 pkgs.util-linux
               ];
-              stopIfChanged = false;
               script = ''
                 set -e
 
@@ -827,12 +831,15 @@ in
                   (lib.nameValuePair "${linkName}-netdev" rec {
                     description = "Dummy interface ${linkName}";
                     wantedBy = [
-                      "network-setup.service"
-                      "multi-user.target"
+                      "network.target"
+                      (subsystemDevice linkName)
                     ];
-                    before = wantedBy;
+                    partOf = [
+                      "network.target"
+                      "networking-scripted.target"
+                    ];
+                    before = [ "network.target" ];
                     after = [ "network-pre.service" ];
-                    requires = [ "network-setup.service" ];
                     path = [
                       pkgs.nettools
                       pkgs.procps
@@ -864,19 +871,20 @@ in
                     (lib.nameValuePair "${iface.link}-netdev" rec {
                       description = "VXLAN link device ${iface.link}";
                       wantedBy = [
-                        "network-setup.service"
-                        "multi-user.target"
+                        "network.target"
+                        (subsystemDevice iface.link)
                       ];
-                      before = wantedBy;
-                      requires = [
-                        "network-addresses-${fclib.underlay.interface}.service"
-                        "network-setup.service"
+                      partOf = [
+                        "network.target"
+                        "networking-scripted.target"
                       ];
-                      # do not order after network-setup.service as we already declare
-                      # a before= dependency.
+                      before = [ "network.target" ];
                       after = [
                         "network-addresses-${fclib.underlay.interface}.service"
                         "network-pre.target"
+                      ];
+                      requires = [
+                        "network-addresses-${fclib.underlay.interface}.service"
                       ];
                       reloadIfChanged = true;
                       path = [
@@ -930,9 +938,11 @@ in
                     iface:
                     (lib.nameValuePair "network-bridge-suppress-flooding-${iface.link}" {
                       description = "Ensure ARP/ND suppression is enabled for bridge port ${iface.link}";
-                      wantedBy = [ "multi-user.target" ];
-                      requires = [ "${iface.interface}-netdev.service" ];
+                      wantedBy = [ "network.target" ];
+                      partOf = [ "networking-scripted.target" ];
+                      before = [ "network.target" ];
                       after = [ "${iface.interface}-netdev.service" ];
+                      requires = [ "${iface.interface}-netdev.service" ];
                       stopIfChanged = false;
                       path = [ fclib.relaxedIp ];
                       script = ''
@@ -955,9 +965,11 @@ in
                   iface:
                   (lib.nameValuePair "network-bridge-disable-learning-${iface.link}" {
                     description = "Ensure MAC address learning is disabled for bridge port ${iface.link}";
-                    wantedBy = [ "multi-user.target" ];
-                    requires = [ "${iface.interface}-netdev.service" ];
+                    wantedBy = [ "network.target" ];
+                    partOf = [ "networking-scripted.target" ];
+                    before = [ "network.target" ];
                     after = [ "${iface.interface}-netdev.service" ];
+                    requires = [ "${iface.interface}-netdev.service" ];
                     stopIfChanged = false;
                     path = [ fclib.relaxedIp ];
                     script = ''
@@ -985,11 +997,12 @@ in
                       description = "Ensure underlay properties for ${iface.link}";
                       wantedBy = [
                         "network-addresses-${iface.link}.service"
-                        "multi-user.target"
+                        "network.target"
                       ];
-                      before = wantedBy;
                       requires = [ "${iface.link}-netdev.service" ];
+                      before = wantedBy;
                       after = requires;
+                      partOf = [ "networking-scripted.target" ];
                       path = [ pkgs.procps ];
                       script = ''
                         sysctl net.ipv4.conf.${iface.link}.rp_filter=0
@@ -1013,17 +1026,20 @@ in
                     lib.nameValuePair "${name}-netdev" {
                       description = "VRF Interface ${name}";
                       wantedBy = [
-                        "network-setup.service"
-                        "sys-subsystem-net-devices-${name}.device"
+                        "network.target"
+                        (subsystemDevice name)
                       ];
                       bindsTo = [ interfaceUnit ];
-                      requires = [ "network-setup.service" ];
+                      partOf = [
+                        "network.target"
+                        "networking-scripted.target"
+                      ];
                       after = [
                         "network-pre.target"
                         interfaceUnit
                       ];
                       before = [
-                        "network-setup.service"
+                        "network.target"
                         addressUnit
                       ];
                       serviceConfig.Type = "oneshot";
@@ -1057,10 +1073,14 @@ in
                       description = "Ensure fallback unreachable route for underlay prefixes";
                       wantedBy = [
                         "network-addresses-${fclib.underlay.interface}.service"
-                        "multi-user.target"
+                        "network.target"
                       ];
                       before = wantedBy;
-                      after = [ "${fclib.underlay.interface}-netdev.service" ];
+                      partOf = [ "networking-scripted.target" ];
+                      after = [
+                        "${fclib.underlay.interface}-netdev.service"
+                        "network-pre.target"
+                      ];
                       path = [ fclib.relaxedIp ];
                       stopIfChanged = false;
                       # https://docs.frrouting.org/en/stable-8.5/zebra.html#administrative-distance

--- a/nixos/platform/network.nix
+++ b/nixos/platform/network.nix
@@ -606,137 +606,15 @@ in
               before = [ "network.target" ];
               stopIfChanged = false;
               path = [
-                pkgs.nettools
-                pkgs.ethtool
-                pkgs.procps
-                fclib.relaxedIp
-                pkgs.jq
-                pkgs.util-linux
+                pkgs.fc.netdev
               ];
-              script = ''
-                set -e
-
-                touch /var/lock/interface-rename.lock
-                exec 4</var/lock/interface-rename.lock
-
-                echo "Ensuring interface name '${iface.link}' ..."
-
-                echo "Acquiring interface renaming lock ..."
-                flock -x -w 60 4 || exit 1
-                echo "Got interface renaming lock ..."
-
-                # Look up the desired interface's current name by mac address
-                interface="$(ip -j -d link show | jq -r '.[] | select(.linkinfo?.info_kind? == null) | select(.address == "${iface.mac}") | .ifname')"
-
-                if [[ "$interface" == "" ]]; then
-                  echo "ERROR: Missing interface with MAC address '${iface.mac}'."
-                  echo "Found interfaces:"
-                  ip link show
-                  exit 1
-                fi
-
-                if [[ "$interface" != "${iface.link}" ]]; then
-                  echo "Interface is currently known as \`$interface\` ..."
-
-                  # Check whether our desired name is also already in use,
-                  # rename that one to a unique name.
-                  counter=0
-                  while ip l show dev ${iface.link} > /dev/null; do
-                    echo "'${iface.link}' is still being used, trying to clean up."
-                    # Down the other interface and rename it
-                    ip l set ${iface.link} down
-                    # Try, don't care if it fails. We check the success on the
-                    # next loop.
-                    ip l set ${iface.link} name eth$counter || true
-                    # The interface's name might not have been it's primary name
-                    # but an altname, try to delete that as well.
-                    # This looks funny, but we can use the altname to look up the
-                    # link to remove the altname ...
-                    # don't do this if the name is already gone
-                    ip l property del altname ${iface.link} dev ${iface.link} || true
-                    counter=$((counter+1))
-                  done
-
-                  echo "Performing rename from '$interface' to '${iface.link}'"
-                  ip l set $interface down
-                  ip l set $interface name ${iface.link}
-                fi
-
-                LINK_DRIVER=$(ethtool -i ${iface.link} | grep "driver: " | cut -d ':' -f 2 | sed -e 's/ //')
-                case $LINK_DRIVER in
-                    e1000|e1000e|igb|ixgbe|i40e)
-                        # Set adaptive interrupt moderation. This does increase
-                        # latency.
-                        echo "Enabling adaptive interrupt moderation ..."
-                        ethtool -C "${iface.link}" rx-usecs 1 || true
-                        # Larger buffers.
-                        echo "Setting ring buffer ..."
-                        ethtool -G "${iface.link}" rx 4096 tx 4096 || true
-                        # Large receive offload to reduce small packet CPU/interrupt impact.
-                        echo "Enabling large receive offload ..."
-                        ethtool -K "${iface.link}" lro on || true
-                        ;;
-                esac
-
-                # TODO: it'd be preferrable to manage this on a by-interface base
-                # and distinguish whether an interface is physical.
-                # Can this be done based on `config.flyingcircus.enc.parameters.interfaces.fe.policy`?
-                ${lib.optionalString (config.flyingcircus.networking.physicalHostNetworking) ''
-                  echo "Disabling flow control"
-                  ethtool -A ${iface.link} autoneg off rx off tx off || true
-                ''}
-
-                # Ensure MTU
-                ip l set ${iface.link} mtu ${toString iface.mtu}
-
-              ''
-
-              + (lib.optionalString (iface.externalLabel != null) ''
-                # Add long alternative names according to the external label
-                if ip l show dev ${quoteLabel iface.externalLabel} > /dev/null; then
-                  # XXX There is an edge case we don't cover here:
-                  # if the desired altname is already the primary name of an interface
-                  # the altname del will fail and this unit will not come up properly
-                  # but that means we notice it and will fix it then.
-                  ip l property del altname ${quoteLabel iface.externalLabel} dev ${quoteLabel iface.externalLabel}
-                fi
-                ip l property add altname ${quoteLabel iface.externalLabel} dev ${iface.link}
-
-              '')
-              + ''
-                echo "Releasing lock"
-                exec 4>&-
-              '';
-              preStop = ''
-                set -e
-
-                touch /var/lock/interface-rename.lock
-                exec 4</var/lock/interface-rename.lock
-
-                echo "Renaming ${iface.link} to neutral name ..."
-
-                echo "Acquiring interface renaming lock ..."
-                flock -x -w 60 4 || exit 1
-                echo "Got interface renaming lock ..."
-
-                # Shut down the interface so the systemd device unit goes away
-                # so we can perform proper renames.
-                ip l set ${iface.link} down
-
-                counter=0
-                while ip l show dev ${iface.link} > /dev/null; do
-                  ip l set ${iface.link} down
-                  # Try, don't care if it fails. We check the success on the
-                  # next loop.
-                  ip l set ${iface.link} name eth$counter || true
-                  # don't do this if the name is already gone
-                  ip l property del altname ${iface.link} dev ${iface.link} || true
-                  counter=$((counter+1))
-                done
-
-                echo "Releasing lock"
-                exec 4>&-
-              '';
+              environment.PYTHONUNBUFFERED = "1";
+              script =
+                "netdev start "
+                + (lib.optionalString config.flyingcircus.networking.physicalHostNetworking "-F ")
+                + (lib.optionalString (iface.externalLabel != null) "-l ${iface.externalLabel} ")
+                + "${iface.link} ${iface.mac} ${toString iface.mtu}";
+              preStop = "netdev stop ${iface.link}";
               serviceConfig = {
                 Type = "oneshot";
                 RemainAfterExit = true;

--- a/nixos/roles/devhost/vm.nix
+++ b/nixos/roles/devhost/vm.nix
@@ -72,7 +72,7 @@ let
       lib.recursiveUpdate defaultService {
         enable = vmCfg.enable;
         wantedBy = [ "machines.target" ];
-        after = [ "network-setup.service" ];
+        after = [ "network.target" ];
 
         serviceConfig = {
           ExecStart = (

--- a/nixos/roles/nfs.nix
+++ b/nixos/roles/nfs.nix
@@ -127,6 +127,18 @@ in
         };
       };
 
+      # Ensure that network filesystems are ordered after any units
+      # which perform address configuration, as these are not normally
+      # part of network.target. Otherwise, IP addresses may be removed
+      # before the NFS share is unmounted at shutdown
+      systemd.targets.remote-fs-pre.after =
+        let
+          addressUnits = map (n: "${n}.service") (
+            filter (lib.hasPrefix "network-addresses-") (attrNames config.systemd.services)
+          );
+        in
+        addressUnits;
+
       systemd.tmpfiles.rules = [
         "d ${mountpoint}"
       ];

--- a/pkgs/fc/default.nix
+++ b/pkgs/fc/default.nix
@@ -45,6 +45,13 @@ rec {
   megacli = callPackage ./megacli { };
   multiping = callPackage ./multiping.nix { };
   neighbour-cache-monitor = callPackage ./neighbour-cache-monitor { };
+  netdev = pkgs.writers.writePython3BinFromFile ./netdev.py {
+    libraries = with pkgs.python3Packages; [ netaddr ];
+    dependencies = with pkgs; [
+      iproute2
+      ethtool
+    ];
+  };
   ping-on-tap = callPackage ./ping-on-tap { };
 
   qemu-nautilus =

--- a/pkgs/fc/netdev.py
+++ b/pkgs/fc/netdev.py
@@ -1,0 +1,269 @@
+import argparse
+import contextlib
+import fcntl
+import json
+import signal
+import subprocess
+import sys
+from pathlib import Path
+
+from netaddr import EUI, AddrFormatError, mac_unix_expanded
+
+INTERFACE_RENAME_LOCKFILE = "/var/lock/interface-rename.lock"
+LOCK_TIMEOUT = 60
+
+RENAME_LIMIT = 60
+INTEL_DRIVER_NAMES = ["e1000", "e1000e", "igb", "ixgbe", "i40e"]
+
+
+def fatal(msg):
+    print(msg, file=sys.stderr)
+    sys.exit(1)
+
+
+class LockTimeoutError(Exception):
+    pass
+
+
+@contextlib.contextmanager
+def interface_renaming_lock():
+    lockfile = Path(INTERFACE_RENAME_LOCKFILE)
+
+    def alarm_handler(sig, frame):
+        raise LockTimeoutError()
+
+    print("Acquiring interface renaming lock ...")
+
+    lockfile.touch()
+    with open(lockfile, "r") as f:
+        old_handler = signal.signal(signal.SIGALRM, alarm_handler)
+        signal.alarm(LOCK_TIMEOUT)
+
+        try:
+            fcntl.flock(f, fcntl.LOCK_EX)
+        except LockTimeoutError:
+            fatal("Timed out acquiring interface renaming lock")
+        except OSError as ex:
+            fatal(f"Could not acquire interface renaming lock: {ex}")
+
+        signal.alarm(0)
+        signal.signal(signal.SIGALRM, old_handler)
+
+        print("Got interface renaming lock ...")
+
+        yield
+
+        print("Releasing lock")
+        fcntl.flock(f, fcntl.LOCK_UN)
+
+
+def ip_link(args, **kwargs):
+    cmd = ["ip", "link"]
+    cmd.extend(args)
+    if "check" not in kwargs:
+        # check by default unless specified otherwise.
+        kwargs["check"] = True
+    return subprocess.run(cmd, **kwargs)  # noqa: PLW1510
+
+
+def ip_link_show():
+    data = subprocess.check_output(["ip", "-d", "-j", "link", "show"])
+    return json.loads(data.decode("utf-8"))
+
+
+def ethtool(args, **kwargs):
+    cmd = ["ethtool"]
+    cmd.extend(args)
+    return subprocess.run(cmd, **kwargs)  # noqa: PLW1510
+
+
+def driver_matches_intel(iface):
+    data = subprocess.check_output(["ethtool", "-i", iface])
+    data = data.decode("utf-8")
+    for line in data.splitlines():
+        if not line.startswith("driver: "):
+            continue
+        driver = line.removeprefix("driver: ")
+        driver = driver.strip()
+        return driver in INTEL_DRIVER_NAMES
+    return False
+
+
+def rename_to_neutral(iface, set_first_down=False):
+    # rename interface from its current name to a neutral name by
+    # repeated brute force
+    for counter in range(RENAME_LIMIT):
+        # does the interface (still) exist under its current name?
+        show_proc = ip_link(
+            ["show", "dev", iface], stdout=subprocess.DEVNULL, check=False
+        )
+        if show_proc.returncode != 0:
+            # interface no longer found under current name, success!
+            return
+
+        # ensure the interface is set down on the first pass if it
+        # does exist if this has not been handled by the caller.
+        if not counter and set_first_down:
+            print(f"'{iface}' is still being used, trying to clean up")
+            ip_link(["set", iface, "down"])
+
+        # attempt to rename the interface from its current name to the
+        # next neutral name. note that an interface with the current
+        # neutral name may already exist, which would cause the
+        # renaming to fail, but we'll test that on the next iteration.
+        target = f"eth{counter}"
+        ip_link(["set", iface, "name", target], check=False)
+
+        # the current name may be an interface altname, in which case
+        # stripping the altname will also satisfy our exit
+        # condition. we also don't care if this succeeds, we'll test
+        # on the next iteration.
+        ip_link(
+            ["property", "del", "altname", iface, "dev", iface], check=False
+        )
+
+    fatal(f"Could not rename interface {iface} to neutral name!")
+
+
+def start(args):
+    print(f"Ensuring interface name '{args.interface}' ...")
+
+    target_name = args.interface
+
+    current_name = None
+    current_links = ip_link_show()
+    for link in current_links:
+        # ignore virtual kernel network devices. virtual devices are
+        # always tagged with linkinfo.
+        if link.get("linkinfo", {}).get("info_kind"):
+            continue
+
+        if link.get("address") == str(args.mac_address):
+            current_name = link["ifname"]
+            break
+
+    if not current_name:
+        fatal(
+            f"ERROR: Missing interface with MAC address '{args.mac_address}'\n"
+            "Found interfaces: {}".format(
+                ", ".join([x["ifname"] for x in current_links])
+            )
+        )
+
+    if current_name != target_name:
+        print(f"Interface is currently known as '{current_name}'")
+        rename_to_neutral(target_name, set_first_down=True)
+
+        print(f"Performing rename from '{current_name}' to '{target_name}'")
+        ip_link(["set", current_name, "down"])
+        ip_link(["set", current_name, "name", target_name])
+
+    if driver_matches_intel(args.interface):
+        print("Enabling adaptive interrupt moderation ...")
+        ethtool(["-C", args.interface, "rx-usecs", "1"])
+
+        print("Setting ring buffer ...")
+        ethtool(["-G", args.interface, "rx", "4096", "tx", "4096"])
+
+        print("Enabling large receive offload ...")
+        ethtool(["-K", args.interface, "lro", "on"])
+
+    if not args.flow_control:
+        print("Disabling flow control")
+        ethtool(
+            ["-A", args.interface, "autoneg", "off", "rx", "off", "tx", "off"]
+        )
+
+    ip_link(["set", args.interface, "mtu", str(args.mtu)])
+
+    if args.label:
+        label = args.label.replace("/", "-")
+
+        show_proc = ip_link(
+            ["show", "dev", label], check=False, stdout=subprocess.DEVNULL
+        )
+        if show_proc.returncode == 0:
+            # an interface with the given altname already exists,
+            # clean it up.
+            #
+            # XXX: this does not cover the edge case where the desired
+            # label is the primary name of another interface.
+            ip_link(["property", "del", "altname", label, "dev", label])
+
+        ip_link(["property", "add", "altname", label, "dev", args.interface])
+
+
+def stop(args):
+    print(f"Renaming {args.interface} to neutral name ...")
+
+    ip_link(["set", args.interface, "down"])
+    rename_to_neutral(args.interface, set_first_down=False)
+
+
+def parse_eui48(addr):
+    try:
+        return EUI(addr, version=48, dialect=mac_unix_expanded)
+    except AddrFormatError as ex:
+        raise ValueError(ex)
+
+
+def main():
+    parser = argparse.ArgumentParser(prog="fc-netdev")
+    subparsers = parser.add_subparsers(required=True, dest="command")
+
+    start_parser = subparsers.add_parser(
+        "start",
+        help="Bring up and configure physical link with the correct name",
+    )
+    start_parser.set_defaults(func=start)
+    start_parser.add_argument(
+        "-F",
+        "--no-flow-control",
+        action="store_false",
+        dest="flow_control",
+        help="Disable flow control on the physical link",
+    )
+    start_parser.add_argument(
+        "-l",
+        "--label",
+        dest="label",
+        help="Add LABEL as alternative name for the physical link",
+    )
+    start_parser.add_argument(
+        "interface",
+        metavar="INTERFACE",
+        help="Target name for the physical link",
+    )
+    start_parser.add_argument(
+        "mac_address",
+        metavar="MAC_ADDRESS",
+        help="MAC address of the physical link",
+    )
+    start_parser.add_argument(
+        "mtu",
+        metavar="MTU",
+        help="MTU of the physical link",
+    )
+
+    stop_parser = subparsers.add_parser(
+        "stop",
+        help="Deconfigure physical link and move it to a neutral name",
+    )
+    stop_parser.set_defaults(func=stop)
+    stop_parser.add_argument(
+        "interface",
+        metavar="INTERFACE",
+        help="Name of physical link to be deconfigured",
+    )
+
+    args = parser.parse_args()
+
+    try:
+        with interface_renaming_lock():
+            args.func(args)
+    except subprocess.CalledProcessError as ex:
+        fatal(f"Exception while running command: {ex}")
+
+
+if __name__ == "__main__":
+    main()

--- a/release/versions.json
+++ b/release/versions.json
@@ -8,10 +8,10 @@
     "url": "https://gitlab.flyingcircus.io/flyingcircus/nixos-mailserver.git/"
   },
   "nixpkgs": {
-    "hash": "sha256-T9K0UY3vyU/Th4xDotkHJaAtX+jA9F5Z2ppnqhZPqVc=",
+    "hash": "sha256-yRo2lE7B6yJDYaHp+omYqD507aoY8VhagUiQsVIVZzA=",
     "owner": "flyingcircusio",
     "repo": "nixpkgs",
-    "rev": "e9b71398db012ea7058200bdc863a422fa8d514e"
+    "rev": "2ed77808d696a487d6d8e939fb46f06beae1d484"
   },
   "poetry2nix": {
     "hash": "sha256-nzgO/ZCSBzWjbMkYDxG+yl9Z2eGbCgQu06Oku3ir5D4=",

--- a/tests/frr.nix
+++ b/tests/frr.nix
@@ -39,12 +39,16 @@ import ./make-test-python.nix (
       {
         networking.interfaces."${name}".ipv4.addresses = lib.mkForce [ ];
         networking.firewall.trustedInterfaces = [ name ];
-        systemd.services."${name}-netdev" = {
+        systemd.services."${name}-netdev" = rec {
           wantedBy = [
-            "network-setup.service"
-            "multi-user.target"
+            "network.target"
           ];
-          requires = [ "network-setup.service" ];
+          before = wantedBy;
+          after = [ "network-pre.target" ];
+          partOf = [
+            "network.target"
+            "networking-scripted.target"
+          ];
           script = ":";
           serviceConfig.Type = "oneshot";
           serviceConfig.RemainAfterExit = true;
@@ -64,12 +68,14 @@ import ./make-test-python.nix (
         systemd.services.underlay-netdev = rec {
           description = "Set up underlay loopback device";
           wantedBy = [
-            "network-setup.service"
-            "multi-user.target"
+            "network.target"
           ];
           before = wantedBy;
-          after = [ "network-pre.service" ];
-          requires = [ "network-setup.service" ];
+          after = [ "network-pre.target" ];
+          partOf = [
+            "network.target"
+            "networking-scripted.target"
+          ];
           path = [ pkgs.iproute2 ];
           script = "ip link add underlay type dummy";
           preStop = "ip link delete underlay";
@@ -112,12 +118,14 @@ import ./make-test-python.nix (
         systemd.services.vxlan0-netdev = rec {
           description = "Set up overlay VXLAN device";
           wantedBy = [
-            "network-setup.service"
-            "multi-user.target"
+            "network.target"
           ];
           before = wantedBy;
-          after = [ "network-pre.service" ];
-          requires = [ "network-setup.service" ];
+          after = [ "network-pre.target" ];
+          partOf = [
+            "network.target"
+            "networking-scripted.target"
+          ];
           path = [ pkgs.iproute2 ];
           script = ''
             ip link add vxlan0 type vxlan \

--- a/tests/nfs.nix
+++ b/tests/nfs.nix
@@ -374,7 +374,7 @@ import ./make-test-python.nix (
 
           reset_specialisation()
 
-          with subtest("changing network-setup.service functions correctly"):
+          with subtest("changing network-local-commands.service functions correctly"):
               switch_to_specialisation("withOtherResolver")
         '';
       };

--- a/tests/testlib.nix
+++ b/tests/testlib.nix
@@ -286,12 +286,14 @@ rec {
         underlay-netdev = rec {
           description = "Set up underlay loopback device";
           wantedBy = [
-            "network-setup.service"
-            "multi-user.target"
+            "network.target"
+          ];
+          partOf = [
+            "network.target"
+            "networking-scripted.target"
           ];
           before = wantedBy;
           after = [ "network-pre.service" ];
-          requires = [ "network-setup.service" ];
           path = [ pkgs.iproute2 ];
           script = "ip link add underlay type dummy";
           preStop = "ip link delete underlay";
@@ -302,12 +304,16 @@ rec {
       // (listToAttrs (
         map (
           name:
-          lib.nameValuePair "${name}-netdev" {
+          lib.nameValuePair "${name}-netdev" rec {
             wantedBy = [
-              "network-setup.service"
-              "multi-user.target"
+              "network.target"
             ];
-            requires = [ "network-setup.service" ];
+            before = wantedBy;
+            after = [ "network-pre.target" ];
+            partOf = [
+              "network.target"
+              "networking-scripted.target"
+            ];
             script = ":";
             serviceConfig.Type = "oneshot";
             serviceConfig.RemainAfterExit = true;


### PR DESCRIPTION
This change refactors the network configuration code in the platform to be compatible with the changes made to scripted networking by NixOS upstream in 26.05. Upstream has removed `network-setup.service` and now uses `network.target` for coordinating network configuration. Additionally, this change reimplements the blob of shell with the jq one-liner which we used for configuring physical ethernet links in Python. There is also a fix for an upstream bug in unit ordering affecting unmounting of NFS filesystems at shutdown.

This PR should not be merged directly, as these changes need to be merged simultaneously with the Nixpkgs bump which drops our previous patch set against scripted networking. See flyingcircusio/nixpkgs#1122.

PL-135549

@flyingcircusio/release-managers

## Release process

This change should be backported:

- [ ] Created changelog entry using `./changelog.sh`
- [ ] Add `backport release-25.11` label

This change should only reach this branch:

- [ ] Created changelog entry using `./changelog.sh`
  internal
or
- [ ] Add a upgrade node in `doc/upgrade.md`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [x] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [x] Security requirements tested? (EVIDENCE)
  - tested on router, releasetest (nfs)