### PR TITLE
PL-135338 openvpn: monitor PKI certificate expiry

### DIFF
--- a/changelog.d/20260805_000000_PL-135338_openvpn-pki-monitoring_scriv.md
+++ b/changelog.d/20260805_000000_PL-135338_openvpn-pki-monitoring_scriv.md
@@ -1,0 +1,3 @@
+### NixOS XX.XX platform
+
+- Added monitoring for OpenVPN PKI certificate expiry, so an expiring CA or server certificate alerts well before the VPN breaks. (PL-135338)

--- a/nixos/roles/external_net/openvpn.nix
+++ b/nixos/roles/external_net/openvpn.nix
@@ -76,6 +76,7 @@ let
   pki = pkgs.callPackage ./generate-pki.nix {
     inherit resource_group location;
   };
+  checkCert = "${pkgs.fc.check-tls-cert}/bin/check_tls_cert";
 
   allNetworks = lib.zipAttrs (lib.catAttrs "networks" (attrValues interfaces));
 
@@ -244,6 +245,18 @@ in
         notification = "OpenVPN management interface";
         command = toString checkOpenVPN;
         interval = 300;
+      };
+      # Warn well before the long-lived OpenVPN PKI certs expire, so an
+      # expired CA does not break the VPN unexpectedly (see PL-135338).
+      openvpn_pki_ca = {
+        notification = "OpenVPN CA certificate will expire soon (${pki.caCrt})";
+        command = "sudo ${checkCert} ${pki.caCrt} openvpn-ca";
+        interval = 3600;
+      };
+      openvpn_pki_server = {
+        notification = "OpenVPN server certificate will expire soon (${pki.serverCrt})";
+        command = "sudo ${checkCert} ${pki.serverCrt} openvpn-server";
+        interval = 3600;
       };
     };
 

--- a/tests/openvpn.nix
+++ b/tests/openvpn.nix
@@ -137,55 +137,61 @@ import ./make-test-python.nix (
         };
     };
 
-    testScript = ''
-      start_all()
-      # copy client config from gateway to client and set user/pass
-      (rc, ovpn) = gw.execute("cat /etc/local/openvpn/*.ovpn")
-      oclient.execute(f"echo '{ovpn}' > /tmp/gw.ovpn")
-      oclient.execute("echo 'test\ntest' > /tmp/user-pass; chmod 600 /tmp/user-pass")
+    testScript =
+      { nodes, ... }:
+      ''
+        start_all()
+        # copy client config from gateway to client and set user/pass
+        (rc, ovpn) = gw.execute("cat /etc/local/openvpn/*.ovpn")
+        oclient.execute(f"echo '{ovpn}' > /tmp/gw.ovpn")
+        oclient.execute("echo 'test\ntest' > /tmp/user-pass; chmod 600 /tmp/user-pass")
 
 
-      gw.wait_for_unit("network.target")
-      internal.wait_for_unit("network.target")
-      oclient.wait_for_unit("network.target")
+        gw.wait_for_unit("network.target")
+        internal.wait_for_unit("network.target")
+        oclient.wait_for_unit("network.target")
 
-      gw.wait_for_unit("openvpn-access.service")
-      gw.wait_until_succeeds("ip link show tun0")
+        gw.wait_for_unit("openvpn-access.service")
+        gw.wait_until_succeeds("ip link show tun0")
 
-      # openvpn gateway should be reachable from the client
-      oclient.succeed("ping -c1 ${gwFeFqdn}")
-      oclient.succeed("ping -6 -c1 ${gwFeFqdn}")
+        # openvpn gateway should be reachable from the client
+        oclient.succeed("ping -c1 ${gwFeFqdn}")
+        oclient.succeed("ping -6 -c1 ${gwFeFqdn}")
 
-      # start openvpn client and wait for tunnel device
-      oclient.succeed("openvpn --config /tmp/gw.ovpn --auth-user-pass /tmp/user-pass >&2 &")
-      oclient.wait_until_succeeds("ip link show tun0")
+        # start openvpn client and wait for tunnel device
+        oclient.succeed("openvpn --config /tmp/gw.ovpn --auth-user-pass /tmp/user-pass >&2 &")
+        oclient.wait_until_succeeds("ip link show tun0")
 
-      # internal machine should be reachable from client via vpn tunnel -> gateway -> internal machine
-      oclient.succeed("ping -c1 ${internal4Srv}")
-      oclient.succeed("ping -c1 ${internal6Srv}")
+        # internal machine should be reachable from client via vpn tunnel -> gateway -> internal machine
+        oclient.succeed("ping -c1 ${internal4Srv}")
+        oclient.succeed("ping -c1 ${internal6Srv}")
 
-      print("======= addresses =========\n")
-      print("=== gw:\n")
-      print(gw.execute("ip a"))
-      print("=== internal:\n")
-      print(internal.execute("ip a"))
-      print("=== client:\n")
-      print(oclient.execute("ip a"))
+        print("======= addresses =========\n")
+        print("=== gw:\n")
+        print(gw.execute("ip a"))
+        print("=== internal:\n")
+        print(internal.execute("ip a"))
+        print("=== client:\n")
+        print(oclient.execute("ip a"))
 
-      print("======= routing =========\n")
-      print("=== gw:\n")
-      print(gw.execute("ip r"))
-      print("=== client:\n")
-      print(oclient.execute("ip r"))
+        print("======= routing =========\n")
+        print("=== gw:\n")
+        print(gw.execute("ip r"))
+        print("=== client:\n")
+        print(oclient.execute("ip r"))
 
-      # sensu check for openvpn server should be green
-      gw.succeed("/etc/local/openvpn/check")
+        # sensu check for openvpn server should be green
+        gw.succeed("/etc/local/openvpn/check")
 
-      gw.succeed("systemctl stop openvpn-access")
-      gw.wait_until_fails("ip link show tun0")
+        # PKI cert expiry checks should be green (certs are valid for years)
+        gw.succeed("${testlib.sensuCheckCmd nodes.gw "openvpn_pki_ca"}")
+        gw.succeed("${testlib.sensuCheckCmd nodes.gw "openvpn_pki_server"}")
 
-      # sensu check should be red when service is stopped
-      gw.fail("/etc/local/openvpn/check")
-    '';
+        gw.succeed("systemctl stop openvpn-access")
+        gw.wait_until_fails("ip link show tun0")
+
+        # sensu check should be red when service is stopped
+        gw.fail("/etc/local/openvpn/check")
+      '';
   }
 )

--- a/tests/openvpn.nix
+++ b/tests/openvpn.nix
@@ -189,6 +189,25 @@ import ./make-test-python.nix (
         gw.succeed("sudo -u sensuclient ${testlib.sensuCheckCmd nodes.gw "openvpn_pki_ca"}")
         gw.succeed("sudo -u sensuclient ${testlib.sensuCheckCmd nodes.gw "openvpn_pki_server"}")
 
+        # PKI cert expiry checks should go red for certs within the warning
+        # (25d) and critical (14d) windows. Swap in short-lived certs and
+        # expect both checks to fail. The CA cert is made to warn (20 days
+        # left), the server cert to fail critically (10 days left).
+        gw.succeed(
+          "openssl req -x509 -newkey rsa:2048 -nodes -days 20"
+          + " -subj /CN=test-expiring-ca -keyout /tmp/test-ca.key"
+          + " -out /var/lib/openvpn-pki/pki/ca.crt"
+        )
+        gw.succeed(
+          "openssl req -x509 -newkey rsa:2048 -nodes -days 10"
+          + " -subj /CN=test-expiring-server -keyout /tmp/test-server.key"
+          + " -out /var/lib/openvpn-pki/server.crt"
+        )
+        ca_out = gw.fail("sudo -u sensuclient ${testlib.sensuCheckCmd nodes.gw "openvpn_pki_ca"}")
+        server_out = gw.fail("sudo -u sensuclient ${testlib.sensuCheckCmd nodes.gw "openvpn_pki_server"}")
+        assert "expires within warning time" in ca_out, ca_out
+        assert "expires within critical time" in server_out, server_out
+
         gw.succeed("systemctl stop openvpn-access")
         gw.wait_until_fails("ip link show tun0")
 

--- a/tests/openvpn.nix
+++ b/tests/openvpn.nix
@@ -183,9 +183,11 @@ import ./make-test-python.nix (
         # sensu check for openvpn server should be green
         gw.succeed("/etc/local/openvpn/check")
 
-        # PKI cert expiry checks should be green (certs are valid for years)
-        gw.succeed("${testlib.sensuCheckCmd nodes.gw "openvpn_pki_ca"}")
-        gw.succeed("${testlib.sensuCheckCmd nodes.gw "openvpn_pki_server"}")
+        # PKI cert expiry checks should be green (certs are valid for years).
+        # Run as the sensuclient user to exercise the actual sudo invocation
+        # path used in production.
+        gw.succeed("sudo -u sensuclient ${testlib.sensuCheckCmd nodes.gw "openvpn_pki_ca"}")
+        gw.succeed("sudo -u sensuclient ${testlib.sensuCheckCmd nodes.gw "openvpn_pki_server"}")
 
         gw.succeed("systemctl stop openvpn-access")
         gw.wait_until_fails("ip link show tun0")


### PR DESCRIPTION
@flyingcircusio/release-managers
PL-135338: Expiration of PKI caused an emergency. The PR uses `pkgs.fc.check-tls-cert` to check certs similiar to acme, might suggest a rename of the check script

## Release process

This change should be backported:

- [ ] Created changelog entry using `./changelog.sh`
- [ ] Add `backport release-25.11` label

This change should only reach this branch:

- [x] Created changelog entry using `./changelog.sh`
or
- [ ] Add a upgrade node in `doc/upgrade.md`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team
<!--
- [ ] set urgency and risk labels
- [ ] ensure the merge bot has determined a merge date
-->
- [ ] ensure all checks are green
- [ ] get a review from a colleague

## Design notes

- [ ] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [ ] All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.
- [ ] Provide warnings in previous platform version and upgrade notes when introducing a breaking change

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - No new deps added, test passes when run by hand
- [x] Security requirements tested? (EVIDENCE)
