### PR TITLE
ceph: fix disabling the osd scrub auto repair in Nautilus

### DIFF
--- a/nixos/roles/ceph/osd.nix
+++ b/nixos/roles/ceph/osd.nix
@@ -293,7 +293,7 @@ in
       # we need to disable autorepair for Nautilus because it has spurious status
       # display issues of generally indicating a `repairing` for deep-scrubbing PGs.
       # see PL-131662
-      flyingcircus.services.ceph.extraSettings.osdScrubAutoRepair = false;
+      flyingcircus.roles.ceph_osd.extraSettings.osdScrubAutoRepair = false;
     })
   ];
 }


### PR DESCRIPTION
Properly override the ceph setting version-gated in Ceph Nautilus, that disables autorepairs during scrub. Such repairs turned out to report spurious status messages in Nautilus and remain disabled in that older release.
The override settings attr path used to be wrong, resulting in 2 settings in different settings in the config file, one true and one false.

Discovered during PL-135552, but likely unrelated.

@flyingcircusio/release-managers

## Release process

This change should only reach this branch:

- [ ] Created changelog entry using `./changelog.sh`
  - no, internal

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [x] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [x] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [x] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - fix an incorrect configuration name attr path in a version-specific override
- [x] Security requirements tested? (EVIDENCE)
  - verified the override result in the ceph.conf of the NixOS test
  - verified a slightly modified variant on a live server
  - noted as a motivation for a follow-up restructuring of the Ceph module settings logic to avoid future mistakes